### PR TITLE
feat: show ∞ and remove step limit when max agent steps slider hits 200

### DIFF
--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -56,6 +56,7 @@ async function loadMaxSteps() {
   if (stored.maxAgentSteps === 0) agent.maxSteps = Infinity;
   else if (stored.maxAgentSteps) agent.maxSteps = stored.maxAgentSteps;
 }
+loadMaxSteps();
 
 async function loadAutoScreenshot() {
   const stored = await chrome.storage.local.get('autoScreenshot');

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -53,7 +53,8 @@ setRecorderProviderManager(providerManager);
 // Load maxSteps setting
 async function loadMaxSteps() {
   const stored = await chrome.storage.local.get('maxAgentSteps');
-  if (stored.maxAgentSteps) agent.maxSteps = stored.maxAgentSteps;
+  if (stored.maxAgentSteps === 0) agent.maxSteps = Infinity;
+  else if (stored.maxAgentSteps) agent.maxSteps = stored.maxAgentSteps;
 }
 
 async function loadAutoScreenshot() {
@@ -113,7 +114,7 @@ chrome.runtime.onStartup?.addListener(async () => {
 // Listen for setting changes
 chrome.storage.onChanged.addListener((changes) => {
   if (changes.maxAgentSteps) {
-    agent.maxSteps = changes.maxAgentSteps.newValue;
+    agent.maxSteps = changes.maxAgentSteps.newValue === 0 ? Infinity : changes.maxAgentSteps.newValue;
   }
   if (changes.autoScreenshot) {
     agent.autoScreenshot = changes.autoScreenshot.newValue;

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -165,8 +165,13 @@ async function init() {
   }
   verboseToggle.checked = stored.verboseMode || false;
   screenshotToggle.checked = stored.screenshotFallback ?? true; // on by default
-  maxStepsRange.value = stored.maxAgentSteps || 130;
-  stepsValueLabel.textContent = maxStepsRange.value;
+  if (stored.maxAgentSteps === 0) {
+    maxStepsRange.value = 200;
+    stepsValueLabel.textContent = '∞';
+  } else {
+    maxStepsRange.value = stored.maxAgentSteps || 130;
+    stepsValueLabel.textContent = maxStepsRange.value;
+  }
   // requestTimeoutMs is stored in milliseconds, displayed as seconds.
   // Default 60s when unset. Floor 10s / ceiling 600s matches the slider.
   if (requestTimeoutRange && requestTimeoutValueLabel) {
@@ -402,11 +407,11 @@ screenshotToggle.addEventListener('change', () => {
 });
 
 maxStepsRange.addEventListener('input', () => {
-  stepsValueLabel.textContent = maxStepsRange.value;
+  stepsValueLabel.textContent = maxStepsRange.value == 200 ? '∞' : maxStepsRange.value;
 });
 
 maxStepsRange.addEventListener('change', () => {
-  chrome.storage.local.set({ maxAgentSteps: parseInt(maxStepsRange.value) });
+  chrome.storage.local.set({ maxAgentSteps: maxStepsRange.value == 200 ? 0 : parseInt(maxStepsRange.value) });
 });
 
 if (requestTimeoutRange) {

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -40,7 +40,8 @@ scheduler.start();
 // Load maxSteps setting
 async function loadMaxSteps() {
   const stored = await browser.storage.local.get('maxAgentSteps');
-  if (stored.maxAgentSteps) agent.maxSteps = stored.maxAgentSteps;
+  if (stored.maxAgentSteps === 0) agent.maxSteps = Infinity;
+  else if (stored.maxAgentSteps) agent.maxSteps = stored.maxAgentSteps;
 }
 
 async function loadAutoScreenshot() {
@@ -89,7 +90,7 @@ browser.runtime.onInstalled.addListener(async () => {
 // Listen for setting changes
 browser.storage.onChanged.addListener((changes) => {
   if (changes.maxAgentSteps) {
-    agent.maxSteps = changes.maxAgentSteps.newValue;
+    agent.maxSteps = changes.maxAgentSteps.newValue === 0 ? Infinity : changes.maxAgentSteps.newValue;
   }
   if (changes.autoScreenshot) {
     agent.autoScreenshot = changes.autoScreenshot.newValue;

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -43,6 +43,7 @@ async function loadMaxSteps() {
   if (stored.maxAgentSteps === 0) agent.maxSteps = Infinity;
   else if (stored.maxAgentSteps) agent.maxSteps = stored.maxAgentSteps;
 }
+loadMaxSteps();
 
 async function loadAutoScreenshot() {
   const stored = await browser.storage.local.get('autoScreenshot');

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -161,8 +161,13 @@ async function init() {
   }
   verboseToggle.checked = stored.verboseMode || false;
   screenshotToggle.checked = stored.screenshotFallback ?? true; // on by default
-  maxStepsRange.value = stored.maxAgentSteps || 130;
-  stepsValueLabel.textContent = maxStepsRange.value;
+  if (stored.maxAgentSteps === 0) {
+    maxStepsRange.value = 200;
+    stepsValueLabel.textContent = '∞';
+  } else {
+    maxStepsRange.value = stored.maxAgentSteps || 130;
+    stepsValueLabel.textContent = maxStepsRange.value;
+  }
   // requestTimeoutMs is stored in milliseconds, displayed as seconds.
   if (requestTimeoutRange && requestTimeoutValueLabel) {
     const tMs = (typeof stored.requestTimeoutMs === 'number' && stored.requestTimeoutMs > 0)
@@ -388,11 +393,11 @@ screenshotToggle.addEventListener('change', () => {
 });
 
 maxStepsRange.addEventListener('input', () => {
-  stepsValueLabel.textContent = maxStepsRange.value;
+  stepsValueLabel.textContent = maxStepsRange.value == 200 ? '∞' : maxStepsRange.value;
 });
 
 maxStepsRange.addEventListener('change', () => {
-  browser.storage.local.set({ maxAgentSteps: parseInt(maxStepsRange.value) });
+  browser.storage.local.set({ maxAgentSteps: maxStepsRange.value == 200 ? 0 : parseInt(maxStepsRange.value) });
 });
 
 if (requestTimeoutRange) {


### PR DESCRIPTION
When the slider reaches 200, the label switches to ∞ and stores 0 as the sentinel; background.js maps 0 → Infinity so the agent loop never hits a step cap.