### PR TITLE
Restore API-driven cloud browser runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog was generated from the repository Git history and release tags. V
 - Added a selection shortcut for Chrome and Firefox with Summarize, Explain, Quiz me, Proofread, Translate, and custom WebBrain prompts.
 - Expanded the native selection context menu with matching preset actions, translation languages, and direct side-panel access.
 - Added a persistent setting to hide or restore the floating selection shortcut.
+- Added the managed cloud-browser bridge for API-driven run, status, abort, active-tab control, and validated structured results.
 
 ### Changed
 - Simplified the selection shortcut to a compact purple question-mark icon.

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1,4 +1,5 @@
 import { AGENT_TOOLS, AGENT_TOOL_NAMES, RESERVED_AGENT_TOOL_NAMES, getToolsForMode, SYSTEM_PROMPT_ASK, SYSTEM_PROMPT_ACT, SYSTEM_PROMPT_ACT_COMPACT, SYSTEM_PROMPT_ACT_MID, SYSTEM_PROMPT_DEV_APPENDIX } from './tools.js';
+import { handleDoneJson } from './cloud-output.js';
 import { URL_FAMILY_TOOLS, resourceBucket, bucketArgsKey } from './loop-bucket.js';
 import { isCredentialField, CREDENTIAL_NOTE_STRICT } from './credential-fields.js';
 import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLedgerDowngrade, isTerminalLedgerStatus, isValidLedgerStatus, ledgerDoneBlock, normalizeLedgerStatus, progressCounts, selectLedgerRows, unresolvedLedgerRows, upsertLedgerItems } from './progress-ledger.js';
@@ -224,6 +225,7 @@ export class Agent {
     // abort() and clearConversation() cancel all pending clarifications so
     // the agent loop doesn't deadlock.
     this._pendingClarifications = new Map();
+    this.cloudRunContexts = new Map(); // tabId -> { outputSchema, schemaRepairUsed }
     // Deterministic capability × origin permission gate. "Always" grants are
     // persisted in extension storage; "once" grants live for the current turn.
     this.permissions = new PermissionManager({
@@ -8071,6 +8073,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   }
 
   async executeTool(tabId, name, args, onUpdate = null) {
+    if (name === 'done_json') {
+      return handleDoneJson(this.cloudRunContexts.get(tabId), args);
+    }
     if (name === 'get_window_info') {
       return await this._getWindowInfo(tabId);
     }
@@ -11595,10 +11600,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     this._clearLoopState(tabId);
     this._runningTabs.add(tabId);
+    const previousCloudContext = this.cloudRunContexts.get(tabId);
+    if (runOptions.cloudRun) {
+      this.cloudRunContexts.set(tabId, { outputSchema: runOptions.outputSchema || null, schemaRepairUsed: false });
+    }
     try {
       return await this._processMessageInner(tabId, userMessage, onUpdate, mode, attachments, runOptions);
     } finally {
       this.currentCostState.delete(tabId);
+      if (runOptions.cloudRun) {
+        if (previousCloudContext) this.cloudRunContexts.set(tabId, previousCloudContext);
+        else this.cloudRunContexts.delete(tabId);
+      }
       this._runningTabs.delete(tabId);
       this._clearLoopState(tabId);
     }
@@ -11746,7 +11759,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     const tier = provider.promptTier;
     const skillTools = this._skillToolDefinitions(mode, tier);
-    const tools = getToolsForMode(mode, { strictSecretMode: this.strictSecretMode, tier, skillTools });
+    const cloudRunContext = this.cloudRunContexts.get(tabId) || null;
+    const tools = getToolsForMode(mode, {
+      strictSecretMode: this.strictSecretMode,
+      tier,
+      skillTools,
+      cloudRun: !!cloudRunContext,
+      outputSchema: cloudRunContext?.outputSchema || null,
+    });
     const allowedToolNames = new Set(tools.map(t => t.function.name));
     const plannerTemperature = this._isActionMode(mode) ? 0.15 : 0.3;
     let steps = 0;
@@ -12058,10 +12078,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     this._clearLoopState(tabId);
     this._runningTabs.add(tabId);
+    const previousCloudContext = this.cloudRunContexts.get(tabId);
+    if (runOptions.cloudRun) {
+      this.cloudRunContexts.set(tabId, { outputSchema: runOptions.outputSchema || null, schemaRepairUsed: false });
+    }
     try {
       return await this._processMessageStreamInner(tabId, userMessage, onUpdate, mode, runOptions);
     } finally {
       this.currentCostState.delete(tabId);
+      if (runOptions.cloudRun) {
+        if (previousCloudContext) this.cloudRunContexts.set(tabId, previousCloudContext);
+        else this.cloudRunContexts.delete(tabId);
+      }
       this._runningTabs.delete(tabId);
       this._clearLoopState(tabId);
     }
@@ -12129,7 +12157,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     const tier = provider.promptTier;
     const skillTools = this._skillToolDefinitions(mode, tier);
-    const tools = getToolsForMode(mode, { strictSecretMode: this.strictSecretMode, tier, skillTools });
+    const cloudRunContext = this.cloudRunContexts.get(tabId) || null;
+    const tools = getToolsForMode(mode, {
+      strictSecretMode: this.strictSecretMode,
+      tier,
+      skillTools,
+      cloudRun: !!cloudRunContext,
+      outputSchema: cloudRunContext?.outputSchema || null,
+    });
     const allowedToolNames = new Set(tools.map(t => t.function.name));
     const plannerTemperature = this._isActionMode(mode) ? 0.15 : 0.3;
     let steps = 0;

--- a/src/chrome/src/agent/cloud-output.js
+++ b/src/chrome/src/agent/cloud-output.js
@@ -1,0 +1,133 @@
+export function validateCloudOutput(value, schema) {
+  const errors = [];
+  const push = (path, message) => errors.push(`${path}: ${message}`);
+  const isObject = item => !!item && typeof item === 'object' && !Array.isArray(item);
+  const keywords = new Set(['type', 'properties', 'required', 'items', 'enum', 'description', 'additionalProperties']);
+
+  const validate = (item, spec, path = '$') => {
+    if (typeof spec === 'string') {
+      let shorthand = spec.trim();
+      const optional = shorthand.endsWith('?');
+      if (optional) shorthand = shorthand.slice(0, -1).trim();
+      if ((item === undefined || item === null) && optional) return;
+      if (shorthand.endsWith('[]')) {
+        if (!Array.isArray(item)) {
+          push(path, `expected array of ${shorthand.slice(0, -2)}`);
+          return;
+        }
+        item.forEach((child, index) => validate(child, shorthand.slice(0, -2) || 'any', `${path}[${index}]`));
+        return;
+      }
+      const valid = shorthand === 'any'
+        || (shorthand === 'string' && typeof item === 'string')
+        || (shorthand === 'number' && typeof item === 'number' && !Number.isNaN(item))
+        || (shorthand === 'integer' && Number.isInteger(item))
+        || (shorthand === 'boolean' && typeof item === 'boolean')
+        || (shorthand === 'object' && isObject(item))
+        || (shorthand === 'array' && Array.isArray(item));
+      if (!valid) push(path, shorthand === 'any' ? 'unsupported value' : `expected ${shorthand}`);
+      return;
+    }
+
+    if (Array.isArray(spec)) {
+      if (!Array.isArray(item)) {
+        push(path, 'expected array');
+        return;
+      }
+      item.forEach((child, index) => validate(child, spec[0] || 'any', `${path}[${index}]`));
+      return;
+    }
+
+    if (!isObject(spec)) return;
+    const jsonSchema = Object.keys(spec).some(key => keywords.has(key));
+    if (!jsonSchema) {
+      if (!isObject(item)) {
+        push(path, 'expected object');
+        return;
+      }
+      for (const [key, childSpec] of Object.entries(spec)) {
+        const optional = typeof childSpec === 'string' && childSpec.trim().endsWith('?');
+        if (!(key in item)) {
+          if (!optional) push(`${path}.${key}`, 'missing required property');
+          continue;
+        }
+        validate(item[key], childSpec, `${path}.${key}`);
+      }
+      return;
+    }
+
+    if (Array.isArray(spec.enum) && !spec.enum.includes(item)) {
+      push(path, `expected one of ${JSON.stringify(spec.enum)}`);
+    }
+    const types = Array.isArray(spec.type) ? spec.type : (spec.type ? [spec.type] : []);
+    if (types.length) {
+      const typeOk = types.some(type => {
+        if (type === 'array') return Array.isArray(item);
+        if (type === 'object') return isObject(item);
+        if (type === 'integer') return Number.isInteger(item);
+        if (type === 'number') return typeof item === 'number' && !Number.isNaN(item);
+        if (type === 'null') return item === null;
+        return typeof item === type;
+      });
+      if (!typeOk) push(path, `expected ${types.join(' or ')}`);
+    }
+    if (spec.properties || spec.required) {
+      if (!isObject(item)) {
+        push(path, 'expected object with properties');
+        return;
+      }
+      for (const key of Array.isArray(spec.required) ? spec.required : []) {
+        if (!(key in item)) push(`${path}.${key}`, 'missing required property');
+      }
+      for (const [key, childSpec] of Object.entries(spec.properties || {})) {
+        if (key in item) validate(item[key], childSpec, `${path}.${key}`);
+      }
+      if (spec.additionalProperties === false) {
+        const allowed = new Set(Object.keys(spec.properties || {}));
+        for (const key of Object.keys(item)) {
+          if (!allowed.has(key)) push(`${path}.${key}`, 'additional property is not allowed');
+        }
+      }
+    }
+    if (spec.items && Array.isArray(item)) {
+      item.forEach((child, index) => validate(child, spec.items, `${path}[${index}]`));
+    }
+  };
+
+  validate(value, schema);
+  return { ok: errors.length === 0, errors };
+}
+export function handleDoneJson(context, args = {}) {
+  if (!context?.outputSchema) {
+    return {
+      success: false,
+      error: 'done_json is only available during a cloud run with an output schema.',
+    };
+  }
+  const result = Object.prototype.hasOwnProperty.call(args, 'result') ? args.result : undefined;
+  const summary = String(args.summary || '').trim() || 'Task completed.';
+  const validation = validateCloudOutput(result, context.outputSchema);
+  if (validation.ok) {
+    return { done: true, doneJson: true, summary, result, cloudResult: result };
+  }
+  const message = `done_json result did not match outputSchema: ${validation.errors.slice(0, 8).join('; ')}`;
+  if (!context.schemaRepairUsed) {
+    context.schemaRepairUsed = true;
+    return {
+      success: false,
+      schemaValidationError: true,
+      error: `${message}. Call done_json exactly one more time with a corrected result.`,
+      expectedSchema: context.outputSchema,
+    };
+  }
+  return {
+    done: true,
+    doneJson: true,
+    cloudFailed: true,
+    schemaValidationError: true,
+    summary: 'Structured cloud run failed schema validation.',
+    error: message,
+    expectedSchema: context.outputSchema,
+    invalidResult: result,
+  };
+}

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -884,7 +884,7 @@ export const ASK_ONLY_TOOLS = [
  */
 export const AGENT_TOOL_NAMES = new Set(AGENT_TOOLS.map(t => t.function.name));
 export const RETIRED_AGENT_TOOL_NAMES = new Set(['screenshot', 'full_page_screenshot', 'record_tab', 'stop_recording']);
-export const RESERVED_AGENT_TOOL_NAMES = new Set([...AGENT_TOOL_NAMES, ...RETIRED_AGENT_TOOL_NAMES]);
+export const RESERVED_AGENT_TOOL_NAMES = new Set([...AGENT_TOOL_NAMES, ...RETIRED_AGENT_TOOL_NAMES, 'done_json']);
 export const DEV_ONLY_TOOL_NAMES = new Set(['read_page_source', 'inspect_element_styles']);
 export const DEV_EXTENDED_TOOL_NAMES = new Set([
   ...DEV_ONLY_TOOL_NAMES,
@@ -956,6 +956,22 @@ const DONE_TOOL_STRICT_WITH_OUTCOME = {
   },
 };
 
+const DONE_JSON_TOOL = {
+  type: 'function',
+  function: {
+    name: 'done_json',
+    description: 'Complete a structured cloud run. Call this only when the task is finished and result exactly matches the requested output schema. If validation fails, repair the result and call done_json once more.',
+    parameters: {
+      type: 'object',
+      properties: {
+        result: { type: 'object', description: 'Machine-readable result matching the requested output schema.' },
+        summary: { type: 'string', description: 'Short human-readable completion summary.' },
+      },
+      required: ['result', 'summary'],
+    },
+  },
+};
+
 /**
  * Get tools filtered by mode.
  *
@@ -996,6 +1012,8 @@ export function getToolsForMode(mode, opts = {}) {
     });
     base = [...base, ...extras];
   }
+  const useDoneJson = normalizedMode === 'act' && tier === 'full' && opts.cloudRun === true && !!opts.outputSchema;
+  if (useDoneJson) return base.map(tool => (tool.function.name === 'done' ? DONE_JSON_TOOL : tool));
   const useOutcomeDone = normalizedMode !== 'ask' && tier !== 'compact';
   if (!opts.strictSecretMode && !useOutcomeDone) return base;
   const replacement = opts.strictSecretMode

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -18,14 +18,14 @@ import {
   getClaudeOAuthStatus,
 } from './providers/oauth-claude.js';
 import { getBalance as capsolverGetBalance } from './agent/captcha-solver.js';
+import { createCloudRunController } from './cloud-runs.js';
+import { ensureOffscreen } from './offscreen/ensure.js';
 import {
   SELECTION_TRANSLATION_LANGUAGES,
   buildContextMenuPrompt,
   buildSelectionPrompt,
   createContextMenuStorage,
 } from './context-menu-storage.js';
-// (ensureOffscreen + transcribeAudio used to be imported here; both are
-// now consumed inside src/recorder/host.js, which background.js calls into.)
 import {
   prepareRecordingHost,
   startTabRecording,
@@ -90,6 +90,14 @@ scheduler.start();
 // can look up the user's configured Whisper-compatible provider. Must
 // happen AFTER providerManager is constructed.
 setRecorderProviderManager(providerManager);
+
+const cloudRunController = createCloudRunController({
+  chromeApi: chrome,
+  agent,
+  ensureOffscreen,
+  sendIndicator: (tabId, type) => sendIndicatorMessage(tabId, type),
+});
+cloudRunController.syncBridge().catch(() => {});
 
 const MAX_AGENT_STEPS_DEFAULT = 130;
 const MAX_AGENT_STEPS_UNLIMITED_SENTINEL = 200;
@@ -679,6 +687,7 @@ chrome.runtime.onInstalled.addListener(async () => {
   await providerManager.load();
   await loadMaxSteps();
   await syncAgentUserMemoryFromStorage().catch(() => {});
+  await cloudRunController.syncBridge().catch(() => {});
   scheduleUserMemoryExtractionDrain(5000);
   console.log('[WebBrain] Extension installed, providers loaded.');
 });
@@ -689,6 +698,7 @@ chrome.runtime.onStartup?.addListener(async () => {
   await providerManager.load();
   await loadMaxSteps();
   await syncAgentUserMemoryFromStorage().catch(() => {});
+  await cloudRunController.syncBridge().catch(() => {});
   scheduleUserMemoryExtractionDrain(5000);
 });
 
@@ -696,6 +706,9 @@ chrome.runtime.onStartup?.addListener(async () => {
 chrome.storage.onChanged.addListener((changes) => {
   if (PROFILE_SYNC_DATA_KEYS.some((key) => changes[key])) profileSync.noteChanges(changes).catch(() => {});
   if (changes.providers || changes.activeProvider) providerManager.load().catch(() => {});
+  if (changes.webbrainCloudBridgeEnabled || changes.webbrainCloudBridgeUrl) {
+    cloudRunController.syncBridge().catch(() => {});
+  }
   if (changes.maxAgentSteps) {
     agent.maxSteps = normalizeMaxAgentSteps(changes.maxAgentSteps.newValue);
   }
@@ -1501,6 +1514,18 @@ async function handleMessage(msg, sender) {
   }
 
   switch (msg.action) {
+    case 'cloud_run':
+      return await cloudRunController.startRun(msg);
+    case 'cloud_status':
+      return await cloudRunController.status(msg);
+    case 'cloud_abort':
+      return await cloudRunController.abort(msg);
+    case 'cloud_bridge_start':
+      return await cloudRunController.startBridge(msg.url);
+    case 'cloud_bridge_stop':
+      return await cloudRunController.stopBridge();
+    case 'cloud_bridge_status':
+      return await cloudRunController.bridgeStatus();
     case 'prepare_recording_host':
       return await prepareRecordingHost();
     case 'start_tab_recording': {

--- a/src/chrome/src/cloud-runs.js
+++ b/src/chrome/src/cloud-runs.js
@@ -1,0 +1,303 @@
+const DEFAULT_CLOUD_BRIDGE_URL = 'ws://127.0.0.1:17373/extension';
+const CLOUD_RUN_STORAGE_KEY = 'webbrainCloudRunSnapshots';
+const CLOUD_UPDATE_LIMIT = 200;
+const CLOUD_RUN_LIMIT = 50;
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'aborted']);
+
+export function normalizeCloudBridgeUrl(value = DEFAULT_CLOUD_BRIDGE_URL) {
+  const url = new URL(String(value || DEFAULT_CLOUD_BRIDGE_URL));
+  const host = url.hostname.toLowerCase();
+  if (url.protocol !== 'ws:' || !['127.0.0.1', 'localhost', '::1'].includes(host)) {
+    throw new Error('WebBrain cloud bridge URL must use ws:// on localhost.');
+  }
+  return url.href;
+}
+
+function scrubCloudValue(value) {
+  try {
+    return JSON.parse(JSON.stringify(value, (key, item) => {
+      if (typeof item === 'string' && item.startsWith('data:image/')) {
+        return `[image omitted: ${item.length} chars]`;
+      }
+      if ((key === '_attachImage' || key === 'screenshot') && typeof item === 'string' && item.length > 500) {
+        return `[large payload omitted: ${item.length} chars]`;
+      }
+      return item;
+    }));
+  } catch {
+    return { unserializable: true };
+  }
+}
+
+function cloudSnapshot(run, { includeUpdates = true } = {}) {
+  if (!run) return null;
+  return {
+    runId: run.runId,
+    status: run.status,
+    tabId: run.tabId,
+    task: run.task,
+    structured: !!run.outputSchema,
+    result: run.result,
+    summary: run.summary,
+    content: run.content,
+    finalUrl: run.finalUrl,
+    error: run.error,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+    completedAt: run.completedAt,
+    updates: includeUpdates ? run.updates : undefined,
+  };
+}
+
+function isUsableCloudTab(tab) {
+  if (tab?.id == null) return false;
+  try {
+    const url = new URL(tab.url || '');
+    return ['http:', 'https:', 'file:'].includes(url.protocol) || url.href === 'about:blank';
+  } catch {
+    return false;
+  }
+}
+
+export function createCloudRunController({
+  chromeApi,
+  agent,
+  ensureOffscreen,
+  sendIndicator = () => {},
+  now = () => new Date(),
+  makeRunId = () => `run_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`,
+} = {}) {
+  const api = chromeApi;
+  const runs = new Map();
+  let hydratePromise = null;
+  let persistQueue = Promise.resolve();
+  let persistTimer = null;
+
+  const isoNow = () => now().toISOString();
+
+  async function persist() {
+    if (!api.storage?.session?.set) return;
+    const rows = [...runs.values()]
+      .sort((a, b) => String(b.createdAt).localeCompare(String(a.createdAt)))
+      .slice(0, CLOUD_RUN_LIMIT)
+      .map(run => scrubCloudValue(run));
+    persistQueue = persistQueue
+      .catch(() => {})
+      .then(() => api.storage.session.set({ [CLOUD_RUN_STORAGE_KEY]: rows }));
+    await persistQueue;
+  }
+
+  function schedulePersist() {
+    if (persistTimer) return;
+    persistTimer = setTimeout(() => {
+      persistTimer = null;
+      persist().catch(() => {});
+    }, 100);
+  }
+
+  async function hydrate() {
+    if (hydratePromise) return hydratePromise;
+    hydratePromise = (async () => {
+      if (!api.storage?.session?.get) return;
+      const stored = await api.storage.session.get(CLOUD_RUN_STORAGE_KEY).catch(() => ({}));
+      const rows = Array.isArray(stored?.[CLOUD_RUN_STORAGE_KEY]) ? stored[CLOUD_RUN_STORAGE_KEY] : [];
+      let changed = false;
+      for (const row of rows) {
+        if (!row?.runId) continue;
+        const restored = { ...row, updates: Array.isArray(row.updates) ? row.updates : [] };
+        if (!TERMINAL_STATUSES.has(restored.status)) {
+          const at = isoNow();
+          restored.status = restored.status === 'aborting' ? 'aborted' : 'failed';
+          restored.error = restored.status === 'aborted'
+            ? 'Run aborted when the WebBrain service worker restarted.'
+            : 'Run interrupted when the WebBrain service worker restarted.';
+          restored.updatedAt = at;
+          restored.completedAt = at;
+          changed = true;
+        }
+        runs.set(restored.runId, restored);
+      }
+      if (changed) await persist();
+    })();
+    return hydratePromise;
+  }
+
+  async function activateTab(tab) {
+    if (!tab?.id) return tab;
+    await api.tabs.update(tab.id, { active: true }).catch(() => {});
+    if (tab.windowId != null && api.windows?.update) {
+      await api.windows.update(tab.windowId, { focused: true }).catch(() => {});
+    }
+    return tab;
+  }
+
+  async function resolveTabId(requestedTabId) {
+    if (requestedTabId != null && requestedTabId !== '') {
+      const tab = await api.tabs.get(Number(requestedTabId));
+      if (!isUsableCloudTab(tab)) throw new Error(`Tab ${requestedTabId} is not a controllable webpage.`);
+      await activateTab(tab);
+      return tab.id;
+    }
+
+    const active = await api.tabs.query({ active: true, lastFocusedWindow: true });
+    const activeTab = active.find(isUsableCloudTab);
+    if (activeTab) return activeTab.id;
+
+    const allTabs = await api.tabs.query({});
+    const fallback = allTabs.find(isUsableCloudTab);
+    if (fallback) {
+      await activateTab(fallback);
+      return fallback.id;
+    }
+
+    const created = await api.tabs.create({ url: 'about:blank', active: true });
+    if (created?.id == null) throw new Error('Could not create a browser tab for the cloud run.');
+    return created.id;
+  }
+
+  async function getTabUrl(tabId) {
+    try {
+      return (await api.tabs.get(tabId))?.url || '';
+    } catch {
+      return '';
+    }
+  }
+
+  function pushUpdate(run, type, data) {
+    run.updatedAt = isoNow();
+    run.updates.push({ type, data: scrubCloudValue(data), ts: run.updatedAt });
+    if (run.updates.length > CLOUD_UPDATE_LIMIT) {
+      run.updates.splice(0, run.updates.length - CLOUD_UPDATE_LIMIT);
+    }
+    if (type === 'tool_result' && data?.name === 'done_json') {
+      const result = data.result || {};
+      if (result.cloudFailed) {
+        run.status = 'failed';
+        run.error = result.error || 'done_json failed';
+        run.summary = result.summary || run.summary;
+      } else if (Object.prototype.hasOwnProperty.call(result, 'cloudResult')) {
+        run.result = result.cloudResult;
+        run.summary = result.summary || run.summary;
+      }
+    }
+    schedulePersist();
+  }
+
+  async function startRun(msg = {}) {
+    await hydrate();
+    const tabId = await resolveTabId(msg.tabId ?? msg.tab_id);
+    const task = String(msg.task || msg.text || '').trim();
+    if (!task) throw new Error('cloud_run requires `task`.');
+    if (agent.isRunning(tabId)) throw new Error(`Tab ${tabId} already has an active WebBrain run.`);
+
+    const outputSchema = msg.outputSchema || msg.output_schema || msg.responseFormat?.schema || msg.response_format?.schema || null;
+    const createdAt = isoNow();
+    const run = {
+      runId: msg.runId || msg.run_id || makeRunId(),
+      status: 'running',
+      tabId,
+      task,
+      outputSchema,
+      result: undefined,
+      summary: '',
+      content: '',
+      finalUrl: '',
+      error: '',
+      updates: [],
+      createdAt,
+      updatedAt: createdAt,
+      completedAt: null,
+    };
+    runs.set(run.runId, run);
+    await persist();
+
+    (async () => {
+      try {
+        sendIndicator(tabId, 'WB_SHOW_AGENT_INDICATORS');
+        const content = await agent.processMessage(tabId, task, (type, data) => {
+          pushUpdate(run, type, data);
+        }, 'act', [], { cloudRun: true, outputSchema });
+        run.content = content;
+        run.finalUrl = await getTabUrl(tabId);
+        if (run.status === 'aborting') {
+          run.status = 'aborted';
+          run.error = run.error || 'Aborted by cloud_abort.';
+        } else if (run.status !== 'failed') {
+          if (outputSchema && run.result === undefined) {
+            run.status = 'failed';
+            run.error = 'Structured cloud run finished without a valid done_json result.';
+          } else {
+            run.status = 'completed';
+            if (!outputSchema) run.result = content;
+          }
+        }
+      } catch (error) {
+        run.status = run.status === 'aborting' ? 'aborted' : 'failed';
+        run.error = error?.message || String(error);
+        run.finalUrl = await getTabUrl(tabId);
+      } finally {
+        run.completedAt = isoNow();
+        run.updatedAt = run.completedAt;
+        sendIndicator(tabId, 'WB_HIDE_AGENT_INDICATORS');
+        await persist().catch(() => {});
+      }
+    })();
+
+    return cloudSnapshot(run, { includeUpdates: false });
+  }
+
+  async function status(msg = {}) {
+    await hydrate();
+    const runId = msg.runId || msg.run_id;
+    if (!runId) return { runs: [...runs.values()].map(run => cloudSnapshot(run, { includeUpdates: false })) };
+    const run = runs.get(runId);
+    if (!run) throw new Error('Unknown cloud run.');
+    return cloudSnapshot(run);
+  }
+
+  async function abort(msg = {}) {
+    await hydrate();
+    const run = runs.get(msg.runId || msg.run_id);
+    if (!run) throw new Error('Unknown cloud run.');
+    if (run.status === 'running') {
+      run.status = 'aborting';
+      run.error = 'Abort requested.';
+      run.updatedAt = isoNow();
+      agent.abort(run.tabId);
+      await persist();
+    }
+    return cloudSnapshot(run);
+  }
+
+  async function startBridge(url = DEFAULT_CLOUD_BRIDGE_URL) {
+    await ensureOffscreen();
+    return api.runtime.sendMessage({ type: 'cloud-bridge-start', url: normalizeCloudBridgeUrl(url) });
+  }
+
+  async function stopBridge() {
+    return api.runtime.sendMessage({ type: 'cloud-bridge-stop' });
+  }
+
+  async function bridgeStatus() {
+    await ensureOffscreen();
+    return api.runtime.sendMessage({ type: 'cloud-bridge-status' });
+  }
+
+  async function syncBridge() {
+    const stored = await api.storage.local.get(['webbrainCloudBridgeEnabled', 'webbrainCloudBridgeUrl']);
+    if (!stored.webbrainCloudBridgeEnabled) return stopBridge().catch(() => ({ enabled: false, connected: false }));
+    return startBridge(stored.webbrainCloudBridgeUrl || DEFAULT_CLOUD_BRIDGE_URL);
+  }
+
+  return {
+    runs,
+    startRun,
+    status,
+    abort,
+    startBridge,
+    stopBridge,
+    bridgeStatus,
+    syncBridge,
+    hydrate,
+  };
+}

--- a/src/chrome/src/offscreen/cloud-bridge.js
+++ b/src/chrome/src/offscreen/cloud-bridge.js
@@ -1,0 +1,150 @@
+/**
+ * Offscreen document — outbound WebSocket bridge for managed cloud sessions.
+ *
+ * The droplet sidecar listens on localhost. The extension connects outbound
+ * from this offscreen page, receives command messages, forwards them to the
+ * background service worker, then returns the response over the socket.
+ */
+
+(() => {
+  let socket = null;
+  let bridgeUrl = null;
+  let enabled = false;
+  let reconnectTimer = null;
+  let reconnectAttempt = 0;
+  let lastError = '';
+
+  function normalizeBridgeUrl(value) {
+    const url = new URL(String(value || 'ws://127.0.0.1:17373/extension'));
+    const host = url.hostname.toLowerCase();
+    if (url.protocol !== 'ws:' || !['127.0.0.1', 'localhost', '::1'].includes(host)) {
+      throw new Error('Cloud bridge URL must use ws:// on localhost.');
+    }
+    return url.href;
+  }
+
+  function status() {
+    return {
+      enabled,
+      url: bridgeUrl,
+      connected: socket?.readyState === WebSocket.OPEN,
+      readyState: socket ? socket.readyState : null,
+      reconnectAttempt,
+      lastError,
+    };
+  }
+
+  function sendJson(obj) {
+    if (!socket || socket.readyState !== WebSocket.OPEN) return;
+    try {
+      socket.send(JSON.stringify(obj));
+    } catch (e) {
+      lastError = e.message || String(e);
+    }
+  }
+
+  function scheduleReconnect() {
+    if (!enabled || !bridgeUrl || reconnectTimer) return;
+    const delay = Math.min(30000, 500 * Math.pow(2, reconnectAttempt++));
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      connect();
+    }, delay);
+  }
+
+  function connect() {
+    if (!enabled || !bridgeUrl) return;
+    if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) return;
+    try {
+      socket = new WebSocket(bridgeUrl);
+      socket.addEventListener('open', () => {
+        reconnectAttempt = 0;
+        lastError = '';
+        sendJson({ type: 'hello', client: 'webbrain-extension', status: status() });
+      });
+      socket.addEventListener('message', async (event) => {
+        let msg;
+        try {
+          msg = JSON.parse(event.data);
+        } catch (e) {
+          sendJson({ ok: false, error: `Invalid JSON message: ${e.message}` });
+          return;
+        }
+
+        const id = msg.id || null;
+        const action = msg.action || msg.command;
+        const payload = msg.payload || msg;
+        if (!action) {
+          sendJson({ id, ok: false, error: 'Missing action' });
+          return;
+        }
+
+        try {
+          const response = await chrome.runtime.sendMessage({
+            ...payload,
+            target: 'background',
+            action,
+          });
+          if (response && response.error) {
+            sendJson({ id, ok: false, error: response.error });
+          } else {
+            sendJson({ id, ok: true, result: response });
+          }
+        } catch (e) {
+          sendJson({ id, ok: false, error: e.message || String(e) });
+        }
+      });
+      socket.addEventListener('close', () => {
+        socket = null;
+        scheduleReconnect();
+      });
+      socket.addEventListener('error', () => {
+        lastError = 'WebSocket error';
+      });
+    } catch (e) {
+      lastError = e.message || String(e);
+      socket = null;
+      scheduleReconnect();
+    }
+  }
+
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (msg.type === 'cloud-bridge-start') {
+      let nextUrl;
+      try {
+        nextUrl = normalizeBridgeUrl(msg.url || bridgeUrl);
+      } catch (error) {
+        lastError = error.message || String(error);
+        sendResponse({ ...status(), error: lastError });
+        return false;
+      }
+      const changed = bridgeUrl && bridgeUrl !== nextUrl;
+      enabled = true;
+      bridgeUrl = nextUrl;
+      if (changed && socket) {
+        try { socket.close(); } catch {}
+        socket = null;
+      }
+      connect();
+      sendResponse(status());
+      return false;
+    }
+    if (msg.type === 'cloud-bridge-stop') {
+      enabled = false;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+      reconnectAttempt = 0;
+      if (socket) {
+        try { socket.close(); } catch {}
+      }
+      socket = null;
+      sendResponse(status());
+      return false;
+    }
+    if (msg.type === 'cloud-bridge-status') {
+      sendResponse(status());
+      return false;
+    }
+    return false;
+  });
+})();

--- a/src/chrome/src/offscreen/ensure.js
+++ b/src/chrome/src/offscreen/ensure.js
@@ -4,8 +4,9 @@
  * Chrome MV3 allows only ONE offscreen document per extension at a time,
  * and the set of `reasons` declared at createDocument time is fixed — you
  * cannot add reasons later. So both consumers of the offscreen document
- * (the localhost-fetch proxy in offscreen.js, and the tab-recorder in
- * recorder.js) must agree on a single createDocument call that lists
+ * (the localhost-fetch proxy in offscreen.js, the tab-recorder in
+ * recorder.js, and the cloud bridge in cloud-bridge.js) must agree on a single
+ * createDocument call that lists
  * every reason either of them might ever need.
  *
  * Callers:
@@ -13,6 +14,8 @@
  *     to a localhost LLM server fails (Private Network Access workaround).
  *   • background.js (record routes) — needs the doc to host the
  *     MediaRecorder and Web Audio mixer when recording starts.
+ *   • background.js (cloud bridge routes) — needs the doc to keep an outbound
+ *     WebSocket open to the local sidecar.
  *
  * Both call `ensureOffscreen()` lazily; whichever fires first creates the
  * doc with the unified reason set, and the second one no-ops via the
@@ -30,7 +33,7 @@ const OFFSCREEN_REASONS = [
   'USER_MEDIA',
 ];
 const OFFSCREEN_JUSTIFICATION =
-  'Proxy fetch to localhost LLM servers; capture active tab + mic for the optional Record feature.';
+  'Proxy fetch to localhost LLM servers; capture active tab + mic for the optional Record feature; maintain a localhost cloud bridge WebSocket.';
 
 let ready = false;
 let inflight = null;

--- a/src/chrome/src/offscreen/offscreen.html
+++ b/src/chrome/src/offscreen/offscreen.html
@@ -5,6 +5,7 @@
     Single offscreen document hosting both:
       • offscreen.js — fetch proxy for localhost LLM servers (existing)
       • recorder.js  — tab/display capture + mic mix + MediaRecorder
+      • cloud-bridge.js — outbound localhost WebSocket for managed cloud runs
 
     Chrome MV3 only allows ONE offscreen document per extension at a time,
     so the two responsibilities share this host. Each script binds its own
@@ -16,6 +17,7 @@
   -->
   <script src="offscreen.js"></script>
   <script src="recorder.js"></script>
+  <script src="cloud-bridge.js"></script>
 </head>
 <body></body>
 </html>

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1,4 +1,5 @@
 import { AGENT_TOOLS, AGENT_TOOL_NAMES, RESERVED_AGENT_TOOL_NAMES, getToolsForMode, SYSTEM_PROMPT_ASK, SYSTEM_PROMPT_ACT, SYSTEM_PROMPT_ACT_COMPACT, SYSTEM_PROMPT_ACT_MID, SYSTEM_PROMPT_DEV_APPENDIX } from './tools.js';
+import { handleDoneJson } from './cloud-output.js';
 import { URL_FAMILY_TOOLS, resourceBucket, bucketArgsKey } from './loop-bucket.js';
 import { isCredentialField, CREDENTIAL_NOTE_STRICT } from './credential-fields.js';
 import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLedgerDowngrade, isTerminalLedgerStatus, isValidLedgerStatus, ledgerDoneBlock, normalizeLedgerStatus, progressCounts, selectLedgerRows, unresolvedLedgerRows, upsertLedgerItems } from './progress-ledger.js';
@@ -171,6 +172,7 @@ export class Agent {
     // Pending clarify() tool calls awaiting user input — see Chrome
     // agent.js. Keyed by tabId → (clarifyId → {resolve, ts}).
     this._pendingClarifications = new Map();
+    this.cloudRunContexts = new Map(); // tabId -> { outputSchema, schemaRepairUsed }
     // Deterministic capability × origin permission gate. "Always" grants are
     // persisted in extension storage; "once" grants live for the current turn.
     this.permissions = new PermissionManager({
@@ -7157,6 +7159,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   }
 
   async executeTool(tabId, name, args, onUpdate = null) {
+    if (name === 'done_json') {
+      return handleDoneJson(this.cloudRunContexts.get(tabId), args);
+    }
     if (name === 'get_window_info') {
       return await this._getWindowInfo(tabId);
     }
@@ -8452,10 +8457,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     this._clearLoopState(tabId);
     this._runningTabs.add(tabId);
+    const previousCloudContext = this.cloudRunContexts.get(tabId);
+    if (runOptions.cloudRun) {
+      this.cloudRunContexts.set(tabId, { outputSchema: runOptions.outputSchema || null, schemaRepairUsed: false });
+    }
     try {
       return await this._processMessageInner(tabId, userMessage, onUpdate, mode, attachments, runOptions);
     } finally {
       this.currentCostState.delete(tabId);
+      if (runOptions.cloudRun) {
+        if (previousCloudContext) this.cloudRunContexts.set(tabId, previousCloudContext);
+        else this.cloudRunContexts.delete(tabId);
+      }
       this._runningTabs.delete(tabId);
       this._clearLoopState(tabId);
     }
@@ -8603,7 +8616,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     const tier = provider.promptTier;
     const skillTools = this._skillToolDefinitions(mode, tier);
-    const tools = getToolsForMode(mode, { strictSecretMode: this.strictSecretMode, tier, skillTools });
+    const cloudRunContext = this.cloudRunContexts.get(tabId) || null;
+    const tools = getToolsForMode(mode, {
+      strictSecretMode: this.strictSecretMode,
+      tier,
+      skillTools,
+      cloudRun: !!cloudRunContext,
+      outputSchema: cloudRunContext?.outputSchema || null,
+    });
     const allowedToolNames = new Set(tools.map(t => t.function.name));
     const plannerTemperature = this._isActionMode(mode) ? 0.15 : 0.3;
     let steps = 0;
@@ -8899,10 +8919,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     this._clearLoopState(tabId);
     this._runningTabs.add(tabId);
+    const previousCloudContext = this.cloudRunContexts.get(tabId);
+    if (runOptions.cloudRun) {
+      this.cloudRunContexts.set(tabId, { outputSchema: runOptions.outputSchema || null, schemaRepairUsed: false });
+    }
     try {
       return await this._processMessageStreamInner(tabId, userMessage, onUpdate, mode, runOptions);
     } finally {
       this.currentCostState.delete(tabId);
+      if (runOptions.cloudRun) {
+        if (previousCloudContext) this.cloudRunContexts.set(tabId, previousCloudContext);
+        else this.cloudRunContexts.delete(tabId);
+      }
       this._runningTabs.delete(tabId);
       this._clearLoopState(tabId);
     }
@@ -8970,7 +8998,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     const tier = provider.promptTier;
     const skillTools = this._skillToolDefinitions(mode, tier);
-    const tools = getToolsForMode(mode, { strictSecretMode: this.strictSecretMode, tier, skillTools });
+    const cloudRunContext = this.cloudRunContexts.get(tabId) || null;
+    const tools = getToolsForMode(mode, {
+      strictSecretMode: this.strictSecretMode,
+      tier,
+      skillTools,
+      cloudRun: !!cloudRunContext,
+      outputSchema: cloudRunContext?.outputSchema || null,
+    });
     const allowedToolNames = new Set(tools.map(t => t.function.name));
     const plannerTemperature = this._isActionMode(mode) ? 0.15 : 0.3;
     let steps = 0;

--- a/src/firefox/src/agent/cloud-output.js
+++ b/src/firefox/src/agent/cloud-output.js
@@ -1,0 +1,133 @@
+export function validateCloudOutput(value, schema) {
+  const errors = [];
+  const push = (path, message) => errors.push(`${path}: ${message}`);
+  const isObject = item => !!item && typeof item === 'object' && !Array.isArray(item);
+  const keywords = new Set(['type', 'properties', 'required', 'items', 'enum', 'description', 'additionalProperties']);
+
+  const validate = (item, spec, path = '$') => {
+    if (typeof spec === 'string') {
+      let shorthand = spec.trim();
+      const optional = shorthand.endsWith('?');
+      if (optional) shorthand = shorthand.slice(0, -1).trim();
+      if ((item === undefined || item === null) && optional) return;
+      if (shorthand.endsWith('[]')) {
+        if (!Array.isArray(item)) {
+          push(path, `expected array of ${shorthand.slice(0, -2)}`);
+          return;
+        }
+        item.forEach((child, index) => validate(child, shorthand.slice(0, -2) || 'any', `${path}[${index}]`));
+        return;
+      }
+      const valid = shorthand === 'any'
+        || (shorthand === 'string' && typeof item === 'string')
+        || (shorthand === 'number' && typeof item === 'number' && !Number.isNaN(item))
+        || (shorthand === 'integer' && Number.isInteger(item))
+        || (shorthand === 'boolean' && typeof item === 'boolean')
+        || (shorthand === 'object' && isObject(item))
+        || (shorthand === 'array' && Array.isArray(item));
+      if (!valid) push(path, shorthand === 'any' ? 'unsupported value' : `expected ${shorthand}`);
+      return;
+    }
+
+    if (Array.isArray(spec)) {
+      if (!Array.isArray(item)) {
+        push(path, 'expected array');
+        return;
+      }
+      item.forEach((child, index) => validate(child, spec[0] || 'any', `${path}[${index}]`));
+      return;
+    }
+
+    if (!isObject(spec)) return;
+    const jsonSchema = Object.keys(spec).some(key => keywords.has(key));
+    if (!jsonSchema) {
+      if (!isObject(item)) {
+        push(path, 'expected object');
+        return;
+      }
+      for (const [key, childSpec] of Object.entries(spec)) {
+        const optional = typeof childSpec === 'string' && childSpec.trim().endsWith('?');
+        if (!(key in item)) {
+          if (!optional) push(`${path}.${key}`, 'missing required property');
+          continue;
+        }
+        validate(item[key], childSpec, `${path}.${key}`);
+      }
+      return;
+    }
+
+    if (Array.isArray(spec.enum) && !spec.enum.includes(item)) {
+      push(path, `expected one of ${JSON.stringify(spec.enum)}`);
+    }
+    const types = Array.isArray(spec.type) ? spec.type : (spec.type ? [spec.type] : []);
+    if (types.length) {
+      const typeOk = types.some(type => {
+        if (type === 'array') return Array.isArray(item);
+        if (type === 'object') return isObject(item);
+        if (type === 'integer') return Number.isInteger(item);
+        if (type === 'number') return typeof item === 'number' && !Number.isNaN(item);
+        if (type === 'null') return item === null;
+        return typeof item === type;
+      });
+      if (!typeOk) push(path, `expected ${types.join(' or ')}`);
+    }
+    if (spec.properties || spec.required) {
+      if (!isObject(item)) {
+        push(path, 'expected object with properties');
+        return;
+      }
+      for (const key of Array.isArray(spec.required) ? spec.required : []) {
+        if (!(key in item)) push(`${path}.${key}`, 'missing required property');
+      }
+      for (const [key, childSpec] of Object.entries(spec.properties || {})) {
+        if (key in item) validate(item[key], childSpec, `${path}.${key}`);
+      }
+      if (spec.additionalProperties === false) {
+        const allowed = new Set(Object.keys(spec.properties || {}));
+        for (const key of Object.keys(item)) {
+          if (!allowed.has(key)) push(`${path}.${key}`, 'additional property is not allowed');
+        }
+      }
+    }
+    if (spec.items && Array.isArray(item)) {
+      item.forEach((child, index) => validate(child, spec.items, `${path}[${index}]`));
+    }
+  };
+
+  validate(value, schema);
+  return { ok: errors.length === 0, errors };
+}
+export function handleDoneJson(context, args = {}) {
+  if (!context?.outputSchema) {
+    return {
+      success: false,
+      error: 'done_json is only available during a cloud run with an output schema.',
+    };
+  }
+  const result = Object.prototype.hasOwnProperty.call(args, 'result') ? args.result : undefined;
+  const summary = String(args.summary || '').trim() || 'Task completed.';
+  const validation = validateCloudOutput(result, context.outputSchema);
+  if (validation.ok) {
+    return { done: true, doneJson: true, summary, result, cloudResult: result };
+  }
+  const message = `done_json result did not match outputSchema: ${validation.errors.slice(0, 8).join('; ')}`;
+  if (!context.schemaRepairUsed) {
+    context.schemaRepairUsed = true;
+    return {
+      success: false,
+      schemaValidationError: true,
+      error: `${message}. Call done_json exactly one more time with a corrected result.`,
+      expectedSchema: context.outputSchema,
+    };
+  }
+  return {
+    done: true,
+    doneJson: true,
+    cloudFailed: true,
+    schemaValidationError: true,
+    summary: 'Structured cloud run failed schema validation.',
+    error: message,
+    expectedSchema: context.outputSchema,
+    invalidResult: result,
+  };
+}

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -858,7 +858,7 @@ export const ASK_ONLY_TOOLS = [
  */
 export const AGENT_TOOL_NAMES = new Set(AGENT_TOOLS.map(t => t.function.name));
 export const RETIRED_AGENT_TOOL_NAMES = new Set(['screenshot', 'full_page_screenshot', 'record_tab', 'stop_recording']);
-export const RESERVED_AGENT_TOOL_NAMES = new Set([...AGENT_TOOL_NAMES, ...RETIRED_AGENT_TOOL_NAMES]);
+export const RESERVED_AGENT_TOOL_NAMES = new Set([...AGENT_TOOL_NAMES, ...RETIRED_AGENT_TOOL_NAMES, 'done_json']);
 export const DEV_ONLY_TOOL_NAMES = new Set(['read_page_source', 'inspect_element_styles', 'execute_js']);
 export const DEV_EXTENDED_TOOL_NAMES = new Set([
   ...DEV_ONLY_TOOL_NAMES,
@@ -940,6 +940,22 @@ const DONE_TOOL_STRICT_WITH_OUTCOME = {
   },
 };
 
+const DONE_JSON_TOOL = {
+  type: 'function',
+  function: {
+    name: 'done_json',
+    description: 'Complete a structured cloud run. Call this only when the task is finished and result exactly matches the requested output schema. If validation fails, repair the result and call done_json once more.',
+    parameters: {
+      type: 'object',
+      properties: {
+        result: { type: 'object', description: 'Machine-readable result matching the requested output schema.' },
+        summary: { type: 'string', description: 'Short human-readable completion summary.' },
+      },
+      required: ['result', 'summary'],
+    },
+  },
+};
+
 /**
  * Get tools filtered by mode.
  *
@@ -979,6 +995,8 @@ export function getToolsForMode(mode, opts = {}) {
     });
     base = [...base, ...extras];
   }
+  const useDoneJson = normalizedMode === 'act' && tier === 'full' && opts.cloudRun === true && !!opts.outputSchema;
+  if (useDoneJson) return base.map(tool => (tool.function.name === 'done' ? DONE_JSON_TOOL : tool));
   const useOutcomeDone = normalizedMode !== 'ask' && tier !== 'compact';
   if (!opts.strictSecretMode && !useOutcomeDone) return base;
   const replacement = opts.strictSecretMode

--- a/test/run.js
+++ b/test/run.js
@@ -98,6 +98,15 @@ const { RunUiJournal: RunUiJournalCh } = await import(
 const { RunUiJournal: RunUiJournalFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/run-ui-journal.js').replace(/\\/g, '/')
 );
+const { createCloudRunController, normalizeCloudBridgeUrl } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/cloud-runs.js').replace(/\\/g, '/')
+);
+const { handleDoneJson: handleDoneJsonCh } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/agent/cloud-output.js').replace(/\\/g, '/')
+);
+const { handleDoneJson: handleDoneJsonFx } = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/agent/cloud-output.js').replace(/\\/g, '/')
+);
 const { claimRunError: claimRunErrorCh } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/ui/run-error-dedupe.js').replace(/\\/g, '/')
 );
@@ -4060,6 +4069,167 @@ test('getToolsForMode: default `done` description is the loose hygiene hint', ()
     // Summary param description stays minimal in loose mode.
     assert.equal(done.function.parameters.properties.summary.description, 'Summary of what was accomplished.');
   }
+});
+
+test('getToolsForMode: done_json is available only for structured full-tier cloud runs', () => {
+  const schema = { title: 'string' };
+  for (const [label, getTools] of [['chrome', getToolsForModeCh], ['firefox', getToolsForModeFx]]) {
+    const cloud = getTools('act', { tier: 'full', cloudRun: true, outputSchema: schema }).map(tool => tool.function.name);
+    assert.equal(cloud.includes('done_json'), true, `[${label}] structured cloud run should expose done_json`);
+    assert.equal(cloud.includes('done'), false, `[${label}] structured cloud run should replace done`);
+    for (const tools of [
+      getTools('act', { tier: 'full', cloudRun: true }),
+      getTools('act', { tier: 'mid', cloudRun: true, outputSchema: schema }),
+      getTools('ask', { tier: 'full', cloudRun: true, outputSchema: schema }),
+    ]) {
+      const names = tools.map(tool => tool.function.name);
+      assert.equal(names.includes('done_json'), false, `[${label}] done_json leaked outside its cloud scope`);
+      assert.equal(names.includes('done'), true, `[${label}] normal done tool should remain available`);
+    }
+  }
+});
+
+test('done_json validates Chrome and Firefox cloud results with one repair attempt', () => {
+  for (const [label, handle] of [['chrome', handleDoneJsonCh], ['firefox', handleDoneJsonFx]]) {
+    const context = { outputSchema: { title: 'string', points: 'string[]' }, schemaRepairUsed: false };
+    const first = handle(context, { result: { title: 'Page', points: 'wrong' }, summary: 'First try' });
+    assert.equal(first.schemaValidationError, true, `[${label}] invalid result should fail validation`);
+    assert.equal(first.done, undefined, `[${label}] first invalid result should permit repair`);
+    const valid = handle(context, { result: { title: 'Page', points: ['A'] }, summary: 'Complete' });
+    assert.equal(valid.done, true, `[${label}] repaired result should complete`);
+    assert.deepEqual(valid.cloudResult, { title: 'Page', points: ['A'] });
+
+    const exhausted = { outputSchema: { title: 'string' }, schemaRepairUsed: true };
+    const failed = handle(exhausted, { result: { title: 42 }, summary: 'Bad' });
+    assert.equal(failed.done, true, `[${label}] second invalid result should terminate`);
+    assert.equal(failed.cloudFailed, true, `[${label}] second invalid result should fail the cloud run`);
+  }
+});
+
+test('cloud run controller uses the visible tab and persists terminal status', async () => {
+  const session = {};
+  const tab = { id: 17, url: 'https://webbrain.one/', active: true, windowId: 3 };
+  let finishRun;
+  let processArgs = null;
+  const agent = {
+    isRunning: () => false,
+    abort: () => {},
+    processMessage: (...args) => {
+      processArgs = args;
+      return new Promise(resolve => { finishRun = resolve; });
+    },
+  };
+  const chromeApi = {
+    tabs: {
+      query: async query => query.active ? [tab] : [tab],
+      get: async () => tab,
+      update: async () => tab,
+      create: async () => ({ id: 18, url: 'about:blank', active: true }),
+    },
+    windows: { update: async () => ({}) },
+    storage: {
+      local: { get: async () => ({ webbrainCloudBridgeEnabled: false }) },
+      session: {
+        get: async key => ({ [key]: session[key] || [] }),
+        set: async value => Object.assign(session, value),
+      },
+    },
+    runtime: { sendMessage: async () => ({ connected: false }) },
+  };
+  const controller = createCloudRunController({
+    chromeApi,
+    agent,
+    ensureOffscreen: async () => {},
+    makeRunId: () => 'run_test',
+    now: (() => { let tick = 0; return () => new Date(1700000000000 + tick++ * 1000); })(),
+  });
+  const started = await controller.startRun({ task: 'Open Google' });
+  assert.equal(started.status, 'running');
+  assert.equal(started.tabId, 17);
+  assert.equal(processArgs[3], 'act');
+  assert.deepEqual(processArgs[4], []);
+  assert.equal(processArgs[5].cloudRun, true);
+  finishRun('Google');
+  await new Promise(resolve => setTimeout(resolve, 0));
+  const completed = await controller.status({ run_id: 'run_test' });
+  assert.equal(completed.status, 'completed');
+  assert.equal(completed.result, 'Google');
+  assert.equal(session.webbrainCloudRunSnapshots[0].status, 'completed');
+});
+
+test('cloud run controller fails interrupted runs after service-worker restart', async () => {
+  const row = { runId: 'run_old', status: 'running', tabId: 2, task: 'Old task', updates: [], createdAt: '2020-01-01T00:00:00.000Z' };
+  const session = { webbrainCloudRunSnapshots: [row] };
+  const controller = createCloudRunController({
+    chromeApi: {
+      tabs: {},
+      storage: {
+        local: { get: async () => ({}) },
+        session: { get: async key => ({ [key]: session[key] }), set: async value => Object.assign(session, value) },
+      },
+      runtime: { sendMessage: async () => ({}) },
+    },
+    agent: {},
+    ensureOffscreen: async () => {},
+    now: () => new Date('2020-01-02T00:00:00.000Z'),
+  });
+  const restored = await controller.status({ runId: 'run_old' });
+  assert.equal(restored.status, 'failed');
+  assert.match(restored.error, /service worker restarted/i);
+});
+
+test('cloud bridge accepts only loopback WebSocket URLs', () => {
+  assert.equal(normalizeCloudBridgeUrl('ws://127.0.0.1:17373/extension'), 'ws://127.0.0.1:17373/extension');
+  assert.equal(normalizeCloudBridgeUrl('ws://localhost:17373/extension'), 'ws://localhost:17373/extension');
+  assert.throws(() => normalizeCloudBridgeUrl('wss://example.com/extension'), /localhost/);
+  assert.throws(() => normalizeCloudBridgeUrl('ws://192.168.1.10/extension'), /localhost/);
+});
+
+test('offscreen cloud bridge reconnects with backoff and rejects remote control URLs', () => {
+  const source = fs.readFileSync(path.join(ROOT, 'src/chrome/src/offscreen/cloud-bridge.js'), 'utf8');
+  const sockets = [];
+  const timers = [];
+  let listener = null;
+  class FakeWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSED = 3;
+    constructor(url) {
+      this.url = url;
+      this.readyState = FakeWebSocket.CONNECTING;
+      this.listeners = new Map();
+      this.sent = [];
+      sockets.push(this);
+    }
+    addEventListener(type, callback) { this.listeners.set(type, callback); }
+    send(value) { this.sent.push(JSON.parse(value)); }
+    close() { this.readyState = FakeWebSocket.CLOSED; this.listeners.get('close')?.(); }
+    emit(type, value = {}) { this.listeners.get(type)?.(value); }
+  }
+  vm.runInNewContext(source, {
+    URL,
+    WebSocket: FakeWebSocket,
+    chrome: { runtime: { onMessage: { addListener: callback => { listener = callback; } }, sendMessage: async () => ({}) } },
+    setTimeout: (callback, delay) => { timers.push({ callback, delay }); return timers.length; },
+    clearTimeout: () => {},
+  });
+
+  let started;
+  listener({ type: 'cloud-bridge-start', url: 'ws://127.0.0.1:17373/extension' }, null, value => { started = value; });
+  assert.equal(started.enabled, true);
+  assert.equal(sockets.length, 1);
+  sockets[0].readyState = FakeWebSocket.OPEN;
+  sockets[0].emit('open');
+  assert.equal(sockets[0].sent[0].type, 'hello');
+  sockets[0].close();
+  assert.equal(timers[0].delay, 500);
+  timers[0].callback();
+  assert.equal(sockets.length, 2);
+
+  let rejected;
+  listener({ type: 'cloud-bridge-start', url: 'wss://attacker.example/extension' }, null, value => { rejected = value; });
+  assert.match(rejected.error, /localhost/);
+  assert.equal(sockets.length, 2);
 });
 
 test('getToolsForMode: `done` outcome is exposed only in full and mid action modes', () => {
@@ -19740,6 +19910,7 @@ test('parity: chrome & firefox permission-gate behave identically', async () => 
 // this list is a security decision, so keep the justification next to it.
 const KNOWN_SAFE_TOOLS = new Set([
   'clarify',              // relays a question to the user (trusted user input)
+  'done_json',            // model-authored structured completion for managed cloud runs
   'scratchpad_write',     // writes an internal agent note, not the page
   'get_window_info',      // reads browser/window metadata, not page content
   // NOTE: hover and list_downloads were moved to UNTRUSTED_CONTENT_TOOLS — both


### PR DESCRIPTION
## What changed

- adds a loopback-only offscreen WebSocket bridge for managed cloud-browser sessions
- implements asynchronous `cloud_run`, `cloud_status`, and `cloud_abort` on the visible active tab
- adds restart-safe run snapshots and reconnect handling
- adds validated structured `done_json` results with Chrome/Firefox agent parity
- preserves current agent attachments, skills, planner behavior, and selection-shortcut work

## Root cause

The platform sidecar protocol already expected these extension actions, but current `main` did not contain the extension half of the bridge. Browser startup therefore returned `Unknown action: cloud_bridge_start`, leaving the sidecar disconnected.

## Validation

- `npm test`: 757 core tests passed
- prompt-injection corpus: 60/60 passed
- loopback URL, reconnect, active-tab, structured-output, and service-worker restart coverage
- `git diff --check`