### PR TITLE
[codex] fix firefox indexed typing

### DIFF
--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -1776,7 +1776,7 @@ async function sendMessage() {
         textEl.innerHTML = formatMarkdown(res?.content || t('sp.stopped_by_user'));
         addMessageCopyButton(currentAssistantEl);
       }
-    } else if (res.content && currentAssistantEl) {
+    } else if (res?.content && currentAssistantEl) {
       const textEl = currentAssistantEl.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
         textEl.innerHTML = formatMarkdown(res.content);
@@ -2561,7 +2561,7 @@ async function continueAgent() {
       mode: agentMode,
     });
 
-    if (res.content && currentAssistantEl) {
+    if (res?.content && currentAssistantEl) {
       const textEl = currentAssistantEl.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
         textEl.innerHTML = formatMarkdown(res.content);
@@ -2827,6 +2827,8 @@ function sendToBackground(action, data = {}) {
       (response) => {
         if (chrome.runtime.lastError) {
           reject(new Error(chrome.runtime.lastError.message));
+        } else if (response == null) {
+          reject(new Error(`No response from WebBrain background for "${action}". The background script may have restarted or crashed; reload the sidebar/extension and check the extension console for the original error.`));
         } else if (response?.error) {
           reject(new Error(response.error));
         } else {

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -469,7 +469,7 @@
     });
   }
 
-  function getInteractiveElementsFull() {
+  function queryInteractiveFull() {
     const collected = [];
     const seen = new Set();
 
@@ -525,7 +525,19 @@
       return a.rect.left - b.rect.left;
     });
 
-    return collected.map((c, i) => {
+    return collected;
+  }
+
+  function queryInteractiveForToolIndex() {
+    // Firefox's agent maps get_interactive_elements to the full/CDP-like
+    // collector below, so index-based follow-up actions must resolve against
+    // that same ordering. The legacy queryInteractive() order is still used
+    // by the plain content handler but it is not the list the agent sees.
+    return queryInteractiveFull().map(c => c.el);
+  }
+
+  function getInteractiveElementsFull() {
+    return queryInteractiveFull().map((c, i) => {
       const el = c.el;
       return {
         index: i,
@@ -621,6 +633,34 @@
   }
 
   let _lastClickIdent = null;
+  let _lastEditableTarget = null;
+
+  function _isTypeableElement(el) {
+    return !!(el && (
+      el.isContentEditable ||
+      el instanceof HTMLInputElement ||
+      el instanceof HTMLTextAreaElement ||
+      el instanceof HTMLSelectElement
+    ));
+  }
+
+  function _rememberEditableTarget(el) {
+    if (!_isTypeableElement(el)) return;
+    _lastEditableTarget = {
+      el,
+      href: location.href,
+      ts: Date.now(),
+    };
+  }
+
+  function _recentEditableTarget() {
+    if (!_lastEditableTarget) return null;
+    const { el, href, ts } = _lastEditableTarget;
+    if (!el || !el.isConnected || href !== location.href) return null;
+    if (Date.now() - ts > 30000) return null;
+    if (!_isTypeableElement(el) || !isVisiblyInteractive(el)) return null;
+    return el;
+  }
 
   /**
    * Click an element by selector or coordinates.
@@ -880,8 +920,7 @@
     } else if (params.selector) {
       el = safeQuerySelector(params.selector);
     } else if (params.index != null) {
-      // Same traversal as getInteractiveElements — index stability.
-      const interactive = queryInteractive();
+      const interactive = queryInteractiveForToolIndex();
       el = interactive[params.index];
       if (!el) return _staleIndexError(params.index, interactive);
     } else if (params.x != null && params.y != null) {
@@ -992,12 +1031,26 @@
       } catch {}
     }
 
+    if (_isTypeableElement(el)) {
+      try { el.focus({ preventScroll: true }); } catch { try { el.focus(); } catch {} }
+      _rememberEditableTarget(el);
+    } else {
+      _lastEditableTarget = null;
+    }
+
     const clickedRect = rememberInteractionPoint(el, 'click');
     el.click();
 
     // Post-click SELECT detection: the click may have activated a <select>
     // via a label, wrapper, or overlapping element. Return error, not success.
     const postActive = document.activeElement;
+    if (_isTypeableElement(postActive)) {
+      _rememberEditableTarget(postActive);
+    } else if (_isTypeableElement(el)) {
+      try { el.focus({ preventScroll: true }); } catch { try { el.focus(); } catch {} }
+      _rememberEditableTarget(el);
+    }
+
     if (postActive && postActive !== el && postActive instanceof HTMLSelectElement) {
       postActive.blur();
       postActive.focus(); // close native popup, keep focus
@@ -1014,7 +1067,7 @@
     // Skip for editable targets — re-clicking a text field / contenteditable
     // is legitimate (positions cursor / re-focuses) and "no page change" is
     // the expected outcome there, not a failure signal.
-    const isEditableTarget = el.isContentEditable || el.tagName === 'INPUT' || el.tagName === 'TEXTAREA';
+    const isEditableTarget = _isTypeableElement(el);
     const ident = `${el.tagName}|${(el.innerText || '').slice(0, 50)}|${location.href}`;
     let warning;
     if (_lastClickIdent === ident && !isEditableTarget) {
@@ -1136,7 +1189,7 @@
     if (params.selector) {
       el = safeQuerySelector(params.selector);
     } else if (params.index != null) {
-      const interactive = queryInteractive();
+      const interactive = queryInteractiveForToolIndex();
       el = interactive[params.index];
       if (!el) return _staleIndexError(params.index, interactive);
     } else {
@@ -1144,28 +1197,29 @@
       // Most reliable for click-then-type flows on forms with weird selectors.
       el = document.activeElement;
       if (!el || el === document.body || el === document.documentElement) {
+        el = _recentEditableTarget();
+      }
+      if (!el || el === document.body || el === document.documentElement) {
         return { success: false, error: 'No editable element is currently focused. Click the target input/textarea first, then call type_text again with no selector.' };
       }
       // Verify it's actually editable
       const editable = el.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(el.tagName);
       if (!editable) {
-        return {
-          success: false,
-          error: `Focused element <${el.tagName.toLowerCase()}> is not an editable field. Click the target input/textarea first, then call type_text again.`,
-        };
+        const recentEditable = _recentEditableTarget();
+        if (recentEditable) {
+          el = recentEditable;
+        } else {
+          return {
+            success: false,
+            error: `Focused element <${el.tagName.toLowerCase()}> is not an editable field. Click the target input/textarea first, then call type_text again.`,
+          };
+        }
       }
     }
 
     if (!el) return { success: false, error: 'Element not found' };
 
-    // Guard: only INPUT, TEXTAREA, SELECT, and contenteditable are typeable.
-    // Calling HTMLInputElement's native value setter on anything else throws
-    // "Illegal invocation" because the setter requires `this` to be an input.
-    const isTypeable = el.isContentEditable
-      || el instanceof HTMLInputElement
-      || el instanceof HTMLTextAreaElement
-      || el instanceof HTMLSelectElement;
-    if (!isTypeable) {
+    if (!_isTypeableElement(el)) {
       const tag = (el.tagName || '').toLowerCase();
       return {
         success: false,

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -379,7 +379,8 @@
    * Detect the topmost modal/overlay/dialog on the page. Returns the modal
    * container element, or null if no overlay is detected.
    */
-  function _findTopmostModal() {
+  function _findTopmostModal(opts = {}) {
+    const includeNonModalDialogs = opts.includeNonModalDialogs !== false;
     const dialogs = document.querySelectorAll('dialog[open]');
     if (dialogs.length > 0) return dialogs[dialogs.length - 1];
 
@@ -389,14 +390,17 @@
       if (r.width > 0 && r.height > 0) return ariaModals[i];
     }
 
-    const roleDialogs = document.querySelectorAll('[role="dialog"]');
-    for (let i = roleDialogs.length - 1; i >= 0; i--) {
-      const r = roleDialogs[i].getBoundingClientRect();
-      if (r.width > 0 && r.height > 0) return roleDialogs[i];
+    if (includeNonModalDialogs) {
+      const roleDialogs = document.querySelectorAll('[role="dialog"]');
+      for (let i = roleDialogs.length - 1; i >= 0; i--) {
+        const r = roleDialogs[i].getBoundingClientRect();
+        if (r.width > 0 && r.height > 0) return roleDialogs[i];
+      }
     }
 
     const candidates = document.querySelectorAll(
-      '[data-overlay], [data-state="open"][role="dialog"], ' +
+      '[data-overlay], ' +
+      (includeNonModalDialogs ? '[data-state="open"][role="dialog"], ' : '') +
       '.modal.show, .modal-overlay, .overlay, [class*="modal"][class*="open"], ' +
       '[class*="overlay"][class*="active"], [class*="DialogOverlay"], ' +
       '[class*="ModalOverlay"]'
@@ -409,9 +413,13 @@
     return null;
   }
 
+  function _findTopmostBlockingModal() {
+    return _findTopmostModal({ includeNonModalDialogs: false });
+  }
+
   function queryInteractive() {
     const all = document.querySelectorAll(INTERACTIVE_SELECTORS.join(', '));
-    const modal = _findTopmostModal();
+    const modal = _findTopmostBlockingModal();
     const out = [];
     for (const el of all) {
       if (!isVisiblyInteractive(el)) continue;
@@ -506,7 +514,7 @@
   function queryInteractiveFull() {
     const collected = [];
     const seen = new Set();
-    const modal = _findTopmostModal();
+    const modal = _findTopmostBlockingModal();
 
     const isUsable = (el, rect) => {
       if (_hasComposedClosest(el, '[aria-hidden="true"], [inert]')) return false;

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1246,15 +1246,11 @@
       // Verify it's actually editable
       const editable = el.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(el.tagName);
       if (!editable) {
-        const recentEditable = _recentEditableTarget();
-        if (recentEditable) {
-          el = recentEditable;
-        } else {
-          return {
-            success: false,
-            error: `Focused element <${el.tagName.toLowerCase()}> is not an editable field. Click the target input/textarea first, then call type_text again.`,
-          };
-        }
+        _lastEditableTarget = null;
+        return {
+          success: false,
+          error: `Focused element <${el.tagName.toLowerCase()}> is not an editable field. Click the target input/textarea first, then call type_text again.`,
+        };
       }
     }
 

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -745,7 +745,16 @@
     return !_NON_TEXT_INPUT_TYPES.has(inputType);
   }
 
+  function _isDisabledEditable(el) {
+    return !!(el && (
+      el.disabled ||
+      el.getAttribute?.('aria-disabled') === 'true' ||
+      el.matches?.(':disabled')
+    ));
+  }
+
   function _isTypeableElement(el) {
+    if (!el || _isDisabledEditable(el)) return false;
     return !!(el && (
       el.isContentEditable ||
       _isTextTypeableInput(el) ||

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -375,6 +375,14 @@
     }
   }
 
+  function _isNativeBlockingDialog(dialog) {
+    if (!dialog) return false;
+    try {
+      if (dialog.matches(':modal')) return true;
+    } catch {}
+    return dialog.getAttribute('aria-modal') === 'true';
+  }
+
   /**
    * Detect the topmost modal/overlay/dialog on the page. Returns the modal
    * container element, or null if no overlay is detected.
@@ -382,7 +390,9 @@
   function _findTopmostModal(opts = {}) {
     const includeNonModalDialogs = opts.includeNonModalDialogs !== false;
     const dialogs = document.querySelectorAll('dialog[open]');
-    if (dialogs.length > 0) return dialogs[dialogs.length - 1];
+    for (let i = dialogs.length - 1; i >= 0; i--) {
+      if (includeNonModalDialogs || _isNativeBlockingDialog(dialogs[i])) return dialogs[i];
+    }
 
     const ariaModals = document.querySelectorAll('[role="dialog"][aria-modal="true"]');
     for (let i = ariaModals.length - 1; i >= 0; i--) {

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -662,6 +662,47 @@
     return el;
   }
 
+  function _shadowAwareElementFromPoint(x, y) {
+    let topmost = document.elementFromPoint(x, y);
+    const seen = new Set();
+    while (topmost && topmost.shadowRoot && !seen.has(topmost)) {
+      seen.add(topmost);
+      let inner = null;
+      try { inner = topmost.shadowRoot.elementFromPoint(x, y); } catch {}
+      if (!inner || inner === topmost) break;
+      topmost = inner;
+    }
+    return topmost;
+  }
+
+  function _isComposedAncestor(ancestor, node) {
+    let cur = node;
+    while (cur) {
+      if (cur === ancestor) return true;
+      const parent = cur.parentNode;
+      if (parent) {
+        cur = (typeof ShadowRoot !== 'undefined' && parent instanceof ShadowRoot)
+          ? parent.host
+          : parent;
+      } else {
+        const root = cur.getRootNode?.();
+        cur = (typeof ShadowRoot !== 'undefined' && root instanceof ShadowRoot)
+          ? root.host
+          : null;
+      }
+    }
+    return false;
+  }
+
+  function _hitTestMatchesTarget(target, topmost) {
+    if (!target || !topmost) return false;
+    if (target === topmost) return true;
+    try {
+      if (target.contains(topmost) || topmost.contains(target)) return true;
+    } catch {}
+    return _isComposedAncestor(target, topmost) || _isComposedAncestor(topmost, target);
+  }
+
   /**
    * Click an element by selector or coordinates.
    */
@@ -1004,8 +1045,8 @@
         if (r.width >= 1 && r.height >= 1 && r.top >= 0 && r.left >= 0 && r.bottom <= window.innerHeight && r.right <= window.innerWidth) {
           const cx = Math.round(r.left + r.width / 2);
           const cy = Math.round(r.top + r.height / 2);
-          const topmost = document.elementFromPoint(cx, cy);
-          if (topmost && topmost !== el && !el.contains(topmost) && !topmost.contains(el)) {
+          const topmost = _shadowAwareElementFromPoint(cx, cy);
+          if (topmost && !_hitTestMatchesTarget(el, topmost)) {
             let blockerInfo = topmost.tagName.toLowerCase();
             const role = topmost.getAttribute && topmost.getAttribute('role');
             if (role) blockerInfo += `[role=${role}]`;

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -279,9 +279,43 @@
     'label',
   ];
 
+  function _composedParent(node) {
+    if (!node) return null;
+    const parent = node.parentNode;
+    if (parent) {
+      return (typeof ShadowRoot !== 'undefined' && parent instanceof ShadowRoot)
+        ? parent.host
+        : parent;
+    }
+    const root = node.getRootNode?.();
+    return (typeof ShadowRoot !== 'undefined' && root instanceof ShadowRoot)
+      ? root.host
+      : null;
+  }
+
+  function _isComposedAncestor(ancestor, node) {
+    let cur = node;
+    while (cur) {
+      if (cur === ancestor) return true;
+      cur = _composedParent(cur);
+    }
+    return false;
+  }
+
+  function _hasComposedClosest(el, selector) {
+    let cur = el;
+    while (cur) {
+      try {
+        if (cur.nodeType === Node.ELEMENT_NODE && cur.matches(selector)) return true;
+      } catch {}
+      cur = _composedParent(cur);
+    }
+    return false;
+  }
+
   function isVisiblyInteractive(el) {
     if (!el || el.tagName === 'BODY' || el.tagName === 'HTML') return false;
-    if (el.closest('[aria-hidden="true"], [inert]')) return false;
+    if (_hasComposedClosest(el, '[aria-hidden="true"], [inert]')) return false;
     const style = el.ownerDocument.defaultView.getComputedStyle(el);
     if (style.display === 'none' || style.visibility === 'hidden') return false;
     if (style.opacity === '0' && el.tagName !== 'SELECT') return false;
@@ -381,7 +415,7 @@
     const out = [];
     for (const el of all) {
       if (!isVisiblyInteractive(el)) continue;
-      if (modal && !modal.contains(el)) continue;
+      if (modal && !_isComposedAncestor(modal, el)) continue;
       out.push(el);
     }
     return out;
@@ -472,8 +506,11 @@
   function queryInteractiveFull() {
     const collected = [];
     const seen = new Set();
+    const modal = _findTopmostModal();
 
     const isUsable = (el, rect) => {
+      if (_hasComposedClosest(el, '[aria-hidden="true"], [inert]')) return false;
+      if (modal && !_isComposedAncestor(modal, el)) return false;
       if (rect.width < 2 || rect.height < 2) return false;
       if (rect.bottom < 0 || rect.top > window.innerHeight) return false;
       if (rect.right < 0 || rect.left > window.innerWidth) return false;
@@ -635,13 +672,40 @@
   let _lastClickIdent = null;
   let _lastEditableTarget = null;
 
+  const _NON_TEXT_INPUT_TYPES = new Set(['checkbox', 'radio', 'file', 'submit', 'button', 'reset', 'image', 'color', 'range', 'hidden']);
+
+  function _isTextTypeableInput(el) {
+    if (!(el instanceof HTMLInputElement)) return false;
+    const inputType = (el.type || el.getAttribute('type') || 'text').toLowerCase();
+    return !_NON_TEXT_INPUT_TYPES.has(inputType);
+  }
+
   function _isTypeableElement(el) {
     return !!(el && (
       el.isContentEditable ||
-      el instanceof HTMLInputElement ||
+      _isTextTypeableInput(el) ||
       el instanceof HTMLTextAreaElement ||
       el instanceof HTMLSelectElement
     ));
+  }
+
+  function _isMeaningfulFocus(el) {
+    return !!(el && el !== document.body && el !== document.documentElement);
+  }
+
+  function _isFocusableElement(el) {
+    if (!el || typeof el.focus !== 'function') return false;
+    if (el.disabled || el.getAttribute?.('aria-disabled') === 'true') return false;
+    if (el.isContentEditable) return true;
+    if (/^(A|BUTTON|INPUT|SELECT|TEXTAREA)$/i.test(el.tagName || '')) return true;
+    const tabIndexAttr = el.getAttribute?.('tabindex');
+    if (tabIndexAttr == null) return false;
+    const tabIndex = Number(tabIndexAttr);
+    return Number.isFinite(tabIndex) && tabIndex >= 0;
+  }
+
+  function _focusElement(el) {
+    try { el.focus({ preventScroll: true }); } catch { try { el.focus(); } catch {} }
   }
 
   function _rememberEditableTarget(el) {
@@ -673,25 +737,6 @@
       topmost = inner;
     }
     return topmost;
-  }
-
-  function _isComposedAncestor(ancestor, node) {
-    let cur = node;
-    while (cur) {
-      if (cur === ancestor) return true;
-      const parent = cur.parentNode;
-      if (parent) {
-        cur = (typeof ShadowRoot !== 'undefined' && parent instanceof ShadowRoot)
-          ? parent.host
-          : parent;
-      } else {
-        const root = cur.getRootNode?.();
-        cur = (typeof ShadowRoot !== 'undefined' && root instanceof ShadowRoot)
-          ? root.host
-          : null;
-      }
-    }
-    return false;
   }
 
   function _hitTestMatchesTarget(target, topmost) {
@@ -1073,10 +1118,11 @@
     }
 
     if (_isTypeableElement(el)) {
-      try { el.focus({ preventScroll: true }); } catch { try { el.focus(); } catch {} }
+      _focusElement(el);
       _rememberEditableTarget(el);
     } else {
       _lastEditableTarget = null;
+      if (_isFocusableElement(el)) _focusElement(el);
     }
 
     const clickedRect = rememberInteractionPoint(el, 'click');
@@ -1087,9 +1133,11 @@
     const postActive = document.activeElement;
     if (_isTypeableElement(postActive)) {
       _rememberEditableTarget(postActive);
-    } else if (_isTypeableElement(el)) {
-      try { el.focus({ preventScroll: true }); } catch { try { el.focus(); } catch {} }
+    } else if (!_isMeaningfulFocus(postActive) && _isTypeableElement(el)) {
+      _focusElement(el);
       _rememberEditableTarget(el);
+    } else if (_isMeaningfulFocus(postActive)) {
+      _lastEditableTarget = null;
     }
 
     if (postActive && postActive !== el && postActive instanceof HTMLSelectElement) {
@@ -1244,7 +1292,7 @@
         return { success: false, error: 'No editable element is currently focused. Click the target input/textarea first, then call type_text again with no selector.' };
       }
       // Verify it's actually editable
-      const editable = el.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(el.tagName);
+      const editable = _isTypeableElement(el);
       if (!editable) {
         _lastEditableTarget = null;
         return {

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -383,6 +383,47 @@
     return dialog.getAttribute('aria-modal') === 'true';
   }
 
+  function _hasVisibleBox(el, minWidth = 1, minHeight = 1) {
+    if (!el || typeof el.getBoundingClientRect !== 'function') return false;
+    try {
+      const r = el.getBoundingClientRect();
+      if (r.width < minWidth || r.height < minHeight) return false;
+      const s = getComputedStyle(el);
+      if (s.visibility === 'hidden' || s.display === 'none' || parseFloat(s.opacity) === 0) return false;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  function _findDialogContentForOverlay(overlay) {
+    const selector = '[role="dialog"],[role="alertdialog"],[aria-modal="true"],dialog[open],[data-state="open"][role="dialog"],[class*="DialogContent"],[class*="ModalContent"],.modal.show';
+    const pick = (node) => {
+      if (!node || node === overlay) return null;
+      try {
+        if (node.matches?.(selector) && _hasVisibleBox(node, 20, 20)) return node;
+        const match = node.querySelector?.(selector);
+        if (match && _hasVisibleBox(match, 20, 20)) return match;
+      } catch {}
+      return null;
+    };
+
+    const siblings = overlay?.parentElement ? Array.from(overlay.parentElement.children) : [];
+    const idx = siblings.indexOf(overlay);
+    if (idx >= 0) {
+      for (let i = idx + 1; i < siblings.length; i++) {
+        const found = pick(siblings[i]);
+        if (found) return found;
+      }
+      for (let i = idx - 1; i >= 0; i--) {
+        const found = pick(siblings[i]);
+        if (found) return found;
+      }
+    }
+
+    return pick(overlay);
+  }
+
   /**
    * Detect the topmost modal/overlay/dialog on the page. Returns the modal
    * container element, or null if no overlay is detected.
@@ -417,7 +458,13 @@
     );
     for (let i = candidates.length - 1; i >= 0; i--) {
       const r = candidates[i].getBoundingClientRect();
-      if (r.width > 100 && r.height > 100) return candidates[i];
+      if (r.width > 100 && r.height > 100) {
+        if (!includeNonModalDialogs) {
+          const dialogContent = _findDialogContentForOverlay(candidates[i]);
+          if (dialogContent) return dialogContent;
+        }
+        return candidates[i];
+      }
     }
 
     return null;
@@ -709,6 +756,16 @@
 
   function _isMeaningfulFocus(el) {
     return !!(el && el !== document.body && el !== document.documentElement);
+  }
+
+  function _isShadowHostForTarget(host, target) {
+    if (!_isMeaningfulFocus(host) || !target || typeof ShadowRoot === 'undefined') return false;
+    let root = target.getRootNode?.();
+    while (root instanceof ShadowRoot) {
+      if (root.host === host) return true;
+      root = root.host?.getRootNode?.();
+    }
+    return false;
   }
 
   function _isFocusableElement(el) {
@@ -1151,6 +1208,8 @@
     const postActive = document.activeElement;
     if (_isTypeableElement(postActive)) {
       _rememberEditableTarget(postActive);
+    } else if (_isTypeableElement(el) && _isShadowHostForTarget(postActive, el)) {
+      _rememberEditableTarget(el);
     } else if (!_isMeaningfulFocus(postActive) && _isTypeableElement(el)) {
       _focusElement(el);
       _rememberEditableTarget(el);
@@ -1312,11 +1371,16 @@
       // Verify it's actually editable
       const editable = _isTypeableElement(el);
       if (!editable) {
-        _lastEditableTarget = null;
-        return {
-          success: false,
-          error: `Focused element <${el.tagName.toLowerCase()}> is not an editable field. Click the target input/textarea first, then call type_text again.`,
-        };
+        const recentEditable = _recentEditableTarget();
+        if (recentEditable && _isShadowHostForTarget(el, recentEditable)) {
+          el = recentEditable;
+        } else {
+          _lastEditableTarget = null;
+          return {
+            success: false,
+            error: `Focused element <${el.tagName.toLowerCase()}> is not an editable field. Click the target input/textarea first, then call type_text again.`,
+          };
+        }
       }
     }
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -1591,7 +1591,7 @@ async function sendMessage() {
         textEl.innerHTML = formatMarkdown(res?.content || t('sp.stopped_by_user'));
         addMessageCopyButton(currentAssistantEl);
       }
-    } else if (res.content && currentAssistantEl) {
+    } else if (res?.content && currentAssistantEl) {
       const textEl = currentAssistantEl.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
         textEl.innerHTML = formatMarkdown(res.content);
@@ -2172,7 +2172,7 @@ async function continueAgent() {
       mode: agentMode,
     });
 
-    if (res.content && currentAssistantEl) {
+    if (res?.content && currentAssistantEl) {
       const textEl = currentAssistantEl.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
         textEl.innerHTML = formatMarkdown(res.content);
@@ -2395,6 +2395,9 @@ async function sendToBackground(action, data = {}) {
   const response = await browser.runtime.sendMessage(
     { target: 'background', action, ...data }
   );
+  if (response == null) {
+    throw new Error(`No response from WebBrain background for "${action}". The background script may have restarted or crashed; reload the sidebar/extension and check the Firefox extension console for the original error.`);
+  }
   if (response?.error) {
     throw new Error(response.error);
   }

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -371,6 +371,38 @@ test('Firefox: full indexed elements exclude inert background controls', async (
   }
 });
 
+test('Firefox: non-modal dialogs do not hide full indexed page controls', async (page) => {
+  await setupFirefoxHtml(page, `<!doctype html>
+    <style>
+      body { margin: 0; font: 16px sans-serif; }
+      #page-action { position: absolute; left: 20px; top: 20px; width: 160px; height: 40px; }
+      #help-widget { position: absolute; left: 20px; top: 90px; width: 220px; padding: 16px; border: 1px solid #888; background: white; }
+      #help-action { width: 160px; height: 40px; }
+    </style>
+    <button id="page-action" onclick="window.__pageClicked = true">Save page</button>
+    <aside id="help-widget" role="dialog" aria-label="Help">
+      <button id="help-action" onclick="window.__helpClicked = true">Open help</button>
+    </aside>`);
+
+  const elements = await call(page, 'get_interactive_elements_cdp', {});
+  const pageIndex = elements.findIndex(e => e.id === 'page-action');
+  const helpIndex = elements.findIndex(e => e.id === 'help-action');
+  if (pageIndex < 0 || helpIndex < 0) {
+    throw new Error(`expected page and non-modal dialog controls in elements, got: ${JSON.stringify(elements)}`);
+  }
+
+  const click = await call(page, 'click', { index: pageIndex });
+  if (!click?.success) throw new Error(`expected page action click success, got: ${JSON.stringify(click)}`);
+
+  const state = await page.evaluate(() => ({
+    page: window.__pageClicked === true,
+    help: window.__helpClicked === true,
+  }));
+  if (!state.page || state.help) {
+    throw new Error(`expected only page action to run, got: ${JSON.stringify(state)}`);
+  }
+});
+
 test('Firefox: type_text rejects non-text input after it receives focus', async (page) => {
   await setupFirefoxHtml(page, `<!doctype html>
     <style>

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -302,6 +302,36 @@ test('Firefox: indexed shadow-DOM click passes occlusion hit test', async (page)
   if (!clicked) throw new Error('expected shadow button click handler to run');
 });
 
+test('Firefox: type_text returns an error after focus moves to a noneditable element', async (page) => {
+  await setupFirefoxHtml(page, `<!doctype html>
+    <style>
+      body { margin: 0; font: 16px sans-serif; }
+      #field { position: absolute; left: 20px; top: 20px; width: 220px; height: 40px; }
+      #opener { position: absolute; left: 20px; top: 90px; width: 140px; height: 40px; }
+    </style>
+    <input id="field" placeholder="Name">
+    <button id="opener">Open menu</button>`);
+
+  const click = await call(page, 'click', { index: 0 });
+  if (!click?.success) throw new Error(`expected input click success, got: ${JSON.stringify(click)}`);
+
+  const typed = await call(page, 'type', { text: 'Ada' });
+  if (!typed?.success) throw new Error(`expected first type success, got: ${JSON.stringify(typed)}`);
+
+  await page.evaluate(() => document.getElementById('opener').focus());
+  const activeId = await page.evaluate(() => document.activeElement?.id || '');
+  if (activeId !== 'opener') throw new Error(`expected opener focus, got: ${activeId}`);
+
+  const staleType = await call(page, 'type', { text: ' Lovelace' });
+  if (staleType?.success) throw new Error(`expected type failure after button focus, got: ${JSON.stringify(staleType)}`);
+  if (!/Focused element <button> is not an editable field/.test(staleType?.error || '')) {
+    throw new Error(`expected focused button error, got: ${JSON.stringify(staleType)}`);
+  }
+
+  const value = await page.evaluate(() => document.getElementById('field').value);
+  if (value !== 'Ada') throw new Error(`expected stale fallback not to mutate input, got: ${value}`);
+});
+
 // ─── main ─────────────────────────────────────────────────────────────────
 // Social media downloader focus safety
 test('SMD: Instagram auto mode downloads the open dialog image, not the feed', async (page) => {

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -21,6 +21,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..', '..');
 const accessibilityTreeJsPath = path.join(root, 'src', 'chrome', 'src', 'content', 'accessibility-tree.js');
 const contentJsPath = path.join(root, 'src', 'chrome', 'src', 'content', 'content.js');
+const firefoxContentJsPath = path.join(root, 'src', 'firefox', 'src', 'content', 'content.js');
 const smdJsPath = path.join(root, 'src', 'chrome', 'src', 'agent', 'social-media-downloader.js');
 
 function fixtureUrl(name) {
@@ -37,6 +38,15 @@ const stubChrome = `
   };
 `;
 
+const stubFirefoxBrowser = `
+  window.browser = window.browser || {};
+  window.browser.runtime = window.browser.runtime || {};
+  window.browser.runtime.getURL = (path) => path;
+  window.browser.runtime.onMessage = {
+    addListener: (fn) => { window.__wb_handler = fn; }
+  };
+`;
+
 async function setup(page, fixture) {
   await page.addInitScript(stubChrome);
   await page.goto(fixtureUrl(fixture));
@@ -45,6 +55,14 @@ async function setup(page, fixture) {
   const src = await readFile(contentJsPath, 'utf-8');
   await page.addScriptTag({ content: src });
   // Ensure handler is registered.
+  await page.waitForFunction(() => typeof window.__wb_handler === 'function');
+}
+
+async function setupFirefoxHtml(page, html) {
+  await page.setContent(html, { waitUntil: 'domcontentloaded' });
+  await page.addScriptTag({ content: stubFirefoxBrowser });
+  const src = await readFile(firefoxContentJsPath, 'utf-8');
+  await page.addScriptTag({ content: src });
   await page.waitForFunction(() => typeof window.__wb_handler === 'function');
 }
 
@@ -222,6 +240,36 @@ test('click_ax: hash popup anchor keeps popup guidance', async (page) => {
 
   const opened = await page.evaluate(() => window.__hashMenuOpened);
   if (opened !== true) throw new Error('expected hash popup click handler to run');
+});
+
+// ─── Firefox index/focus parity ───────────────────────────────────────────
+test('Firefox: click({index}) matches full interactive ordering and preserves type focus', async (page) => {
+  await setupFirefoxHtml(page, `<!doctype html>
+    <style>
+      body { margin: 0; font: 16px sans-serif; }
+      #late { position: absolute; left: 20px; top: 180px; width: 120px; height: 40px; }
+      #search { position: absolute; left: 20px; top: 20px; width: 240px; height: 40px; }
+    </style>
+    <button id="late" onclick="window.__clicked='late'">Later button</button>
+    <input id="search" role="combobox" placeholder="Search">`);
+
+  const elements = await call(page, 'get_interactive_elements_cdp', {});
+  if (elements?.[0]?.id !== 'search') {
+    throw new Error(`expected visually first element to be search input, got: ${JSON.stringify(elements?.[0])}`);
+  }
+
+  const click = await call(page, 'click', { index: 0 });
+  if (!click?.success) throw new Error(`expected click success, got: ${JSON.stringify(click)}`);
+  if (click.tag !== 'INPUT') throw new Error(`expected click index 0 to hit INPUT, got: ${JSON.stringify(click)}`);
+
+  const activeId = await page.evaluate(() => document.activeElement?.id || '');
+  if (activeId !== 'search') throw new Error(`expected search input focus after click, got: ${activeId}`);
+
+  const typed = await call(page, 'type', { text: 'mchiang0610' });
+  if (!typed?.success) throw new Error(`expected type success, got: ${JSON.stringify(typed)}`);
+
+  const value = await page.evaluate(() => document.getElementById('search').value);
+  if (value !== 'mchiang0610') throw new Error(`expected typed value, got: ${value}`);
 });
 
 // ─── main ─────────────────────────────────────────────────────────────────

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -578,6 +578,31 @@ test('Firefox: type_text rejects non-text input after it receives focus', async 
   }
 });
 
+test('Firefox: type_text rejects disabled indexed text input fallback', async (page) => {
+  await setupFirefoxHtml(page, `<!doctype html>
+    <style>
+      body { margin: 0; font: 16px sans-serif; }
+      #disabled-field { position: absolute; left: 20px; top: 20px; width: 220px; height: 40px; }
+    </style>
+    <input id="disabled-field" value="Locked" disabled>`);
+
+  const elements = await call(page, 'get_interactive_elements_cdp', {});
+  const disabledIndex = elements.findIndex(e => e.id === 'disabled-field');
+  if (disabledIndex < 0) throw new Error(`expected disabled field in elements, got: ${JSON.stringify(elements)}`);
+
+  const click = await call(page, 'click', { index: disabledIndex });
+  if (!click?.success) throw new Error(`expected disabled field click path to complete, got: ${JSON.stringify(click)}`);
+
+  const activeTag = await page.evaluate(() => document.activeElement?.tagName || '');
+  if (activeTag === 'INPUT') throw new Error('disabled input should not receive focus');
+
+  const rejected = await call(page, 'type', { text: ' hacked' });
+  if (rejected?.success) throw new Error(`expected disabled input type failure, got: ${JSON.stringify(rejected)}`);
+
+  const value = await page.evaluate(() => document.getElementById('disabled-field').value);
+  if (value !== 'Locked') throw new Error(`expected disabled value to remain unchanged, got: ${value}`);
+});
+
 // ─── main ─────────────────────────────────────────────────────────────────
 // Social media downloader focus safety
 test('SMD: Instagram auto mode downloads the open dialog image, not the feed', async (page) => {

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -272,6 +272,36 @@ test('Firefox: click({index}) matches full interactive ordering and preserves ty
   if (value !== 'mchiang0610') throw new Error(`expected typed value, got: ${value}`);
 });
 
+test('Firefox: indexed shadow-DOM click passes occlusion hit test', async (page) => {
+  await setupFirefoxHtml(page, `<!doctype html>
+    <style>
+      body { margin: 0; font: 16px sans-serif; }
+      #host { position: absolute; left: 20px; top: 20px; width: 180px; height: 44px; }
+      #late { position: absolute; left: 20px; top: 160px; width: 120px; height: 40px; }
+    </style>
+    <div id="host"></div>
+    <button id="late">Later button</button>
+    <script>
+      const root = document.getElementById('host').attachShadow({ mode: 'open' });
+      root.innerHTML = '<style>button { width: 180px; height: 44px; }</style><button id="shadow-button">Shadow Action</button>';
+      root.getElementById('shadow-button').addEventListener('click', () => { window.__shadowClicked = true; });
+    </script>`);
+
+  const elements = await call(page, 'get_interactive_elements_cdp', {});
+  const shadowIndex = elements.findIndex(e => e.text === 'Shadow Action');
+  if (shadowIndex < 0) throw new Error(`expected shadow button in elements, got: ${JSON.stringify(elements)}`);
+  if (elements[shadowIndex].inShadowDOM !== true) {
+    throw new Error(`expected inShadowDOM:true, got: ${JSON.stringify(elements[shadowIndex])}`);
+  }
+
+  const click = await call(page, 'click', { index: shadowIndex });
+  if (!click?.success) throw new Error(`expected shadow click success, got: ${JSON.stringify(click)}`);
+  if (click.occluded) throw new Error(`shadow click should not be reported occluded: ${JSON.stringify(click)}`);
+
+  const clicked = await page.evaluate(() => window.__shadowClicked === true);
+  if (!clicked) throw new Error('expected shadow button click handler to run');
+});
+
 // ─── main ─────────────────────────────────────────────────────────────────
 // Social media downloader focus safety
 test('SMD: Instagram auto mode downloads the open dialog image, not the feed', async (page) => {

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -403,6 +403,72 @@ test('Firefox: non-modal dialogs do not hide full indexed page controls', async 
   }
 });
 
+test('Firefox: native non-modal dialog does not hide full indexed page controls', async (page) => {
+  await setupFirefoxHtml(page, `<!doctype html>
+    <style>
+      body { margin: 0; font: 16px sans-serif; }
+      #page-action { position: absolute; left: 20px; top: 20px; width: 160px; height: 40px; }
+      #native-help { position: absolute; left: 20px; top: 90px; width: 220px; padding: 16px; border: 1px solid #888; background: white; }
+      #help-action { width: 160px; height: 40px; }
+    </style>
+    <button id="page-action" onclick="window.__pageClicked = true">Save page</button>
+    <dialog id="native-help" open>
+      <button id="help-action" onclick="window.__helpClicked = true">Open help</button>
+    </dialog>`);
+
+  const elements = await call(page, 'get_interactive_elements_cdp', {});
+  const pageIndex = elements.findIndex(e => e.id === 'page-action');
+  const helpIndex = elements.findIndex(e => e.id === 'help-action');
+  if (pageIndex < 0 || helpIndex < 0) {
+    throw new Error(`expected page and native non-modal dialog controls in elements, got: ${JSON.stringify(elements)}`);
+  }
+
+  const click = await call(page, 'click', { index: pageIndex });
+  if (!click?.success) throw new Error(`expected page action click success, got: ${JSON.stringify(click)}`);
+
+  const state = await page.evaluate(() => ({
+    page: window.__pageClicked === true,
+    help: window.__helpClicked === true,
+  }));
+  if (!state.page || state.help) {
+    throw new Error(`expected only page action to run, got: ${JSON.stringify(state)}`);
+  }
+});
+
+test('Firefox: native modal dialog scopes full indexed page controls', async (page) => {
+  await setupFirefoxHtml(page, `<!doctype html>
+    <style>
+      body { margin: 0; font: 16px sans-serif; }
+      #page-action { position: absolute; left: 20px; top: 20px; width: 160px; height: 40px; }
+      #native-modal { width: 220px; padding: 16px; border: 1px solid #888; background: white; }
+      #modal-action { width: 160px; height: 40px; }
+    </style>
+    <button id="page-action" onclick="window.__pageClicked = true">Save page</button>
+    <dialog id="native-modal">
+      <button id="modal-action" onclick="window.__modalClicked = true">Confirm</button>
+    </dialog>
+    <script>document.getElementById('native-modal').showModal();</script>`);
+
+  const elements = await call(page, 'get_interactive_elements_cdp', {});
+  if (elements.some(e => e.id === 'page-action')) {
+    throw new Error(`expected page action to be filtered behind native modal, got: ${JSON.stringify(elements)}`);
+  }
+  if (elements?.[0]?.id !== 'modal-action') {
+    throw new Error(`expected modal action to be first actionable index, got: ${JSON.stringify(elements?.[0])}`);
+  }
+
+  const click = await call(page, 'click', { index: 0 });
+  if (!click?.success) throw new Error(`expected modal action click success, got: ${JSON.stringify(click)}`);
+
+  const state = await page.evaluate(() => ({
+    page: window.__pageClicked === true,
+    modal: window.__modalClicked === true,
+  }));
+  if (state.page || !state.modal) {
+    throw new Error(`expected only modal action to run, got: ${JSON.stringify(state)}`);
+  }
+});
+
 test('Firefox: type_text rejects non-text input after it receives focus', async (page) => {
   await setupFirefoxHtml(page, `<!doctype html>
     <style>

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -332,6 +332,88 @@ test('Firefox: type_text returns an error after focus moves to a noneditable ele
   if (value !== 'Ada') throw new Error(`expected stale fallback not to mutate input, got: ${value}`);
 });
 
+test('Firefox: full indexed elements exclude inert background controls', async (page) => {
+  await setupFirefoxHtml(page, `<!doctype html>
+    <style>
+      body { margin: 0; font: 16px sans-serif; }
+      #background { position: absolute; left: 20px; top: 20px; }
+      #dialog { position: absolute; left: 20px; top: 90px; width: 220px; padding: 16px; border: 1px solid #888; background: white; }
+      button { width: 160px; height: 40px; }
+    </style>
+    <main id="background" aria-hidden="true">
+      <button id="background-action" onclick="window.__backgroundClicked = true">Publish</button>
+    </main>
+    <section id="disabled-zone" inert>
+      <button id="inert-action" onclick="window.__inertClicked = true">Archive</button>
+    </section>
+    <div id="dialog" role="dialog" aria-modal="true">
+      <button id="dialog-action" onclick="window.__dialogClicked = true">Create</button>
+    </div>`);
+
+  const elements = await call(page, 'get_interactive_elements_cdp', {});
+  if (elements.some(e => e.id === 'background-action' || e.id === 'inert-action')) {
+    throw new Error(`expected hidden/inert background controls to be filtered, got: ${JSON.stringify(elements)}`);
+  }
+  if (elements?.[0]?.id !== 'dialog-action') {
+    throw new Error(`expected dialog action to be first actionable index, got: ${JSON.stringify(elements?.[0])}`);
+  }
+
+  const click = await call(page, 'click', { index: 0 });
+  if (!click?.success) throw new Error(`expected dialog click success, got: ${JSON.stringify(click)}`);
+
+  const state = await page.evaluate(() => ({
+    dialog: window.__dialogClicked === true,
+    background: window.__backgroundClicked === true,
+    inert: window.__inertClicked === true,
+  }));
+  if (!state.dialog || state.background || state.inert) {
+    throw new Error(`expected only dialog action to run, got: ${JSON.stringify(state)}`);
+  }
+});
+
+test('Firefox: type_text rejects non-text input after it receives focus', async (page) => {
+  await setupFirefoxHtml(page, `<!doctype html>
+    <style>
+      body { margin: 0; font: 16px sans-serif; }
+      #field { position: absolute; left: 20px; top: 20px; width: 220px; height: 40px; }
+      #button-input { position: absolute; left: 20px; top: 90px; width: 140px; height: 40px; }
+    </style>
+    <input id="field" placeholder="Name">
+    <input id="button-input" type="button" value="Open" onclick="window.__buttonInputClicked = true">`);
+
+  const elements = await call(page, 'get_interactive_elements_cdp', {});
+  const fieldIndex = elements.findIndex(e => e.id === 'field');
+  const buttonIndex = elements.findIndex(e => e.id === 'button-input');
+  if (fieldIndex < 0 || buttonIndex < 0) throw new Error(`expected both controls in elements, got: ${JSON.stringify(elements)}`);
+
+  const fieldClick = await call(page, 'click', { index: fieldIndex });
+  if (!fieldClick?.success) throw new Error(`expected field click success, got: ${JSON.stringify(fieldClick)}`);
+
+  const typed = await call(page, 'type', { text: 'Ada' });
+  if (!typed?.success) throw new Error(`expected field type success, got: ${JSON.stringify(typed)}`);
+
+  const buttonClick = await call(page, 'click', { index: buttonIndex });
+  if (!buttonClick?.success) throw new Error(`expected button input click success, got: ${JSON.stringify(buttonClick)}`);
+
+  const activeId = await page.evaluate(() => document.activeElement?.id || '');
+  if (activeId !== 'button-input') throw new Error(`expected button input focus, got: ${activeId}`);
+
+  const rejected = await call(page, 'type', { text: ' Lovelace' });
+  if (rejected?.success) throw new Error(`expected non-text input type failure, got: ${JSON.stringify(rejected)}`);
+  if (!/Focused element <input> is not an editable field/.test(rejected?.error || '')) {
+    throw new Error(`expected focused input error, got: ${JSON.stringify(rejected)}`);
+  }
+
+  const values = await page.evaluate(() => ({
+    field: document.getElementById('field').value,
+    button: document.getElementById('button-input').value,
+    clicked: window.__buttonInputClicked === true,
+  }));
+  if (values.field !== 'Ada' || values.button !== 'Open' || !values.clicked) {
+    throw new Error(`expected no stale/non-text value mutation, got: ${JSON.stringify(values)}`);
+  }
+});
+
 // ─── main ─────────────────────────────────────────────────────────────────
 // Social media downloader focus safety
 test('SMD: Instagram auto mode downloads the open dialog image, not the feed', async (page) => {

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -302,6 +302,38 @@ test('Firefox: indexed shadow-DOM click passes occlusion hit test', async (page)
   if (!clicked) throw new Error('expected shadow button click handler to run');
 });
 
+test('Firefox: click-then-type preserves shadow-root input focus', async (page) => {
+  await setupFirefoxHtml(page, `<!doctype html>
+    <style>
+      body { margin: 0; font: 16px sans-serif; }
+      #host { position: absolute; left: 20px; top: 20px; width: 220px; height: 44px; }
+    </style>
+    <div id="host"></div>
+    <script>
+      const root = document.getElementById('host').attachShadow({ mode: 'open' });
+      root.innerHTML = '<style>input { width: 220px; height: 44px; box-sizing: border-box; }</style><input id="shadow-input" placeholder="Shadow Name">';
+    </script>`);
+
+  const elements = await call(page, 'get_interactive_elements_cdp', {});
+  const shadowIndex = elements.findIndex(e => e.id === 'shadow-input');
+  if (shadowIndex < 0) throw new Error(`expected shadow input in elements, got: ${JSON.stringify(elements)}`);
+  if (elements[shadowIndex].inShadowDOM !== true) {
+    throw new Error(`expected inShadowDOM:true, got: ${JSON.stringify(elements[shadowIndex])}`);
+  }
+
+  const click = await call(page, 'click', { index: shadowIndex });
+  if (!click?.success) throw new Error(`expected shadow input click success, got: ${JSON.stringify(click)}`);
+
+  const activeId = await page.evaluate(() => document.activeElement?.id || '');
+  if (activeId !== 'host') throw new Error(`expected document focus on shadow host, got: ${activeId}`);
+
+  const typed = await call(page, 'type', { text: 'Ada' });
+  if (!typed?.success) throw new Error(`expected shadow input type success, got: ${JSON.stringify(typed)}`);
+
+  const value = await page.evaluate(() => document.getElementById('host').shadowRoot.getElementById('shadow-input').value);
+  if (value !== 'Ada') throw new Error(`expected typed shadow value, got: ${value}`);
+});
+
 test('Firefox: type_text returns an error after focus moves to a noneditable element', async (page) => {
   await setupFirefoxHtml(page, `<!doctype html>
     <style>
@@ -367,6 +399,40 @@ test('Firefox: full indexed elements exclude inert background controls', async (
     inert: window.__inertClicked === true,
   }));
   if (!state.dialog || state.background || state.inert) {
+    throw new Error(`expected only dialog action to run, got: ${JSON.stringify(state)}`);
+  }
+});
+
+test('Firefox: blocking overlay resolves sibling dialog content for indexed controls', async (page) => {
+  await setupFirefoxHtml(page, `<!doctype html>
+    <style>
+      body { margin: 0; font: 16px sans-serif; }
+      #page-action { position: absolute; left: 20px; top: 20px; width: 160px; height: 40px; }
+      #backdrop { position: fixed; inset: 0; background: rgba(0, 0, 0, .35); }
+      #dialog-panel { position: fixed; left: 20px; top: 90px; width: 220px; padding: 16px; border: 1px solid #888; background: white; }
+      #dialog-action { width: 160px; height: 40px; }
+    </style>
+    <button id="page-action" onclick="window.__pageClicked = true">Save page</button>
+    <div id="backdrop" data-overlay></div>
+    <section id="dialog-panel" role="dialog">
+      <button id="dialog-action" onclick="window.__dialogClicked = true">Confirm</button>
+    </section>`);
+
+  const elements = await call(page, 'get_interactive_elements_cdp', {});
+  if (elements.some(e => e.id === 'page-action')) {
+    throw new Error(`expected page action to be filtered behind overlay, got: ${JSON.stringify(elements)}`);
+  }
+  const dialogIndex = elements.findIndex(e => e.id === 'dialog-action');
+  if (dialogIndex < 0) throw new Error(`expected sibling dialog action in elements, got: ${JSON.stringify(elements)}`);
+
+  const click = await call(page, 'click', { index: dialogIndex });
+  if (!click?.success) throw new Error(`expected dialog action click success, got: ${JSON.stringify(click)}`);
+
+  const state = await page.evaluate(() => ({
+    page: window.__pageClicked === true,
+    dialog: window.__dialogClicked === true,
+  }));
+  if (state.page || !state.dialog) {
     throw new Error(`expected only dialog action to run, got: ${JSON.stringify(state)}`);
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -1908,6 +1908,19 @@ test('sidepanel exposes show-scratchpad slash command in both builds', () => {
   }
 });
 
+test('sidepanel reports missing background responses without res.content crash', () => {
+  for (const [label, panelRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    assert.match(panel, /No response from WebBrain background/, `${label}: missing background response should become a clear error`);
+    assert.match(panel, /response == null/, `${label}: sendToBackground should reject nullish responses`);
+    assert.equal((panel.match(/res\?\.content && currentAssistantEl/g) || []).length >= 2, true, `${label}: chat and continue should not dereference missing responses`);
+    assert.doesNotMatch(panel, /(?:else\s+)?if \(res\.content && currentAssistantEl\)/, `${label}: unsafe res.content render guard returned`);
+  }
+});
+
 test('download_social_media exposes merged DOM/vision strategy in act tiers only', () => {
   for (const [label, getTools] of [
     ['chrome', getToolsForModeCh],


### PR DESCRIPTION
## Summary

- Align Firefox `click({index})` and `type_text({index})` with the same full interactive-element ordering returned to the agent.
- Preserve and recover the most recently clicked editable target so Firefox click-then-type flows keep working on React/ARIA inputs such as X search.
- Add a Playwright fixture regression that exercises Firefox content-script index resolution and typing focus.

## Root Cause

Firefox maps `get_interactive_elements` to the full/CDP-like collector, but indexed click/type actions were resolving against the older DOM-order collector. On X, the agent saw the search input at one index, then Firefox clicked a different element. Programmatic clicks also did not reliably leave the input focused before `type_text` ran.

## Validation

- `npm run test:fixtures`
- `npm test`