### PR TITLE
[codex] Prefer URL targets for scheduled tasks

### DIFF
--- a/src/chrome/src/agent/scheduler.js
+++ b/src/chrome/src/agent/scheduler.js
@@ -929,7 +929,7 @@ export class ScheduledJobManager {
     const tab = await this.api.tabs.get(tabId);
     const currentUrl = tab?.url || '';
     if (currentUrl && !sameDocumentUrl(originalUrl, currentUrl)) {
-      throw new Error('Target tab changed before the scheduled task ran.');
+      throw new Error('Target tab changed before the scheduled task ran. Recreate this schedule with Target = URL if it should reopen the original page automatically.');
     }
   }
 

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -406,7 +406,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'schedule_task',
-      description: 'Create a one-shot or recurring scheduled task. Use only when the user explicitly asks to schedule future work, create a reminder, monitor/check something later, or run a recurring task. Do NOT use this as a generic wait/retry tool for the current run — use schedule_resume for deferring the current task, or wait_for_element/wait_for_stable for seconds-level page waits.',
+      description: 'Create a one-shot or recurring scheduled task. Use only when the user explicitly asks to schedule future work, create a reminder, monitor/check something later, or run a recurring task. Prefer target.type="url" for automations, monitors, and repeatable tasks that can reopen a page; use target.type="current_tab" only when the task depends on the exact live tab state and should fail if that tab navigates. Do NOT use this as a generic wait/retry tool for the current run — use schedule_resume for deferring the current task, or wait_for_element/wait_for_stable for seconds-level page waits.',
       parameters: {
         type: 'object',
         properties: {
@@ -427,7 +427,7 @@ export const AGENT_TOOLS = [
             type: 'object',
             description: 'Where to run the task.',
             properties: {
-              type: { type: 'string', enum: ['current_tab', 'url'], description: 'Use current_tab for this tab or url to open/reuse a tab for a URL.' },
+              type: { type: 'string', enum: ['current_tab', 'url'], description: 'Use url to open/reuse a tab at a URL, best for repeatable automations. Use current_tab only for exact live-tab state that should fail after navigation.' },
               url: { type: 'string', description: 'Required when target.type is url. Must be http(s).' },
             },
             required: ['type'],
@@ -1095,7 +1095,7 @@ Available tools:
 - read_page_source: Read raw View Source-style HTML and linked CSS/JS URLs
 - wait_for_element: Wait for an element to appear
 - schedule_resume: Durably pause this current task and resume it later in the same tab/conversation. Terminal tool; use only for external waits.
-- schedule_task: Create a one-shot or recurring scheduled task only when the user explicitly asks for future scheduled work.
+- schedule_task: Create a one-shot or recurring scheduled task only when the user explicitly asks for future scheduled work. Prefer URL targets for repeatable automations; current_tab is strict and fails if the tab changes.
 - get_selection: Get highlighted text
 - new_tab: Open a new tab
 - clarify: Pause and ask the user a question. Use ONLY for material ambiguity that you cannot resolve by reading the page (e.g. "my API key" on a site with multiple plugins that each have one). Do NOT use to confirm correct actions; do NOT call before every step. Budget 1-2 per run, max.
@@ -1410,7 +1410,7 @@ TOOLS — use only these:
 - extract_data: tables/headings/images/links. inspect_element_styles: live computed CSS/box model. get_selection: highlighted text. read_pdf: read a PDF.
 - wait_for_element({selector}) / wait_for_stable({quietMs}): wait for an element / for the page to go quiet after an action.
 - schedule_resume({after_seconds|run_at, reason, resume_instruction}): terminal durable pause for this current task.
-- schedule_task({title, prompt, schedule, target, mode}): create one-shot or recurring future work only when explicitly requested by the user.
+- schedule_task({title, prompt, schedule, target, mode}): create one-shot or recurring future work only when explicitly requested by the user. Prefer target.type:"url" for monitors/repeatable automations; use current_tab only for exact current-tab state.
 - iframe_read / iframe_click / iframe_type ({urlFilter, selector, text}): interact inside cross-origin iframes (Stripe, payment widgets, embeds).
 - fetch_url({url}) / research_url({url}): read OTHER URLs (not the active tab). list_downloads, download_files, read_downloaded_file, upload_file({selector, downloadId}): file workflows. download_files auto-pins each file's downloadId to the scratchpad as an \`[auto]\` line — attach with upload_file({downloadId, selector}) and re-read with read_downloaded_file({downloadId}); no need to recall the path.
 - download_social_media: one-shot image/video download from supported social sites; strategy:"auto" uses DOM first, then vision crop only when needed and available.

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -853,11 +853,12 @@ function addScheduleField(form, labelText, control) {
   return label;
 }
 
-function renderScheduleComposer(prefillPrompt = '') {
+async function renderScheduleComposer(prefillPrompt = '') {
   const msgEl = addMessage('system', t('sp.schedule_form.opened'));
   const content = msgEl.querySelector('.message-content');
   const form = document.createElement('form');
   form.className = 'schedule-composer';
+  const initialScheduleUrl = await getCurrentScheduleUrl();
 
   const titleInput = document.createElement('input');
   titleInput.type = 'text';
@@ -913,7 +914,10 @@ function renderScheduleComposer(prefillPrompt = '') {
   urlInput.type = 'url';
   urlInput.placeholder = 'https://example.com/';
   const urlField = addScheduleField(form, t('sp.schedule_form.target_url'), urlInput);
-  let targetTypeTouched = false;
+  if (isHttpScheduleUrl(initialScheduleUrl)) {
+    urlInput.value = initialScheduleUrl;
+    targetType.value = 'url';
+  }
 
   const modeInput = document.createElement('select');
   modeInput.innerHTML = `<option value="act">${escapeHtml(t('sp.mode.act'))}</option><option value="ask">${escapeHtml(t('sp.mode.ask'))}</option>`;
@@ -946,19 +950,8 @@ function renderScheduleComposer(prefillPrompt = '') {
   }
   scheduleType.addEventListener('change', updateVisibility);
   timeMode.addEventListener('change', updateVisibility);
-  targetType.addEventListener('change', () => {
-    targetTypeTouched = true;
-    updateVisibility();
-  });
+  targetType.addEventListener('change', updateVisibility);
   updateVisibility();
-  getCurrentScheduleUrl().then((url) => {
-    if (!isHttpScheduleUrl(url)) return;
-    if (!urlInput.value) urlInput.value = url;
-    if (!targetTypeTouched) {
-      targetType.value = 'url';
-      updateVisibility();
-    }
-  }).catch(() => {});
 
   cancel.addEventListener('click', () => msgEl.remove());
 

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -823,6 +823,25 @@ function datetimeLocalValue(ms) {
   return local.toISOString().slice(0, 16);
 }
 
+function isHttpScheduleUrl(value) {
+  try {
+    const url = new URL(String(value || ''));
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+async function getCurrentScheduleUrl() {
+  if (currentTabId == null) return '';
+  try {
+    const tab = await chrome.tabs.get(currentTabId);
+    return tab?.url || '';
+  } catch {
+    return '';
+  }
+}
+
 function addScheduleField(form, labelText, control) {
   const label = document.createElement('label');
   label.className = 'schedule-field';
@@ -894,6 +913,7 @@ function renderScheduleComposer(prefillPrompt = '') {
   urlInput.type = 'url';
   urlInput.placeholder = 'https://example.com/';
   const urlField = addScheduleField(form, t('sp.schedule_form.target_url'), urlInput);
+  let targetTypeTouched = false;
 
   const modeInput = document.createElement('select');
   modeInput.innerHTML = `<option value="act">${escapeHtml(t('sp.mode.act'))}</option><option value="ask">${escapeHtml(t('sp.mode.ask'))}</option>`;
@@ -926,8 +946,19 @@ function renderScheduleComposer(prefillPrompt = '') {
   }
   scheduleType.addEventListener('change', updateVisibility);
   timeMode.addEventListener('change', updateVisibility);
-  targetType.addEventListener('change', updateVisibility);
+  targetType.addEventListener('change', () => {
+    targetTypeTouched = true;
+    updateVisibility();
+  });
   updateVisibility();
+  getCurrentScheduleUrl().then((url) => {
+    if (!isHttpScheduleUrl(url)) return;
+    if (!urlInput.value) urlInput.value = url;
+    if (!targetTypeTouched) {
+      targetType.value = 'url';
+      updateVisibility();
+    }
+  }).catch(() => {});
 
   cancel.addEventListener('click', () => msgEl.remove());
 

--- a/src/firefox/src/agent/scheduler.js
+++ b/src/firefox/src/agent/scheduler.js
@@ -906,7 +906,7 @@ export class ScheduledJobManager {
     const tab = await this.api.tabs.get(tabId);
     const currentUrl = tab?.url || '';
     if (currentUrl && !sameDocumentUrl(originalUrl, currentUrl)) {
-      throw new Error('Target tab changed before the scheduled task ran.');
+      throw new Error('Target tab changed before the scheduled task ran. Recreate this schedule with Target = URL if it should reopen the original page automatically.');
     }
   }
 

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -393,7 +393,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'schedule_task',
-      description: 'Create a one-shot or recurring scheduled task. Use only when the user explicitly asks to schedule future work, create a reminder, monitor/check something later, or run a recurring task. Do NOT use this as a generic wait/retry tool for the current run — use schedule_resume for deferring the current task, or wait_for_element/wait_for_stable for seconds-level page waits.',
+      description: 'Create a one-shot or recurring scheduled task. Use only when the user explicitly asks to schedule future work, create a reminder, monitor/check something later, or run a recurring task. Prefer target.type="url" for automations, monitors, and repeatable tasks that can reopen a page; use target.type="current_tab" only when the task depends on the exact live tab state and should fail if that tab navigates. Do NOT use this as a generic wait/retry tool for the current run — use schedule_resume for deferring the current task, or wait_for_element/wait_for_stable for seconds-level page waits.',
       parameters: {
         type: 'object',
         properties: {
@@ -414,7 +414,7 @@ export const AGENT_TOOLS = [
             type: 'object',
             description: 'Where to run the task.',
             properties: {
-              type: { type: 'string', enum: ['current_tab', 'url'], description: 'Use current_tab for this tab or url to open/reuse a tab for a URL.' },
+              type: { type: 'string', enum: ['current_tab', 'url'], description: 'Use url to open/reuse a tab at a URL, best for repeatable automations. Use current_tab only for exact live-tab state that should fail after navigation.' },
               url: { type: 'string', description: 'Required when target.type is url. Must be http(s).' },
             },
             required: ['type'],
@@ -1040,7 +1040,7 @@ Available tools:
 - read_page_source: Read raw View Source-style HTML and linked CSS/JS URLs
 - wait_for_element: Wait for an element to appear
 - schedule_resume: Durably pause this current task and resume it later in the same tab/conversation. Terminal tool; use only for external waits.
-- schedule_task: Create a one-shot or recurring scheduled task only when the user explicitly asks for future scheduled work.
+- schedule_task: Create a one-shot or recurring scheduled task only when the user explicitly asks for future scheduled work. Prefer URL targets for repeatable automations; current_tab is strict and fails if the tab changes.
 - get_selection: Get highlighted text
 - execute_js: Run custom JavaScript
 - new_tab: Open a new tab
@@ -1246,7 +1246,7 @@ TOOLS — use only these:
 - extract_data: tables/headings/images/links. inspect_element_styles: live computed CSS/box model. get_selection: highlighted text. read_pdf: read a PDF.
 - wait_for_element({selector}) / wait_for_stable({quietMs}): wait for an element / for the page to go quiet after an action.
 - schedule_resume({after_seconds|run_at, reason, resume_instruction}): terminal durable pause for this current task.
-- schedule_task({title, prompt, schedule, target, mode}): create one-shot or recurring future work only when explicitly requested by the user.
+- schedule_task({title, prompt, schedule, target, mode}): create one-shot or recurring future work only when explicitly requested by the user. Prefer target.type:"url" for monitors/repeatable automations; use current_tab only for exact current-tab state.
 - iframe_read / iframe_click / iframe_type ({urlFilter, selector, text}): interact inside cross-origin iframes (Stripe, payment widgets, embeds).
 - fetch_url({url}) / research_url({url}): read OTHER URLs (not the active tab). list_downloads, download_files, read_downloaded_file: file workflows. download_files auto-pins each file's downloadId to the scratchpad as an \`[auto]\` line — re-read with read_downloaded_file({downloadId}); no need to recall the path.
 - download_social_media: one-shot image/video download from supported social sites; strategy:"auto" uses DOM first, then vision crop only when needed and available.

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -762,11 +762,12 @@ function addScheduleField(form, labelText, control) {
   return label;
 }
 
-function renderScheduleComposer(prefillPrompt = '') {
+async function renderScheduleComposer(prefillPrompt = '') {
   const msgEl = addMessage('system', t('sp.schedule_form.opened'));
   const content = msgEl.querySelector('.message-content');
   const form = document.createElement('form');
   form.className = 'schedule-composer';
+  const initialScheduleUrl = await getCurrentScheduleUrl();
 
   const titleInput = document.createElement('input');
   titleInput.type = 'text';
@@ -822,7 +823,10 @@ function renderScheduleComposer(prefillPrompt = '') {
   urlInput.type = 'url';
   urlInput.placeholder = 'https://example.com/';
   const urlField = addScheduleField(form, t('sp.schedule_form.target_url'), urlInput);
-  let targetTypeTouched = false;
+  if (isHttpScheduleUrl(initialScheduleUrl)) {
+    urlInput.value = initialScheduleUrl;
+    targetType.value = 'url';
+  }
 
   const modeInput = document.createElement('select');
   modeInput.innerHTML = `<option value="act">${escapeHtml(t('sp.mode.act'))}</option><option value="ask">${escapeHtml(t('sp.mode.ask'))}</option>`;
@@ -855,19 +859,8 @@ function renderScheduleComposer(prefillPrompt = '') {
   }
   scheduleType.addEventListener('change', updateVisibility);
   timeMode.addEventListener('change', updateVisibility);
-  targetType.addEventListener('change', () => {
-    targetTypeTouched = true;
-    updateVisibility();
-  });
+  targetType.addEventListener('change', updateVisibility);
   updateVisibility();
-  getCurrentScheduleUrl().then((url) => {
-    if (!isHttpScheduleUrl(url)) return;
-    if (!urlInput.value) urlInput.value = url;
-    if (!targetTypeTouched) {
-      targetType.value = 'url';
-      updateVisibility();
-    }
-  }).catch(() => {});
 
   cancel.addEventListener('click', () => msgEl.remove());
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -732,6 +732,25 @@ function datetimeLocalValue(ms) {
   return local.toISOString().slice(0, 16);
 }
 
+function isHttpScheduleUrl(value) {
+  try {
+    const url = new URL(String(value || ''));
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+async function getCurrentScheduleUrl() {
+  if (currentTabId == null) return '';
+  try {
+    const tab = await browser.tabs.get(currentTabId);
+    return tab?.url || '';
+  } catch {
+    return '';
+  }
+}
+
 function addScheduleField(form, labelText, control) {
   const label = document.createElement('label');
   label.className = 'schedule-field';
@@ -803,6 +822,7 @@ function renderScheduleComposer(prefillPrompt = '') {
   urlInput.type = 'url';
   urlInput.placeholder = 'https://example.com/';
   const urlField = addScheduleField(form, t('sp.schedule_form.target_url'), urlInput);
+  let targetTypeTouched = false;
 
   const modeInput = document.createElement('select');
   modeInput.innerHTML = `<option value="act">${escapeHtml(t('sp.mode.act'))}</option><option value="ask">${escapeHtml(t('sp.mode.ask'))}</option>`;
@@ -835,8 +855,19 @@ function renderScheduleComposer(prefillPrompt = '') {
   }
   scheduleType.addEventListener('change', updateVisibility);
   timeMode.addEventListener('change', updateVisibility);
-  targetType.addEventListener('change', updateVisibility);
+  targetType.addEventListener('change', () => {
+    targetTypeTouched = true;
+    updateVisibility();
+  });
   updateVisibility();
+  getCurrentScheduleUrl().then((url) => {
+    if (!isHttpScheduleUrl(url)) return;
+    if (!urlInput.value) urlInput.value = url;
+    if (!targetTypeTouched) {
+      targetType.value = 'url';
+      updateVisibility();
+    }
+  }).catch(() => {});
 
   cancel.addEventListener('click', () => msgEl.remove());
 

--- a/test/run.js
+++ b/test/run.js
@@ -1889,10 +1889,11 @@ test('sidepanel exposes schedule slash commands in both builds', () => {
     assert.match(panel, /let assistantEl = currentAssistantEl/, `${label}: forced scheduled clarify cards should not overwrite the active assistant bubble`);
     assert.match(panel, /currentAssistantEl\.dataset\?\.scheduledJobId === scheduledJobId/, `${label}: scheduled clarify submission should not steal an unrelated active reply`);
     assert.match(panel, /res\?\.success === false \|\| res\?\.ok === false \|\| !res\?\.scheduledAt/, `${label}: schedule form should reject failed create responses before showing success`);
-    assert.match(panel, /getCurrentScheduleUrl\(\)\.then/, `${label}: schedule form should inspect the active tab URL`);
-    assert.match(panel, /if \(!urlInput\.value\) urlInput\.value = url/, `${label}: schedule form should prefill URL targets from the active tab`);
+    assert.match(panel, /async function renderScheduleComposer/, `${label}: schedule form should resolve initial defaults before display`);
+    assert.match(panel, /const initialScheduleUrl = await getCurrentScheduleUrl\(\)/, `${label}: schedule form should inspect the active tab URL before rendering`);
+    assert.match(panel, /urlInput\.value = initialScheduleUrl/, `${label}: schedule form should prefill URL targets from the active tab`);
     assert.match(panel, /targetType\.value = 'url'/, `${label}: schedule form should default http(s) pages to URL targets`);
-    assert.match(panel, /targetTypeTouched/, `${label}: schedule form should not override a manual target choice`);
+    assert.match(panel, /content\.appendChild\(form\)/, `${label}: schedule form should append after initial target defaults are applied`);
     assert.match(locale, /\/schedule/, `${label}: help should mention /schedule`);
     assert.match(locale, /\/list-schedules/, `${label}: help should mention /list-schedules`);
   }

--- a/test/run.js
+++ b/test/run.js
@@ -1889,6 +1889,10 @@ test('sidepanel exposes schedule slash commands in both builds', () => {
     assert.match(panel, /let assistantEl = currentAssistantEl/, `${label}: forced scheduled clarify cards should not overwrite the active assistant bubble`);
     assert.match(panel, /currentAssistantEl\.dataset\?\.scheduledJobId === scheduledJobId/, `${label}: scheduled clarify submission should not steal an unrelated active reply`);
     assert.match(panel, /res\?\.success === false \|\| res\?\.ok === false \|\| !res\?\.scheduledAt/, `${label}: schedule form should reject failed create responses before showing success`);
+    assert.match(panel, /getCurrentScheduleUrl\(\)\.then/, `${label}: schedule form should inspect the active tab URL`);
+    assert.match(panel, /if \(!urlInput\.value\) urlInput\.value = url/, `${label}: schedule form should prefill URL targets from the active tab`);
+    assert.match(panel, /targetType\.value = 'url'/, `${label}: schedule form should default http(s) pages to URL targets`);
+    assert.match(panel, /targetTypeTouched/, `${label}: schedule form should not override a manual target choice`);
     assert.match(locale, /\/schedule/, `${label}: help should mention /schedule`);
     assert.match(locale, /\/list-schedules/, `${label}: help should mention /list-schedules`);
   }


### PR DESCRIPTION
## What changed

- Default the schedule composer to URL targets when the active tab has an HTTP(S) URL, while preserving a user’s manual target selection.
- Prefill the schedule target URL from the active tab in both Chrome and Firefox side panels.
- Tighten schedule_task tool guidance so repeatable automations prefer URL targets and current_tab remains strict live-tab state.
- Improve the stale current-tab error copy to tell users to recreate the schedule with Target = URL when appropriate.
- Add test assertions for URL prefill/defaulting behavior in both builds.

## Why

Current-tab scheduled tasks intentionally fail after navigation because they depend on the exact live tab state. The UI and tool guidance now steer repeatable scheduled work toward URL targets, which can reopen the original page automatically.

## Validation

- `npm test`