### PR TITLE
[codex] Fix context-menu prompt race conditions

### DIFF
--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -598,7 +598,7 @@ async function handleMessage(msg, sender) {
       // the prompt recoverable) but before the agent run starts (so a
       // mid-run panel close does not replay the prompt on reopen).
       if (msg.contextMenuClear?.tabId != null) {
-        contextMenuStorage.clear(msg.contextMenuClear.tabId, msg.contextMenuClear.promptId).catch(() => {});
+        await contextMenuStorage.clear(msg.contextMenuClear.tabId, msg.contextMenuClear.promptId);
       }
 
       const updates = [];

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -2682,6 +2682,11 @@ async function continueAgent() {
     hideActivity();
     currentAssistantEl = null;
     scrollToBottom();
+    if (pendingTabSwitch != null) {
+      const pending = pendingTabSwitch;
+      pendingTabSwitch = null;
+      await switchToTab(pending);
+    }
     drainQueuedContextMenuPrompts();
   }
 }

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -446,7 +446,7 @@ async function handleMessage(msg, sender) {
       // the prompt recoverable) but before the agent run starts (so a
       // mid-run panel close does not replay the prompt on reopen).
       if (msg.contextMenuClear?.tabId != null) {
-        contextMenuStorage.clear(msg.contextMenuClear.tabId, msg.contextMenuClear.promptId).catch(() => {});
+        await contextMenuStorage.clear(msg.contextMenuClear.tabId, msg.contextMenuClear.promptId);
       }
 
       const updates = [];

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -2293,6 +2293,11 @@ async function continueAgent() {
     hideActivity();
     currentAssistantEl = null;
     scrollToBottom();
+    if (pendingTabSwitch != null) {
+      const pending = pendingTabSwitch;
+      pendingTabSwitch = null;
+      switchToTab(pending);
+    }
     drainQueuedContextMenuPrompts();
   }
 }

--- a/test/run.js
+++ b/test/run.js
@@ -1986,10 +1986,36 @@ test('sidepanel drains queued context-menu prompts after Continue finishes', () 
     assert.ok(match, `${label}: continueAgent finally block missing`);
     const finallyBody = match[1];
     const idleIdx = finallyBody.indexOf('isProcessing = false;');
+    const pendingIdx = finallyBody.indexOf('if (pendingTabSwitch != null)');
+    const switchIdx = finallyBody.indexOf('switchToTab(pending);');
     const drainIdx = finallyBody.indexOf('drainQueuedContextMenuPrompts();');
     assert.notEqual(idleIdx, -1, `${label}: continueAgent should clear processing state`);
+    assert.notEqual(pendingIdx, -1, `${label}: Continue completion should apply pending tab switches`);
+    assert.notEqual(switchIdx, -1, `${label}: Continue completion should switch to the pending tab`);
     assert.notEqual(drainIdx, -1, `${label}: Continue completion should drain queued context-menu prompts`);
     assert.equal(idleIdx < drainIdx, true, `${label}: context-menu queue must drain after processing is cleared`);
+    assert.equal(idleIdx < pendingIdx, true, `${label}: pending tab switch must wait until processing is cleared`);
+    assert.equal(pendingIdx < switchIdx, true, `${label}: pending tab switch should capture the target before switching`);
+    assert.equal(switchIdx < drainIdx, true, `${label}: context-menu queue must drain after pending tab switch is applied`);
+  }
+});
+
+test('background awaits context-menu prompt clear before agent chat starts', () => {
+  for (const [label, bgRel] of [
+    ['chrome', 'src/chrome/src/background.js'],
+    ['firefox', 'src/firefox/src/background.js'],
+  ]) {
+    const bg = fs.readFileSync(path.join(ROOT, bgRel), 'utf8');
+    const match = bg.match(/case 'chat': \{([\s\S]*?)\n\s+case 'chat_stream':/);
+    assert.ok(match, `${label}: chat handler missing`);
+    const chatBody = match[1];
+    const clear = 'await contextMenuStorage.clear(msg.contextMenuClear.tabId, msg.contextMenuClear.promptId);';
+    const clearIdx = chatBody.indexOf(clear);
+    const processIdx = chatBody.indexOf('agent.processMessage(');
+    assert.notEqual(clearIdx, -1, `${label}: context-menu prompt clear should be awaited`);
+    assert.notEqual(processIdx, -1, `${label}: chat handler should start an agent run`);
+    assert.equal(clearIdx < processIdx, true, `${label}: context-menu prompt clear must finish before the agent run starts`);
+    assert.doesNotMatch(chatBody, /contextMenuStorage\.clear\(msg\.contextMenuClear\.tabId,\s*msg\.contextMenuClear\.promptId\)\.catch\(\(\) => \{\}\)/, `${label}: context-menu clear should not be fire-and-forget`);
   }
 });
 


### PR DESCRIPTION
## Summary
- Await context-menu prompt storage clearing before starting chat agent runs so accepted selected-text prompts cannot replay after panel or worker interruption.
- Apply pending tab switches before draining queued context-menu prompts after Continue runs complete.
- Add regression coverage for both ordering guarantees across Chrome and Firefox builds.

## Testing
- `npm test` passed: 365 main tests, 0 failed.
- Injection corpus passed: 59/59 checks.