### PR TITLE
[codex] Handle settings and sidepanel async status failures

### DIFF
--- a/src/chrome/src/ui/i18n.js
+++ b/src/chrome/src/ui/i18n.js
@@ -52,14 +52,14 @@ export function getLocale() {
   return currentLocale;
 }
 
-export function setLocale(code) {
+export async function setLocale(code) {
   if (!DICTS[code] || code === currentLocale) return;
   currentLocale = code;
   try { localStorage.setItem(LS_KEY, code); } catch { /* ignore */ }
   // Mirror to browser storage so other extension pages pick it up.
   try {
     const api = (typeof browser !== 'undefined' && browser?.storage) ? browser : (typeof chrome !== 'undefined' ? chrome : null);
-    api?.storage?.local?.set?.({ wbLocale: code });
+    await api?.storage?.local?.set?.({ wbLocale: code });
   } catch { /* ignore */ }
   applyDOMTranslations(document);
   document.dispatchEvent(new CustomEvent('wb-locale-changed', { detail: { code } }));

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -103,8 +103,8 @@ renderSubtitle();
 if (languageSelect) {
   languageSelect.innerHTML = LANGUAGES.map((l) => `<option value="${l.code}">${l.label}</option>`).join('');
   languageSelect.value = getLocale();
-  languageSelect.addEventListener('change', () => {
-    setLocale(languageSelect.value);
+  languageSelect.addEventListener('change', async () => {
+    await setLocale(languageSelect.value);
     // Re-render dynamic bits whose text comes from JS.
     renderSubtitle();
     renderAuthSection();

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -393,13 +393,13 @@ async function logout() {
   renderAuthSection();
 }
 
-window.addEventListener('message', (event) => {
+window.addEventListener('message', async (event) => {
   if (event.data?.type === 'WB_AUTH_TOKEN') {
     const { token, email, defaultModel } = event.data;
     authToken = token;
     authEmail = email;
     authDefaultModel = defaultModel || 'openai/gpt-4o';
-    chrome.storage.local.set({ authToken, authEmail, authDefaultModel });
+    await chrome.storage.local.set({ authToken, authEmail, authDefaultModel }).catch(() => {});
     renderAuthSection();
     autoConfigureWebbrainProvider();
   }
@@ -414,57 +414,57 @@ async function autoConfigureWebbrainProvider() {
 
 // --- Display Settings ---
 
-verboseToggle.addEventListener('change', () => {
-  chrome.storage.local.set({ verboseMode: verboseToggle.checked });
+verboseToggle.addEventListener('change', async () => {
+  await chrome.storage.local.set({ verboseMode: verboseToggle.checked }).catch(() => {});
 });
 
-screenshotToggle.addEventListener('change', () => {
-  chrome.storage.local.set({ screenshotFallback: screenshotToggle.checked });
+screenshotToggle.addEventListener('change', async () => {
+  await chrome.storage.local.set({ screenshotFallback: screenshotToggle.checked }).catch(() => {});
 });
 
 maxStepsRange.addEventListener('input', () => {
   stepsValueLabel.textContent = Number(maxStepsRange.value) === MAX_AGENT_STEPS_UNLIMITED_SENTINEL ? '∞' : maxStepsRange.value;
 });
 
-maxStepsRange.addEventListener('change', () => {
-  chrome.storage.local.set({
+maxStepsRange.addEventListener('change', async () => {
+  await chrome.storage.local.set({
     maxAgentSteps: Number(maxStepsRange.value) === MAX_AGENT_STEPS_UNLIMITED_SENTINEL
       ? 0
       : parseInt(maxStepsRange.value, 10),
-  });
+  }).catch(() => {});
 });
 
 if (requestTimeoutRange) {
   requestTimeoutRange.addEventListener('input', () => {
     requestTimeoutValueLabel.textContent = requestTimeoutRange.value + 's';
   });
-  requestTimeoutRange.addEventListener('change', () => {
+  requestTimeoutRange.addEventListener('change', async () => {
     // Stored as ms (the provider code consumes ms). UI shows seconds.
     const sec = parseInt(requestTimeoutRange.value, 10);
-    chrome.storage.local.set({ requestTimeoutMs: sec * 1000 });
+    await chrome.storage.local.set({ requestTimeoutMs: sec * 1000 }).catch(() => {});
   });
 }
 
-autoScreenshotSelect.addEventListener('change', () => {
-  chrome.storage.local.set({ autoScreenshot: autoScreenshotSelect.value });
+autoScreenshotSelect.addEventListener('change', async () => {
+  await chrome.storage.local.set({ autoScreenshot: autoScreenshotSelect.value }).catch(() => {});
 });
 
-siteAdaptersToggle.addEventListener('change', () => {
-  chrome.storage.local.set({ useSiteAdapters: siteAdaptersToggle.checked });
+siteAdaptersToggle.addEventListener('change', async () => {
+  await chrome.storage.local.set({ useSiteAdapters: siteAdaptersToggle.checked }).catch(() => {});
 });
 
-notifySoundToggle.addEventListener('change', () => {
-  chrome.storage.local.set({ notifySound: notifySoundToggle.checked });
+notifySoundToggle.addEventListener('change', async () => {
+  await chrome.storage.local.set({ notifySound: notifySoundToggle.checked }).catch(() => {});
 });
 
-tracingToggle.addEventListener('change', () => {
-  chrome.storage.local.set({ tracingEnabled: tracingToggle.checked });
+tracingToggle.addEventListener('change', async () => {
+  await chrome.storage.local.set({ tracingEnabled: tracingToggle.checked }).catch(() => {});
 });
 
-costSessionLimitInput?.addEventListener('change', () => {
+costSessionLimitInput?.addEventListener('change', async () => {
   const value = normalizeCostAmount(costSessionLimitInput.value);
   costSessionLimitInput.value = value.toFixed(2);
-  chrome.storage.local.set({ costAllowanceSessionUsd: value });
+  await chrome.storage.local.set({ costAllowanceSessionUsd: value }).catch(() => {});
 });
 
 costTotalLimitInput?.addEventListener('change', async () => {
@@ -472,7 +472,7 @@ costTotalLimitInput?.addEventListener('change', async () => {
   costTotalLimitInput.value = value.toFixed(2);
   const stored = await chrome.storage.local.get(['cloudCostSpentUsd']);
   renderCostAllowanceSpent(normalizeCostAmount(stored.cloudCostSpentUsd, 0), value);
-  chrome.storage.local.set({ costAllowanceTotalUsd: value });
+  await chrome.storage.local.set({ costAllowanceTotalUsd: value }).catch(() => {});
 });
 
 btnResetCostSpend?.addEventListener('click', async () => {
@@ -481,26 +481,26 @@ btnResetCostSpend?.addEventListener('click', async () => {
 });
 
 if (strictSecretToggle) {
-  strictSecretToggle.addEventListener('change', () => {
-    chrome.storage.local.set({ strictSecretMode: strictSecretToggle.checked });
+  strictSecretToggle.addEventListener('change', async () => {
+    await chrome.storage.local.set({ strictSecretMode: strictSecretToggle.checked }).catch(() => {});
   });
 }
 
 if (allowLocalNetworkToggle) {
-  allowLocalNetworkToggle.addEventListener('change', () => {
-    chrome.storage.local.set({ agentAllowLocalNetwork: allowLocalNetworkToggle.checked });
+  allowLocalNetworkToggle.addEventListener('change', async () => {
+    await chrome.storage.local.set({ agentAllowLocalNetwork: allowLocalNetworkToggle.checked }).catch(() => {});
   });
 }
 
 if (scheduledTasksToggle) {
-  scheduledTasksToggle.addEventListener('change', () => {
-    chrome.storage.local.set({ scheduledTasksEnabled: scheduledTasksToggle.checked });
+  scheduledTasksToggle.addEventListener('change', async () => {
+    await chrome.storage.local.set({ scheduledTasksEnabled: scheduledTasksToggle.checked }).catch(() => {});
   });
 }
 
 if (scheduledConfirmToggle) {
-  scheduledConfirmToggle.addEventListener('change', () => {
-    chrome.storage.local.set({ scheduledRequireConsequentialConfirmation: scheduledConfirmToggle.checked });
+  scheduledConfirmToggle.addEventListener('change', async () => {
+    await chrome.storage.local.set({ scheduledRequireConsequentialConfirmation: scheduledConfirmToggle.checked }).catch(() => {});
   });
 }
 

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1194,17 +1194,17 @@ function renderProviderFilterBar() {
     btn.className = `provider-filter-pill${providerFilter === f.key ? ' active' : ''}`;
     btn.dataset.filter = f.key;
     btn.textContent = t(f.labelKey);
-    btn.addEventListener('click', () => {
+    btn.addEventListener('click', async () => {
       if (providerFilter === f.key) return;
-    // Snapshot whatever the user has typed but not yet saved BEFORE we
-    // rebuild the DOM — otherwise input values for the currently-rendered
-    // cards are lost (e.g. typed an API key, then clicked a filter pill
-    // to compare two providers).
-    syncInputsIntoProvidersData();
-    providerFilter = f.key;
-    void chrome.storage.local.set({ providerFilter: f.key }).catch(() => {});
-    renderProviders();
-  });
+      // Snapshot whatever the user has typed but not yet saved BEFORE we
+      // rebuild the DOM — otherwise input values for the currently-rendered
+      // cards are lost (e.g. typed an API key, then clicked a filter pill
+      // to compare two providers).
+      syncInputsIntoProvidersData();
+      providerFilter = f.key;
+      await chrome.storage.local.set({ providerFilter: f.key }).catch(() => {});
+      renderProviders();
+    });
     bar.appendChild(btn);
   }
   return bar;

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -506,10 +506,16 @@ if (scheduledConfirmToggle) {
 
 // --- Vision Model ---
 
-function flashVisionResult(className, text) {
-  visionTestResult.className = `test-result show ${className}`;
+function showVisionResult(className, text, color = '') {
+  visionTestResult.className = `test-result show${className ? ` ${className}` : ''}`;
   visionTestResult.textContent = text;
-  setTimeout(() => visionTestResult.classList.remove('show'), 2000);
+  visionTestResult.style.color = color;
+  return visionTestResult;
+}
+
+function flashVisionResult(className, text) {
+  const resultEl = showVisionResult(className, text);
+  setTimeout(() => resultEl.classList.remove('show'), 2000);
 }
 
 btnSaveVision.addEventListener('click', async () => {
@@ -535,9 +541,8 @@ btnTestVision.addEventListener('click', async () => {
   const model = visionModelInput.value.trim();
 
   if (!baseUrl || !model) {
-    visionTestResult.className = 'test-result show fail';
-    visionTestResult.textContent = t('st.vision.fill_required');
-    setTimeout(() => visionTestResult.classList.remove('show'), 2500);
+    const resultEl = showVisionResult('fail', t('st.vision.fill_required'));
+    setTimeout(() => resultEl.classList.remove('show'), 2500);
     return;
   }
 
@@ -545,17 +550,17 @@ btnTestVision.addEventListener('click', async () => {
     visionModel: { baseUrl, apiKey, model },
   });
 
-  visionTestResult.className = 'test-result show';
-  visionTestResult.textContent = t('st.vision.testing');
-  visionTestResult.style.color = 'var(--text2)';
+  showVisionResult('', t('st.vision.testing'), 'var(--text2)');
 
-  const res = await sendToBackground('test_vision_provider');
-  if (res.ok) {
-    visionTestResult.className = 'test-result show ok';
-    visionTestResult.textContent = t('st.vision.connected', { model: res.model || model });
-  } else {
-    visionTestResult.className = 'test-result show fail';
-    visionTestResult.textContent = t('st.vision.failed', { error: res.error });
+  try {
+    const res = await sendToBackground('test_vision_provider');
+    if (res?.ok) {
+      showVisionResult('ok', t('st.vision.connected', { model: res.model || model }));
+    } else {
+      showVisionResult('fail', t('st.vision.failed', { error: res?.error || 'Unknown error' }));
+    }
+  } catch (e) {
+    showVisionResult('fail', t('st.vision.failed', { error: e.message }));
   }
 });
 
@@ -575,11 +580,17 @@ btnClearVision.addEventListener('click', async () => {
 // filled, and falls back to the auto-pick-from-providers behavior when
 // any field is empty.
 
-function flashTranscriptionResult(className, text) {
+function showTranscriptionResult(className, text, color = '') {
   if (!transcriptionTestResult) return;
-  transcriptionTestResult.className = `test-result show ${className}`;
+  transcriptionTestResult.className = `test-result show${className ? ` ${className}` : ''}`;
   transcriptionTestResult.textContent = text;
-  setTimeout(() => transcriptionTestResult.classList.remove('show'), 2000);
+  transcriptionTestResult.style.color = color;
+  return transcriptionTestResult;
+}
+
+function flashTranscriptionResult(className, text) {
+  const resultEl = showTranscriptionResult(className, text);
+  if (resultEl) setTimeout(() => resultEl.classList.remove('show'), 2000);
 }
 
 if (btnSaveTranscription) {
@@ -608,9 +619,8 @@ if (btnTestTranscription) {
     const model = transcriptionModelInput.value.trim();
 
     if (!baseUrl || !model) {
-      transcriptionTestResult.className = 'test-result show fail';
-      transcriptionTestResult.textContent = t('st.transcription.fill_required');
-      setTimeout(() => transcriptionTestResult.classList.remove('show'), 2500);
+      const resultEl = showTranscriptionResult('fail', t('st.transcription.fill_required'));
+      if (resultEl) setTimeout(() => resultEl.classList.remove('show'), 2500);
       return;
     }
 
@@ -619,17 +629,17 @@ if (btnTestTranscription) {
       transcriptionModel: { baseUrl, apiKey, model },
     });
 
-    transcriptionTestResult.className = 'test-result show';
-    transcriptionTestResult.textContent = t('st.transcription.testing');
-    transcriptionTestResult.style.color = 'var(--text2)';
+    showTranscriptionResult('', t('st.transcription.testing'), 'var(--text2)');
 
-    const res = await sendToBackground('test_transcription_provider');
-    if (res.ok) {
-      transcriptionTestResult.className = 'test-result show ok';
-      transcriptionTestResult.textContent = t('st.transcription.connected', { model: res.model || model });
-    } else {
-      transcriptionTestResult.className = 'test-result show fail';
-      transcriptionTestResult.textContent = t('st.transcription.failed', { error: res.error });
+    try {
+      const res = await sendToBackground('test_transcription_provider');
+      if (res?.ok) {
+        showTranscriptionResult('ok', t('st.transcription.connected', { model: res.model || model }));
+      } else {
+        showTranscriptionResult('fail', t('st.transcription.failed', { error: res?.error || 'Unknown error' }));
+      }
+    } catch (e) {
+      showTranscriptionResult('fail', t('st.transcription.failed', { error: e.message }));
     }
   });
 }
@@ -685,11 +695,17 @@ if (btnClearProfile) {
 // Toggle persists immediately so the prompt updates on the next agent turn
 // without forcing a Save click. The API key needs an explicit Save.
 
-function flashCaptchaResult(className, text) {
+function showCaptchaResult(className, text, color = '') {
   if (!captchaTestResult) return;
-  captchaTestResult.className = `test-result show ${className}`;
+  captchaTestResult.className = `test-result show${className ? ` ${className}` : ''}`;
   captchaTestResult.textContent = text;
-  setTimeout(() => captchaTestResult.classList.remove('show'), 3000);
+  captchaTestResult.style.color = color;
+  return captchaTestResult;
+}
+
+function flashCaptchaResult(className, text) {
+  const resultEl = showCaptchaResult(className, text);
+  if (resultEl) setTimeout(() => resultEl.classList.remove('show'), 3000);
 }
 
 if (captchaEnabledToggle) {
@@ -713,14 +729,16 @@ if (btnTestCaptcha) {
       flashCaptchaResult('fail', t('st.captcha.need_key'));
       return;
     }
-    captchaTestResult.className = 'test-result show';
-    captchaTestResult.textContent = t('st.captcha.checking');
-    captchaTestResult.style.color = 'var(--text2)';
-    const res = await sendToBackground('test_capsolver_balance', { apiKey: key });
-    if (res.ok) {
-      flashCaptchaResult('ok', t('st.captcha.balance_ok', { balance: `$${Number(res.balance).toFixed(4)}` }));
-    } else {
-      flashCaptchaResult('fail', t('st.captcha.balance_fail', { error: res.error }));
+    showCaptchaResult('', t('st.captcha.checking'), 'var(--text2)');
+    try {
+      const res = await sendToBackground('test_capsolver_balance', { apiKey: key });
+      if (res?.ok) {
+        flashCaptchaResult('ok', t('st.captcha.balance_ok', { balance: `$${Number(res.balance).toFixed(4)}` }));
+      } else {
+        flashCaptchaResult('fail', t('st.captcha.balance_fail', { error: res?.error || 'Unknown error' }));
+      }
+    } catch (e) {
+      flashCaptchaResult('fail', t('st.captcha.balance_fail', { error: e.message }));
     }
   });
 }
@@ -1355,36 +1373,44 @@ async function signOutOfClaude(id) {
   await refreshClaudeOAuthStatus(id);
 }
 
-async function loadProviderModels(id) {
+function setProviderLoadModelsStatus(id, message, color = 'var(--text2)') {
   const statusEl = document.querySelector(`.load-models-status[data-provider="${id}"]`);
-  const datalistEl = document.getElementById(`models-${id}`);
+  if (!statusEl) return null;
+  statusEl.textContent = message;
+  statusEl.style.color = color;
+  return statusEl;
+}
+
+async function loadProviderModels(id) {
+  let datalistEl = document.getElementById(`models-${id}`);
   if (!datalistEl) return;
   // Persist whatever the user has typed in baseUrl/model so the background
   // call uses the current values, not stale storage.
   try {
     await saveProvider(id, { showFlash: false });
   } catch (e) {
-    if (statusEl) {
-      statusEl.textContent = e.message;
-      statusEl.style.color = 'var(--danger, #c33)';
-    }
+    setProviderLoadModelsStatus(id, e.message, 'var(--danger, #c33)');
     return;
   }
-  if (statusEl) statusEl.textContent = t('st.providers.loading');
-  const res = await sendToBackground('list_provider_models', { providerId: id });
-  if (res.ok) {
+
+  setProviderLoadModelsStatus(id, t('st.providers.loading'));
+  let res;
+  try {
+    res = await sendToBackground('list_provider_models', { providerId: id });
+  } catch (e) {
+    setProviderLoadModelsStatus(id, e.message, 'var(--danger, #c33)');
+    return;
+  }
+
+  datalistEl = document.getElementById(`models-${id}`);
+  if (!datalistEl) return;
+  if (res?.ok) {
     datalistEl.innerHTML = res.models
       .map((m) => `<option value="${escapeHtml(m)}"></option>`)
       .join('');
-    if (statusEl) {
-      statusEl.textContent = t('st.providers.models_loaded', { count: res.models.length });
-      statusEl.style.color = 'var(--text2)';
-    }
+    setProviderLoadModelsStatus(id, t('st.providers.models_loaded', { count: res.models.length }));
   } else {
-    if (statusEl) {
-      statusEl.textContent = res.error || 'Failed to load models';
-      statusEl.style.color = 'var(--danger, #c33)';
-    }
+    setProviderLoadModelsStatus(id, res?.error || 'Failed to load models', 'var(--danger, #c33)');
   }
 }
 

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -509,7 +509,7 @@ if (scheduledConfirmToggle) {
 function showVisionResult(className, text, color = '') {
   visionTestResult.className = `test-result show${className ? ` ${className}` : ''}`;
   visionTestResult.textContent = text;
-  visionTestResult.style.color = color;
+  visionTestResult.style.color = color || '';
   return visionTestResult;
 }
 
@@ -584,7 +584,7 @@ function showTranscriptionResult(className, text, color = '') {
   if (!transcriptionTestResult) return;
   transcriptionTestResult.className = `test-result show${className ? ` ${className}` : ''}`;
   transcriptionTestResult.textContent = text;
-  transcriptionTestResult.style.color = color;
+  transcriptionTestResult.style.color = color || '';
   return transcriptionTestResult;
 }
 
@@ -699,7 +699,7 @@ function showCaptchaResult(className, text, color = '') {
   if (!captchaTestResult) return;
   captchaTestResult.className = `test-result show${className ? ` ${className}` : ''}`;
   captchaTestResult.textContent = text;
-  captchaTestResult.style.color = color;
+  captchaTestResult.style.color = color || '';
   return captchaTestResult;
 }
 
@@ -1419,7 +1419,7 @@ function setProviderTestResult(id, className, message, color) {
   if (!testEl) return null;
   testEl.className = `test-result show${className ? ` ${className}` : ''}`;
   testEl.textContent = message;
-  if (color) testEl.style.color = color;
+  testEl.style.color = color || '';
   return testEl;
 }
 

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -74,10 +74,10 @@ if (themeSelect) {
     themeSelect.value = mode;
     applyMode(mode, { syncStorage: false }); // already loaded, just paint
   });
-  themeSelect.addEventListener('change', () => {
+  themeSelect.addEventListener('change', async () => {
     const mode = THEME_MODES.includes(themeSelect.value) ? themeSelect.value : 'system';
     currentThemeMode = mode;
-    applyMode(mode);
+    await applyMode(mode);
   });
   watch(() => currentThemeMode);
   // If another Settings tab or the side panel flips the theme, watch()
@@ -670,8 +670,8 @@ function flashProfileResult(className, text) {
 // for the on/off state so users don't get confused when the toggle
 // appears to not do anything.
 if (profileEnabledToggle) {
-  profileEnabledToggle.addEventListener('change', () => {
-    chrome.storage.local.set({ profileEnabled: profileEnabledToggle.checked });
+  profileEnabledToggle.addEventListener('change', async () => {
+    await chrome.storage.local.set({ profileEnabled: profileEnabledToggle.checked }).catch(() => {});
   });
 }
 
@@ -709,8 +709,8 @@ function flashCaptchaResult(className, text) {
 }
 
 if (captchaEnabledToggle) {
-  captchaEnabledToggle.addEventListener('change', () => {
-    chrome.storage.local.set({ captchaSolverEnabled: captchaEnabledToggle.checked });
+  captchaEnabledToggle.addEventListener('change', async () => {
+    await chrome.storage.local.set({ captchaSolverEnabled: captchaEnabledToggle.checked }).catch(() => {});
   });
 }
 
@@ -1196,15 +1196,15 @@ function renderProviderFilterBar() {
     btn.textContent = t(f.labelKey);
     btn.addEventListener('click', () => {
       if (providerFilter === f.key) return;
-      // Snapshot whatever the user has typed but not yet saved BEFORE we
-      // rebuild the DOM — otherwise input values for the currently-rendered
-      // cards are lost (e.g. typed an API key, then clicked a filter pill
-      // to compare two providers).
-      syncInputsIntoProvidersData();
-      providerFilter = f.key;
-      try { chrome.storage.local.set({ providerFilter: f.key }); } catch {}
-      renderProviders();
-    });
+    // Snapshot whatever the user has typed but not yet saved BEFORE we
+    // rebuild the DOM — otherwise input values for the currently-rendered
+    // cards are lost (e.g. typed an API key, then clicked a filter pill
+    // to compare two providers).
+    syncInputsIntoProvidersData();
+    providerFilter = f.key;
+    void chrome.storage.local.set({ providerFilter: f.key }).catch(() => {});
+    renderProviders();
+  });
     bar.appendChild(btn);
   }
   return bar;

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1487,7 +1487,14 @@ async function activateProvider(id) {
   syncInputsIntoProvidersData();
   requestedActiveProviderId = id;
   const requestId = ++providerActivationRequestId;
-  await sendToBackground('set_active_provider', { providerId: id });
+  try {
+    await sendToBackground('set_active_provider', { providerId: id });
+  } catch (e) {
+    if (requestId === providerActivationRequestId && requestedActiveProviderId === id) {
+      setProviderTestResult(id, 'fail', t('st.providers.failed', { error: e.message }));
+    }
+    return;
+  }
   if (requestId !== providerActivationRequestId || requestedActiveProviderId !== id) {
     const latestProviderId = requestedActiveProviderId;
     if (latestProviderId) {

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -1334,7 +1334,7 @@ if (verboseBtn) {
     // Normal click → toggle verbose mode
     verboseMode = !verboseMode;
     verboseBtn.classList.toggle('active', verboseMode);
-    chrome.storage.local.set({ verboseMode }).catch(() => {});
+    await chrome.storage.local.set({ verboseMode }).catch(() => {});
   });
 }
 
@@ -1395,7 +1395,7 @@ function setRecommendedActionsCollapsed(collapsed, { persist = true } = {}) {
   recommendedActionsCollapsed = Boolean(collapsed);
   updateRecommendedActionsCollapsedState();
   if (persist) {
-    chrome.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: recommendedActionsCollapsed }).catch(() => {});
+    void chrome.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: recommendedActionsCollapsed }).catch(() => {});
   }
 }
 
@@ -1910,7 +1910,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
   if (/^\/verbose\b\s*/i.test(text)) {
     verboseMode = !verboseMode;
     if (verboseBtn) verboseBtn.classList.toggle('active', verboseMode);
-    chrome.storage.local.set({ verboseMode }).catch(() => {});
+    await chrome.storage.local.set({ verboseMode }).catch(() => {});
     addMessage('system', verboseMode
       ? t('sp.compact.verbose_on')
       : t('sp.compact.verbose_off'));

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -444,10 +444,30 @@ function playCompletionSound() {
 // conversation survives the side panel being closed and reopened.
 const tabChats = new Map();
 const TAB_CHAT_PREFIX = 'tabChat:';
+const tabChatOperations = new Map();
+
+function enqueueTabChatOperation(tabId, fn) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return Promise.resolve({ ok: true });
+  const previous = tabChatOperations.get(numericTabId) || Promise.resolve();
+  const operation = previous.catch(() => {}).then(() => fn(numericTabId));
+  tabChatOperations.set(numericTabId, operation);
+  operation.finally(() => {
+    if (tabChatOperations.get(numericTabId) === operation) tabChatOperations.delete(numericTabId);
+  }).catch(() => {});
+  return operation;
+}
+
+async function waitForTabChatOperation(tabId) {
+  const operation = tabChatOperations.get(Number(tabId));
+  if (!operation) return;
+  try { await operation; } catch { /* ignore */ }
+}
 
 async function loadTabChat(tabId) {
   if (tabChats.has(tabId)) return tabChats.get(tabId);
   try {
+    await waitForTabChatOperation(tabId);
     const key = TAB_CHAT_PREFIX + tabId;
     const stored = await chrome.storage.session.get(key);
     const html = stored?.[key];
@@ -461,10 +481,14 @@ async function loadTabChat(tabId) {
 
 function persistTabChat(tabId, html) {
   if (tabId == null) return;
-  tabChats.set(tabId, html);
-  try {
-    chrome.storage.session.set({ [TAB_CHAT_PREFIX + tabId]: html }).catch(() => {});
-  } catch (e) { /* ignore */ }
+  return enqueueTabChatOperation(tabId, async (numericTabId) => {
+    tabChats.set(numericTabId, html);
+    const key = TAB_CHAT_PREFIX + numericTabId;
+    try {
+      await chrome.storage.session.set({ [key]: html }).catch(() => {});
+    } catch (e) { /* ignore */ }
+    return { ok: true };
+  });
 }
 
 function clearCachedTabChat(tabId) {
@@ -474,10 +498,13 @@ function clearCachedTabChat(tabId) {
     persistTimer = null;
     persistTimerTabId = null;
   }
-  tabChats.delete(tabId);
-  try {
-    chrome.storage.session?.remove(TAB_CHAT_PREFIX + tabId).catch(() => {});
-  } catch (e) { /* ignore */ }
+  return enqueueTabChatOperation(tabId, async (numericTabId) => {
+    tabChats.delete(numericTabId);
+    try {
+      await chrome.storage.session?.remove(TAB_CHAT_PREFIX + numericTabId).catch(() => {});
+    } catch (e) { /* ignore */ }
+    return { ok: true };
+  });
 }
 
 function renderClearedConversationForTab(tabId) {

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -3406,8 +3406,8 @@ if (languageSelect) {
     .map((l) => `<option value="${l.code}">${l.label}</option>`)
     .join('');
   languageSelect.value = getLocale();
-  languageSelect.addEventListener('change', () => {
-    setLocale(languageSelect.value);
+  languageSelect.addEventListener('change', async () => {
+    await setLocale(languageSelect.value);
     applyDOMTranslations(document);
     updateInputPlaceholder();
   });

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -1426,8 +1426,8 @@ function setRecommendedActionsCollapsed(collapsed, { persist = true } = {}) {
 if (recommendedActionsToggleEl) {
   recommendedActionsToggleEl.addEventListener('click', async () => {
     const next = !recommendedActionsCollapsed;
-    await chrome.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: next }).catch(() => {});
     setRecommendedActionsCollapsed(next, { persist: false });
+    await chrome.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: next }).catch(() => {});
   });
 }
 
@@ -1918,8 +1918,9 @@ async function parseSlashCommands(text, tabId = currentTabId) {
   // /compact — force context compaction for this conversation
   const mCompact = text.match(/^\/compact\b\s*/i);
   if (mCompact) {
+    const remainder = text.slice(mCompact[0].length).trim();
     const res = await sendToBackground('compact_conversation', { tabId });
-    if (currentTabId !== tabId) return '';
+    if (currentTabId !== tabId) return remainder;
     if (res?.ok && res.compacted) {
       addContextCompactedNote({ ...res, manual: true });
     } else if (res?.ok && res.reason === 'busy') {
@@ -1929,7 +1930,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     } else {
       addMessage('system', tSystemHtml('sp.compact.failed', { error: res?.error || 'unknown error' }));
     }
-    return text.slice(mCompact[0].length).trim();
+    return remainder;
   }
 
   // /verbose — toggle verbose/compact tool display
@@ -2107,7 +2108,8 @@ async function sendMessage(extraChatParams) {
   // Parse any leading slash command. parseSlashCommands may strip the
   // command from `text` and toggle apiMutationsAllowed as a side effect.
   text = await parseSlashCommands(text, tabId);
-  if (currentTabId !== tabId) return false;
+  const renderToCurrentTab = currentTabId === tabId;
+  if (!renderToCurrentTab && !text) return false;
   // If the entire message was just the slash command, there's nothing
   // left to send to the agent — bail out after the side effect.
   if (!text) {
@@ -2117,16 +2119,19 @@ async function sendMessage(extraChatParams) {
   }
 
   isProcessing = true;
-  hideRecommendedActions();
   abortRequested = false;
   sendBtn.disabled = true;
   inputEl.value = '';
   autoResizeInput();
 
-  addMessage('user', text);
-  showActivity(t('sp.activity.thinking'));
-
-  currentAssistantEl = addMessage('assistant', '');
+  let assistantEl = null;
+  if (renderToCurrentTab) {
+    hideRecommendedActions();
+    addMessage('user', text);
+    showActivity(t('sp.activity.thinking'));
+    assistantEl = addMessage('assistant', '');
+    currentAssistantEl = assistantEl;
+  }
 
   let accepted = false;
   try {
@@ -2139,26 +2144,26 @@ async function sendMessage(extraChatParams) {
     });
     accepted = true;
 
-    if (abortRequested) {
+    if (renderToCurrentTab && currentTabId === tabId && abortRequested) {
       // Agent was stopped — show what we got so far
-      const textEl = currentAssistantEl?.querySelector('.message-text');
+      const textEl = assistantEl?.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
         textEl.innerHTML = formatMarkdown(res?.content || t('sp.stopped_by_user'));
-        addMessageCopyButton(currentAssistantEl);
+        addMessageCopyButton(assistantEl);
       }
-    } else if (res?.content && currentAssistantEl) {
-      const textEl = currentAssistantEl.querySelector('.message-text');
+    } else if (renderToCurrentTab && currentTabId === tabId && res?.content && assistantEl) {
+      const textEl = assistantEl.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
         textEl.innerHTML = formatMarkdown(res.content);
-        addMessageCopyButton(currentAssistantEl);
+        addMessageCopyButton(assistantEl);
       }
     }
   } catch (e) {
-    if (!abortRequested) {
+    if (renderToCurrentTab && currentTabId === tabId && !abortRequested) {
       addMessage('error', t('sp.error_prefix', { msg: e.message }));
     }
   } finally {
-    finalizeSteps();
+    if (renderToCurrentTab && currentTabId === tabId) finalizeSteps(assistantEl);
     // Chime the user when the agent finishes. We play on both success and
     // error completion — anything that wasn't an explicit user abort. The
     // sound is what takes them from "glance back at the tab" to "know it's
@@ -2168,10 +2173,10 @@ async function sendMessage(extraChatParams) {
     abortRequested = false;
     sendBtn.disabled = false;
     hideActivity();
-    currentAssistantEl = null;
-    scrollToBottom();
+    if (currentAssistantEl === assistantEl) currentAssistantEl = null;
+    if (renderToCurrentTab && currentTabId === tabId) scrollToBottom();
     if (!wasAborted) playCompletionSound();
-    refreshRecommendedActions();
+    if (renderToCurrentTab && currentTabId === tabId) refreshRecommendedActions();
     await drainQueuedContextMenuPromptsAfterPendingTabSwitch();
   }
   return accepted;

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -495,8 +495,8 @@ function clearCachedTabChat(tabId) {
     persistTimer = null;
     persistTimerTabId = null;
   }
+  tabChats.delete(tabId);
   return enqueueTabChatOperation(tabId, async (numericTabId) => {
-    tabChats.delete(numericTabId);
     try {
       await chrome.storage.session?.remove(TAB_CHAT_PREFIX + numericTabId).catch(() => {});
     } catch (e) { /* ignore */ }
@@ -1425,8 +1425,9 @@ function setRecommendedActionsCollapsed(collapsed, { persist = true } = {}) {
 
 if (recommendedActionsToggleEl) {
   recommendedActionsToggleEl.addEventListener('click', async () => {
-    await chrome.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: !recommendedActionsCollapsed }).catch(() => {});
-    setRecommendedActionsCollapsed(!recommendedActionsCollapsed, { persist: false });
+    const next = !recommendedActionsCollapsed;
+    await chrome.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: next }).catch(() => {});
+    setRecommendedActionsCollapsed(next, { persist: false });
   });
 }
 

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -459,9 +459,14 @@ function enqueueTabChatOperation(tabId, fn) {
 }
 
 async function waitForTabChatOperation(tabId) {
-  const operation = tabChatOperations.get(Number(tabId));
-  if (!operation) return;
-  try { await operation; } catch { /* ignore */ }
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return;
+  while (true) {
+    const operation = tabChatOperations.get(numericTabId);
+    if (!operation) return;
+    try { await operation; } catch { /* ignore */ }
+    if (tabChatOperations.get(numericTabId) === operation) return;
+  }
 }
 
 async function loadTabChat(tabId) {

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -460,15 +460,17 @@ function enqueueTabChatOperation(tabId, fn) {
 }
 
 async function loadTabChat(tabId) {
-  if (tabChats.has(tabId)) return tabChats.get(tabId);
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return null;
+  if (!tabChatOperations.has(numericTabId) && tabChats.has(numericTabId)) return tabChats.get(numericTabId);
   try {
-    return await enqueueTabChatOperation(tabId, async (numericTabId) => {
-      if (tabChats.has(numericTabId)) return tabChats.get(numericTabId);
-      const key = TAB_CHAT_PREFIX + numericTabId;
+    return await enqueueTabChatOperation(numericTabId, async (queuedTabId) => {
+      if (tabChats.has(queuedTabId)) return tabChats.get(queuedTabId);
+      const key = TAB_CHAT_PREFIX + queuedTabId;
       const stored = await chrome.storage.session.get(key);
       const html = stored?.[key];
       if (typeof html === 'string') {
-        tabChats.set(numericTabId, html);
+        tabChats.set(queuedTabId, html);
         return html;
       }
       return null;

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -511,7 +511,7 @@ function renderClearedConversationForTab(tabId) {
   if (currentTabId !== tabId) return;
   messagesEl.innerHTML = '';
   addMessage('system', t('sp.cleared_message'));
-  refreshScheduledJobs();
+  refreshScheduledJobs({ tabId });
   refreshRecommendedActions();
 }
 
@@ -776,11 +776,12 @@ function renderScheduledJobs(jobs = []) {
   ensureScheduledClarifyCards(visible);
 }
 
-async function refreshScheduledJobs() {
+async function refreshScheduledJobs({ tabId = null } = {}) {
   if (!scheduledJobsEl) return;
   try {
     const response = await sendToBackground('list_scheduled_jobs', { all: true });
     const jobs = response?.jobs || [];
+    if (tabId != null && currentTabId !== tabId) return jobs;
     renderScheduledJobs(jobs);
     return jobs;
   } catch (e) {
@@ -807,7 +808,7 @@ async function scheduledJobAction(action, jobId) {
         addMessage('error', t('sp.error_prefix', { msg: response.error || 'Scheduled job action failed.' }));
       }
     }
-    await refreshScheduledJobs();
+    await refreshScheduledJobs({ tabId });
   } catch (e) {
     if (currentTabId === tabId) {
       addMessage('error', t('sp.error_prefix', { msg: e.message }));
@@ -855,7 +856,7 @@ function settleScheduledRun(event, job) {
 }
 
 function handleScheduledJobEvent(data, tabId) {
-  refreshScheduledJobs();
+  refreshScheduledJobs({ tabId: currentTabId });
   const event = data?.event;
   const job = data?.job;
   if (!event || !job) return;
@@ -1071,7 +1072,7 @@ async function submitScheduleComposer(e, form) {
     if (textEl) {
       textEl.innerHTML = createdHtml;
     }
-    await refreshScheduledJobs();
+    await refreshScheduledJobs({ tabId });
   } catch (err) {
     if (currentTabId !== tabId) {
       updateCachedScheduleComposerError(tabId, form.dataset.composerId, err.message);
@@ -1299,7 +1300,7 @@ async function init() {
   if (activeTab?.id && activeTab.id !== currentTabId) {
     await switchToTab(activeTab.id);
   }
-  refreshScheduledJobs();
+  refreshScheduledJobs({ tabId: currentTabId });
   refreshRecommendedActions();
   await consumePendingContextMenuPrompt();
   drainQueuedContextMenuPrompts();
@@ -1391,7 +1392,7 @@ async function switchToTab(newTabId) {
     addMessage('system', t('sp.help_message'));
   }
   scrollToBottom();
-  refreshScheduledJobs();
+  refreshScheduledJobs({ tabId: newTabId });
   refreshRecommendedActions();
   consumePendingContextMenuPrompt().then(() => drainQueuedContextMenuPrompts()).catch(() => {});
 }
@@ -1884,7 +1885,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
 
   // /list-schedules — refresh the scheduled job strip
   if (/^\/list-schedules\b\s*/i.test(text)) {
-    const jobs = await refreshScheduledJobs();
+    const jobs = await refreshScheduledJobs({ tabId });
     if (currentTabId !== tabId) return '';
     addMessage('system', visibleScheduledJobs(jobs).length
       ? t('sp.schedule_form.list_refreshed')
@@ -2950,6 +2951,8 @@ function showContinueButton() {
 }
 
 async function continueAgent() {
+  const tabId = currentTabId;
+  const modeForSend = agentMode;
   // Remove the continue bar
   document.querySelectorAll('.continue-bar').forEach(el => el.remove());
 
@@ -2957,34 +2960,35 @@ async function continueAgent() {
   abortRequested = false;
   sendBtn.disabled = true;
 
-  currentAssistantEl = addMessage('assistant', '');
+  const assistantEl = addMessage('assistant', '');
+  currentAssistantEl = assistantEl;
   showActivity(t('sp.activity.continuing'));
 
   try {
     const res = await sendToBackground('continue', {
-      tabId: currentTabId,
-      mode: agentMode,
+      tabId,
+      mode: modeForSend,
     });
 
-    if (res?.content && currentAssistantEl) {
-      const textEl = currentAssistantEl.querySelector('.message-text');
+    if (currentTabId === tabId && res?.content && assistantEl) {
+      const textEl = assistantEl.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
         textEl.innerHTML = formatMarkdown(res.content);
-        addMessageCopyButton(currentAssistantEl);
+        addMessageCopyButton(assistantEl);
       }
     }
   } catch (e) {
-    if (!abortRequested) {
+    if (currentTabId === tabId && !abortRequested) {
       addMessage('error', t('sp.error_prefix', { msg: e.message }));
     }
   } finally {
-    finalizeSteps();
+    if (currentTabId === tabId) finalizeSteps(assistantEl);
     isProcessing = false;
     abortRequested = false;
     sendBtn.disabled = false;
     hideActivity();
-    currentAssistantEl = null;
-    scrollToBottom();
+    if (currentAssistantEl === assistantEl) currentAssistantEl = null;
+    if (currentTabId === tabId) scrollToBottom();
     await drainQueuedContextMenuPromptsAfterPendingTabSwitch();
   }
 }

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -458,28 +458,20 @@ function enqueueTabChatOperation(tabId, fn) {
   return operation;
 }
 
-async function waitForTabChatOperation(tabId) {
-  const numericTabId = Number(tabId);
-  if (!Number.isFinite(numericTabId)) return;
-  while (true) {
-    const operation = tabChatOperations.get(numericTabId);
-    if (!operation) return;
-    try { await operation; } catch { /* ignore */ }
-    if (tabChatOperations.get(numericTabId) === operation) return;
-  }
-}
-
 async function loadTabChat(tabId) {
   if (tabChats.has(tabId)) return tabChats.get(tabId);
   try {
-    await waitForTabChatOperation(tabId);
-    const key = TAB_CHAT_PREFIX + tabId;
-    const stored = await chrome.storage.session.get(key);
-    const html = stored?.[key];
-    if (typeof html === 'string') {
-      tabChats.set(tabId, html);
-      return html;
-    }
+    return await enqueueTabChatOperation(tabId, async (numericTabId) => {
+      if (tabChats.has(numericTabId)) return tabChats.get(numericTabId);
+      const key = TAB_CHAT_PREFIX + numericTabId;
+      const stored = await chrome.storage.session.get(key);
+      const html = stored?.[key];
+      if (typeof html === 'string') {
+        tabChats.set(numericTabId, html);
+        return html;
+      }
+      return null;
+    });
   } catch (e) { /* ignore */ }
   return null;
 }

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -3225,7 +3225,7 @@ function sendToBackground(action, data = {}) {
 
 // --- Keyboard shortcuts ---
 
-function handleGlobalKeydown(e) {
+async function handleGlobalKeydown(e) {
   if (e.defaultPrevented) return;
 
   // Don't steal shortcuts from other input elements (e.g. schedule form fields)
@@ -3250,7 +3250,7 @@ function handleGlobalKeydown(e) {
   // Ctrl+Shift+X: switch to Act mode (blocked while agent is running)
   if (mod && e.shiftKey && e.key === 'X' && !isProcessing) {
     e.preventDefault();
-    ensureActMode();
+    await ensureActMode();
     return;
   }
   // Escape: abort running agent (only when slash menu is not open)
@@ -3293,7 +3293,7 @@ async function ensureActMode() {
     if (!stored.actConfirmed) {
       const ok = confirm(t('sp.mode.act.confirm'));
       if (!ok) return false;
-      chrome.storage.local.set({ actConfirmed: true }).catch(() => {});
+      await chrome.storage.local.set({ actConfirmed: true }).catch(() => {});
     }
   } catch (e) { /* storage unavailable, fall through */ }
   setMode('act');
@@ -3302,8 +3302,8 @@ async function ensureActMode() {
 
 modeAskBtn.addEventListener('click', () => setMode('ask'));
 
-modeActBtn.addEventListener('click', () => {
-  ensureActMode();
+modeActBtn.addEventListener('click', async () => {
+  await ensureActMode();
 });
 
 

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -57,8 +57,8 @@ if (globalThis.chrome?.storage?.onChanged) {
   let localModelChoices = [];
   let cloudReady = false;
 
-  function dismissOnboarding() {
-    chrome.storage.local.set({ onboardingComplete: true }).catch(() => {});
+  async function dismissOnboarding() {
+    await chrome.storage.local.set({ onboardingComplete: true }).catch(() => {});
     overlay.classList.add('hidden');
   }
 
@@ -139,10 +139,10 @@ if (globalThis.chrome?.storage?.onChanged) {
       changeLink.target = '_blank';
       changeLink.rel = 'noopener noreferrer';
       changeLink.textContent = 'Change';
-      changeLink.addEventListener('click', (event) => {
+      changeLink.addEventListener('click', async (event) => {
         event.preventDefault();
         openProviderSettings();
-        dismissOnboarding();
+        await dismissOnboarding();
       });
       providerStatus.append(
         document.createTextNode('Using WebBrain Cloud. '),
@@ -262,7 +262,7 @@ if (globalThis.chrome?.storage?.onChanged) {
 
   settingsBtn.addEventListener('click', async () => {
     if (cloudReady) {
-      dismissOnboarding();
+      await dismissOnboarding();
       inputEl?.focus();
       return;
     }
@@ -293,10 +293,12 @@ if (globalThis.chrome?.storage?.onChanged) {
     }
 
     openProviderSettings();
-    dismissOnboarding();
+    await dismissOnboarding();
   });
 
-  skipBtn.addEventListener('click', dismissOnboarding);
+  skipBtn.addEventListener('click', async () => {
+    await dismissOnboarding();
+  });
 })();
 
 const messagesEl = document.getElementById('messages');

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -497,6 +497,7 @@ function clearCachedTabChat(tabId) {
   }
   tabChats.delete(tabId);
   return enqueueTabChatOperation(tabId, async (numericTabId) => {
+    tabChats.delete(numericTabId);
     try {
       await chrome.storage.session?.remove(TAB_CHAT_PREFIX + numericTabId).catch(() => {});
     } catch (e) { /* ignore */ }
@@ -2097,6 +2098,8 @@ async function sendMessage(extraChatParams) {
   let text = inputEl.value.trim();
   if (!text || isProcessing) return;
   const tabId = currentTabId;
+  const modeForSend = /^\/(?:ask|plan)\b/i.test(text) ? 'ask' : agentMode;
+  const apiMutationsAllowedForSend = isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);
   hideSlashCommandAutocomplete();
 
   // Clear input early so slash commands don't linger visually.
@@ -2118,14 +2121,13 @@ async function sendMessage(extraChatParams) {
     return;
   }
 
-  isProcessing = true;
-  abortRequested = false;
-  sendBtn.disabled = true;
-  inputEl.value = '';
-  autoResizeInput();
-
   let assistantEl = null;
   if (renderToCurrentTab) {
+    isProcessing = true;
+    abortRequested = false;
+    sendBtn.disabled = true;
+    inputEl.value = '';
+    autoResizeInput();
     hideRecommendedActions();
     addMessage('user', text);
     showActivity(t('sp.activity.thinking'));
@@ -2138,8 +2140,8 @@ async function sendMessage(extraChatParams) {
     const res = await sendToBackground('chat', {
       tabId,
       text,
-      mode: agentMode,
-      apiMutationsAllowed,
+      mode: modeForSend,
+      apiMutationsAllowed: apiMutationsAllowedForSend,
       ...extraChatParams,
     });
     accepted = true;
@@ -2169,13 +2171,15 @@ async function sendMessage(extraChatParams) {
     // sound is what takes them from "glance back at the tab" to "know it's
     // done" without having to sit and watch the sidebar.
     const wasAborted = abortRequested;
-    isProcessing = false;
-    abortRequested = false;
-    sendBtn.disabled = false;
-    hideActivity();
+    if (renderToCurrentTab) {
+      isProcessing = false;
+      abortRequested = false;
+      sendBtn.disabled = false;
+      hideActivity();
+    }
     if (currentAssistantEl === assistantEl) currentAssistantEl = null;
     if (renderToCurrentTab && currentTabId === tabId) scrollToBottom();
-    if (!wasAborted) playCompletionSound();
+    if (renderToCurrentTab && !wasAborted) playCompletionSound();
     if (renderToCurrentTab && currentTabId === tabId) refreshRecommendedActions();
     await drainQueuedContextMenuPromptsAfterPendingTabSwitch();
   }

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -1840,7 +1840,7 @@ function syncApiMutationsAllowedForCurrentTab() {
  * Returns the cleaned text (empty string if fully consumed).
  * May trigger async UI side effects (screenshot, export, etc.).
  */
-async function parseSlashCommands(text) {
+async function parseSlashCommands(text, tabId = currentTabId) {
   // /help — list all available slash commands
   if (/^\/help\b\s*/i.test(text)) {
     addMessage('system', t('sp.help_html'));
@@ -1849,7 +1849,6 @@ async function parseSlashCommands(text) {
 
   // /list-schedules — refresh the scheduled job strip
   if (/^\/list-schedules\b\s*/i.test(text)) {
-    const tabId = currentTabId;
     const jobs = await refreshScheduledJobs();
     if (currentTabId !== tabId) return '';
     addMessage('system', visibleScheduledJobs(jobs).length
@@ -1860,21 +1859,20 @@ async function parseSlashCommands(text) {
 
   // /show-scratchpad — dump the current tab's agent scratchpad
   if (/^\/show-scratchpad\b\s*/i.test(text)) {
-    await showScratchpad(currentTabId);
+    await showScratchpad(tabId);
     return '';
   }
 
   // /schedule — open a deterministic scheduled-task composer
   const mSchedule = text.match(/^\/schedule\b\s*/i);
   if (mSchedule) {
-    renderScheduleComposer(text.slice(mSchedule[0].length).trim(), currentTabId);
+    renderScheduleComposer(text.slice(mSchedule[0].length).trim(), tabId);
     return '';
   }
 
   // /allow-api — enable API mutation override
   const mApi = text.match(/^\/allow-api\b\s*/i);
   if (mApi) {
-    const tabId = currentTabId;
     const wasAlreadyAllowed = isApiMutationsAllowedForTab(tabId);
     setApiMutationsAllowedForTab(tabId, true);
     if (!wasAlreadyAllowed) {
@@ -1886,7 +1884,6 @@ async function parseSlashCommands(text) {
   // /compact — force context compaction for this conversation
   const mCompact = text.match(/^\/compact\b\s*/i);
   if (mCompact) {
-    const tabId = currentTabId;
     const res = await sendToBackground('compact_conversation', { tabId });
     if (currentTabId !== tabId) return '';
     if (res?.ok && res.compacted) {
@@ -1914,7 +1911,6 @@ async function parseSlashCommands(text) {
 
   // /reset — clear conversation (same as clear button)
   if (/^\/reset\b\s*/i.test(text)) {
-    const tabId = currentTabId;
     await sendToBackground('clear_conversation', { tabId });
     renderClearedConversationForTab(tabId);
     return '';
@@ -1922,7 +1918,6 @@ async function parseSlashCommands(text) {
 
   // /screenshot — capture visible tab and display in chat
   if (/^\/screenshot\b\s*/i.test(text)) {
-    const tabId = currentTabId;
     try {
       const tab = tabId == null ? null : await chrome.tabs.get(tabId);
       if (currentTabId !== tabId || !tab?.active) return '';
@@ -1942,7 +1937,6 @@ async function parseSlashCommands(text) {
 
   // /record — start recording the current tab without LLM involvement
   if (/^\/record(?:\s|$)/i.test(text)) {
-    const tabId = currentTabId;
     try {
       const res = await sendToBackground('start_tab_recording', {
         tabId,
@@ -1996,7 +1990,6 @@ async function parseSlashCommands(text) {
 
   // /profile — toggle profile auto-fill on/off
   if (/^\/profile\b\s*/i.test(text)) {
-    const tabId = currentTabId;
     const stored = await chrome.storage.local.get(['profileEnabled', 'profileText']);
     const newState = !stored.profileEnabled;
     await chrome.storage.local.set({ profileEnabled: newState });
@@ -2024,7 +2017,6 @@ async function parseSlashCommands(text) {
 
   // /vision — toggle vision support on active provider
   if (/^\/vision\b\s*/i.test(text)) {
-    const tabId = currentTabId;
     try {
       const { providers, active } = await sendToBackground('get_providers');
       const config = providers[active];
@@ -2068,6 +2060,7 @@ function updateApiBadge() {
 async function sendMessage(extraChatParams) {
   let text = inputEl.value.trim();
   if (!text || isProcessing) return;
+  const tabId = currentTabId;
   hideSlashCommandAutocomplete();
 
   // Clear input early so slash commands don't linger visually.
@@ -2078,7 +2071,8 @@ async function sendMessage(extraChatParams) {
 
   // Parse any leading slash command. parseSlashCommands may strip the
   // command from `text` and toggle apiMutationsAllowed as a side effect.
-  text = await parseSlashCommands(text);
+  text = await parseSlashCommands(text, tabId);
+  if (currentTabId !== tabId) return false;
   // If the entire message was just the slash command, there's nothing
   // left to send to the agent — bail out after the side effect.
   if (!text) {
@@ -2102,7 +2096,7 @@ async function sendMessage(extraChatParams) {
   let accepted = false;
   try {
     const res = await sendToBackground('chat', {
-      tabId: currentTabId,
+      tabId,
       text,
       mode: agentMode,
       apiMutationsAllowed,

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -445,6 +445,7 @@ function playCompletionSound() {
 const tabChats = new Map();
 const TAB_CHAT_PREFIX = 'tabChat:';
 const tabChatOperations = new Map();
+const tabInputDrafts = new Map();
 
 function enqueueTabChatOperation(tabId, fn) {
   const numericTabId = Number(tabId);
@@ -505,11 +506,39 @@ function clearCachedTabChat(tabId) {
   });
 }
 
+function saveInputDraftForTab(tabId, text) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return;
+  const draft = String(text || '');
+  if (draft.trim()) {
+    tabInputDrafts.set(numericTabId, draft);
+  } else {
+    tabInputDrafts.delete(numericTabId);
+  }
+}
+
+function captureInputDraftForTab(tabId) {
+  if (!inputEl) return;
+  saveInputDraftForTab(tabId, inputEl.value || '');
+}
+
+function restoreInputDraftForTab(tabId) {
+  if (!inputEl) return;
+  const numericTabId = Number(tabId);
+  const draft = Number.isFinite(numericTabId) ? tabInputDrafts.get(numericTabId) || '' : '';
+  inputEl.value = draft;
+  autoResizeInput();
+  updateSlashCommandAutocomplete();
+}
+
 function renderClearedConversationForTab(tabId) {
   clearCachedTabChat(tabId);
+  saveInputDraftForTab(tabId, '');
   setApiMutationsAllowedForTab(tabId, false);
   if (currentTabId !== tabId) return;
   messagesEl.innerHTML = '';
+  inputEl.value = '';
+  autoResizeInput();
   addMessage('system', t('sp.cleared_message'));
   refreshScheduledJobs({ tabId });
   refreshRecommendedActions();
@@ -1375,6 +1404,7 @@ async function switchToTab(newTabId) {
   // Save current tab's chat (in-memory + storage).
   if (currentTabId != null) {
     persistTabChat(currentTabId, messagesEl.innerHTML);
+    captureInputDraftForTab(currentTabId);
   }
 
   currentTabId = newTabId;
@@ -1391,6 +1421,7 @@ async function switchToTab(newTabId) {
     messagesEl.innerHTML = '';
     addMessage('system', t('sp.help_message'));
   }
+  restoreInputDraftForTab(newTabId);
   scrollToBottom();
   refreshScheduledJobs({ tabId: newTabId });
   refreshRecommendedActions();
@@ -2101,6 +2132,7 @@ async function sendMessage(extraChatParams) {
   const tabId = currentTabId;
   const modeForSend = /^\/(?:ask|plan)\b/i.test(text) ? 'ask' : agentMode;
   const apiMutationsAllowedForSend = isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);
+  saveInputDraftForTab(tabId, '');
   hideSlashCommandAutocomplete();
 
   // Clear input early so slash commands don't linger visually.
@@ -2113,7 +2145,10 @@ async function sendMessage(extraChatParams) {
   // command from `text` and toggle apiMutationsAllowed as a side effect.
   text = await parseSlashCommands(text, tabId);
   const renderToCurrentTab = currentTabId === tabId;
-  if (!renderToCurrentTab && !text) return false;
+  if (!renderToCurrentTab) {
+    if (text) saveInputDraftForTab(tabId, text);
+    return false;
+  }
   // If the entire message was just the slash command, there's nothing
   // left to send to the agent — bail out after the side effect.
   if (!text) {

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -1579,6 +1579,12 @@ function markSelectedProviderUntested() {
   statusDot.title = providerSelect?.selectedOptions?.[0]?.textContent || providerSelect?.value || '';
 }
 
+function markSelectedProviderFailed(error) {
+  const msg = error?.message || t('sp.status.failed');
+  statusDot.className = 'status-dot offline';
+  statusDot.title = t('sp.status.error', { msg });
+}
+
 async function testConnection(options = {}) {
   const providerId = options.providerId || providerSelect.value;
   const requestId = ++providerTestRequestId;
@@ -3367,7 +3373,15 @@ clearBtn.addEventListener('click', async () => {
 providerSelect.addEventListener('change', async () => {
   const providerId = providerSelect.value;
   const requestId = ++providerSelectionRequestId;
-  await sendToBackground('set_active_provider', { providerId });
+  providerTestRequestId += 1;
+  try {
+    await sendToBackground('set_active_provider', { providerId });
+  } catch (e) {
+    if (requestId === providerSelectionRequestId && providerSelect.value === providerId) {
+      markSelectedProviderFailed(e);
+    }
+    return;
+  }
   if (requestId !== providerSelectionRequestId || providerSelect.value !== providerId) {
     const latestProviderId = providerSelect.value;
     if (latestProviderId && latestProviderId !== providerId) {

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -1936,6 +1936,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     verboseMode = !verboseMode;
     if (verboseBtn) verboseBtn.classList.toggle('active', verboseMode);
     await chrome.storage.local.set({ verboseMode }).catch(() => {});
+    if (currentTabId !== tabId) return '';
     addMessage('system', verboseMode
       ? t('sp.compact.verbose_on')
       : t('sp.compact.verbose_off'));

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -1400,8 +1400,9 @@ function setRecommendedActionsCollapsed(collapsed, { persist = true } = {}) {
 }
 
 if (recommendedActionsToggleEl) {
-  recommendedActionsToggleEl.addEventListener('click', () => {
-    setRecommendedActionsCollapsed(!recommendedActionsCollapsed);
+  recommendedActionsToggleEl.addEventListener('click', async () => {
+    await chrome.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: !recommendedActionsCollapsed }).catch(() => {});
+    setRecommendedActionsCollapsed(!recommendedActionsCollapsed, { persist: false });
   });
 }
 

--- a/src/chrome/src/ui/theme.js
+++ b/src/chrome/src/ui/theme.js
@@ -41,13 +41,13 @@ export function resolveTheme(mode) {
 }
 
 /** Apply a mode to <html data-theme="..."> and remember it. */
-export function applyMode(mode, opts = {}) {
+export async function applyMode(mode, opts = {}) {
   if (!THEME_MODES.includes(mode)) mode = DEFAULT_MODE;
   document.documentElement.setAttribute('data-theme', resolveTheme(mode));
   if (opts.persist !== false) {
     writeLocal(mode);
     if (opts.syncStorage !== false && globalThis.chrome?.storage?.local) {
-      chrome.storage.local.set({ themeMode: mode });
+      await chrome.storage.local.set({ themeMode: mode }).catch(() => {});
     }
   }
 }

--- a/src/firefox/src/ui/i18n.js
+++ b/src/firefox/src/ui/i18n.js
@@ -52,14 +52,14 @@ export function getLocale() {
   return currentLocale;
 }
 
-export function setLocale(code) {
+export async function setLocale(code) {
   if (!DICTS[code] || code === currentLocale) return;
   currentLocale = code;
   try { localStorage.setItem(LS_KEY, code); } catch { /* ignore */ }
   // Mirror to browser storage so other extension pages pick it up.
   try {
     const api = (typeof browser !== 'undefined' && browser?.storage) ? browser : (typeof chrome !== 'undefined' ? chrome : null);
-    api?.storage?.local?.set?.({ wbLocale: code });
+    await api?.storage?.local?.set?.({ wbLocale: code });
   } catch { /* ignore */ }
   applyDOMTranslations(document);
   document.dispatchEvent(new CustomEvent('wb-locale-changed', { detail: { code } }));

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1147,17 +1147,17 @@ function renderProviderFilterBar() {
     btn.className = `provider-filter-pill${providerFilter === f.key ? ' active' : ''}`;
     btn.dataset.filter = f.key;
     btn.textContent = t(f.labelKey);
-    btn.addEventListener('click', () => {
+    btn.addEventListener('click', async () => {
       if (providerFilter === f.key) return;
-    // Snapshot whatever the user has typed but not yet saved BEFORE we
-    // rebuild the DOM — otherwise input values for the currently-rendered
-    // cards are lost (e.g. typed an API key, then clicked a filter pill
-    // to compare two providers).
-    syncInputsIntoProvidersData();
-    providerFilter = f.key;
-    void browser.storage.local.set({ providerFilter: f.key }).catch(() => {});
-    renderProviders();
-  });
+      // Snapshot whatever the user has typed but not yet saved BEFORE we
+      // rebuild the DOM — otherwise input values for the currently-rendered
+      // cards are lost (e.g. typed an API key, then clicked a filter pill
+      // to compare two providers).
+      syncInputsIntoProvidersData();
+      providerFilter = f.key;
+      await browser.storage.local.set({ providerFilter: f.key }).catch(() => {});
+      renderProviders();
+    });
     bar.appendChild(btn);
   }
   return bar;

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -379,13 +379,13 @@ async function logout() {
   renderAuthSection();
 }
 
-window.addEventListener('message', (event) => {
+window.addEventListener('message', async (event) => {
   if (event.data?.type === 'WB_AUTH_TOKEN') {
     const { token, email, defaultModel } = event.data;
     authToken = token;
     authEmail = email;
     authDefaultModel = defaultModel || 'openai/gpt-4o';
-    browser.storage.local.set({ authToken, authEmail, authDefaultModel });
+    await browser.storage.local.set({ authToken, authEmail, authDefaultModel }).catch(() => {});
     renderAuthSection();
     autoConfigureWebbrainProvider();
   }
@@ -400,52 +400,52 @@ async function autoConfigureWebbrainProvider() {
 
 // --- Display Settings ---
 
-verboseToggle.addEventListener('change', () => {
-  browser.storage.local.set({ verboseMode: verboseToggle.checked });
+verboseToggle.addEventListener('change', async () => {
+  await browser.storage.local.set({ verboseMode: verboseToggle.checked }).catch(() => {});
 });
 
-screenshotToggle.addEventListener('change', () => {
-  browser.storage.local.set({ screenshotFallback: screenshotToggle.checked });
+screenshotToggle.addEventListener('change', async () => {
+  await browser.storage.local.set({ screenshotFallback: screenshotToggle.checked }).catch(() => {});
 });
 
 maxStepsRange.addEventListener('input', () => {
   stepsValueLabel.textContent = Number(maxStepsRange.value) === MAX_AGENT_STEPS_UNLIMITED_SENTINEL ? '∞' : maxStepsRange.value;
 });
 
-maxStepsRange.addEventListener('change', () => {
-  browser.storage.local.set({
+maxStepsRange.addEventListener('change', async () => {
+  await browser.storage.local.set({
     maxAgentSteps: Number(maxStepsRange.value) === MAX_AGENT_STEPS_UNLIMITED_SENTINEL
       ? 0
       : parseInt(maxStepsRange.value, 10),
-  });
+  }).catch(() => {});
 });
 
 if (requestTimeoutRange) {
   requestTimeoutRange.addEventListener('input', () => {
     requestTimeoutValueLabel.textContent = requestTimeoutRange.value + 's';
   });
-  requestTimeoutRange.addEventListener('change', () => {
+  requestTimeoutRange.addEventListener('change', async () => {
     const sec = parseInt(requestTimeoutRange.value, 10);
-    browser.storage.local.set({ requestTimeoutMs: sec * 1000 });
+    await browser.storage.local.set({ requestTimeoutMs: sec * 1000 }).catch(() => {});
   });
 }
 
-autoScreenshotSelect?.addEventListener('change', () => {
-  browser.storage.local.set({ autoScreenshot: autoScreenshotSelect.value });
+autoScreenshotSelect?.addEventListener('change', async () => {
+  await browser.storage.local.set({ autoScreenshot: autoScreenshotSelect.value }).catch(() => {});
 });
 
-siteAdaptersToggle?.addEventListener('change', () => {
-  browser.storage.local.set({ useSiteAdapters: siteAdaptersToggle.checked });
+siteAdaptersToggle?.addEventListener('change', async () => {
+  await browser.storage.local.set({ useSiteAdapters: siteAdaptersToggle.checked }).catch(() => {});
 });
 
-tracingToggle?.addEventListener('change', () => {
-  browser.storage.local.set({ tracingEnabled: tracingToggle.checked });
+tracingToggle?.addEventListener('change', async () => {
+  await browser.storage.local.set({ tracingEnabled: tracingToggle.checked }).catch(() => {});
 });
 
-costSessionLimitInput?.addEventListener('change', () => {
+costSessionLimitInput?.addEventListener('change', async () => {
   const value = normalizeCostAmount(costSessionLimitInput.value);
   costSessionLimitInput.value = value.toFixed(2);
-  browser.storage.local.set({ costAllowanceSessionUsd: value });
+  await browser.storage.local.set({ costAllowanceSessionUsd: value }).catch(() => {});
 });
 
 costTotalLimitInput?.addEventListener('change', async () => {
@@ -453,7 +453,7 @@ costTotalLimitInput?.addEventListener('change', async () => {
   costTotalLimitInput.value = value.toFixed(2);
   const stored = await browser.storage.local.get(['cloudCostSpentUsd']);
   renderCostAllowanceSpent(normalizeCostAmount(stored.cloudCostSpentUsd, 0), value);
-  browser.storage.local.set({ costAllowanceTotalUsd: value });
+  await browser.storage.local.set({ costAllowanceTotalUsd: value }).catch(() => {});
 });
 
 btnResetCostSpend?.addEventListener('click', async () => {
@@ -461,20 +461,20 @@ btnResetCostSpend?.addEventListener('click', async () => {
   renderCostAllowanceSpent(0, normalizeCostAmount(costTotalLimitInput?.value));
 });
 
-strictSecretToggle?.addEventListener('change', () => {
-  browser.storage.local.set({ strictSecretMode: strictSecretToggle.checked });
+strictSecretToggle?.addEventListener('change', async () => {
+  await browser.storage.local.set({ strictSecretMode: strictSecretToggle.checked }).catch(() => {});
 });
 
-allowLocalNetworkToggle?.addEventListener('change', () => {
-  browser.storage.local.set({ agentAllowLocalNetwork: allowLocalNetworkToggle.checked });
+allowLocalNetworkToggle?.addEventListener('change', async () => {
+  await browser.storage.local.set({ agentAllowLocalNetwork: allowLocalNetworkToggle.checked }).catch(() => {});
 });
 
-scheduledTasksToggle?.addEventListener('change', () => {
-  browser.storage.local.set({ scheduledTasksEnabled: scheduledTasksToggle.checked });
+scheduledTasksToggle?.addEventListener('change', async () => {
+  await browser.storage.local.set({ scheduledTasksEnabled: scheduledTasksToggle.checked }).catch(() => {});
 });
 
-scheduledConfirmToggle?.addEventListener('change', () => {
-  browser.storage.local.set({ scheduledRequireConsequentialConfirmation: scheduledConfirmToggle.checked });
+scheduledConfirmToggle?.addEventListener('change', async () => {
+  await browser.storage.local.set({ scheduledRequireConsequentialConfirmation: scheduledConfirmToggle.checked }).catch(() => {});
 });
 
 // --- Vision Model ---

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -102,8 +102,8 @@ renderSubtitle();
 if (languageSelect) {
   languageSelect.innerHTML = LANGUAGES.map((l) => `<option value="${l.code}">${l.label}</option>`).join('');
   languageSelect.value = getLocale();
-  languageSelect.addEventListener('change', () => {
-    setLocale(languageSelect.value);
+  languageSelect.addEventListener('change', async () => {
+    await setLocale(languageSelect.value);
     renderSubtitle();
     renderAuthSection();
     renderProviders();

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -479,10 +479,16 @@ scheduledConfirmToggle?.addEventListener('change', () => {
 
 // --- Vision Model ---
 
-function flashVisionResult(className, text) {
-  visionTestResult.className = `test-result show ${className}`;
+function showVisionResult(className, text, color = '') {
+  visionTestResult.className = `test-result show${className ? ` ${className}` : ''}`;
   visionTestResult.textContent = text;
-  setTimeout(() => visionTestResult.classList.remove('show'), 2000);
+  visionTestResult.style.color = color;
+  return visionTestResult;
+}
+
+function flashVisionResult(className, text) {
+  const resultEl = showVisionResult(className, text);
+  setTimeout(() => resultEl.classList.remove('show'), 2000);
 }
 
 btnSaveVision.addEventListener('click', async () => {
@@ -508,9 +514,8 @@ btnTestVision.addEventListener('click', async () => {
   const model = visionModelInput.value.trim();
 
   if (!baseUrl || !model) {
-    visionTestResult.className = 'test-result show fail';
-    visionTestResult.textContent = t('st.vision.fill_required');
-    setTimeout(() => visionTestResult.classList.remove('show'), 2500);
+    const resultEl = showVisionResult('fail', t('st.vision.fill_required'));
+    setTimeout(() => resultEl.classList.remove('show'), 2500);
     return;
   }
 
@@ -518,17 +523,17 @@ btnTestVision.addEventListener('click', async () => {
     visionModel: { baseUrl, apiKey, model },
   });
 
-  visionTestResult.className = 'test-result show';
-  visionTestResult.textContent = t('st.vision.testing');
-  visionTestResult.style.color = 'var(--text2)';
+  showVisionResult('', t('st.vision.testing'), 'var(--text2)');
 
-  const res = await sendToBackground('test_vision_provider');
-  if (res.ok) {
-    visionTestResult.className = 'test-result show ok';
-    visionTestResult.textContent = t('st.vision.connected', { model: res.model || model });
-  } else {
-    visionTestResult.className = 'test-result show fail';
-    visionTestResult.textContent = t('st.vision.failed', { error: res.error });
+  try {
+    const res = await sendToBackground('test_vision_provider');
+    if (res?.ok) {
+      showVisionResult('ok', t('st.vision.connected', { model: res.model || model }));
+    } else {
+      showVisionResult('fail', t('st.vision.failed', { error: res?.error || 'Unknown error' }));
+    }
+  } catch (e) {
+    showVisionResult('fail', t('st.vision.failed', { error: e.message }));
   }
 });
 
@@ -548,11 +553,17 @@ btnClearVision.addEventListener('click', async () => {
 // filled, and falls back to the auto-pick-from-providers behavior when
 // any field is empty.
 
-function flashTranscriptionResult(className, text) {
+function showTranscriptionResult(className, text, color = '') {
   if (!transcriptionTestResult) return;
-  transcriptionTestResult.className = `test-result show ${className}`;
+  transcriptionTestResult.className = `test-result show${className ? ` ${className}` : ''}`;
   transcriptionTestResult.textContent = text;
-  setTimeout(() => transcriptionTestResult.classList.remove('show'), 2000);
+  transcriptionTestResult.style.color = color;
+  return transcriptionTestResult;
+}
+
+function flashTranscriptionResult(className, text) {
+  const resultEl = showTranscriptionResult(className, text);
+  if (resultEl) setTimeout(() => resultEl.classList.remove('show'), 2000);
 }
 
 if (btnSaveTranscription) {
@@ -581,9 +592,8 @@ if (btnTestTranscription) {
     const model = transcriptionModelInput.value.trim();
 
     if (!baseUrl || !model) {
-      transcriptionTestResult.className = 'test-result show fail';
-      transcriptionTestResult.textContent = t('st.transcription.fill_required');
-      setTimeout(() => transcriptionTestResult.classList.remove('show'), 2500);
+      const resultEl = showTranscriptionResult('fail', t('st.transcription.fill_required'));
+      if (resultEl) setTimeout(() => resultEl.classList.remove('show'), 2500);
       return;
     }
 
@@ -591,17 +601,17 @@ if (btnTestTranscription) {
       transcriptionModel: { baseUrl, apiKey, model },
     });
 
-    transcriptionTestResult.className = 'test-result show';
-    transcriptionTestResult.textContent = t('st.transcription.testing');
-    transcriptionTestResult.style.color = 'var(--text2)';
+    showTranscriptionResult('', t('st.transcription.testing'), 'var(--text2)');
 
-    const res = await sendToBackground('test_transcription_provider');
-    if (res.ok) {
-      transcriptionTestResult.className = 'test-result show ok';
-      transcriptionTestResult.textContent = t('st.transcription.connected', { model: res.model || model });
-    } else {
-      transcriptionTestResult.className = 'test-result show fail';
-      transcriptionTestResult.textContent = t('st.transcription.failed', { error: res.error });
+    try {
+      const res = await sendToBackground('test_transcription_provider');
+      if (res?.ok) {
+        showTranscriptionResult('ok', t('st.transcription.connected', { model: res.model || model }));
+      } else {
+        showTranscriptionResult('fail', t('st.transcription.failed', { error: res?.error || 'Unknown error' }));
+      }
+    } catch (e) {
+      showTranscriptionResult('fail', t('st.transcription.failed', { error: e.message }));
     }
   });
 }
@@ -653,11 +663,17 @@ if (btnClearProfile) {
 // --- CapSolver (captcha solving) ---
 // Toggle persists immediately. The API key needs an explicit Save.
 
-function flashCaptchaResult(className, text) {
+function showCaptchaResult(className, text, color = '') {
   if (!captchaTestResult) return;
-  captchaTestResult.className = `test-result show ${className}`;
+  captchaTestResult.className = `test-result show${className ? ` ${className}` : ''}`;
   captchaTestResult.textContent = text;
-  setTimeout(() => captchaTestResult.classList.remove('show'), 3000);
+  captchaTestResult.style.color = color;
+  return captchaTestResult;
+}
+
+function flashCaptchaResult(className, text) {
+  const resultEl = showCaptchaResult(className, text);
+  if (resultEl) setTimeout(() => resultEl.classList.remove('show'), 3000);
 }
 
 if (captchaEnabledToggle) {
@@ -681,14 +697,16 @@ if (btnTestCaptcha) {
       flashCaptchaResult('fail', t('st.captcha.need_key'));
       return;
     }
-    captchaTestResult.className = 'test-result show';
-    captchaTestResult.textContent = t('st.captcha.checking');
-    captchaTestResult.style.color = 'var(--text2)';
-    const res = await sendToBackground('test_capsolver_balance', { apiKey: key });
-    if (res.ok) {
-      flashCaptchaResult('ok', t('st.captcha.balance_ok', { balance: `$${Number(res.balance).toFixed(4)}` }));
-    } else {
-      flashCaptchaResult('fail', t('st.captcha.balance_fail', { error: res.error }));
+    showCaptchaResult('', t('st.captcha.checking'), 'var(--text2)');
+    try {
+      const res = await sendToBackground('test_capsolver_balance', { apiKey: key });
+      if (res?.ok) {
+        flashCaptchaResult('ok', t('st.captcha.balance_ok', { balance: `$${Number(res.balance).toFixed(4)}` }));
+      } else {
+        flashCaptchaResult('fail', t('st.captcha.balance_fail', { error: res?.error || 'Unknown error' }));
+      }
+    } catch (e) {
+      flashCaptchaResult('fail', t('st.captcha.balance_fail', { error: e.message }));
     }
   });
 }
@@ -1290,34 +1308,42 @@ async function signOutOfClaude(id) {
   await refreshClaudeOAuthStatus(id);
 }
 
-async function loadProviderModels(id) {
+function setProviderLoadModelsStatus(id, message, color = 'var(--text2)') {
   const statusEl = document.querySelector(`.load-models-status[data-provider="${id}"]`);
-  const datalistEl = document.getElementById(`models-${id}`);
+  if (!statusEl) return null;
+  statusEl.textContent = message;
+  statusEl.style.color = color;
+  return statusEl;
+}
+
+async function loadProviderModels(id) {
+  let datalistEl = document.getElementById(`models-${id}`);
   if (!datalistEl) return;
   try {
     await saveProvider(id, { showFlash: false });
   } catch (e) {
-    if (statusEl) {
-      statusEl.textContent = e.message;
-      statusEl.style.color = 'var(--danger, #c33)';
-    }
+    setProviderLoadModelsStatus(id, e.message, 'var(--danger, #c33)');
     return;
   }
-  if (statusEl) statusEl.textContent = t('st.providers.loading');
-  const res = await sendToBackground('list_provider_models', { providerId: id });
-  if (res.ok) {
+
+  setProviderLoadModelsStatus(id, t('st.providers.loading'));
+  let res;
+  try {
+    res = await sendToBackground('list_provider_models', { providerId: id });
+  } catch (e) {
+    setProviderLoadModelsStatus(id, e.message, 'var(--danger, #c33)');
+    return;
+  }
+
+  datalistEl = document.getElementById(`models-${id}`);
+  if (!datalistEl) return;
+  if (res?.ok) {
     datalistEl.innerHTML = res.models
       .map((m) => `<option value="${escapeHtml(m)}"></option>`)
       .join('');
-    if (statusEl) {
-      statusEl.textContent = t('st.providers.models_loaded', { count: res.models.length });
-      statusEl.style.color = 'var(--text2)';
-    }
+    setProviderLoadModelsStatus(id, t('st.providers.models_loaded', { count: res.models.length }));
   } else {
-    if (statusEl) {
-      statusEl.textContent = res.error || 'Failed to load models';
-      statusEl.style.color = 'var(--danger, #c33)';
-    }
+    setProviderLoadModelsStatus(id, res?.error || 'Failed to load models', 'var(--danger, #c33)');
   }
 }
 

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -482,7 +482,7 @@ scheduledConfirmToggle?.addEventListener('change', () => {
 function showVisionResult(className, text, color = '') {
   visionTestResult.className = `test-result show${className ? ` ${className}` : ''}`;
   visionTestResult.textContent = text;
-  visionTestResult.style.color = color;
+  visionTestResult.style.color = color || '';
   return visionTestResult;
 }
 
@@ -557,7 +557,7 @@ function showTranscriptionResult(className, text, color = '') {
   if (!transcriptionTestResult) return;
   transcriptionTestResult.className = `test-result show${className ? ` ${className}` : ''}`;
   transcriptionTestResult.textContent = text;
-  transcriptionTestResult.style.color = color;
+  transcriptionTestResult.style.color = color || '';
   return transcriptionTestResult;
 }
 
@@ -667,7 +667,7 @@ function showCaptchaResult(className, text, color = '') {
   if (!captchaTestResult) return;
   captchaTestResult.className = `test-result show${className ? ` ${className}` : ''}`;
   captchaTestResult.textContent = text;
-  captchaTestResult.style.color = color;
+  captchaTestResult.style.color = color || '';
   return captchaTestResult;
 }
 
@@ -1352,7 +1352,7 @@ function setProviderTestResult(id, className, message, color) {
   if (!testEl) return null;
   testEl.className = `test-result show${className ? ` ${className}` : ''}`;
   testEl.textContent = message;
-  if (color) testEl.style.color = color;
+  testEl.style.color = color || '';
   return testEl;
 }
 

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1414,7 +1414,14 @@ async function activateProvider(id) {
   syncInputsIntoProvidersData();
   requestedActiveProviderId = id;
   const requestId = ++providerActivationRequestId;
-  await sendToBackground('set_active_provider', { providerId: id });
+  try {
+    await sendToBackground('set_active_provider', { providerId: id });
+  } catch (e) {
+    if (requestId === providerActivationRequestId && requestedActiveProviderId === id) {
+      setProviderTestResult(id, 'fail', t('st.providers.failed', { error: e.message }));
+    }
+    return;
+  }
   if (requestId !== providerActivationRequestId || requestedActiveProviderId !== id) {
     const latestProviderId = requestedActiveProviderId;
     if (latestProviderId) {

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -73,10 +73,10 @@ if (themeSelect) {
     themeSelect.value = mode;
     applyMode(mode, { syncStorage: false }); // already loaded, just paint
   });
-  themeSelect.addEventListener('change', () => {
+  themeSelect.addEventListener('change', async () => {
     const mode = THEME_MODES.includes(themeSelect.value) ? themeSelect.value : 'system';
     currentThemeMode = mode;
-    applyMode(mode);
+    await applyMode(mode);
   });
   watch(() => currentThemeMode);
   // If another Settings tab or the side panel flips the theme, watch()
@@ -639,8 +639,8 @@ function flashProfileResult(className, text) {
 }
 
 if (profileEnabledToggle) {
-  profileEnabledToggle.addEventListener('change', () => {
-    browser.storage.local.set({ profileEnabled: profileEnabledToggle.checked });
+  profileEnabledToggle.addEventListener('change', async () => {
+    await browser.storage.local.set({ profileEnabled: profileEnabledToggle.checked }).catch(() => {});
   });
 }
 
@@ -677,8 +677,8 @@ function flashCaptchaResult(className, text) {
 }
 
 if (captchaEnabledToggle) {
-  captchaEnabledToggle.addEventListener('change', () => {
-    browser.storage.local.set({ captchaSolverEnabled: captchaEnabledToggle.checked });
+  captchaEnabledToggle.addEventListener('change', async () => {
+    await browser.storage.local.set({ captchaSolverEnabled: captchaEnabledToggle.checked }).catch(() => {});
   });
 }
 
@@ -1149,15 +1149,15 @@ function renderProviderFilterBar() {
     btn.textContent = t(f.labelKey);
     btn.addEventListener('click', () => {
       if (providerFilter === f.key) return;
-      // Snapshot whatever the user has typed but not yet saved BEFORE we
-      // rebuild the DOM — otherwise input values for the currently-rendered
-      // cards are lost (e.g. typed an API key, then clicked a filter pill
-      // to compare two providers).
-      syncInputsIntoProvidersData();
-      providerFilter = f.key;
-      try { browser.storage.local.set({ providerFilter: f.key }); } catch {}
-      renderProviders();
-    });
+    // Snapshot whatever the user has typed but not yet saved BEFORE we
+    // rebuild the DOM — otherwise input values for the currently-rendered
+    // cards are lost (e.g. typed an API key, then clicked a filter pill
+    // to compare two providers).
+    syncInputsIntoProvidersData();
+    providerFilter = f.key;
+    void browser.storage.local.set({ providerFilter: f.key }).catch(() => {});
+    renderProviders();
+  });
     bar.appendChild(btn);
   }
   return bar;

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -402,7 +402,7 @@ function renderClearedConversationForTab(tabId) {
   if (currentTabId !== tabId) return;
   messagesEl.innerHTML = '';
   addMessage('system', t('sp.cleared_message'));
-  refreshScheduledJobs();
+  refreshScheduledJobs({ tabId });
   refreshRecommendedActions();
 }
 
@@ -648,11 +648,12 @@ function renderScheduledJobs(jobs = []) {
   ensureScheduledClarifyCards(visible);
 }
 
-async function refreshScheduledJobs() {
+async function refreshScheduledJobs({ tabId = null } = {}) {
   if (!scheduledJobsEl) return;
   try {
     const response = await sendToBackground('list_scheduled_jobs', { all: true });
     const jobs = response?.jobs || [];
+    if (tabId != null && currentTabId !== tabId) return jobs;
     renderScheduledJobs(jobs);
     return jobs;
   } catch (e) {
@@ -679,7 +680,7 @@ async function scheduledJobAction(action, jobId) {
         addMessage('error', t('sp.error_prefix', { msg: response.error || 'Scheduled job action failed.' }));
       }
     }
-    await refreshScheduledJobs();
+    await refreshScheduledJobs({ tabId });
   } catch (e) {
     if (currentTabId === tabId) {
       addMessage('error', t('sp.error_prefix', { msg: e.message }));
@@ -726,7 +727,7 @@ function settleScheduledRun(event, job) {
 }
 
 function handleScheduledJobEvent(data, tabId) {
-  refreshScheduledJobs();
+  refreshScheduledJobs({ tabId: currentTabId });
   const event = data?.event;
   const job = data?.job;
   if (!event || !job) return;
@@ -942,7 +943,7 @@ async function submitScheduleComposer(e, form) {
     if (textEl) {
       textEl.innerHTML = createdHtml;
     }
-    await refreshScheduledJobs();
+    await refreshScheduledJobs({ tabId });
   } catch (err) {
     if (currentTabId !== tabId) {
       updateCachedScheduleComposerError(tabId, form.dataset.composerId, err.message);
@@ -1146,7 +1147,7 @@ async function init() {
   if (activeTab?.id && activeTab.id !== currentTabId) {
     await switchToTab(activeTab.id);
   }
-  refreshScheduledJobs();
+  refreshScheduledJobs({ tabId: currentTabId });
   refreshRecommendedActions();
   await consumePendingContextMenuPrompt();
   drainQueuedContextMenuPrompts();
@@ -1233,7 +1234,7 @@ function switchToTab(newTabId) {
     addMessage('system', t('sp.help_message'));
   }
   scrollToBottom();
-  refreshScheduledJobs();
+  refreshScheduledJobs({ tabId: newTabId });
   refreshRecommendedActions();
   consumePendingContextMenuPrompt().then(() => drainQueuedContextMenuPrompts()).catch(() => {});
 }
@@ -1719,7 +1720,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
 
   // /list-schedules — refresh the scheduled job strip
   if (/^\/list-schedules\b\s*/i.test(text)) {
-    const jobs = await refreshScheduledJobs();
+    const jobs = await refreshScheduledJobs({ tabId });
     if (currentTabId !== tabId) return '';
     addMessage('system', visibleScheduledJobs(jobs).length
       ? t('sp.schedule_form.list_refreshed')
@@ -2562,40 +2563,43 @@ function showContinueButton() {
 }
 
 async function continueAgent() {
+  const tabId = currentTabId;
+  const modeForSend = agentMode;
   document.querySelectorAll('.continue-bar').forEach(el => el.remove());
 
   isProcessing = true;
   abortRequested = false;
   sendBtn.disabled = true;
 
-  currentAssistantEl = addMessage('assistant', '');
+  const assistantEl = addMessage('assistant', '');
+  currentAssistantEl = assistantEl;
   showActivity(t('sp.activity.continuing'));
 
   try {
     const res = await sendToBackground('continue', {
-      tabId: currentTabId,
-      mode: agentMode,
+      tabId,
+      mode: modeForSend,
     });
 
-    if (res?.content && currentAssistantEl) {
-      const textEl = currentAssistantEl.querySelector('.message-text');
+    if (currentTabId === tabId && res?.content && assistantEl) {
+      const textEl = assistantEl.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
         textEl.innerHTML = formatMarkdown(res.content);
-        addMessageCopyButton(currentAssistantEl);
+        addMessageCopyButton(assistantEl);
       }
     }
   } catch (e) {
-    if (!abortRequested) {
+    if (currentTabId === tabId && !abortRequested) {
       addMessage('error', t('sp.error_prefix', { msg: e.message }));
     }
   } finally {
-    finalizeSteps();
+    if (currentTabId === tabId) finalizeSteps(assistantEl);
     isProcessing = false;
     abortRequested = false;
     sendBtn.disabled = false;
     hideActivity();
-    currentAssistantEl = null;
-    scrollToBottom();
+    if (currentAssistantEl === assistantEl) currentAssistantEl = null;
+    if (currentTabId === tabId) scrollToBottom();
     await drainQueuedContextMenuPromptsAfterPendingTabSwitch();
   }
 }

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -2951,8 +2951,8 @@ if (languageSelect) {
     .map((l) => `<option value="${l.code}">${l.label}</option>`)
     .join('');
   languageSelect.value = getLocale();
-  languageSelect.addEventListener('change', () => {
-    setLocale(languageSelect.value);
+  languageSelect.addEventListener('change', async () => {
+    await setLocale(languageSelect.value);
     applyDOMTranslations(document);
   });
   document.addEventListener('wb-locale-changed', () => {

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -1268,8 +1268,9 @@ function setRecommendedActionsCollapsed(collapsed, { persist = true } = {}) {
 
 if (recommendedActionsToggleEl) {
   recommendedActionsToggleEl.addEventListener('click', async () => {
-    await browser.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: !recommendedActionsCollapsed }).catch(() => {});
-    setRecommendedActionsCollapsed(!recommendedActionsCollapsed, { persist: false });
+    const next = !recommendedActionsCollapsed;
+    await browser.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: next }).catch(() => {});
+    setRecommendedActionsCollapsed(next, { persist: false });
   });
 }
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -1269,8 +1269,8 @@ function setRecommendedActionsCollapsed(collapsed, { persist = true } = {}) {
 if (recommendedActionsToggleEl) {
   recommendedActionsToggleEl.addEventListener('click', async () => {
     const next = !recommendedActionsCollapsed;
-    await browser.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: next }).catch(() => {});
     setRecommendedActionsCollapsed(next, { persist: false });
+    await browser.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: next }).catch(() => {});
   });
 }
 
@@ -1754,8 +1754,9 @@ async function parseSlashCommands(text, tabId = currentTabId) {
   // /compact — force context compaction for this conversation
   const mCompact = text.match(/^\/compact\b\s*/i);
   if (mCompact) {
+    const remainder = text.slice(mCompact[0].length).trim();
     const res = await sendToBackground('compact_conversation', { tabId });
-    if (currentTabId !== tabId) return '';
+    if (currentTabId !== tabId) return remainder;
     if (res?.ok && res.compacted) {
       addContextCompactedNote({ ...res, manual: true });
     } else if (res?.ok && res.reason === 'busy') {
@@ -1765,7 +1766,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     } else {
       addMessage('system', tSystemHtml('sp.compact.failed', { error: res?.error || 'unknown error' }));
     }
-    return text.slice(mCompact[0].length).trim();
+    return remainder;
   }
 
   // /verbose — toggle verbose/compact tool display
@@ -1923,7 +1924,8 @@ async function sendMessage(extraChatParams) {
   }
 
   text = await parseSlashCommands(text, tabId);
-  if (currentTabId !== tabId) return false;
+  const renderToCurrentTab = currentTabId === tabId;
+  if (!renderToCurrentTab && !text) return false;
   if (!text) {
     inputEl.value = '';
     autoResizeInput();
@@ -1931,16 +1933,19 @@ async function sendMessage(extraChatParams) {
   }
 
   isProcessing = true;
-  hideRecommendedActions();
   abortRequested = false;
   sendBtn.disabled = true;
   inputEl.value = '';
   autoResizeInput();
 
-  addMessage('user', text);
-  showActivity(t('sp.activity.thinking'));
-
-  currentAssistantEl = addMessage('assistant', '');
+  let assistantEl = null;
+  if (renderToCurrentTab) {
+    hideRecommendedActions();
+    addMessage('user', text);
+    showActivity(t('sp.activity.thinking'));
+    assistantEl = addMessage('assistant', '');
+    currentAssistantEl = assistantEl;
+  }
 
   let accepted = false;
   try {
@@ -1953,33 +1958,35 @@ async function sendMessage(extraChatParams) {
     });
     accepted = true;
 
-    if (abortRequested) {
+    if (renderToCurrentTab && currentTabId === tabId && abortRequested) {
       // Agent was stopped — show what we got so far
-      const textEl = currentAssistantEl?.querySelector('.message-text');
+      const textEl = assistantEl?.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
         textEl.innerHTML = formatMarkdown(res?.content || t('sp.stopped_by_user'));
-        addMessageCopyButton(currentAssistantEl);
+        addMessageCopyButton(assistantEl);
       }
-    } else if (res?.content && currentAssistantEl) {
-      const textEl = currentAssistantEl.querySelector('.message-text');
+    } else if (renderToCurrentTab && currentTabId === tabId && res?.content && assistantEl) {
+      const textEl = assistantEl.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
         textEl.innerHTML = formatMarkdown(res.content);
-        addMessageCopyButton(currentAssistantEl);
+        addMessageCopyButton(assistantEl);
       }
     }
   } catch (e) {
-    if (!abortRequested) {
+    if (renderToCurrentTab && currentTabId === tabId && !abortRequested) {
       addMessage('error', t('sp.error_prefix', { msg: e.message }));
     }
   } finally {
-    finalizeSteps();
+    if (renderToCurrentTab && currentTabId === tabId) finalizeSteps(assistantEl);
     isProcessing = false;
     abortRequested = false;
     sendBtn.disabled = false;
     hideActivity();
-    currentAssistantEl = null;
-    scrollToBottom();
-    refreshRecommendedActions();
+    if (currentAssistantEl === assistantEl) currentAssistantEl = null;
+    if (renderToCurrentTab && currentTabId === tabId) {
+      scrollToBottom();
+      refreshRecommendedActions();
+    }
     await drainQueuedContextMenuPromptsAfterPendingTabSwitch();
   }
   return accepted;

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -1203,7 +1203,7 @@ if (verboseBtn) {
     // Normal click → toggle verbose mode
     verboseMode = !verboseMode;
     verboseBtn.classList.toggle('active', verboseMode);
-    browser.storage.local.set({ verboseMode }).catch(() => {});
+    await browser.storage.local.set({ verboseMode }).catch(() => {});
   });
 }
 
@@ -1262,7 +1262,7 @@ function setRecommendedActionsCollapsed(collapsed, { persist = true } = {}) {
   recommendedActionsCollapsed = Boolean(collapsed);
   updateRecommendedActionsCollapsedState();
   if (persist) {
-    browser.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: recommendedActionsCollapsed }).catch(() => {});
+    void browser.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: recommendedActionsCollapsed }).catch(() => {});
   }
 }
 
@@ -1770,7 +1770,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
   if (/^\/verbose\b\s*/i.test(text)) {
     verboseMode = !verboseMode;
     if (verboseBtn) verboseBtn.classList.toggle('active', verboseMode);
-    browser.storage.local.set({ verboseMode }).catch(() => {});
+    await browser.storage.local.set({ verboseMode }).catch(() => {});
     addMessage('system', verboseMode
       ? t('sp.compact.verbose_on')
       : t('sp.compact.verbose_off'));

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -2843,7 +2843,7 @@ async function ensureActMode() {
     if (!stored.actConfirmed) {
       const ok = confirm(t('sp.mode.act.confirm'));
       if (!ok) return false;
-      browser.storage.local.set({ actConfirmed: true }).catch(() => {});
+      await browser.storage.local.set({ actConfirmed: true }).catch(() => {});
     }
   } catch (e) { /* ignore */ }
   setMode('act');
@@ -2852,8 +2852,8 @@ async function ensureActMode() {
 
 modeAskBtn.addEventListener('click', () => setMode('ask'));
 
-modeActBtn.addEventListener('click', () => {
-  ensureActMode();
+modeActBtn.addEventListener('click', async () => {
+  await ensureActMode();
 });
 
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -56,8 +56,8 @@ if (globalThis.browser?.storage?.onChanged) {
   let localModelChoices = [];
   let cloudReady = false;
 
-  function dismissOnboarding() {
-    browser.storage.local.set({ onboardingComplete: true }).catch(() => {});
+  async function dismissOnboarding() {
+    await browser.storage.local.set({ onboardingComplete: true }).catch(() => {});
     overlay.classList.add('hidden');
   }
 
@@ -138,10 +138,10 @@ if (globalThis.browser?.storage?.onChanged) {
       changeLink.target = '_blank';
       changeLink.rel = 'noopener noreferrer';
       changeLink.textContent = 'Change';
-      changeLink.addEventListener('click', (event) => {
+      changeLink.addEventListener('click', async (event) => {
         event.preventDefault();
         openProviderSettings();
-        dismissOnboarding();
+        await dismissOnboarding();
       });
       providerStatus.append(
         document.createTextNode('Using WebBrain Cloud. '),
@@ -258,7 +258,7 @@ if (globalThis.browser?.storage?.onChanged) {
 
   settingsBtn.addEventListener('click', async () => {
     if (cloudReady) {
-      dismissOnboarding();
+      await dismissOnboarding();
       inputEl?.focus();
       return;
     }
@@ -289,10 +289,12 @@ if (globalThis.browser?.storage?.onChanged) {
     }
 
     openProviderSettings();
-    dismissOnboarding();
+    await dismissOnboarding();
   });
 
-  skipBtn.addEventListener('click', dismissOnboarding);
+  skipBtn.addEventListener('click', async () => {
+    await dismissOnboarding();
+  });
 })();
 
 const messagesEl = document.getElementById('messages');

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -390,17 +390,46 @@ function updateActWarning() {
 
 // Per-tab chat history (stores innerHTML of messages container)
 const tabChats = new Map();
+const tabInputDrafts = new Map();
 
 function clearCachedTabChat(tabId) {
   if (tabId == null) return;
   tabChats.delete(tabId);
 }
 
+function saveInputDraftForTab(tabId, text) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return;
+  const draft = String(text || '');
+  if (draft.trim()) {
+    tabInputDrafts.set(numericTabId, draft);
+  } else {
+    tabInputDrafts.delete(numericTabId);
+  }
+}
+
+function captureInputDraftForTab(tabId) {
+  if (!inputEl) return;
+  saveInputDraftForTab(tabId, inputEl.value || '');
+}
+
+function restoreInputDraftForTab(tabId) {
+  if (!inputEl) return;
+  const numericTabId = Number(tabId);
+  const draft = Number.isFinite(numericTabId) ? tabInputDrafts.get(numericTabId) || '' : '';
+  inputEl.value = draft;
+  autoResizeInput();
+  updateSlashCommandAutocomplete();
+}
+
 function renderClearedConversationForTab(tabId) {
   clearCachedTabChat(tabId);
+  saveInputDraftForTab(tabId, '');
   setApiMutationsAllowedForTab(tabId, false);
   if (currentTabId !== tabId) return;
   messagesEl.innerHTML = '';
+  inputEl.value = '';
+  autoResizeInput();
   addMessage('system', t('sp.cleared_message'));
   refreshScheduledJobs({ tabId });
   refreshRecommendedActions();
@@ -1219,6 +1248,7 @@ function switchToTab(newTabId) {
   // Save current tab's chat
   if (currentTabId != null) {
     tabChats.set(currentTabId, messagesEl.innerHTML);
+    captureInputDraftForTab(currentTabId);
   }
 
   currentTabId = newTabId;
@@ -1233,6 +1263,7 @@ function switchToTab(newTabId) {
     messagesEl.innerHTML = '';
     addMessage('system', t('sp.help_message'));
   }
+  restoreInputDraftForTab(newTabId);
   scrollToBottom();
   refreshScheduledJobs({ tabId: newTabId });
   refreshRecommendedActions();
@@ -1919,6 +1950,7 @@ async function sendMessage(extraChatParams) {
   const tabId = currentTabId;
   const modeForSend = /^\/(?:ask|plan)\b/i.test(text) ? 'ask' : agentMode;
   const apiMutationsAllowedForSend = isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);
+  saveInputDraftForTab(tabId, '');
   hideSlashCommandAutocomplete();
 
   if (text.startsWith('/')) {
@@ -1928,7 +1960,10 @@ async function sendMessage(extraChatParams) {
 
   text = await parseSlashCommands(text, tabId);
   const renderToCurrentTab = currentTabId === tabId;
-  if (!renderToCurrentTab && !text) return false;
+  if (!renderToCurrentTab) {
+    if (text) saveInputDraftForTab(tabId, text);
+    return false;
+  }
   if (!text) {
     inputEl.value = '';
     autoResizeInput();

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -1700,7 +1700,7 @@ function syncApiMutationsAllowedForCurrentTab() {
   updateApiBadge();
 }
 
-async function parseSlashCommands(text) {
+async function parseSlashCommands(text, tabId = currentTabId) {
   // /help — list all available slash commands
   if (/^\/help\b\s*/i.test(text)) {
     addMessage('system', t('sp.help_html'));
@@ -1709,7 +1709,6 @@ async function parseSlashCommands(text) {
 
   // /list-schedules — refresh the scheduled job strip
   if (/^\/list-schedules\b\s*/i.test(text)) {
-    const tabId = currentTabId;
     const jobs = await refreshScheduledJobs();
     if (currentTabId !== tabId) return '';
     addMessage('system', visibleScheduledJobs(jobs).length
@@ -1720,21 +1719,20 @@ async function parseSlashCommands(text) {
 
   // /show-scratchpad — dump the current tab's agent scratchpad
   if (/^\/show-scratchpad\b\s*/i.test(text)) {
-    await showScratchpad(currentTabId);
+    await showScratchpad(tabId);
     return '';
   }
 
   // /schedule — open a deterministic scheduled-task composer
   const mSchedule = text.match(/^\/schedule\b\s*/i);
   if (mSchedule) {
-    renderScheduleComposer(text.slice(mSchedule[0].length).trim(), currentTabId);
+    renderScheduleComposer(text.slice(mSchedule[0].length).trim(), tabId);
     return '';
   }
 
   // /allow-api — enable API mutation override
   const mApi = text.match(/^\/allow-api\b\s*/i);
   if (mApi) {
-    const tabId = currentTabId;
     const wasAlreadyAllowed = isApiMutationsAllowedForTab(tabId);
     setApiMutationsAllowedForTab(tabId, true);
     if (!wasAlreadyAllowed) {
@@ -1746,7 +1744,6 @@ async function parseSlashCommands(text) {
   // /compact — force context compaction for this conversation
   const mCompact = text.match(/^\/compact\b\s*/i);
   if (mCompact) {
-    const tabId = currentTabId;
     const res = await sendToBackground('compact_conversation', { tabId });
     if (currentTabId !== tabId) return '';
     if (res?.ok && res.compacted) {
@@ -1774,7 +1771,6 @@ async function parseSlashCommands(text) {
 
   // /reset — clear conversation (same as clear button)
   if (/^\/reset\b\s*/i.test(text)) {
-    const tabId = currentTabId;
     await sendToBackground('clear_conversation', { tabId });
     renderClearedConversationForTab(tabId);
     return '';
@@ -1782,7 +1778,6 @@ async function parseSlashCommands(text) {
 
   // /screenshot — capture visible tab and display in chat
   if (/^\/screenshot\b\s*/i.test(text)) {
-    const tabId = currentTabId;
     try {
       const tab = tabId == null ? null : await browser.tabs.get(tabId);
       if (currentTabId !== tabId || !tab?.active) return '';
@@ -1838,7 +1833,6 @@ async function parseSlashCommands(text) {
 
   // /profile — toggle profile auto-fill on/off
   if (/^\/profile\b\s*/i.test(text)) {
-    const tabId = currentTabId;
     const stored = await browser.storage.local.get(['profileEnabled', 'profileText']);
     const newState = !stored.profileEnabled;
     await browser.storage.local.set({ profileEnabled: newState });
@@ -1866,7 +1860,6 @@ async function parseSlashCommands(text) {
 
   // /vision — toggle vision support on active provider
   if (/^\/vision\b\s*/i.test(text)) {
-    const tabId = currentTabId;
     try {
       const { providers, active } = await sendToBackground('get_providers');
       const config = providers[active];
@@ -1910,6 +1903,7 @@ function updateApiBadge() {
 async function sendMessage(extraChatParams) {
   let text = inputEl.value.trim();
   if (!text || isProcessing) return;
+  const tabId = currentTabId;
   hideSlashCommandAutocomplete();
 
   if (text.startsWith('/')) {
@@ -1917,7 +1911,8 @@ async function sendMessage(extraChatParams) {
     autoResizeInput();
   }
 
-  text = await parseSlashCommands(text);
+  text = await parseSlashCommands(text, tabId);
+  if (currentTabId !== tabId) return false;
   if (!text) {
     inputEl.value = '';
     autoResizeInput();
@@ -1939,7 +1934,7 @@ async function sendMessage(extraChatParams) {
   let accepted = false;
   try {
     const res = await sendToBackground('chat', {
-      tabId: currentTabId,
+      tabId,
       text,
       mode: agentMode,
       apiMutationsAllowed,

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -1916,6 +1916,8 @@ async function sendMessage(extraChatParams) {
   let text = inputEl.value.trim();
   if (!text || isProcessing) return;
   const tabId = currentTabId;
+  const modeForSend = /^\/(?:ask|plan)\b/i.test(text) ? 'ask' : agentMode;
+  const apiMutationsAllowedForSend = isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);
   hideSlashCommandAutocomplete();
 
   if (text.startsWith('/')) {
@@ -1932,14 +1934,13 @@ async function sendMessage(extraChatParams) {
     return;
   }
 
-  isProcessing = true;
-  abortRequested = false;
-  sendBtn.disabled = true;
-  inputEl.value = '';
-  autoResizeInput();
-
   let assistantEl = null;
   if (renderToCurrentTab) {
+    isProcessing = true;
+    abortRequested = false;
+    sendBtn.disabled = true;
+    inputEl.value = '';
+    autoResizeInput();
     hideRecommendedActions();
     addMessage('user', text);
     showActivity(t('sp.activity.thinking'));
@@ -1952,8 +1953,8 @@ async function sendMessage(extraChatParams) {
     const res = await sendToBackground('chat', {
       tabId,
       text,
-      mode: agentMode,
-      apiMutationsAllowed,
+      mode: modeForSend,
+      apiMutationsAllowed: apiMutationsAllowedForSend,
       ...extraChatParams,
     });
     accepted = true;
@@ -1978,10 +1979,12 @@ async function sendMessage(extraChatParams) {
     }
   } finally {
     if (renderToCurrentTab && currentTabId === tabId) finalizeSteps(assistantEl);
-    isProcessing = false;
-    abortRequested = false;
-    sendBtn.disabled = false;
-    hideActivity();
+    if (renderToCurrentTab) {
+      isProcessing = false;
+      abortRequested = false;
+      sendBtn.disabled = false;
+      hideActivity();
+    }
     if (currentAssistantEl === assistantEl) currentAssistantEl = null;
     if (renderToCurrentTab && currentTabId === tabId) {
       scrollToBottom();

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -1772,6 +1772,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     verboseMode = !verboseMode;
     if (verboseBtn) verboseBtn.classList.toggle('active', verboseMode);
     await browser.storage.local.set({ verboseMode }).catch(() => {});
+    if (currentTabId !== tabId) return '';
     addMessage('system', verboseMode
       ? t('sp.compact.verbose_on')
       : t('sp.compact.verbose_off'));

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -1267,8 +1267,9 @@ function setRecommendedActionsCollapsed(collapsed, { persist = true } = {}) {
 }
 
 if (recommendedActionsToggleEl) {
-  recommendedActionsToggleEl.addEventListener('click', () => {
-    setRecommendedActionsCollapsed(!recommendedActionsCollapsed);
+  recommendedActionsToggleEl.addEventListener('click', async () => {
+    await browser.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: !recommendedActionsCollapsed }).catch(() => {});
+    setRecommendedActionsCollapsed(!recommendedActionsCollapsed, { persist: false });
   });
 }
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -1446,6 +1446,12 @@ function markSelectedProviderUntested() {
   statusDot.title = providerSelect?.selectedOptions?.[0]?.textContent || providerSelect?.value || '';
 }
 
+function markSelectedProviderFailed(error) {
+  const msg = error?.message || t('sp.status.failed');
+  statusDot.className = 'status-dot offline';
+  statusDot.title = t('sp.status.error', { msg });
+}
+
 async function testConnection(options = {}) {
   const providerId = options.providerId || providerSelect.value;
   const requestId = ++providerTestRequestId;
@@ -2912,7 +2918,15 @@ clearBtn.addEventListener('click', async () => {
 providerSelect.addEventListener('change', async () => {
   const providerId = providerSelect.value;
   const requestId = ++providerSelectionRequestId;
-  await sendToBackground('set_active_provider', { providerId });
+  providerTestRequestId += 1;
+  try {
+    await sendToBackground('set_active_provider', { providerId });
+  } catch (e) {
+    if (requestId === providerSelectionRequestId && providerSelect.value === providerId) {
+      markSelectedProviderFailed(e);
+    }
+    return;
+  }
   if (requestId !== providerSelectionRequestId || providerSelect.value !== providerId) {
     const latestProviderId = providerSelect.value;
     if (latestProviderId && latestProviderId !== providerId) {

--- a/src/firefox/src/ui/theme.js
+++ b/src/firefox/src/ui/theme.js
@@ -41,13 +41,13 @@ export function resolveTheme(mode) {
 }
 
 /** Apply a mode to <html data-theme="..."> and remember it. */
-export function applyMode(mode, opts = {}) {
+export async function applyMode(mode, opts = {}) {
   if (!THEME_MODES.includes(mode)) mode = DEFAULT_MODE;
   document.documentElement.setAttribute('data-theme', resolveTheme(mode));
   if (opts.persist !== false) {
     writeLocal(mode);
     if (opts.syncStorage !== false && globalThis.browser?.storage?.local) {
-      browser.storage.local.set({ themeMode: mode });
+      await browser.storage.local.set({ themeMode: mode }).catch(() => {});
     }
   }
 }

--- a/test/run.js
+++ b/test/run.js
@@ -3027,6 +3027,18 @@ test('settings waits for immediate preference writes and theme persistence', () 
       /export async function applyMode\(mode, opts = \{\}\) \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ themeMode: mode \}\)\.catch\(\(\) => \{\}\);[\s\S]*?\}/,
       `${label}: shared theme helper should await storage persistence`,
     );
+
+    const i18n = fs.readFileSync(path.join(ROOT, label === 'chrome' ? 'src/chrome/src/ui/i18n.js' : 'src/firefox/src/ui/i18n.js'), 'utf8');
+    assert.match(
+      i18n,
+      /export async function setLocale\(code\) \{[\s\S]*?await api\?\.storage\?\.local\?\.set\?\.?\(\{ wbLocale: code \}\);[\s\S]*?applyDOMTranslations\(document\);/,
+      `${label}: locale helper should await storage persistence before broadcasting`,
+    );
+    assert.match(
+      settings,
+      /languageSelect\.addEventListener\('change', async \(\) => \{[\s\S]*?await setLocale\(languageSelect\.value\);[\s\S]*?renderSubtitle\(\);/,
+      `${label}: settings language change should await locale persistence`,
+    );
   }
 });
 
@@ -3165,6 +3177,20 @@ test('sidepanel awaits recommended-actions collapse persistence', () => {
       panel,
       /recommendedActionsToggleEl\.addEventListener\('click', async \(\) => \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ \[RECOMMENDED_ACTIONS_COLLAPSED_KEY\]: !recommendedActionsCollapsed \}\)\.catch\(\(\) => \{\}\);[\s\S]*?setRecommendedActionsCollapsed\(!recommendedActionsCollapsed, \{ persist: false \}\);[\s\S]*?\}\);/,
       `${label}: recommended-actions collapse should await persistence`,
+    );
+  }
+});
+
+test('sidepanel language changes await locale persistence', () => {
+  for (const [label, panelRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    assert.match(
+      panel,
+      /languageSelect\.addEventListener\('change', async \(\) => \{[\s\S]*?await setLocale\(languageSelect\.value\);[\s\S]*?applyDOMTranslations\(document\);/,
+      `${label}: sidepanel language change should await locale persistence`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -2657,7 +2657,7 @@ test('sidepanel does not miss startup tab switches before consuming tab-scoped s
     const testConnectionIdx = body.indexOf("await testConnection({ skipWebBrainCloud: true });");
     const resyncQueryIdx = body.lastIndexOf('tabs.query({ active: true, currentWindow: true })');
     const resyncSwitchIdx = body.indexOf('await switchToTab(activeTab.id);');
-    const refreshJobsIdx = body.indexOf('refreshScheduledJobs();', resyncSwitchIdx);
+    const refreshJobsIdx = body.indexOf('refreshScheduledJobs({ tabId: currentTabId });', resyncSwitchIdx);
     const refreshActionsIdx = body.indexOf('refreshRecommendedActions();', resyncSwitchIdx);
     const consumeIdx = body.indexOf('await consumePendingContextMenuPrompt();', resyncSwitchIdx);
     assert.notEqual(listenerIdx, -1, `${label}: startup should register tab activation listener`);
@@ -3092,12 +3092,12 @@ test('sidepanel scopes allow-api override to the tab conversation', () => {
 
     const switchStart = panel.indexOf('function switchToTab(newTabId)');
     assert.notEqual(switchStart, -1, `${label}: switchToTab missing`);
-    const switchBody = panel.slice(switchStart, panel.indexOf('refreshScheduledJobs();', switchStart));
+    const switchBody = panel.slice(switchStart, panel.indexOf('refreshScheduledJobs({', switchStart));
     assert.match(switchBody, /currentTabId = newTabId;[\s\S]*?syncApiMutationsAllowedForCurrentTab\(\);/, `${label}: switching tabs should load the selected tab's /allow-api state`);
 
     const resetStart = panel.indexOf('function renderClearedConversationForTab(tabId)');
     assert.notEqual(resetStart, -1, `${label}: renderClearedConversationForTab missing`);
-    const resetBody = panel.slice(resetStart, panel.indexOf('refreshScheduledJobs();', resetStart));
+    const resetBody = panel.slice(resetStart, panel.indexOf('refreshScheduledJobs({', resetStart));
     assert.match(resetBody, /clearCachedTabChat\(tabId\);[\s\S]*?setApiMutationsAllowedForTab\(tabId, false\);[\s\S]*?if \(currentTabId !== tabId\) return;/, `${label}: reset should clear the target tab's /allow-api state before visible-tab guards`);
 
     const allowIdx = panel.indexOf('// /allow-api');
@@ -3120,6 +3120,7 @@ test('sidepanel scopes async tab commands to the original tab', () => {
     assert.notEqual(helperStart, -1, `${label}: clear helper missing`);
     const helperBody = panel.slice(helperStart, panel.indexOf('\n}', helperStart) + 2);
     assert.match(helperBody, /clearCachedTabChat\(tabId\);[\s\S]*?if \(currentTabId !== tabId\) return;[\s\S]*?messagesEl\.innerHTML = '';/, `${label}: clear helper should clear cached target tab and only mutate visible UI for the same tab`);
+    assert.match(helperBody, /refreshScheduledJobs\(\{ tabId \}\);/, `${label}: clear helper should scope async scheduled-job refresh to the cleared tab`);
 
     const resetIdx = panel.indexOf("// /reset");
     const resetBody = panel.slice(resetIdx, panel.indexOf("// /screenshot", resetIdx));
@@ -3136,7 +3137,10 @@ test('sidepanel scopes async tab commands to the original tab', () => {
 
     const listIdx = panel.indexOf('// /list-schedules');
     const listBody = panel.slice(listIdx, panel.indexOf('// /show-scratchpad', listIdx));
-    assert.match(listBody, /const jobs = await refreshScheduledJobs\(\);[\s\S]*?if \(currentTabId !== tabId\) return '';/, `${label}: /list-schedules should not render a result into a different tab`);
+    assert.match(listBody, /const jobs = await refreshScheduledJobs\(\{ tabId \}\);[\s\S]*?if \(currentTabId !== tabId\) return '';/, `${label}: /list-schedules should not render or refresh results into a different tab`);
+
+    assert.match(panel, /async function refreshScheduledJobs\(\{ tabId = null \} = \{\}\) \{[\s\S]*?const jobs = response\?\.jobs \|\| \[\];[\s\S]*?if \(tabId != null && currentTabId !== tabId\) return jobs;[\s\S]*?renderScheduledJobs\(jobs\);/, `${label}: scheduled-job refreshes should be able to drop stale tab completions before rendering`);
+    assert.match(panel, /await refreshScheduledJobs\(\{ tabId \}\);/, `${label}: tab-scoped scheduled-job actions should not repaint a later visible tab`);
 
     assert.match(panel, /async function showScratchpad\(tabId = currentTabId\) \{[\s\S]*?sendToBackground\('get_scratchpad', \{ tabId \}\);[\s\S]*?if \(currentTabId !== tabId\) return;[\s\S]*?catch \(e\) \{[\s\S]*?if \(currentTabId !== tabId\) return;[\s\S]*?sp\.scratchpad\.error/, `${label}: /show-scratchpad should not render success or error results into a different tab`);
     assert.match(panel, /\/\/ \/show-scratchpad[\s\S]*?await showScratchpad\(tabId\);/, `${label}: /show-scratchpad should use the initiating tab id from the parser`);
@@ -3241,6 +3245,23 @@ test('sidepanel sends residual slash-command prompts to the initiating tab', () 
       /sendToBackground\('chat', \{[\s\S]*?tabId: currentTabId/,
       `${label}: chat dispatch should not read currentTabId after slash parsing`,
     );
+  }
+});
+
+test('sidepanel continue runs use the initiating tab state', () => {
+  for (const [label, panelRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    const match = panel.match(/async function continueAgent\(\) \{[\s\S]*?\n\}/);
+    assert.ok(match, `${label}: continueAgent missing`);
+    const body = match[0];
+    assert.match(body, /const tabId = currentTabId;[\s\S]*?const modeForSend = agentMode;[\s\S]*?sendToBackground\('continue', \{[\s\S]*?tabId,[\s\S]*?mode: modeForSend,/, `${label}: Continue should send with the tab and mode captured before awaiting`);
+    assert.doesNotMatch(body, /sendToBackground\('continue', \{[\s\S]*?tabId: currentTabId/, `${label}: Continue should not read currentTabId inside the async send payload`);
+    assert.doesNotMatch(body, /sendToBackground\('continue', \{[\s\S]*?mode: agentMode/, `${label}: Continue should not read agentMode inside the async send payload`);
+    assert.match(body, /const assistantEl = addMessage\('assistant', ''\);[\s\S]*?currentAssistantEl = assistantEl;[\s\S]*?if \(currentTabId === tabId && res\?\.content && assistantEl\) \{[\s\S]*?addMessageCopyButton\(assistantEl\);/, `${label}: Continue should render only into its captured assistant bubble for the initiating tab`);
+    assert.match(body, /if \(currentTabId === tabId\) finalizeSteps\(assistantEl\);[\s\S]*?if \(currentAssistantEl === assistantEl\) currentAssistantEl = null;/, `${label}: Continue should finalize and clear only its captured assistant bubble`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -2535,8 +2535,8 @@ test('sidepanel reports missing background responses without res.content crash',
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
     assert.match(panel, /No response from WebBrain background/, `${label}: missing background response should become a clear error`);
     assert.match(panel, /response == null/, `${label}: sendToBackground should reject nullish responses`);
-    assert.equal((panel.match(/res\?\.content && currentAssistantEl/g) || []).length >= 2, true, `${label}: chat and continue should not dereference missing responses`);
-    assert.doesNotMatch(panel, /(?:else\s+)?if \(res\.content && currentAssistantEl\)/, `${label}: unsafe res.content render guard returned`);
+    assert.equal((panel.match(/res\?\.content && (?:currentAssistantEl|assistantEl)/g) || []).length >= 2, true, `${label}: chat and continue should not dereference missing responses`);
+    assert.doesNotMatch(panel, /res\.content && (?:currentAssistantEl|assistantEl)/, `${label}: unsafe res.content render guard returned`);
   }
 });
 
@@ -3132,7 +3132,7 @@ test('sidepanel scopes async tab commands to the original tab', () => {
 
     const compactIdx = panel.indexOf('// /compact');
     const compactBody = panel.slice(compactIdx, panel.indexOf('// /verbose', compactIdx));
-    assert.match(compactBody, /sendToBackground\('compact_conversation', \{ tabId \}\);[\s\S]*?if \(currentTabId !== tabId\) return '';/, `${label}: /compact should not render a result into a different tab`);
+    assert.match(compactBody, /const remainder = text\.slice\(mCompact\[0\]\.length\)\.trim\(\);[\s\S]*?sendToBackground\('compact_conversation', \{ tabId \}\);[\s\S]*?if \(currentTabId !== tabId\) return remainder;/, `${label}: /compact should preserve residual prompt text after tab switches without rendering into a different tab`);
 
     const listIdx = panel.indexOf('// /list-schedules');
     const listBody = panel.slice(listIdx, panel.indexOf('// /show-scratchpad', listIdx));
@@ -3189,8 +3189,8 @@ test('sidepanel awaits recommended-actions collapse persistence', () => {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
     assert.match(
       panel,
-      /recommendedActionsToggleEl\.addEventListener\('click', async \(\) => \{[\s\S]*?const next = !recommendedActionsCollapsed;[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ \[RECOMMENDED_ACTIONS_COLLAPSED_KEY\]: next \}\)\.catch\(\(\) => \{\}\);[\s\S]*?setRecommendedActionsCollapsed\(next, \{ persist: false \}\);[\s\S]*?\}\);/,
-      `${label}: recommended-actions collapse should capture the target state before awaiting persistence`,
+      /recommendedActionsToggleEl\.addEventListener\('click', async \(\) => \{[\s\S]*?const next = !recommendedActionsCollapsed;[\s\S]*?setRecommendedActionsCollapsed\(next, \{ persist: false \}\);[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ \[RECOMMENDED_ACTIONS_COLLAPSED_KEY\]: next \}\)\.catch\(\(\) => \{\}\);[\s\S]*?\}\);/,
+      `${label}: recommended-actions collapse should update local state before awaiting persistence`,
     );
   }
 });
@@ -3220,8 +3220,13 @@ test('sidepanel sends residual slash-command prompts to the initiating tab', () 
     const sendBody = sendMatch[0];
     assert.match(
       sendBody,
-      /const tabId = currentTabId;[\s\S]*?text = await parseSlashCommands\(text, tabId\);[\s\S]*?if \(currentTabId !== tabId\) return false;[\s\S]*?sendToBackground\('chat', \{[\s\S]*?tabId,[\s\S]*?text,/,
-      `${label}: residual slash-command prompts should use the tab captured before async parsing`,
+      /const tabId = currentTabId;[\s\S]*?text = await parseSlashCommands\(text, tabId\);[\s\S]*?const renderToCurrentTab = currentTabId === tabId;[\s\S]*?if \(!renderToCurrentTab && !text\) return false;[\s\S]*?sendToBackground\('chat', \{[\s\S]*?tabId,[\s\S]*?text,/,
+      `${label}: residual slash-command prompts should still dispatch to the tab captured before async parsing`,
+    );
+    assert.match(
+      sendBody,
+      /if \(renderToCurrentTab\) \{[\s\S]*?addMessage\('user', text\);[\s\S]*?currentAssistantEl = assistantEl;[\s\S]*?\}/,
+      `${label}: stale-tab residual sends should not render chat UI into the currently visible tab`,
     );
     assert.doesNotMatch(
       sendBody,

--- a/test/run.js
+++ b/test/run.js
@@ -3017,8 +3017,8 @@ test('settings waits for immediate preference writes and theme persistence', () 
     );
     assert.match(
       settings,
-      /try \{[\s\S]*?void (chrome|browser)\.storage\.local\.set\(\{ providerFilter: f\.key \}\)\.catch\(\(\) => \{\}\);[\s\S]*?renderProviders\(\);/,
-      `${label}: provider filter changes should still persist even if the render rebuilds immediately`,
+      /btn\.addEventListener\('click', async \(\) => \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ providerFilter: f\.key \}\)\.catch\(\(\) => \{\}\);[\s\S]*?renderProviders\(\);[\s\S]*?\}\);/,
+      `${label}: provider filter clicks should await persistence before rerendering`,
     );
 
     const theme = fs.readFileSync(path.join(ROOT, label === 'chrome' ? 'src/chrome/src/ui/theme.js' : 'src/firefox/src/ui/theme.js'), 'utf8');

--- a/test/run.js
+++ b/test/run.js
@@ -2608,7 +2608,12 @@ test('chrome sidepanel serializes tab-chat storage writes with clears and reads'
   const panel = fs.readFileSync(path.join(ROOT, 'src/chrome/src/ui/sidepanel.js'), 'utf8');
   assert.match(panel, /const tabChatOperations = new Map\(\);/, 'chrome: tab-chat operations should be queued per tab');
   assert.match(panel, /function enqueueTabChatOperation\(tabId, fn\) \{[\s\S]*?const previous = tabChatOperations\.get\(numericTabId\) \|\| Promise\.resolve\(\);[\s\S]*?tabChatOperations\.set\(numericTabId, operation\);[\s\S]*?\}/, 'chrome: tab-chat writes should be serialized behind prior operations');
-  assert.match(panel, /async function loadTabChat\(tabId\) \{[\s\S]*?return await enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{[\s\S]*?const stored = await chrome\.storage\.session\.get\(key\);/, 'chrome: tab-chat restore should read session storage on the queue');
+  const loadStart = panel.indexOf('async function loadTabChat(tabId) {');
+  assert.notEqual(loadStart, -1, 'chrome: loadTabChat missing');
+  const loadBody = panel.slice(loadStart, panel.indexOf('\n}\n\nfunction persistTabChat', loadStart) + 2);
+  assert.match(loadBody, /const numericTabId = Number\(tabId\);[\s\S]*?if \(!Number\.isFinite\(numericTabId\)\) return null;/, 'chrome: tab-chat restore should normalize tab ids before checking the cache');
+  assert.match(loadBody, /if \(!tabChatOperations\.has\(numericTabId\) && tabChats\.has\(numericTabId\)\) return tabChats\.get\(numericTabId\);/, 'chrome: tab-chat restore should only trust cached HTML when no queued operation can update it');
+  assert.match(loadBody, /return await enqueueTabChatOperation\(numericTabId, async \(queuedTabId\) => \{[\s\S]*?if \(tabChats\.has\(queuedTabId\)\) return tabChats\.get\(queuedTabId\);[\s\S]*?const stored = await chrome\.storage\.session\.get\(key\);/, 'chrome: tab-chat restore should wait behind pending per-tab operations before reading cache or storage');
   assert.match(panel, /return enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{[\s\S]*?await chrome\.storage\.session\.set\(\{ \[key\]: html \}\)\.catch\(\(\) => \{\}\);/, 'chrome: tab-chat persistence should be serialized through the queue');
   const clearStart = panel.indexOf('function clearCachedTabChat(tabId) {');
   assert.notEqual(clearStart, -1, 'chrome: clearCachedTabChat missing');

--- a/test/run.js
+++ b/test/run.js
@@ -2604,6 +2604,20 @@ test('chrome sidepanel persists tab chat to the tab captured before debounce', (
   assert.doesNotMatch(body, /persistTabChat\(currentTabId,\s*messagesEl\.innerHTML\)/, 'chrome: debounced persistence should not save live DOM under the later currentTabId');
 });
 
+test('chrome sidepanel serializes tab-chat storage writes with clears and reads', () => {
+  const panel = fs.readFileSync(path.join(ROOT, 'src/chrome/src/ui/sidepanel.js'), 'utf8');
+  assert.match(panel, /const tabChatOperations = new Map\(\);/, 'chrome: tab-chat operations should be queued per tab');
+  assert.match(panel, /function enqueueTabChatOperation\(tabId, fn\) \{[\s\S]*?const previous = tabChatOperations\.get\(numericTabId\) \|\| Promise\.resolve\(\);[\s\S]*?tabChatOperations\.set\(numericTabId, operation\);[\s\S]*?\}/, 'chrome: tab-chat writes should be serialized behind prior operations');
+  assert.match(panel, /async function waitForTabChatOperation\(tabId\) \{[\s\S]*?await operation;[\s\S]*?\}/, 'chrome: tab-chat reads should wait for in-flight operations');
+  assert.match(panel, /async function loadTabChat\(tabId\) \{[\s\S]*?await waitForTabChatOperation\(tabId\);[\s\S]*?const stored = await chrome\.storage\.session\.get\(key\);/, 'chrome: tab-chat restore should wait before reading session storage');
+  assert.match(panel, /return enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{[\s\S]*?await chrome\.storage\.session\.set\(\{ \[key\]: html \}\)\.catch\(\(\) => \{\}\);/, 'chrome: tab-chat persistence should be serialized through the queue');
+  const clearStart = panel.indexOf('function clearCachedTabChat(tabId) {');
+  assert.notEqual(clearStart, -1, 'chrome: clearCachedTabChat missing');
+  const clearBody = panel.slice(clearStart, panel.indexOf('\n}\n\nfunction renderClearedConversationForTab', clearStart) + 2);
+  assert.match(clearBody, /return enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{/, 'chrome: clearing tab chat should be serialized through the queue');
+  assert.match(clearBody, /tabChats\.delete\(numericTabId\);[\s\S]*?chrome\.storage\.session\?\.remove\(TAB_CHAT_PREFIX \+ numericTabId\)/, 'chrome: clearing tab chat should remove the stored HTML after queued writes settle');
+});
+
 test('chrome sidepanel cancels stale tab-chat persistence when clearing a tab', () => {
   const panel = fs.readFileSync(path.join(ROOT, 'src/chrome/src/ui/sidepanel.js'), 'utf8');
   assert.match(panel, /let persistTimer = null;\s*let persistTimerTabId = null;/, 'chrome: pending persistence should remember its target tab');
@@ -2622,7 +2636,7 @@ test('chrome sidepanel cancels stale tab-chat persistence when clearing a tab', 
   const clearBody = panel.slice(clearStart, panel.indexOf('\n}\n\nfunction renderClearedConversationForTab', clearStart) + 2);
   assert.match(
     clearBody,
-    /if \(persistTimer && persistTimerTabId === tabId\) \{[\s\S]*?clearTimeout\(persistTimer\);[\s\S]*?persistTimer = null;[\s\S]*?persistTimerTabId = null;[\s\S]*?\}[\s\S]*?tabChats\.delete\(tabId\);[\s\S]*?chrome\.storage\.session\?\.remove\(TAB_CHAT_PREFIX \+ tabId\)/,
+    /if \(persistTimer && persistTimerTabId === tabId\) \{[\s\S]*?clearTimeout\(persistTimer\);[\s\S]*?persistTimer = null;[\s\S]*?persistTimerTabId = null;[\s\S]*?\}[\s\S]*?return enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{[\s\S]*?tabChats\.delete\(numericTabId\);[\s\S]*?chrome\.storage\.session\?\.remove\(TAB_CHAT_PREFIX \+ numericTabId\)/,
     'chrome: clearing a tab should cancel any pending stale write before removing cached chat',
   );
 });

--- a/test/run.js
+++ b/test/run.js
@@ -2608,7 +2608,7 @@ test('chrome sidepanel serializes tab-chat storage writes with clears and reads'
   const panel = fs.readFileSync(path.join(ROOT, 'src/chrome/src/ui/sidepanel.js'), 'utf8');
   assert.match(panel, /const tabChatOperations = new Map\(\);/, 'chrome: tab-chat operations should be queued per tab');
   assert.match(panel, /function enqueueTabChatOperation\(tabId, fn\) \{[\s\S]*?const previous = tabChatOperations\.get\(numericTabId\) \|\| Promise\.resolve\(\);[\s\S]*?tabChatOperations\.set\(numericTabId, operation\);[\s\S]*?\}/, 'chrome: tab-chat writes should be serialized behind prior operations');
-  assert.match(panel, /async function waitForTabChatOperation\(tabId\) \{[\s\S]*?await operation;[\s\S]*?\}/, 'chrome: tab-chat reads should wait for in-flight operations');
+  assert.match(panel, /async function waitForTabChatOperation\(tabId\) \{[\s\S]*?while \(true\) \{[\s\S]*?const operation = tabChatOperations\.get\(numericTabId\);[\s\S]*?await operation;[\s\S]*?if \(tabChatOperations\.get\(numericTabId\) === operation\) return;[\s\S]*?\}/, 'chrome: tab-chat reads should keep waiting while newer in-flight operations are queued');
   assert.match(panel, /async function loadTabChat\(tabId\) \{[\s\S]*?await waitForTabChatOperation\(tabId\);[\s\S]*?const stored = await chrome\.storage\.session\.get\(key\);/, 'chrome: tab-chat restore should wait before reading session storage');
   assert.match(panel, /return enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{[\s\S]*?await chrome\.storage\.session\.set\(\{ \[key\]: html \}\)\.catch\(\(\) => \{\}\);/, 'chrome: tab-chat persistence should be serialized through the queue');
   const clearStart = panel.indexOf('function clearCachedTabChat(tabId) {');

--- a/test/run.js
+++ b/test/run.js
@@ -2608,8 +2608,7 @@ test('chrome sidepanel serializes tab-chat storage writes with clears and reads'
   const panel = fs.readFileSync(path.join(ROOT, 'src/chrome/src/ui/sidepanel.js'), 'utf8');
   assert.match(panel, /const tabChatOperations = new Map\(\);/, 'chrome: tab-chat operations should be queued per tab');
   assert.match(panel, /function enqueueTabChatOperation\(tabId, fn\) \{[\s\S]*?const previous = tabChatOperations\.get\(numericTabId\) \|\| Promise\.resolve\(\);[\s\S]*?tabChatOperations\.set\(numericTabId, operation\);[\s\S]*?\}/, 'chrome: tab-chat writes should be serialized behind prior operations');
-  assert.match(panel, /async function waitForTabChatOperation\(tabId\) \{[\s\S]*?while \(true\) \{[\s\S]*?const operation = tabChatOperations\.get\(numericTabId\);[\s\S]*?await operation;[\s\S]*?if \(tabChatOperations\.get\(numericTabId\) === operation\) return;[\s\S]*?\}/, 'chrome: tab-chat reads should keep waiting while newer in-flight operations are queued');
-  assert.match(panel, /async function loadTabChat\(tabId\) \{[\s\S]*?await waitForTabChatOperation\(tabId\);[\s\S]*?const stored = await chrome\.storage\.session\.get\(key\);/, 'chrome: tab-chat restore should wait before reading session storage');
+  assert.match(panel, /async function loadTabChat\(tabId\) \{[\s\S]*?return await enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{[\s\S]*?const stored = await chrome\.storage\.session\.get\(key\);/, 'chrome: tab-chat restore should read session storage on the queue');
   assert.match(panel, /return enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{[\s\S]*?await chrome\.storage\.session\.set\(\{ \[key\]: html \}\)\.catch\(\(\) => \{\}\);/, 'chrome: tab-chat persistence should be serialized through the queue');
   const clearStart = panel.indexOf('function clearCachedTabChat(tabId) {');
   assert.notEqual(clearStart, -1, 'chrome: clearCachedTabChat missing');

--- a/test/run.js
+++ b/test/run.js
@@ -2994,6 +2994,30 @@ test('settings async test controls surface rejected background results', () => {
   }
 });
 
+test('settings page awaits immediate preference writes before moving on', () => {
+  for (const [label, settingsRel] of [
+    ['chrome', 'src/chrome/src/ui/settings.js'],
+    ['firefox', 'src/firefox/src/ui/settings.js'],
+  ]) {
+    const settings = fs.readFileSync(path.join(ROOT, settingsRel), 'utf8');
+    assert.match(
+      settings,
+      /window\.addEventListener\('message', async \(event\) => \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ authToken, authEmail, authDefaultModel \}\)\.catch\(\(\) => \{\}\);[\s\S]*?renderAuthSection\(\);/,
+      `${label}: auth token hydration should persist before the settings UI proceeds`,
+    );
+    assert.match(
+      settings,
+      /verboseToggle\.addEventListener\('change', async \(\) => \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ verboseMode: verboseToggle\.checked \}\)\.catch\(\(\) => \{\}\);[\s\S]*?\}\);/,
+      `${label}: verbose toggle should await its storage write`,
+    );
+    assert.match(
+      settings,
+      /requestTimeoutRange\.addEventListener\('change', async \(\) => \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ requestTimeoutMs: sec \* 1000 \}\)\.catch\(\(\) => \{\}\);[\s\S]*?\}\);/,
+      `${label}: request timeout changes should await persistence`,
+    );
+  }
+});
+
 test('sidepanel scopes allow-api override to the tab conversation', () => {
   for (const [label, panelRel] of [
     ['chrome', 'src/chrome/src/ui/sidepanel.js'],
@@ -3073,6 +3097,25 @@ test('sidepanel scopes async tab commands to the original tab', () => {
     const visionIdx = panel.indexOf('// /vision');
     const visionBody = panel.slice(visionIdx, panel.indexOf('return text;', visionIdx));
     assert.match(visionBody, /sendToBackground\('get_providers'\);[\s\S]*?sendToBackground\('update_provider'[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?addMessage\('system'/, `${label}: /vision should not render a result into a different tab`);
+  }
+});
+
+test('sidepanel awaits immediate verbose preference writes', () => {
+  for (const [label, panelRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    assert.match(
+      panel,
+      /verboseMode = !verboseMode;[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ verboseMode \}\)\.catch\(\(\) => \{\}\);/,
+      `${label}: verbose toggles should await persistence before continuing`,
+    );
+    assert.match(
+      panel,
+      /if \(\s*\/\^\\\/verbose\\b\\s\*\/i\.test\(text\)\s*\) \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ verboseMode \}\)\.catch\(\(\) => \{\}\);/,
+      `${label}: /verbose should await persistence before echoing the mode change`,
+    );
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -2613,8 +2613,9 @@ test('chrome sidepanel serializes tab-chat storage writes with clears and reads'
   const clearStart = panel.indexOf('function clearCachedTabChat(tabId) {');
   assert.notEqual(clearStart, -1, 'chrome: clearCachedTabChat missing');
   const clearBody = panel.slice(clearStart, panel.indexOf('\n}\n\nfunction renderClearedConversationForTab', clearStart) + 2);
+  assert.match(clearBody, /tabChats\.delete\(tabId\);/, 'chrome: clearing tab chat should delete the cached HTML before queuing storage removal');
   assert.match(clearBody, /return enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{/, 'chrome: clearing tab chat should be serialized through the queue');
-  assert.match(clearBody, /tabChats\.delete\(numericTabId\);[\s\S]*?chrome\.storage\.session\?\.remove\(TAB_CHAT_PREFIX \+ numericTabId\)/, 'chrome: clearing tab chat should remove the stored HTML after queued writes settle');
+  assert.match(clearBody, /chrome\.storage\.session\?\.remove\(TAB_CHAT_PREFIX \+ numericTabId\)/, 'chrome: clearing tab chat should remove the stored HTML after queued writes settle');
 });
 
 test('chrome sidepanel cancels stale tab-chat persistence when clearing a tab', () => {
@@ -2635,7 +2636,7 @@ test('chrome sidepanel cancels stale tab-chat persistence when clearing a tab', 
   const clearBody = panel.slice(clearStart, panel.indexOf('\n}\n\nfunction renderClearedConversationForTab', clearStart) + 2);
   assert.match(
     clearBody,
-    /if \(persistTimer && persistTimerTabId === tabId\) \{[\s\S]*?clearTimeout\(persistTimer\);[\s\S]*?persistTimer = null;[\s\S]*?persistTimerTabId = null;[\s\S]*?\}[\s\S]*?return enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{[\s\S]*?tabChats\.delete\(numericTabId\);[\s\S]*?chrome\.storage\.session\?\.remove\(TAB_CHAT_PREFIX \+ numericTabId\)/,
+    /if \(persistTimer && persistTimerTabId === tabId\) \{[\s\S]*?clearTimeout\(persistTimer\);[\s\S]*?persistTimer = null;[\s\S]*?persistTimerTabId = null;[\s\S]*?\}[\s\S]*?tabChats\.delete\(tabId\);[\s\S]*?return enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{[\s\S]*?chrome\.storage\.session\?\.remove\(TAB_CHAT_PREFIX \+ numericTabId\)/,
     'chrome: clearing a tab should cancel any pending stale write before removing cached chat',
   );
 });
@@ -3188,8 +3189,8 @@ test('sidepanel awaits recommended-actions collapse persistence', () => {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
     assert.match(
       panel,
-      /recommendedActionsToggleEl\.addEventListener\('click', async \(\) => \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ \[RECOMMENDED_ACTIONS_COLLAPSED_KEY\]: !recommendedActionsCollapsed \}\)\.catch\(\(\) => \{\}\);[\s\S]*?setRecommendedActionsCollapsed\(!recommendedActionsCollapsed, \{ persist: false \}\);[\s\S]*?\}\);/,
-      `${label}: recommended-actions collapse should await persistence`,
+      /recommendedActionsToggleEl\.addEventListener\('click', async \(\) => \{[\s\S]*?const next = !recommendedActionsCollapsed;[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ \[RECOMMENDED_ACTIONS_COLLAPSED_KEY\]: next \}\)\.catch\(\(\) => \{\}\);[\s\S]*?setRecommendedActionsCollapsed\(next, \{ persist: false \}\);[\s\S]*?\}\);/,
+      `${label}: recommended-actions collapse should capture the target state before awaiting persistence`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -2810,9 +2810,12 @@ test('settings provider save and test status updates are DOM-safe', () => {
     const settings = fs.readFileSync(path.join(ROOT, settingsRel), 'utf8');
     assert.match(
       settings,
-      /function setProviderTestResult\(id, className, message, color\) \{[\s\S]*?const testEl = document\.getElementById\(`test-\$\{id\}`\);[\s\S]*?if \(!testEl\) return null;[\s\S]*?testEl\.className = `test-result show\$\{className \? ` \$\{className\}` : ''\}`;[\s\S]*?return testEl;[\s\S]*?\}/,
+      /function setProviderTestResult\(id, className, message, color\) \{[\s\S]*?const testEl = document\.getElementById\(`test-\$\{id\}`\);[\s\S]*?if \(!testEl\) return null;[\s\S]*?testEl\.className = `test-result show\$\{className \? ` \$\{className\}` : ''\}`;[\s\S]*?testEl\.style\.color = color \|\| '';[\s\S]*?return testEl;[\s\S]*?\}/,
       `${label}: provider status writes should tolerate re-rendered or filtered-away cards`,
     );
+    assert.match(settings, /visionTestResult\.style\.color = color \|\| '';/, `${label}: vision results should clear stale inline colors`);
+    assert.match(settings, /transcriptionTestResult\.style\.color = color \|\| '';/, `${label}: transcription results should clear stale inline colors`);
+    assert.match(settings, /captchaTestResult\.style\.color = color \|\| '';/, `${label}: captcha results should clear stale inline colors`);
 
     const saveStart = settings.indexOf('async function saveProvider(id, { showFlash = true } = {}) {');
     assert.notEqual(saveStart, -1, `${label}: saveProvider missing`);
@@ -2871,17 +2874,17 @@ test('settings async test controls surface rejected background results', () => {
 
     assert.match(
       settings,
-      /function showVisionResult\(className, text, color = ''\) \{[\s\S]*?visionTestResult\.style\.color = color;[\s\S]*?return visionTestResult;[\s\S]*?\}/,
+      /function showVisionResult\(className, text, color = ''\) \{[\s\S]*?visionTestResult\.style\.color = color \|\| '';[\s\S]*?return visionTestResult;[\s\S]*?\}/,
       `${label}: vision status helper should clear stale inline colors and return the current node`,
     );
     assert.match(
       settings,
-      /function showTranscriptionResult\(className, text, color = ''\) \{[\s\S]*?if \(!transcriptionTestResult\) return;[\s\S]*?transcriptionTestResult\.style\.color = color;[\s\S]*?return transcriptionTestResult;[\s\S]*?\}/,
+      /function showTranscriptionResult\(className, text, color = ''\) \{[\s\S]*?if \(!transcriptionTestResult\) return;[\s\S]*?transcriptionTestResult\.style\.color = color \|\| '';[\s\S]*?return transcriptionTestResult;[\s\S]*?\}/,
       `${label}: transcription status helper should clear stale inline colors and tolerate absent controls`,
     );
     assert.match(
       settings,
-      /function showCaptchaResult\(className, text, color = ''\) \{[\s\S]*?if \(!captchaTestResult\) return;[\s\S]*?captchaTestResult\.style\.color = color;[\s\S]*?return captchaTestResult;[\s\S]*?\}/,
+      /function showCaptchaResult\(className, text, color = ''\) \{[\s\S]*?if \(!captchaTestResult\) return;[\s\S]*?captchaTestResult\.style\.color = color \|\| '';[\s\S]*?return captchaTestResult;[\s\S]*?\}/,
       `${label}: captcha status helper should clear stale inline colors and tolerate absent controls`,
     );
 

--- a/test/run.js
+++ b/test/run.js
@@ -2795,8 +2795,79 @@ test('settings provider save and test status updates are DOM-safe', () => {
     const loadBody = settings.slice(loadStart, settings.indexOf('\n}\n\nfunction setProviderTestResult', loadStart) + 2);
     assert.match(
       loadBody,
-      /try \{[\s\S]*?await saveProvider\(id, \{ showFlash: false \}\);[\s\S]*?\} catch \(e\) \{[\s\S]*?statusEl\.textContent = e\.message;[\s\S]*?return;[\s\S]*?\}/,
+      /try \{[\s\S]*?await saveProvider\(id, \{ showFlash: false \}\);[\s\S]*?\} catch \(e\) \{[\s\S]*?setProviderLoadModelsStatus\(id, e\.message, 'var\(--danger, #c33\)'\);[\s\S]*?return;[\s\S]*?\}/,
       `${label}: model loading should stop and report if the pre-save fails`,
+    );
+  }
+});
+
+test('settings async test controls surface rejected background results', () => {
+  for (const [label, settingsRel] of [
+    ['chrome', 'src/chrome/src/ui/settings.js'],
+    ['firefox', 'src/firefox/src/ui/settings.js'],
+  ]) {
+    const settings = fs.readFileSync(path.join(ROOT, settingsRel), 'utf8');
+
+    assert.match(
+      settings,
+      /function showVisionResult\(className, text, color = ''\) \{[\s\S]*?visionTestResult\.style\.color = color;[\s\S]*?return visionTestResult;[\s\S]*?\}/,
+      `${label}: vision status helper should clear stale inline colors and return the current node`,
+    );
+    assert.match(
+      settings,
+      /function showTranscriptionResult\(className, text, color = ''\) \{[\s\S]*?if \(!transcriptionTestResult\) return;[\s\S]*?transcriptionTestResult\.style\.color = color;[\s\S]*?return transcriptionTestResult;[\s\S]*?\}/,
+      `${label}: transcription status helper should clear stale inline colors and tolerate absent controls`,
+    );
+    assert.match(
+      settings,
+      /function showCaptchaResult\(className, text, color = ''\) \{[\s\S]*?if \(!captchaTestResult\) return;[\s\S]*?captchaTestResult\.style\.color = color;[\s\S]*?return captchaTestResult;[\s\S]*?\}/,
+      `${label}: captcha status helper should clear stale inline colors and tolerate absent controls`,
+    );
+
+    const visionStart = settings.indexOf("btnTestVision.addEventListener('click', async () => {");
+    assert.notEqual(visionStart, -1, `${label}: vision test handler missing`);
+    const visionBody = settings.slice(visionStart, settings.indexOf('\n});\n\nbtnClearVision', visionStart) + 4);
+    assert.match(
+      visionBody,
+      /showVisionResult\('', t\('st\.vision\.testing'\), 'var\(--text2\)'\);[\s\S]*?try \{[\s\S]*?const res = await sendToBackground\('test_vision_provider'\);[\s\S]*?showVisionResult\('ok'[\s\S]*?showVisionResult\('fail'[\s\S]*?\} catch \(e\) \{[\s\S]*?showVisionResult\('fail', t\('st\.vision\.failed', \{ error: e\.message \}\)\);[\s\S]*?\}/,
+      `${label}: rejected vision provider checks should replace the testing state with a failure`,
+    );
+
+    const transcriptionStart = settings.indexOf("btnTestTranscription.addEventListener('click', async () => {");
+    assert.notEqual(transcriptionStart, -1, `${label}: transcription test handler missing`);
+    const transcriptionEnd = settings.indexOf('\n  });\n}\n\nif (btnClearTranscription', transcriptionStart);
+    assert.notEqual(transcriptionEnd, -1, `${label}: transcription test handler boundary missing`);
+    const transcriptionBody = settings.slice(transcriptionStart, transcriptionEnd + 7);
+    assert.match(
+      transcriptionBody,
+      /showTranscriptionResult\('', t\('st\.transcription\.testing'\), 'var\(--text2\)'\);[\s\S]*?try \{[\s\S]*?const res = await sendToBackground\('test_transcription_provider'\);[\s\S]*?showTranscriptionResult\('ok'[\s\S]*?showTranscriptionResult\('fail'[\s\S]*?\} catch \(e\) \{[\s\S]*?showTranscriptionResult\('fail', t\('st\.transcription\.failed', \{ error: e\.message \}\)\);[\s\S]*?\}/,
+      `${label}: rejected transcription provider checks should replace the testing state with a failure`,
+    );
+
+    const captchaStart = settings.indexOf("btnTestCaptcha.addEventListener('click', async () => {");
+    assert.notEqual(captchaStart, -1, `${label}: captcha test handler missing`);
+    const captchaEnd = settings.indexOf('\n  });\n}\n\nif (btnClearCaptcha', captchaStart);
+    assert.notEqual(captchaEnd, -1, `${label}: captcha test handler boundary missing`);
+    const captchaBody = settings.slice(captchaStart, captchaEnd + 7);
+    assert.match(
+      captchaBody,
+      /showCaptchaResult\('', t\('st\.captcha\.checking'\), 'var\(--text2\)'\);[\s\S]*?try \{[\s\S]*?const res = await sendToBackground\('test_capsolver_balance', \{ apiKey: key \}\);[\s\S]*?flashCaptchaResult\('ok'[\s\S]*?flashCaptchaResult\('fail'[\s\S]*?\} catch \(e\) \{[\s\S]*?flashCaptchaResult\('fail', t\('st\.captcha\.balance_fail', \{ error: e\.message \}\)\);[\s\S]*?\}/,
+      `${label}: rejected captcha balance checks should replace the checking state with a failure`,
+    );
+
+    assert.match(
+      settings,
+      /function setProviderLoadModelsStatus\(id, message, color = 'var\(--text2\)'\) \{[\s\S]*?document\.querySelector\(`\.load-models-status\[data-provider="\$\{id\}"\]`\);[\s\S]*?statusEl\.textContent = message;[\s\S]*?statusEl\.style\.color = color;[\s\S]*?return statusEl;[\s\S]*?\}/,
+      `${label}: model-load status writes should re-query the current provider card`,
+    );
+
+    const loadStart = settings.indexOf('async function loadProviderModels(id) {');
+    assert.notEqual(loadStart, -1, `${label}: loadProviderModels missing`);
+    const loadBody = settings.slice(loadStart, settings.indexOf('\n}\n\nfunction setProviderTestResult', loadStart) + 2);
+    assert.match(
+      loadBody,
+      /let datalistEl = document\.getElementById\(`models-\$\{id\}`\);[\s\S]*?setProviderLoadModelsStatus\(id, t\('st\.providers\.loading'\)\);[\s\S]*?try \{[\s\S]*?res = await sendToBackground\('list_provider_models', \{ providerId: id \}\);[\s\S]*?\} catch \(e\) \{[\s\S]*?setProviderLoadModelsStatus\(id, e\.message, 'var\(--danger, #c33\)'\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?datalistEl = document\.getElementById\(`models-\$\{id\}`\);[\s\S]*?if \(!datalistEl\) return;[\s\S]*?setProviderLoadModelsStatus\(id, res\?\.error \|\| 'Failed to load models', 'var\(--danger, #c33\)'\);/,
+      `${label}: model loading should report rejected background results and avoid stale datalist writes`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -2717,6 +2717,35 @@ test('sidepanel drops stale recommended-action clicks after async act confirmati
   }
 });
 
+test('sidepanel awaits act confirmation persistence before switching modes', () => {
+  for (const [label, panelRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    const ensureStart = panel.indexOf('async function ensureActMode() {');
+    assert.notEqual(ensureStart, -1, `${label}: ensureActMode missing`);
+    const ensureBody = panel.slice(ensureStart, panel.indexOf('\n}\n\nmodeAskBtn.addEventListener', ensureStart) + 2);
+    assert.match(
+      ensureBody,
+      /const stored = await (chrome|browser)\.storage\.local\.get\('actConfirmed'\);[\s\S]*?if \(!stored\.actConfirmed\) \{[\s\S]*?const ok = confirm\(t\('sp\.mode\.act\.confirm'\)\);[\s\S]*?if \(!ok\) return false;[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ actConfirmed: true \}\)\.catch\(\(\) => \{\}\);[\s\S]*?\}[\s\S]*?setMode\('act'\);/,
+      `${label}: act confirmation should persist before mode switches to Act`,
+    );
+    assert.match(
+      panel,
+      /modeActBtn\.addEventListener\('click', async \(\) => \{[\s\S]*?await ensureActMode\(\);[\s\S]*?\}\);/,
+      `${label}: Act button should await confirmation persistence`,
+    );
+    if (label === 'chrome') {
+      assert.match(
+        panel,
+        /async function handleGlobalKeydown\(e\) \{[\s\S]*?await ensureActMode\(\);[\s\S]*?\}/,
+        `${label}: Ctrl+Shift+X should await act confirmation persistence`,
+      );
+    }
+  }
+});
+
 test('sidepanel drops stale provider selection and connection checks', () => {
   for (const [label, panelRel] of [
     ['chrome', 'src/chrome/src/ui/sidepanel.js'],

--- a/test/run.js
+++ b/test/run.js
@@ -3213,12 +3213,21 @@ test('sidepanel language changes await locale persistence', () => {
   }
 });
 
-test('sidepanel sends residual slash-command prompts to the initiating tab', () => {
+test('sidepanel preserves stale residual slash-command prompts without hidden runs', () => {
   for (const [label, panelRel] of [
     ['chrome', 'src/chrome/src/ui/sidepanel.js'],
     ['firefox', 'src/firefox/src/ui/sidepanel.js'],
   ]) {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    assert.match(panel, /const tabInputDrafts = new Map\(\);/, `${label}: sidepanel should track per-tab composer drafts`);
+    assert.match(panel, /function saveInputDraftForTab\(tabId, text\) \{[\s\S]*?tabInputDrafts\.set\(numericTabId, draft\);[\s\S]*?tabInputDrafts\.delete\(numericTabId\);[\s\S]*?\}/, `${label}: tab drafts should save non-empty text and clear empty text`);
+    assert.match(panel, /function restoreInputDraftForTab\(tabId\) \{[\s\S]*?inputEl\.value = draft;[\s\S]*?autoResizeInput\(\);[\s\S]*?updateSlashCommandAutocomplete\(\);[\s\S]*?\}/, `${label}: tab drafts should restore into the composer when returning to a tab`);
+
+    const switchStart = panel.indexOf('function switchToTab(newTabId)');
+    assert.notEqual(switchStart, -1, `${label}: switchToTab missing`);
+    const switchBody = panel.slice(switchStart, panel.indexOf('refreshScheduledJobs({', switchStart));
+    assert.match(switchBody, /captureInputDraftForTab\(currentTabId\);[\s\S]*?restoreInputDraftForTab\(newTabId\);/, `${label}: tab switches should capture and restore per-tab composer drafts`);
+
     const sendMatch = panel.match(/async function sendMessage\(extraChatParams\) \{[\s\S]*?\n  return accepted;\n\}/);
     assert.ok(sendMatch, `${label}: sendMessage missing`);
     const sendBody = sendMatch[0];
@@ -3232,9 +3241,14 @@ test('sidepanel sends residual slash-command prompts to the initiating tab', () 
     assert.equal(modeCaptureIdx < parseIdx && apiCaptureIdx < parseIdx, true, `${label}: stale-tab residual sends should not read visible-tab options after slash parsing`);
     assert.match(
       sendBody,
-      /const tabId = currentTabId;[\s\S]*?text = await parseSlashCommands\(text, tabId\);[\s\S]*?const renderToCurrentTab = currentTabId === tabId;[\s\S]*?if \(!renderToCurrentTab && !text\) return false;[\s\S]*?sendToBackground\('chat', \{[\s\S]*?tabId,[\s\S]*?text,[\s\S]*?mode: modeForSend,[\s\S]*?apiMutationsAllowed: apiMutationsAllowedForSend,/,
-      `${label}: residual slash-command prompts should still dispatch to the tab captured before async parsing`,
+      /const tabId = currentTabId;[\s\S]*?text = await parseSlashCommands\(text, tabId\);[\s\S]*?const renderToCurrentTab = currentTabId === tabId;[\s\S]*?if \(!renderToCurrentTab\) \{[\s\S]*?if \(text\) saveInputDraftForTab\(tabId, text\);[\s\S]*?return false;[\s\S]*?\}/,
+      `${label}: stale residual slash-command prompts should be preserved as drafts instead of hidden runs`,
     );
+    const staleReturnIdx = sendBody.indexOf('if (!renderToCurrentTab) {');
+    const sendIdx = sendBody.indexOf("sendToBackground('chat'");
+    assert.notEqual(staleReturnIdx, -1, `${label}: stale-tab residual guard missing`);
+    assert.notEqual(sendIdx, -1, `${label}: chat send missing`);
+    assert.equal(staleReturnIdx < sendIdx, true, `${label}: stale-tab residual guard must run before chat dispatch`);
     assert.match(
       sendBody,
       /if \(renderToCurrentTab\) \{\s*isProcessing = true;\s*abortRequested = false;\s*sendBtn\.disabled = true;\s*inputEl\.value = '';\s*autoResizeInput\(\);[\s\S]*?addMessage\('user', text\);[\s\S]*?currentAssistantEl = assistantEl;[\s\S]*?\}/,

--- a/test/run.js
+++ b/test/run.js
@@ -2615,7 +2615,7 @@ test('chrome sidepanel serializes tab-chat storage writes with clears and reads'
   const clearBody = panel.slice(clearStart, panel.indexOf('\n}\n\nfunction renderClearedConversationForTab', clearStart) + 2);
   assert.match(clearBody, /tabChats\.delete\(tabId\);/, 'chrome: clearing tab chat should delete the cached HTML before queuing storage removal');
   assert.match(clearBody, /return enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{/, 'chrome: clearing tab chat should be serialized through the queue');
-  assert.match(clearBody, /chrome\.storage\.session\?\.remove\(TAB_CHAT_PREFIX \+ numericTabId\)/, 'chrome: clearing tab chat should remove the stored HTML after queued writes settle');
+  assert.match(clearBody, /return enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{[\s\S]*?tabChats\.delete\(numericTabId\);[\s\S]*?chrome\.storage\.session\?\.remove\(TAB_CHAT_PREFIX \+ numericTabId\)/, 'chrome: queued clears should delete stale HTML re-cached by older queued writes before removing storage');
 });
 
 test('chrome sidepanel cancels stale tab-chat persistence when clearing a tab', () => {
@@ -2636,7 +2636,7 @@ test('chrome sidepanel cancels stale tab-chat persistence when clearing a tab', 
   const clearBody = panel.slice(clearStart, panel.indexOf('\n}\n\nfunction renderClearedConversationForTab', clearStart) + 2);
   assert.match(
     clearBody,
-    /if \(persistTimer && persistTimerTabId === tabId\) \{[\s\S]*?clearTimeout\(persistTimer\);[\s\S]*?persistTimer = null;[\s\S]*?persistTimerTabId = null;[\s\S]*?\}[\s\S]*?tabChats\.delete\(tabId\);[\s\S]*?return enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{[\s\S]*?chrome\.storage\.session\?\.remove\(TAB_CHAT_PREFIX \+ numericTabId\)/,
+    /if \(persistTimer && persistTimerTabId === tabId\) \{[\s\S]*?clearTimeout\(persistTimer\);[\s\S]*?persistTimer = null;[\s\S]*?persistTimerTabId = null;[\s\S]*?\}[\s\S]*?tabChats\.delete\(tabId\);[\s\S]*?return enqueueTabChatOperation\(tabId, async \(numericTabId\) => \{[\s\S]*?tabChats\.delete\(numericTabId\);[\s\S]*?chrome\.storage\.session\?\.remove\(TAB_CHAT_PREFIX \+ numericTabId\)/,
     'chrome: clearing a tab should cancel any pending stale write before removing cached chat',
   );
 });
@@ -3218,15 +3218,23 @@ test('sidepanel sends residual slash-command prompts to the initiating tab', () 
     const sendMatch = panel.match(/async function sendMessage\(extraChatParams\) \{[\s\S]*?\n  return accepted;\n\}/);
     assert.ok(sendMatch, `${label}: sendMessage missing`);
     const sendBody = sendMatch[0];
+    const modeCapture = "const modeForSend = /^\\/(?:ask|plan)\\b/i.test(text) ? 'ask' : agentMode;";
+    const apiCapture = "const apiMutationsAllowedForSend = isApiMutationsAllowedForTab(tabId) || /^\\/allow-api\\b/i.test(text);";
+    const modeCaptureIdx = sendBody.indexOf(modeCapture);
+    const apiCaptureIdx = sendBody.indexOf(apiCapture);
+    const parseIdx = sendBody.indexOf('text = await parseSlashCommands(text, tabId);');
+    assert.notEqual(modeCaptureIdx, -1, `${label}: send mode should be captured from the initiating command before async slash parsing`);
+    assert.notEqual(apiCaptureIdx, -1, `${label}: API override should be captured from the initiating tab before async slash parsing`);
+    assert.equal(modeCaptureIdx < parseIdx && apiCaptureIdx < parseIdx, true, `${label}: stale-tab residual sends should not read visible-tab options after slash parsing`);
     assert.match(
       sendBody,
-      /const tabId = currentTabId;[\s\S]*?text = await parseSlashCommands\(text, tabId\);[\s\S]*?const renderToCurrentTab = currentTabId === tabId;[\s\S]*?if \(!renderToCurrentTab && !text\) return false;[\s\S]*?sendToBackground\('chat', \{[\s\S]*?tabId,[\s\S]*?text,/,
+      /const tabId = currentTabId;[\s\S]*?text = await parseSlashCommands\(text, tabId\);[\s\S]*?const renderToCurrentTab = currentTabId === tabId;[\s\S]*?if \(!renderToCurrentTab && !text\) return false;[\s\S]*?sendToBackground\('chat', \{[\s\S]*?tabId,[\s\S]*?text,[\s\S]*?mode: modeForSend,[\s\S]*?apiMutationsAllowed: apiMutationsAllowedForSend,/,
       `${label}: residual slash-command prompts should still dispatch to the tab captured before async parsing`,
     );
     assert.match(
       sendBody,
-      /if \(renderToCurrentTab\) \{[\s\S]*?addMessage\('user', text\);[\s\S]*?currentAssistantEl = assistantEl;[\s\S]*?\}/,
-      `${label}: stale-tab residual sends should not render chat UI into the currently visible tab`,
+      /if \(renderToCurrentTab\) \{\s*isProcessing = true;\s*abortRequested = false;\s*sendBtn\.disabled = true;\s*inputEl\.value = '';\s*autoResizeInput\(\);[\s\S]*?addMessage\('user', text\);[\s\S]*?currentAssistantEl = assistantEl;[\s\S]*?\}/,
+      `${label}: stale-tab residual sends should not mutate or render chat UI in the currently visible tab`,
     );
     assert.doesNotMatch(
       sendBody,

--- a/test/run.js
+++ b/test/run.js
@@ -1954,7 +1954,7 @@ test('sidepanel exposes schedule slash commands in both builds', () => {
     assert.match(panel, /create_scheduled_job'[\s\S]*?\{\s*tabId,[\s\S]*?job:/, `${label}: schedule form should create jobs for the captured tab`);
     assert.match(panel, /const createdHtml = tSystemHtml\('sp\.schedule_form\.created'[\s\S]*?if \(currentTabId !== tabId\) \{[\s\S]*?replaceCachedScheduleComposer\(tabId, form\.dataset\.composerId, createdHtml\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?form\.remove\(\);/, `${label}: schedule form should update hidden cached composers instead of leaving stale disabled forms`);
     assert.match(panel, /catch \(err\) \{[\s\S]*?if \(currentTabId !== tabId\) \{[\s\S]*?updateCachedScheduleComposerError\(tabId, form\.dataset\.composerId, err\.message\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?submit\.disabled = false;[\s\S]*?errorEl\.textContent = err\.message;/, `${label}: schedule form failures should update hidden cached composers instead of leaving disabled forms`);
-    assert.match(panel, /renderScheduleComposer\(text\.slice\(mSchedule\[0\]\.length\)\.trim\(\), currentTabId\)/, `${label}: /schedule should pass the initiating tab into the async composer`);
+    assert.match(panel, /renderScheduleComposer\(text\.slice\(mSchedule\[0\]\.length\)\.trim\(\), tabId\)/, `${label}: /schedule should pass the initiating tab into the async composer`);
     assert.match(panel, /urlInput\.value = initialScheduleUrl/, `${label}: schedule form should prefill URL targets from the active tab`);
     assert.match(panel, /targetType\.value = 'url'/, `${label}: schedule form should default http(s) pages to URL targets`);
     assert.match(panel, /content\.appendChild\(form\)/, `${label}: schedule form should append after initial target defaults are applied`);
@@ -2895,7 +2895,7 @@ test('sidepanel scopes allow-api override to the tab conversation', () => {
     const allowIdx = panel.indexOf('// /allow-api');
     assert.notEqual(allowIdx, -1, `${label}: /allow-api parser missing`);
     const allowBody = panel.slice(allowIdx, panel.indexOf('// /compact', allowIdx));
-    assert.match(allowBody, /const tabId = currentTabId;[\s\S]*?const wasAlreadyAllowed = isApiMutationsAllowedForTab\(tabId\);[\s\S]*?setApiMutationsAllowedForTab\(tabId, true\);/, `${label}: /allow-api should enable only the current tab conversation`);
+    assert.match(allowBody, /const wasAlreadyAllowed = isApiMutationsAllowedForTab\(tabId\);[\s\S]*?setApiMutationsAllowedForTab\(tabId, true\);/, `${label}: /allow-api should enable only the initiating tab conversation`);
     assert.doesNotMatch(allowBody, /apiMutationsAllowed = true;/, `${label}: /allow-api should not enable a global mutation override`);
   }
 });
@@ -2906,6 +2906,7 @@ test('sidepanel scopes async tab commands to the original tab', () => {
     ['firefox', 'src/firefox/src/ui/sidepanel.js'],
   ]) {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    assert.match(panel, /async function parseSlashCommands\(text, tabId = currentTabId\) \{/, `${label}: slash-command parsing should accept the initiating tab id`);
 
     const helperStart = panel.indexOf('function renderClearedConversationForTab(tabId)');
     assert.notEqual(helperStart, -1, `${label}: clear helper missing`);
@@ -2914,7 +2915,7 @@ test('sidepanel scopes async tab commands to the original tab', () => {
 
     const resetIdx = panel.indexOf("// /reset");
     const resetBody = panel.slice(resetIdx, panel.indexOf("// /screenshot", resetIdx));
-    assert.match(resetBody, /const tabId = currentTabId;[\s\S]*?await sendToBackground\('clear_conversation', \{ tabId \}\);[\s\S]*?renderClearedConversationForTab\(tabId\);/, `${label}: /reset should clear the originally requested tab only`);
+    assert.match(resetBody, /await sendToBackground\('clear_conversation', \{ tabId \}\);[\s\S]*?renderClearedConversationForTab\(tabId\);/, `${label}: /reset should clear the originally requested tab only`);
     assert.doesNotMatch(resetBody, /sendToBackground\('clear_conversation', \{ tabId: currentTabId \}\)/, `${label}: /reset should not use currentTabId after async delay`);
 
     const clearStart = panel.indexOf("clearBtn.addEventListener('click', async () => {");
@@ -2923,32 +2924,55 @@ test('sidepanel scopes async tab commands to the original tab', () => {
 
     const compactIdx = panel.indexOf('// /compact');
     const compactBody = panel.slice(compactIdx, panel.indexOf('// /verbose', compactIdx));
-    assert.match(compactBody, /const tabId = currentTabId;[\s\S]*?sendToBackground\('compact_conversation', \{ tabId \}\);[\s\S]*?if \(currentTabId !== tabId\) return '';/, `${label}: /compact should not render a result into a different tab`);
+    assert.match(compactBody, /sendToBackground\('compact_conversation', \{ tabId \}\);[\s\S]*?if \(currentTabId !== tabId\) return '';/, `${label}: /compact should not render a result into a different tab`);
 
     const listIdx = panel.indexOf('// /list-schedules');
     const listBody = panel.slice(listIdx, panel.indexOf('// /show-scratchpad', listIdx));
-    assert.match(listBody, /const tabId = currentTabId;[\s\S]*?const jobs = await refreshScheduledJobs\(\);[\s\S]*?if \(currentTabId !== tabId\) return '';/, `${label}: /list-schedules should not render a result into a different tab`);
+    assert.match(listBody, /const jobs = await refreshScheduledJobs\(\);[\s\S]*?if \(currentTabId !== tabId\) return '';/, `${label}: /list-schedules should not render a result into a different tab`);
 
     assert.match(panel, /async function showScratchpad\(tabId = currentTabId\) \{[\s\S]*?sendToBackground\('get_scratchpad', \{ tabId \}\);[\s\S]*?if \(currentTabId !== tabId\) return;[\s\S]*?catch \(e\) \{[\s\S]*?if \(currentTabId !== tabId\) return;[\s\S]*?sp\.scratchpad\.error/, `${label}: /show-scratchpad should not render success or error results into a different tab`);
+    assert.match(panel, /\/\/ \/show-scratchpad[\s\S]*?await showScratchpad\(tabId\);/, `${label}: /show-scratchpad should use the initiating tab id from the parser`);
 
     const screenshotIdx = panel.indexOf('// /screenshot');
     const screenshotEnd = panel.indexOf('// /record', screenshotIdx);
     const screenshotBody = panel.slice(screenshotIdx, screenshotEnd);
-    assert.match(screenshotBody, /const tabId = currentTabId;[\s\S]*?if \(currentTabId !== tabId \|\| !tab\?\.active\) return '';[\s\S]*?captureVisibleTab[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?addMessage\('system', imgHtml\);/, `${label}: /screenshot should not render a captured image into a different tab`);
+    assert.match(screenshotBody, /if \(currentTabId !== tabId \|\| !tab\?\.active\) return '';[\s\S]*?captureVisibleTab[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?addMessage\('system', imgHtml\);/, `${label}: /screenshot should not render a captured image into a different tab`);
 
     if (label === 'chrome') {
       const recordIdx = panel.indexOf('// /record');
       const recordBody = panel.slice(recordIdx, panel.indexOf('// /export', recordIdx));
-      assert.match(recordBody, /const tabId = currentTabId;[\s\S]*?sendToBackground\('start_tab_recording', \{[\s\S]*?tabId,[\s\S]*?\}\);[\s\S]*?if \(currentTabId !== tabId\) return '';/, `${label}: /record should not render recording status into a different tab`);
+      assert.match(recordBody, /sendToBackground\('start_tab_recording', \{[\s\S]*?tabId,[\s\S]*?\}\);[\s\S]*?if \(currentTabId !== tabId\) return '';/, `${label}: /record should not render recording status into a different tab`);
     }
 
     const profileIdx = panel.indexOf('// /profile');
     const profileBody = panel.slice(profileIdx, panel.indexOf('// /ask', profileIdx));
-    assert.match(profileBody, /const tabId = currentTabId;[\s\S]*?storage\.local\.get\(\['profileEnabled', 'profileText'\]\);[\s\S]*?storage\.local\.set\(\{ profileEnabled: newState \}\);[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?addMessage\('system'/, `${label}: /profile should not render a result into a different tab`);
+    assert.match(profileBody, /storage\.local\.get\(\['profileEnabled', 'profileText'\]\);[\s\S]*?storage\.local\.set\(\{ profileEnabled: newState \}\);[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?addMessage\('system'/, `${label}: /profile should not render a result into a different tab`);
 
     const visionIdx = panel.indexOf('// /vision');
     const visionBody = panel.slice(visionIdx, panel.indexOf('return text;', visionIdx));
-    assert.match(visionBody, /const tabId = currentTabId;[\s\S]*?sendToBackground\('get_providers'\);[\s\S]*?sendToBackground\('update_provider'[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?addMessage\('system'/, `${label}: /vision should not render a result into a different tab`);
+    assert.match(visionBody, /sendToBackground\('get_providers'\);[\s\S]*?sendToBackground\('update_provider'[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?addMessage\('system'/, `${label}: /vision should not render a result into a different tab`);
+  }
+});
+
+test('sidepanel sends residual slash-command prompts to the initiating tab', () => {
+  for (const [label, panelRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    const sendMatch = panel.match(/async function sendMessage\(extraChatParams\) \{[\s\S]*?\n  return accepted;\n\}/);
+    assert.ok(sendMatch, `${label}: sendMessage missing`);
+    const sendBody = sendMatch[0];
+    assert.match(
+      sendBody,
+      /const tabId = currentTabId;[\s\S]*?text = await parseSlashCommands\(text, tabId\);[\s\S]*?if \(currentTabId !== tabId\) return false;[\s\S]*?sendToBackground\('chat', \{[\s\S]*?tabId,[\s\S]*?text,/,
+      `${label}: residual slash-command prompts should use the tab captured before async parsing`,
+    );
+    assert.doesNotMatch(
+      sendBody,
+      /sendToBackground\('chat', \{[\s\S]*?tabId: currentTabId/,
+      `${label}: chat dispatch should not read currentTabId after slash parsing`,
+    );
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -1992,6 +1992,35 @@ test('sidepanel exposes show-scratchpad slash command in both builds', () => {
   }
 });
 
+test('sidepanel awaits onboarding completion persistence before hiding', () => {
+  for (const [label, panelRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    assert.match(
+      panel,
+      /async function dismissOnboarding\(\) \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ onboardingComplete: true \}\)\.catch\(\(\) => \{\}\);[\s\S]*?overlay\.classList\.add\('hidden'\);[\s\S]*?\}/,
+      `${label}: onboarding completion should persist before the overlay is hidden`,
+    );
+    assert.match(
+      panel,
+      /changeLink\.addEventListener\('click', async \(event\) => \{[\s\S]*?await dismissOnboarding\(\);[\s\S]*?\}\);/,
+      `${label}: onboarding change link should await completion persistence`,
+    );
+    assert.match(
+      panel,
+      /settingsBtn\.addEventListener\('click', async \(\) => \{[\s\S]*?if \(cloudReady\) \{[\s\S]*?await dismissOnboarding\(\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?await dismissOnboarding\(\);[\s\S]*?\}\);/,
+      `${label}: onboarding settings flow should await completion persistence before closing`,
+    );
+    assert.match(
+      panel,
+      /skipBtn\.addEventListener\('click', async \(\) => \{[\s\S]*?await dismissOnboarding\(\);[\s\S]*?\}\);/,
+      `${label}: onboarding skip button should await completion persistence`,
+    );
+  }
+});
+
 test('chrome /record reports mic denial as a warning, not recording failure', () => {
   const panel = fs.readFileSync(path.join(ROOT, 'src/chrome/src/ui/sidepanel.js'), 'utf8');
   const locale = fs.readFileSync(path.join(ROOT, 'src/chrome/src/ui/locales/en.js'), 'utf8');

--- a/test/run.js
+++ b/test/run.js
@@ -3174,8 +3174,8 @@ test('sidepanel awaits immediate verbose preference writes', () => {
     );
     assert.match(
       panel,
-      /if \(\s*\/\^\\\/verbose\\b\\s\*\/i\.test\(text\)\s*\) \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ verboseMode \}\)\.catch\(\(\) => \{\}\);/,
-      `${label}: /verbose should await persistence before echoing the mode change`,
+      /if \(\s*\/\^\\\/verbose\\b\\s\*\/i\.test\(text\)\s*\) \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ verboseMode \}\)\.catch\(\(\) => \{\}\);[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?addMessage\('system', verboseMode/,
+      `${label}: /verbose should guard against stale tabs after persisting the mode change`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -2994,6 +2994,42 @@ test('settings async test controls surface rejected background results', () => {
   }
 });
 
+test('settings waits for immediate preference writes and theme persistence', () => {
+  for (const [label, settingsRel] of [
+    ['chrome', 'src/chrome/src/ui/settings.js'],
+    ['firefox', 'src/firefox/src/ui/settings.js'],
+  ]) {
+    const settings = fs.readFileSync(path.join(ROOT, settingsRel), 'utf8');
+    assert.match(
+      settings,
+      /themeSelect\.addEventListener\('change', async \(\) => \{[\s\S]*?await applyMode\(mode\);[\s\S]*?\}\);/,
+      `${label}: theme selection should await persistence`,
+    );
+    assert.match(
+      settings,
+      /profileEnabledToggle\.addEventListener\('change', async \(\) => \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ profileEnabled: profileEnabledToggle\.checked \}\)\.catch\(\(\) => \{\}\);[\s\S]*?\}\);/,
+      `${label}: profile toggle should await persistence`,
+    );
+    assert.match(
+      settings,
+      /captchaEnabledToggle\.addEventListener\('change', async \(\) => \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ captchaSolverEnabled: captchaEnabledToggle\.checked \}\)\.catch\(\(\) => \{\}\);[\s\S]*?\}\);/,
+      `${label}: captcha toggle should await persistence`,
+    );
+    assert.match(
+      settings,
+      /try \{[\s\S]*?void (chrome|browser)\.storage\.local\.set\(\{ providerFilter: f\.key \}\)\.catch\(\(\) => \{\}\);[\s\S]*?renderProviders\(\);/,
+      `${label}: provider filter changes should still persist even if the render rebuilds immediately`,
+    );
+
+    const theme = fs.readFileSync(path.join(ROOT, label === 'chrome' ? 'src/chrome/src/ui/theme.js' : 'src/firefox/src/ui/theme.js'), 'utf8');
+    assert.match(
+      theme,
+      /export async function applyMode\(mode, opts = \{\}\) \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ themeMode: mode \}\)\.catch\(\(\) => \{\}\);[\s\S]*?\}/,
+      `${label}: shared theme helper should await storage persistence`,
+    );
+  }
+});
+
 test('settings page awaits immediate preference writes before moving on', () => {
   for (const [label, settingsRel] of [
     ['chrome', 'src/chrome/src/ui/settings.js'],
@@ -3115,6 +3151,20 @@ test('sidepanel awaits immediate verbose preference writes', () => {
       panel,
       /if \(\s*\/\^\\\/verbose\\b\\s\*\/i\.test\(text\)\s*\) \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ verboseMode \}\)\.catch\(\(\) => \{\}\);/,
       `${label}: /verbose should await persistence before echoing the mode change`,
+    );
+  }
+});
+
+test('sidepanel awaits recommended-actions collapse persistence', () => {
+  for (const [label, panelRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    assert.match(
+      panel,
+      /recommendedActionsToggleEl\.addEventListener\('click', async \(\) => \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ \[RECOMMENDED_ACTIONS_COLLAPSED_KEY\]: !recommendedActionsCollapsed \}\)\.catch\(\(\) => \{\}\);[\s\S]*?setRecommendedActionsCollapsed\(!recommendedActionsCollapsed, \{ persist: false \}\);[\s\S]*?\}\);/,
+      `${label}: recommended-actions collapse should await persistence`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -2766,10 +2766,38 @@ test('settings page drops stale provider activation completions', () => {
     const activateStart = settings.indexOf('async function activateProvider(id) {');
     assert.notEqual(activateStart, -1, `${label}: activateProvider missing`);
     const activateBody = settings.slice(activateStart, settings.indexOf('\n}\n\n', activateStart) + 2);
-    assert.match(
-      activateBody,
-      /requestedActiveProviderId = id;[\s\S]*?const requestId = \+\+providerActivationRequestId;[\s\S]*?sendToBackground\('set_active_provider', \{ providerId: id \}\);[\s\S]*?if \(requestId !== providerActivationRequestId \|\| requestedActiveProviderId !== id\) \{[\s\S]*?const latestProviderId = requestedActiveProviderId;[\s\S]*?sendToBackground\('set_active_provider', \{ providerId: latestProviderId \}\)\.catch\(\(\) => \{\}\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?activeProviderId = id;[\s\S]*?renderProviders\(\);/,
-      `${label}: stale settings provider activations should repair the latest provider and skip stale rendering`,
+    const requestedIdx = activateBody.indexOf('requestedActiveProviderId = id;');
+    const requestIdx = activateBody.indexOf('const requestId = ++providerActivationRequestId;');
+    const activateIdx = activateBody.indexOf("await sendToBackground('set_active_provider', { providerId: id });");
+    const catchIdx = activateBody.indexOf('} catch (e) {');
+    const failureGuardIdx = activateBody.indexOf('if (requestId === providerActivationRequestId && requestedActiveProviderId === id) {');
+    const failureStatusIdx = activateBody.indexOf("setProviderTestResult(id, 'fail', t('st.providers.failed', { error: e.message }));");
+    const staleGuardIdx = activateBody.indexOf('if (requestId !== providerActivationRequestId || requestedActiveProviderId !== id) {');
+    const repairIdx = activateBody.indexOf("sendToBackground('set_active_provider', { providerId: latestProviderId }).catch(() => {});");
+    const activeIdx = activateBody.indexOf('activeProviderId = id;');
+    const renderIdx = activateBody.indexOf('renderProviders();');
+    assert.notEqual(requestedIdx, -1, `${label}: settings activation should track the latest requested provider`);
+    assert.notEqual(requestIdx, -1, `${label}: settings activation should increment a request sequence`);
+    assert.notEqual(activateIdx, -1, `${label}: settings activation request missing`);
+    assert.notEqual(catchIdx, -1, `${label}: settings activation failures should be caught`);
+    assert.notEqual(failureGuardIdx, -1, `${label}: stale settings activation failures should be dropped`);
+    assert.notEqual(failureStatusIdx, -1, `${label}: current settings activation failures should update the provider status`);
+    assert.notEqual(staleGuardIdx, -1, `${label}: stale settings activation completions should be dropped`);
+    assert.notEqual(repairIdx, -1, `${label}: stale settings activation completions should repair the latest provider`);
+    assert.notEqual(activeIdx, -1, `${label}: successful settings activation should update active provider`);
+    assert.notEqual(renderIdx, -1, `${label}: successful settings activation should rerender providers`);
+    assert.equal(
+      requestedIdx < requestIdx
+        && requestIdx < activateIdx
+        && activateIdx < catchIdx
+        && catchIdx < failureGuardIdx
+        && failureGuardIdx < failureStatusIdx
+        && failureStatusIdx < staleGuardIdx
+        && staleGuardIdx < repairIdx
+        && repairIdx < activeIdx
+        && activeIdx < renderIdx,
+      true,
+      `${label}: settings activation should handle failures and stale completions before rendering success`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -2712,11 +2712,44 @@ test('sidepanel drops stale provider selection and connection checks', () => {
     assert.notEqual(statusIdx, -1, `${label}: provider status update missing`);
     assert.equal(captureIdx < requestIdx && requestIdx < sendIdx && sendIdx < staleGuardIdx && staleGuardIdx < statusIdx, true, `${label}: provider test stale guard must run after the async request and before status updates`);
     assert.doesNotMatch(testBody, /providerId: providerSelect\.value/, `${label}: provider test should not read the mutable selection after async delay`);
+    assert.match(panel, /function markSelectedProviderFailed\(error\) \{[\s\S]*?const msg = error\?\.message \|\| t\('sp\.status\.failed'\);[\s\S]*?statusDot\.className = 'status-dot offline';[\s\S]*?statusDot\.title = t\('sp\.status\.error', \{ msg \}\);[\s\S]*?\}/, `${label}: provider activation failures should surface on the selected provider`);
 
     const changeStart = panel.indexOf("providerSelect.addEventListener('change', async () => {");
     assert.notEqual(changeStart, -1, `${label}: provider change handler missing`);
     const changeBody = panel.slice(changeStart, panel.indexOf('\n});', changeStart) + 4);
-    assert.match(changeBody, /const providerId = providerSelect\.value;[\s\S]*?const requestId = \+\+providerSelectionRequestId;[\s\S]*?sendToBackground\('set_active_provider', \{ providerId \}\);[\s\S]*?if \(requestId !== providerSelectionRequestId \|\| providerSelect\.value !== providerId\) \{[\s\S]*?const latestProviderId = providerSelect\.value;[\s\S]*?sendToBackground\('set_active_provider', \{ providerId: latestProviderId \}\)\.catch\(\(\) => \{\}\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?await testConnection\(\{ providerId \}\);/, `${label}: provider changes should drop stale completions and test only the captured provider`);
+    const changeCaptureIdx = changeBody.indexOf('const providerId = providerSelect.value;');
+    const changeRequestIdx = changeBody.indexOf('const requestId = ++providerSelectionRequestId;');
+    const invalidateIdx = changeBody.indexOf('providerTestRequestId += 1;');
+    const activateIdx = changeBody.indexOf("await sendToBackground('set_active_provider', { providerId });");
+    const catchIdx = changeBody.indexOf('} catch (e) {');
+    const failureGuardIdx = changeBody.indexOf('if (requestId === providerSelectionRequestId && providerSelect.value === providerId) {');
+    const failureStatusIdx = changeBody.indexOf('markSelectedProviderFailed(e);');
+    const changeStaleGuardIdx = changeBody.indexOf('if (requestId !== providerSelectionRequestId || providerSelect.value !== providerId) {');
+    const repairIdx = changeBody.indexOf("sendToBackground('set_active_provider', { providerId: latestProviderId }).catch(() => {});");
+    const changeTestIdx = changeBody.indexOf('await testConnection({ providerId });');
+    assert.notEqual(changeCaptureIdx, -1, `${label}: provider change should capture the intended provider`);
+    assert.notEqual(changeRequestIdx, -1, `${label}: provider change should increment a request sequence`);
+    assert.notEqual(invalidateIdx, -1, `${label}: provider change should invalidate pending provider tests`);
+    assert.notEqual(activateIdx, -1, `${label}: provider activation request missing`);
+    assert.notEqual(catchIdx, -1, `${label}: provider activation failures should be caught`);
+    assert.notEqual(failureGuardIdx, -1, `${label}: stale provider activation failures should be dropped`);
+    assert.notEqual(failureStatusIdx, -1, `${label}: current provider activation failures should update status`);
+    assert.notEqual(changeStaleGuardIdx, -1, `${label}: stale provider activation completions should be dropped`);
+    assert.notEqual(repairIdx, -1, `${label}: stale provider activation completions should repair the latest selected provider`);
+    assert.notEqual(changeTestIdx, -1, `${label}: provider change should test the captured provider`);
+    assert.equal(
+      changeCaptureIdx < changeRequestIdx
+        && changeRequestIdx < invalidateIdx
+        && invalidateIdx < activateIdx
+        && activateIdx < catchIdx
+        && catchIdx < failureGuardIdx
+        && failureGuardIdx < failureStatusIdx
+        && failureStatusIdx < changeStaleGuardIdx
+        && changeStaleGuardIdx < repairIdx
+        && repairIdx < changeTestIdx,
+      true,
+      `${label}: provider activation failure/stale guards should run before testing the captured provider`,
+    );
     assert.match(panel, /await testConnection\(\{ providerId: choice\.providerId \}\);/, `${label}: onboarding provider enablement should test the selected provider explicitly`);
   }
 });


### PR DESCRIPTION
## Summary

- Surface rejected background responses from the settings Vision, Transcription, and CapSolver test controls as visible failure messages instead of leaving the UI in a testing/checking state.
- Re-query provider model-load status/datalist elements after async gaps and report rejected model-load requests through the current provider card.
- Catch settings provider activation failures and show them on the current provider card instead of leaving an unhandled rejected Set Active click.
- Clear stale inline colors when settings status helpers transition back to success or idle, so earlier testing/failure colors do not stick around after later updates.
- Await onboarding completion persistence before hiding the overlay, so first-run dismissal is not lost if the sidepanel is torn down immediately after the click.
- Await Act-mode confirmation persistence before switching modes, so the first-run Act warning does not reappear after a fast teardown or shortcut-driven transition.
- Scope residual slash-command sends, such as `/compact follow-up`, to the tab where the user pressed Send even if tab activation changes during async command parsing.
- Catch sidepanel provider activation failures, show the failure on the current selection, and invalidate stale provider-test completions before they can overwrite that status.
- Add Chrome/Firefox regression coverage for these settings async status and sidepanel async state paths.

## Root Cause

The settings `sendToBackground` wrapper rejects responses that include an `error` field. Several controls still had `if (res.ok) ... else ...` handling without a local `catch`, so provider/model/captcha failures skipped the visible failure path and could leave stale testing/loading UI behind.

The settings provider activation path had the same issue for `set_active_provider`: rejected activations escaped the click handler before any visible status update, while stale activation completions still needed request sequencing to avoid rendering the wrong active card.

The settings status helpers also kept the previous inline `color` style when callers switched from testing or failure states back to success without specifying a new color, so a resolved check could still look grey or red until the card re-rendered.

The onboarding dismiss helper wrote `onboardingComplete` fire-and-forget and hid the overlay immediately, so a close or teardown right after the click could drop the persistence write and show the wizard again next time.

The Act-mode confirmation helper had the same persistence race: it wrote `actConfirmed` without waiting for the storage write before completing the mode switch, so a quick teardown or shortcut-driven transition could lose the confirmation and show the warning again.

The sidepanel send path parsed slash commands before capturing the run target for chat dispatch. Async slash commands can leave residual text to send; if the active tab changed during that await, the residual prompt could be submitted against the new tab instead of the initiating conversation.

The sidepanel provider dropdown also awaited `set_active_provider` without a local failure path. If activation rejected, the event handler aborted through an unhandled rejection and any older provider-test result for the same selected provider could still update the status dot afterward.

## Validation

- `node --check src/chrome/src/ui/settings.js`
- `node --check src/firefox/src/ui/settings.js`
- `node --check src/chrome/src/ui/sidepanel.js`
- `node --check src/firefox/src/ui/sidepanel.js`
- `node --check test/run.js`
- `git diff --check`
- `node test/run.js` (413 passed)
- `npm test` (413 unit tests + 59/59 injection corpus)
