### PR TITLE
[codex] Track rendered tab for Chrome draft saves

### DIFF
--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -358,6 +358,7 @@ const recordingTimerEl = document.getElementById('recording-timer');
 const recordingStopBtn = document.getElementById('btn-recording-stop');
 
 let currentTabId = null;
+let renderedTabId = null;
 let pendingTabSwitch = null; // tab the user switched to while isProcessing was true
 let isProcessing = false;
 let currentAssistantEl = null;
@@ -538,6 +539,7 @@ function renderClearedConversationForTab(tabId) {
   saveInputDraftForTab(tabId, '');
   setApiMutationsAllowedForTab(tabId, false);
   if (currentTabId !== tabId) return;
+  renderedTabId = tabId;
   messagesEl.innerHTML = '';
   inputEl.value = '';
   autoResizeInput();
@@ -552,7 +554,7 @@ let persistTimer = null;
 let persistTimerTabId = null;
 function schedulePersist() {
   if (persistTimer) clearTimeout(persistTimer);
-  const tabId = currentTabId;
+  const tabId = renderedTabId;
   const html = messagesEl.innerHTML;
   persistTimerTabId = tabId;
   persistTimer = setTimeout(() => {
@@ -1285,6 +1287,7 @@ async function showScratchpad(tabId = currentTabId) {
 async function init() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   currentTabId = tab?.id;
+  renderedTabId = currentTabId;
 
   chrome.tabs.onActivated.addListener(async (info) => {
     switchToTab(info.tabId);
@@ -1396,17 +1399,18 @@ if (verboseBtn) {
 }
 
 async function switchToTab(newTabId) {
-  if (newTabId === currentTabId) { pendingTabSwitch = null; return; }
+  if (newTabId === currentTabId && renderedTabId === newTabId) { pendingTabSwitch = null; return; }
   if (isProcessing) {
     pendingTabSwitch = newTabId; // apply after the run ends
     return;
   }
   pendingTabSwitch = null;
 
-  // Save current tab's chat (in-memory + storage).
-  if (currentTabId != null) {
-    persistTabChat(currentTabId, messagesEl.innerHTML);
-    captureInputDraftForTab(currentTabId);
+  // Save the tab currently represented by the DOM. During an async restore,
+  // currentTabId may already point at the target while the DOM is still older.
+  if (renderedTabId != null) {
+    persistTabChat(renderedTabId, messagesEl.innerHTML);
+    captureInputDraftForTab(renderedTabId);
   }
 
   currentTabId = newTabId;
@@ -1415,6 +1419,7 @@ async function switchToTab(newTabId) {
   // Restore new tab's chat from memory or storage.
   const html = await loadTabChat(newTabId);
   if (currentTabId !== newTabId) return;
+  renderedTabId = newTabId;
   if (html) {
     messagesEl.innerHTML = html;
     messagesEl.querySelectorAll('[data-bound]').forEach(el => delete el.dataset.bound);

--- a/test/run.js
+++ b/test/run.js
@@ -2571,20 +2571,25 @@ test('sidepanel rebinds interactive controls after restoring serialized tab chat
 
 test('chrome sidepanel drops stale async tab-chat restores', () => {
   const panel = fs.readFileSync(path.join(ROOT, 'src/chrome/src/ui/sidepanel.js'), 'utf8');
+  assert.match(panel, /let renderedTabId = null;/, 'chrome: sidepanel should track which tab is actually rendered in the DOM');
   const match = panel.match(/async function switchToTab\(newTabId\) \{([\s\S]*?)\n\}/);
   assert.ok(match, 'chrome: switchToTab body missing');
   const body = match[1];
   const setIdx = body.indexOf('currentTabId = newTabId;');
   const loadIdx = body.indexOf('const html = await loadTabChat(newTabId);');
   const guardIdx = body.indexOf('if (currentTabId !== newTabId) return;');
+  const renderedSetIdx = body.indexOf('renderedTabId = newTabId;');
   const restoreIdx = body.indexOf('messagesEl.innerHTML =');
   const consumeIdx = body.indexOf('consumePendingContextMenuPrompt()');
   assert.notEqual(setIdx, -1, 'chrome: switchToTab should set the visible tab before restoring chat');
   assert.notEqual(loadIdx, -1, 'chrome: switchToTab should load persisted tab chat asynchronously');
   assert.notEqual(guardIdx, -1, 'chrome: stale async tab-chat restores should be dropped');
+  assert.notEqual(renderedSetIdx, -1, 'chrome: switchToTab should mark the rendered tab only after stale async restores are dropped');
   assert.notEqual(restoreIdx, -1, 'chrome: switchToTab restore point missing');
   assert.notEqual(consumeIdx, -1, 'chrome: switchToTab context-menu consume point missing');
-  assert.equal(setIdx < loadIdx && loadIdx < guardIdx && guardIdx < restoreIdx && guardIdx < consumeIdx, true, 'chrome: stale guard must run after async chat load and before DOM/context-menu work');
+  assert.equal(setIdx < loadIdx && loadIdx < guardIdx && guardIdx < renderedSetIdx && renderedSetIdx < restoreIdx && guardIdx < consumeIdx, true, 'chrome: stale guard must run after async chat load and before rendered-tab/DOM/context-menu work');
+  assert.match(body, /if \(renderedTabId != null\) \{[\s\S]*?persistTabChat\(renderedTabId, messagesEl\.innerHTML\);[\s\S]*?captureInputDraftForTab\(renderedTabId\);[\s\S]*?\}/, 'chrome: overlapping tab switches should save drafts for the tab represented by the DOM');
+  assert.doesNotMatch(body, /persistTabChat\(currentTabId,\s*messagesEl\.innerHTML\)|captureInputDraftForTab\(currentTabId\)/, 'chrome: overlapping tab switches must not save DOM or drafts under a pending target tab');
 });
 
 test('chrome sidepanel persists tab chat to the tab captured before debounce', () => {
@@ -2592,11 +2597,11 @@ test('chrome sidepanel persists tab chat to the tab captured before debounce', (
   const start = panel.indexOf('function schedulePersist() {');
   assert.notEqual(start, -1, 'chrome: schedulePersist missing');
   const body = panel.slice(start, panel.indexOf('\n}\n\n// Observe', start) + 2);
-  const captureTabIdx = body.indexOf('const tabId = currentTabId;');
+  const captureTabIdx = body.indexOf('const tabId = renderedTabId;');
   const captureHtmlIdx = body.indexOf('const html = messagesEl.innerHTML;');
   const timerIdx = body.indexOf('persistTimer = setTimeout(() => {');
   const persistIdx = body.indexOf('persistTabChat(tabId, html);');
-  assert.notEqual(captureTabIdx, -1, 'chrome: persistence should capture the tab id before the debounce delay');
+  assert.notEqual(captureTabIdx, -1, 'chrome: persistence should capture the rendered tab id before the debounce delay');
   assert.notEqual(captureHtmlIdx, -1, 'chrome: persistence should capture the chat HTML before the debounce delay');
   assert.notEqual(timerIdx, -1, 'chrome: persistence debounce missing');
   assert.notEqual(persistIdx, -1, 'chrome: persistence should write the captured tab/html');
@@ -2632,7 +2637,7 @@ test('chrome sidepanel cancels stale tab-chat persistence when clearing a tab', 
   const scheduleBody = panel.slice(scheduleStart, panel.indexOf('\n}\n\n// Observe', scheduleStart) + 2);
   assert.match(
     scheduleBody,
-    /const tabId = currentTabId;[\s\S]*?const html = messagesEl\.innerHTML;[\s\S]*?persistTimerTabId = tabId;[\s\S]*?persistTimer = setTimeout\(\(\) => \{[\s\S]*?persistTimer = null;[\s\S]*?persistTimerTabId = null;[\s\S]*?persistTabChat\(tabId, html\);/,
+    /const tabId = renderedTabId;[\s\S]*?const html = messagesEl\.innerHTML;[\s\S]*?persistTimerTabId = tabId;[\s\S]*?persistTimer = setTimeout\(\(\) => \{[\s\S]*?persistTimer = null;[\s\S]*?persistTimerTabId = null;[\s\S]*?persistTabChat\(tabId, html\);/,
     'chrome: debounced persistence should associate and clear the pending tab id',
   );
 
@@ -3231,7 +3236,10 @@ test('sidepanel preserves stale residual slash-command prompts without hidden ru
     const switchStart = panel.indexOf('function switchToTab(newTabId)');
     assert.notEqual(switchStart, -1, `${label}: switchToTab missing`);
     const switchBody = panel.slice(switchStart, panel.indexOf('refreshScheduledJobs({', switchStart));
-    assert.match(switchBody, /captureInputDraftForTab\(currentTabId\);[\s\S]*?restoreInputDraftForTab\(newTabId\);/, `${label}: tab switches should capture and restore per-tab composer drafts`);
+    const captureDraftPattern = label === 'chrome'
+      ? /captureInputDraftForTab\(renderedTabId\);[\s\S]*?restoreInputDraftForTab\(newTabId\);/
+      : /captureInputDraftForTab\(currentTabId\);[\s\S]*?restoreInputDraftForTab\(newTabId\);/;
+    assert.match(switchBody, captureDraftPattern, `${label}: tab switches should capture and restore per-tab composer drafts`);
 
     const sendMatch = panel.match(/async function sendMessage\(extraChatParams\) \{[\s\S]*?\n  return accepted;\n\}/);
     assert.ok(sendMatch, `${label}: sendMessage missing`);


### PR DESCRIPTION
## Summary
- track the Chrome sidepanel tab currently represented by the DOM separately from the selected tab
- save chat HTML and composer drafts against the rendered tab during overlapping async restores
- extend regression tests for stale restore ordering and draft capture

## Validation
- node --check src/chrome/src/ui/sidepanel.js
- node --check test/run.js
- git diff --check
- npm test