### PR TITLE
Add Subscribe button to WebBrain Cloud quota error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to WebBrain are documented in this file.
 
 This changelog was generated from the repository Git history and release tags. Versions without a Git tag are inferred from version-bump commits and the current `package.json` / `manifest.json` version.
 
+## [17.1.0] - 2026-06-24
+
+### Added
+- Introduced a better payment UI for WebBrain Cloud: the quota-exceeded error now surfaces a Subscribe button that links users directly to upgrade their plan, with the button persisting and rebinding across chat restores.
+
+### Changed
+- Translated the Subscribe button strings into all supported locales.
+
 ## [17.0.0] - 2026-06-23
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "17.0.1",
+  "version": "17.1.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webbrain",
-  "version": "17.0.1",
+  "version": "17.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webbrain",
-      "version": "17.0.1",
+      "version": "17.1.0",
       "license": "MIT",
       "devDependencies": {
         "playwright": "^1.48.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webbrain",
-  "version": "17.0.1",
+  "version": "17.1.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "private": true,
   "type": "module",

--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Chrome Extension — Architecture
 
-> Version 17.0.1 · Manifest V3 · Service Worker background
+> Version 17.1.0 · Manifest V3 · Service Worker background
 
 ## High-Level Overview
 

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "17.0.1",
+  "version": "17.1.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/src/chrome/src/ui/locales/ar.js
+++ b/src/chrome/src/ui/locales/ar.js
@@ -102,6 +102,8 @@ export default {
   'sp.copy.code.title': 'نسخ الكود',
 
   'sp.error_prefix': 'خطأ: {msg}',
+  'sp.subscribe.allowance_used': 'تم استخدام الحصة اليومية المجانية من WebBrain Cloud.',
+  'sp.subscribe.btn': 'اشترك',
   'sp.stopped_by_user': '[أوقفه المستخدم]',
   'sp.stopped_by_user_html': '<em>أوقفه المستخدم.</em>',
 

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -130,6 +130,8 @@ export default {
   'sp.copy.code.title': 'Copy code',
 
   'sp.error_prefix': 'Error: {msg}',
+  'sp.subscribe.allowance_used': 'Daily free WebBrain Cloud allowance used.',
+  'sp.subscribe.btn': 'Subscribe',
   'sp.stopped_by_user': '[Stopped by user]',
   'sp.stopped_by_user_html': '<em>Stopped by user.</em>',
 

--- a/src/chrome/src/ui/locales/es.js
+++ b/src/chrome/src/ui/locales/es.js
@@ -102,6 +102,8 @@ export default {
   'sp.copy.code.title': 'Copiar código',
 
   'sp.error_prefix': 'Error: {msg}',
+  'sp.subscribe.allowance_used': 'Se agotó la asignación diaria gratuita de WebBrain Cloud.',
+  'sp.subscribe.btn': 'Suscribirse',
   'sp.stopped_by_user': '[Detenido por el usuario]',
   'sp.stopped_by_user_html': '<em>Detenido por el usuario.</em>',
 

--- a/src/chrome/src/ui/locales/fr.js
+++ b/src/chrome/src/ui/locales/fr.js
@@ -102,6 +102,8 @@ export default {
   'sp.copy.code.title': 'Copier le code',
 
   'sp.error_prefix': 'Erreur : {msg}',
+  'sp.subscribe.allowance_used': 'Quota quotidien gratuit de WebBrain Cloud épuisé.',
+  'sp.subscribe.btn': 'S’abonner',
   'sp.stopped_by_user': '[Arrêté par l\'utilisateur]',
   'sp.stopped_by_user_html': '<em>Arrêté par l\'utilisateur.</em>',
 

--- a/src/chrome/src/ui/locales/id.js
+++ b/src/chrome/src/ui/locales/id.js
@@ -102,6 +102,8 @@ export default {
   'sp.copy.code.title': 'Salin kode',
 
   'sp.error_prefix': 'Galat: {msg}',
+  'sp.subscribe.allowance_used': 'Kuota harian gratis WebBrain Cloud telah habis.',
+  'sp.subscribe.btn': 'Berlangganan',
   'sp.stopped_by_user': '[Dihentikan oleh pengguna]',
   'sp.stopped_by_user_html': '<em>Dihentikan oleh pengguna.</em>',
 

--- a/src/chrome/src/ui/locales/ja.js
+++ b/src/chrome/src/ui/locales/ja.js
@@ -102,6 +102,8 @@ export default {
   'sp.copy.code.title': 'コードをコピー',
 
   'sp.error_prefix': 'エラー: {msg}',
+  'sp.subscribe.allowance_used': 'WebBrain Cloud の無料の1日あたりの利用枠を使い切りました。',
+  'sp.subscribe.btn': '購読する',
   'sp.stopped_by_user': '[ユーザーが停止]',
   'sp.stopped_by_user_html': '<em>ユーザーが停止しました。</em>',
 

--- a/src/chrome/src/ui/locales/ko.js
+++ b/src/chrome/src/ui/locales/ko.js
@@ -102,6 +102,8 @@ export default {
   'sp.copy.code.title': '코드 복사',
 
   'sp.error_prefix': '오류: {msg}',
+  'sp.subscribe.allowance_used': 'WebBrain Cloud의 무료 일일 사용량을 모두 사용했습니다.',
+  'sp.subscribe.btn': '구독하기',
   'sp.stopped_by_user': '[사용자가 중지함]',
   'sp.stopped_by_user_html': '<em>사용자가 중지했습니다.</em>',
 

--- a/src/chrome/src/ui/locales/ms.js
+++ b/src/chrome/src/ui/locales/ms.js
@@ -102,6 +102,8 @@ export default {
   'sp.copy.code.title': 'Salin kod',
 
   'sp.error_prefix': 'Ralat: {msg}',
+  'sp.subscribe.allowance_used': 'Peruntukan harian percuma WebBrain Cloud telah digunakan.',
+  'sp.subscribe.btn': 'Langgan',
   'sp.stopped_by_user': '[Dihentikan oleh pengguna]',
   'sp.stopped_by_user_html': '<em>Dihentikan oleh pengguna.</em>',
 

--- a/src/chrome/src/ui/locales/ru.js
+++ b/src/chrome/src/ui/locales/ru.js
@@ -102,6 +102,8 @@ export default {
   'sp.copy.code.title': 'Копировать код',
 
   'sp.error_prefix': 'Ошибка: {msg}',
+  'sp.subscribe.allowance_used': 'Бесплатный дневной лимит WebBrain Cloud исчерпан.',
+  'sp.subscribe.btn': 'Оформить подписку',
   'sp.stopped_by_user': '[Остановлено пользователем]',
   'sp.stopped_by_user_html': '<em>Остановлено пользователем.</em>',
 

--- a/src/chrome/src/ui/locales/th.js
+++ b/src/chrome/src/ui/locales/th.js
@@ -102,6 +102,8 @@ export default {
   'sp.copy.code.title': 'คัดลอกโค้ด',
 
   'sp.error_prefix': 'ข้อผิดพลาด: {msg}',
+  'sp.subscribe.allowance_used': 'ใช้โควตารายวันฟรีของ WebBrain Cloud หมดแล้ว',
+  'sp.subscribe.btn': 'สมัครสมาชิก',
   'sp.stopped_by_user': '[ผู้ใช้หยุด]',
   'sp.stopped_by_user_html': '<em>ผู้ใช้หยุดแล้ว</em>',
 

--- a/src/chrome/src/ui/locales/tl.js
+++ b/src/chrome/src/ui/locales/tl.js
@@ -102,6 +102,8 @@ export default {
   'sp.copy.code.title': 'Kopyahin ang code',
 
   'sp.error_prefix': 'Error: {msg}',
+  'sp.subscribe.allowance_used': 'Naubos na ang libreng pang-araw-araw na alokasyon ng WebBrain Cloud.',
+  'sp.subscribe.btn': 'Mag-subscribe',
   'sp.stopped_by_user': '[Itinigil ng user]',
   'sp.stopped_by_user_html': '<em>Itinigil ng user.</em>',
 

--- a/src/chrome/src/ui/locales/tr.js
+++ b/src/chrome/src/ui/locales/tr.js
@@ -102,6 +102,8 @@ export default {
   'sp.copy.code.title': 'Kodu kopyala',
 
   'sp.error_prefix': 'Hata: {msg}',
+  'sp.subscribe.allowance_used': 'Ücretsiz günlük WebBrain Cloud kullanım hakkınız doldu.',
+  'sp.subscribe.btn': 'Abone ol',
   'sp.stopped_by_user': '[Kullanıcı durdurdu]',
   'sp.stopped_by_user_html': '<em>Kullanıcı durdurdu.</em>',
 

--- a/src/chrome/src/ui/locales/uk.js
+++ b/src/chrome/src/ui/locales/uk.js
@@ -102,6 +102,8 @@ export default {
   'sp.copy.code.title': 'Копіювати код',
 
   'sp.error_prefix': 'Помилка: {msg}',
+  'sp.subscribe.allowance_used': 'Безкоштовний денний ліміт WebBrain Cloud вичерпано.',
+  'sp.subscribe.btn': 'Оформити підписку',
   'sp.stopped_by_user': '[Зупинено користувачем]',
   'sp.stopped_by_user_html': '<em>Зупинено користувачем.</em>',
 

--- a/src/chrome/src/ui/locales/zh.js
+++ b/src/chrome/src/ui/locales/zh.js
@@ -102,6 +102,8 @@ export default {
   'sp.copy.code.title': '复制代码',
 
   'sp.error_prefix': '错误：{msg}',
+  'sp.subscribe.allowance_used': '今日免费的 WebBrain Cloud 额度已用完。',
+  'sp.subscribe.btn': '订阅',
   'sp.stopped_by_user': '[用户已停止]',
   'sp.stopped_by_user_html': '<em>用户已停止。</em>',
 

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -8,7 +8,7 @@ import { CAPABILITY_LABEL } from '../agent/permission-gate.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '17.0.1';
+const EXT_VERSION = '17.1.0';
 
 const providersContainer = document.getElementById('providers');
 const verboseToggle = document.getElementById('toggle-verbose');

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -1615,11 +1615,20 @@ function rebindScheduleComposers() {
   });
 }
 
+function rebindSubscribeButtons() {
+  document.querySelectorAll('.subscribe-btn').forEach(btn => {
+    if (btn.dataset.bound) return;
+    btn.dataset.bound = 'true';
+    btn.addEventListener('click', () => openSubscribeUrl(btn.dataset.subscribeUrl));
+  });
+}
+
 function rebindRestoredMessageControls() {
   rebindCopyButtons();
   rebindContinueButtons();
   rebindClarifyCards();
   rebindScheduleComposers();
+  rebindSubscribeButtons();
 }
 
 async function loadProviders() {
@@ -2926,9 +2935,17 @@ function parseSubscribeError(content) {
   return { url, message };
 }
 
+function openSubscribeUrl(url) {
+  if (!url) return;
+  try { chrome.tabs.create({ url }); }
+  catch { window.open(url, '_blank', 'noopener'); }
+}
+
 // Render the quota error as a card with a one-click Subscribe button. Returns
 // true when `content` matched and the card was rendered into `textEl`, so the
-// caller can skip its normal markdown rendering.
+// caller can skip its normal markdown rendering. The URL is stashed on the
+// button's dataset so it survives chat-history restore (messagesEl.innerHTML),
+// where the click closure is lost and rebindSubscribeButtons re-attaches it.
 function renderSubscribeError(textEl, content) {
   const parsed = parseSubscribeError(content);
   if (!parsed) return false;
@@ -2944,10 +2961,9 @@ function renderSubscribeError(textEl, content) {
   const btn = document.createElement('button');
   btn.className = 'subscribe-btn';
   btn.textContent = t('sp.subscribe.btn');
-  btn.addEventListener('click', () => {
-    try { chrome.tabs.create({ url: parsed.url }); }
-    catch { window.open(parsed.url, '_blank', 'noopener'); }
-  });
+  btn.dataset.subscribeUrl = parsed.url;
+  btn.dataset.bound = 'true';
+  btn.addEventListener('click', () => openSubscribeUrl(btn.dataset.subscribeUrl));
   textEl.appendChild(btn);
   return true;
 }

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -2199,7 +2199,9 @@ async function sendMessage(extraChatParams) {
     } else if (renderToCurrentTab && currentTabId === tabId && res?.content && assistantEl) {
       const textEl = assistantEl.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
-        textEl.innerHTML = formatMarkdown(res.content);
+        if (!renderSubscribeError(textEl, res.content)) {
+          textEl.innerHTML = formatMarkdown(res.content);
+        }
         addMessageCopyButton(assistantEl);
       }
     }
@@ -2909,6 +2911,47 @@ function appendVerboseToolResult(name, result) {
 // UI Helpers
 // ==========================================================================
 
+// WebBrain Cloud returns a 402 with a trailing "Subscribe for more usage: <url>"
+// line once the free daily allowance runs out. Detect that shape so we can turn
+// the bare URL into a real Subscribe button instead of making the user copy it.
+const SUBSCRIBE_ERROR_RE = /Subscribe for more usage:\s*(https?:\/\/\S+)/i;
+
+function parseSubscribeError(content) {
+  if (typeof content !== 'string') return null;
+  const m = content.match(SUBSCRIBE_ERROR_RE);
+  if (!m) return null;
+  // Strip trailing punctuation that markdown/markup might have appended.
+  const url = m[1].replace(/[)\].,"'>]+$/, '');
+  const message = content.slice(0, m.index).replace(/\s+$/, '').trim();
+  return { url, message };
+}
+
+// Render the quota error as a card with a one-click Subscribe button. Returns
+// true when `content` matched and the card was rendered into `textEl`, so the
+// caller can skip its normal markdown rendering.
+function renderSubscribeError(textEl, content) {
+  const parsed = parseSubscribeError(content);
+  if (!parsed) return false;
+
+  textEl.innerHTML = '';
+  textEl.classList.add('subscribe-error');
+
+  const msg = document.createElement('div');
+  msg.className = 'subscribe-error-text';
+  msg.textContent = parsed.message || t('sp.subscribe.allowance_used');
+  textEl.appendChild(msg);
+
+  const btn = document.createElement('button');
+  btn.className = 'subscribe-btn';
+  btn.textContent = t('sp.subscribe.btn');
+  btn.addEventListener('click', () => {
+    try { chrome.tabs.create({ url: parsed.url }); }
+    catch { window.open(parsed.url, '_blank', 'noopener'); }
+  });
+  textEl.appendChild(btn);
+  return true;
+}
+
 function addMessage(role, content) {
   const msgEl = document.createElement('div');
   msgEl.className = `message ${role}`;
@@ -2922,7 +2965,7 @@ function addMessage(role, content) {
     textEl.textContent = content;
   } else if (role === 'system') {
     textEl.innerHTML = content || '';
-  } else {
+  } else if (!renderSubscribeError(textEl, content)) {
     textEl.innerHTML = content ? formatMarkdown(content) : '';
   }
 
@@ -3015,7 +3058,9 @@ async function continueAgent() {
     if (currentTabId === tabId && res?.content && assistantEl) {
       const textEl = assistantEl.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
-        textEl.innerHTML = formatMarkdown(res.content);
+        if (!renderSubscribeError(textEl, res.content)) {
+          textEl.innerHTML = formatMarkdown(res.content);
+        }
         addMessageCopyButton(assistantEl);
       }
     }

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -1521,6 +1521,35 @@ body {
   color: var(--error-soft);
 }
 
+/* WebBrain Cloud quota / subscribe prompt — bare URL upgraded to a button */
+.message-text.subscribe-error {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.subscribe-error-text {
+  line-height: 1.45;
+}
+
+.subscribe-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 8px 22px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.subscribe-btn:hover {
+  background: var(--accent-hover);
+}
+
 /* Clarify card — agent paused to ask user a question */
 .clarify-card {
   margin: 8px 0;

--- a/src/firefox/ARCHITECTURE.md
+++ b/src/firefox/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Firefox Extension — Architecture
 
-> Version 17.0.1 · Manifest V2 · Background Page
+> Version 17.1.0 · Manifest V2 · Background Page
 
 ## How Firefox Differs from Chrome
 

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "WebBrain",
-  "version": "17.0.1",
+  "version": "17.1.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "activeTab",

--- a/src/firefox/src/ui/locales/ar.js
+++ b/src/firefox/src/ui/locales/ar.js
@@ -100,6 +100,8 @@ export default {
   'sp.copy.code.title': 'نسخ الكود',
 
   'sp.error_prefix': 'خطأ: {msg}',
+  'sp.subscribe.allowance_used': 'تم استخدام الحصة اليومية المجانية من WebBrain Cloud.',
+  'sp.subscribe.btn': 'اشترك',
   'sp.stopped_by_user': '[أوقفه المستخدم]',
   'sp.stopped_by_user_html': '<em>أوقفه المستخدم.</em>',
 

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -119,6 +119,8 @@ export default {
   'sp.copy.code.title': 'Copy code',
 
   'sp.error_prefix': 'Error: {msg}',
+  'sp.subscribe.allowance_used': 'Daily free WebBrain Cloud allowance used.',
+  'sp.subscribe.btn': 'Subscribe',
   'sp.stopped_by_user': '[Stopped by user]',
   'sp.stopped_by_user_html': '<em>Stopped by user.</em>',
 

--- a/src/firefox/src/ui/locales/es.js
+++ b/src/firefox/src/ui/locales/es.js
@@ -100,6 +100,8 @@ export default {
   'sp.copy.code.title': 'Copiar código',
 
   'sp.error_prefix': 'Error: {msg}',
+  'sp.subscribe.allowance_used': 'Se agotó la asignación diaria gratuita de WebBrain Cloud.',
+  'sp.subscribe.btn': 'Suscribirse',
   'sp.stopped_by_user': '[Detenido por el usuario]',
   'sp.stopped_by_user_html': '<em>Detenido por el usuario.</em>',
 

--- a/src/firefox/src/ui/locales/fr.js
+++ b/src/firefox/src/ui/locales/fr.js
@@ -100,6 +100,8 @@ export default {
   'sp.copy.code.title': 'Copier le code',
 
   'sp.error_prefix': 'Erreur : {msg}',
+  'sp.subscribe.allowance_used': 'Quota quotidien gratuit de WebBrain Cloud épuisé.',
+  'sp.subscribe.btn': 'S’abonner',
   'sp.stopped_by_user': '[Arrêté par l\'utilisateur]',
   'sp.stopped_by_user_html': '<em>Arrêté par l\'utilisateur.</em>',
 

--- a/src/firefox/src/ui/locales/id.js
+++ b/src/firefox/src/ui/locales/id.js
@@ -100,6 +100,8 @@ export default {
   'sp.copy.code.title': 'Salin kode',
 
   'sp.error_prefix': 'Galat: {msg}',
+  'sp.subscribe.allowance_used': 'Kuota harian gratis WebBrain Cloud telah habis.',
+  'sp.subscribe.btn': 'Berlangganan',
   'sp.stopped_by_user': '[Dihentikan oleh pengguna]',
   'sp.stopped_by_user_html': '<em>Dihentikan oleh pengguna.</em>',
 

--- a/src/firefox/src/ui/locales/ja.js
+++ b/src/firefox/src/ui/locales/ja.js
@@ -100,6 +100,8 @@ export default {
   'sp.copy.code.title': 'コードをコピー',
 
   'sp.error_prefix': 'エラー: {msg}',
+  'sp.subscribe.allowance_used': 'WebBrain Cloud の無料の1日あたりの利用枠を使い切りました。',
+  'sp.subscribe.btn': '購読する',
   'sp.stopped_by_user': '[ユーザーが停止]',
   'sp.stopped_by_user_html': '<em>ユーザーが停止しました。</em>',
 

--- a/src/firefox/src/ui/locales/ko.js
+++ b/src/firefox/src/ui/locales/ko.js
@@ -100,6 +100,8 @@ export default {
   'sp.copy.code.title': '코드 복사',
 
   'sp.error_prefix': '오류: {msg}',
+  'sp.subscribe.allowance_used': 'WebBrain Cloud의 무료 일일 사용량을 모두 사용했습니다.',
+  'sp.subscribe.btn': '구독하기',
   'sp.stopped_by_user': '[사용자가 중지함]',
   'sp.stopped_by_user_html': '<em>사용자가 중지했습니다.</em>',
 

--- a/src/firefox/src/ui/locales/ms.js
+++ b/src/firefox/src/ui/locales/ms.js
@@ -100,6 +100,8 @@ export default {
   'sp.copy.code.title': 'Salin kod',
 
   'sp.error_prefix': 'Ralat: {msg}',
+  'sp.subscribe.allowance_used': 'Peruntukan harian percuma WebBrain Cloud telah digunakan.',
+  'sp.subscribe.btn': 'Langgan',
   'sp.stopped_by_user': '[Dihentikan oleh pengguna]',
   'sp.stopped_by_user_html': '<em>Dihentikan oleh pengguna.</em>',
 

--- a/src/firefox/src/ui/locales/ru.js
+++ b/src/firefox/src/ui/locales/ru.js
@@ -100,6 +100,8 @@ export default {
   'sp.copy.code.title': 'Копировать код',
 
   'sp.error_prefix': 'Ошибка: {msg}',
+  'sp.subscribe.allowance_used': 'Бесплатный дневной лимит WebBrain Cloud исчерпан.',
+  'sp.subscribe.btn': 'Оформить подписку',
   'sp.stopped_by_user': '[Остановлено пользователем]',
   'sp.stopped_by_user_html': '<em>Остановлено пользователем.</em>',
 

--- a/src/firefox/src/ui/locales/th.js
+++ b/src/firefox/src/ui/locales/th.js
@@ -100,6 +100,8 @@ export default {
   'sp.copy.code.title': 'คัดลอกโค้ด',
 
   'sp.error_prefix': 'ข้อผิดพลาด: {msg}',
+  'sp.subscribe.allowance_used': 'ใช้โควตารายวันฟรีของ WebBrain Cloud หมดแล้ว',
+  'sp.subscribe.btn': 'สมัครสมาชิก',
   'sp.stopped_by_user': '[ผู้ใช้หยุด]',
   'sp.stopped_by_user_html': '<em>ผู้ใช้หยุดแล้ว</em>',
 

--- a/src/firefox/src/ui/locales/tl.js
+++ b/src/firefox/src/ui/locales/tl.js
@@ -100,6 +100,8 @@ export default {
   'sp.copy.code.title': 'Kopyahin ang code',
 
   'sp.error_prefix': 'Error: {msg}',
+  'sp.subscribe.allowance_used': 'Naubos na ang libreng pang-araw-araw na alokasyon ng WebBrain Cloud.',
+  'sp.subscribe.btn': 'Mag-subscribe',
   'sp.stopped_by_user': '[Itinigil ng user]',
   'sp.stopped_by_user_html': '<em>Itinigil ng user.</em>',
 

--- a/src/firefox/src/ui/locales/tr.js
+++ b/src/firefox/src/ui/locales/tr.js
@@ -100,6 +100,8 @@ export default {
   'sp.copy.code.title': 'Kodu kopyala',
 
   'sp.error_prefix': 'Hata: {msg}',
+  'sp.subscribe.allowance_used': 'Ücretsiz günlük WebBrain Cloud kullanım hakkınız doldu.',
+  'sp.subscribe.btn': 'Abone ol',
   'sp.stopped_by_user': '[Kullanıcı durdurdu]',
   'sp.stopped_by_user_html': '<em>Kullanıcı durdurdu.</em>',
 

--- a/src/firefox/src/ui/locales/uk.js
+++ b/src/firefox/src/ui/locales/uk.js
@@ -100,6 +100,8 @@ export default {
   'sp.copy.code.title': 'Копіювати код',
 
   'sp.error_prefix': 'Помилка: {msg}',
+  'sp.subscribe.allowance_used': 'Безкоштовний денний ліміт WebBrain Cloud вичерпано.',
+  'sp.subscribe.btn': 'Оформити підписку',
   'sp.stopped_by_user': '[Зупинено користувачем]',
   'sp.stopped_by_user_html': '<em>Зупинено користувачем.</em>',
 

--- a/src/firefox/src/ui/locales/zh.js
+++ b/src/firefox/src/ui/locales/zh.js
@@ -100,6 +100,8 @@ export default {
   'sp.copy.code.title': '复制代码',
 
   'sp.error_prefix': '错误：{msg}',
+  'sp.subscribe.allowance_used': '今日免费的 WebBrain Cloud 额度已用完。',
+  'sp.subscribe.btn': '订阅',
   'sp.stopped_by_user': '[用户已停止]',
   'sp.stopped_by_user_html': '<em>用户已停止。</em>',
 

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -8,7 +8,7 @@ import { CAPABILITY_LABEL } from '../agent/permission-gate.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '17.0.1';
+const EXT_VERSION = '17.1.0';
 
 const providersContainer = document.getElementById('providers');
 const verboseToggle = document.getElementById('toggle-verbose');

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -1450,11 +1450,20 @@ function rebindScheduleComposers() {
   });
 }
 
+function rebindSubscribeButtons() {
+  document.querySelectorAll('.subscribe-btn').forEach(btn => {
+    if (btn.dataset.bound) return;
+    btn.dataset.bound = 'true';
+    btn.addEventListener('click', () => openSubscribeUrl(btn.dataset.subscribeUrl));
+  });
+}
+
 function rebindRestoredMessageControls() {
   rebindCopyButtons();
   rebindContinueButtons();
   rebindClarifyCards();
   rebindScheduleComposers();
+  rebindSubscribeButtons();
 }
 
 async function loadProviders() {
@@ -2532,9 +2541,17 @@ function parseSubscribeError(content) {
   return { url, message };
 }
 
+function openSubscribeUrl(url) {
+  if (!url) return;
+  try { browser.tabs.create({ url }); }
+  catch { window.open(url, '_blank', 'noopener'); }
+}
+
 // Render the quota error as a card with a one-click Subscribe button. Returns
 // true when `content` matched and the card was rendered into `textEl`, so the
-// caller can skip its normal markdown rendering.
+// caller can skip its normal markdown rendering. The URL is stashed on the
+// button's dataset so it survives chat-history restore (messagesEl.innerHTML),
+// where the click closure is lost and rebindSubscribeButtons re-attaches it.
 function renderSubscribeError(textEl, content) {
   const parsed = parseSubscribeError(content);
   if (!parsed) return false;
@@ -2550,10 +2567,9 @@ function renderSubscribeError(textEl, content) {
   const btn = document.createElement('button');
   btn.className = 'subscribe-btn';
   btn.textContent = t('sp.subscribe.btn');
-  btn.addEventListener('click', () => {
-    try { browser.tabs.create({ url: parsed.url }); }
-    catch { window.open(parsed.url, '_blank', 'noopener'); }
-  });
+  btn.dataset.subscribeUrl = parsed.url;
+  btn.dataset.bound = 'true';
+  btn.addEventListener('click', () => openSubscribeUrl(btn.dataset.subscribeUrl));
   textEl.appendChild(btn);
   return true;
 }

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -2005,7 +2005,9 @@ async function sendMessage(extraChatParams) {
     } else if (renderToCurrentTab && currentTabId === tabId && res?.content && assistantEl) {
       const textEl = assistantEl.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
-        textEl.innerHTML = formatMarkdown(res.content);
+        if (!renderSubscribeError(textEl, res.content)) {
+          textEl.innerHTML = formatMarkdown(res.content);
+        }
         addMessageCopyButton(assistantEl);
       }
     }
@@ -2515,6 +2517,47 @@ function appendVerboseToolResult(name, result) {
 // UI Helpers
 // ==========================================================================
 
+// WebBrain Cloud returns a 402 with a trailing "Subscribe for more usage: <url>"
+// line once the free daily allowance runs out. Detect that shape so we can turn
+// the bare URL into a real Subscribe button instead of making the user copy it.
+const SUBSCRIBE_ERROR_RE = /Subscribe for more usage:\s*(https?:\/\/\S+)/i;
+
+function parseSubscribeError(content) {
+  if (typeof content !== 'string') return null;
+  const m = content.match(SUBSCRIBE_ERROR_RE);
+  if (!m) return null;
+  // Strip trailing punctuation that markdown/markup might have appended.
+  const url = m[1].replace(/[)\].,"'>]+$/, '');
+  const message = content.slice(0, m.index).replace(/\s+$/, '').trim();
+  return { url, message };
+}
+
+// Render the quota error as a card with a one-click Subscribe button. Returns
+// true when `content` matched and the card was rendered into `textEl`, so the
+// caller can skip its normal markdown rendering.
+function renderSubscribeError(textEl, content) {
+  const parsed = parseSubscribeError(content);
+  if (!parsed) return false;
+
+  textEl.innerHTML = '';
+  textEl.classList.add('subscribe-error');
+
+  const msg = document.createElement('div');
+  msg.className = 'subscribe-error-text';
+  msg.textContent = parsed.message || t('sp.subscribe.allowance_used');
+  textEl.appendChild(msg);
+
+  const btn = document.createElement('button');
+  btn.className = 'subscribe-btn';
+  btn.textContent = t('sp.subscribe.btn');
+  btn.addEventListener('click', () => {
+    try { browser.tabs.create({ url: parsed.url }); }
+    catch { window.open(parsed.url, '_blank', 'noopener'); }
+  });
+  textEl.appendChild(btn);
+  return true;
+}
+
 function addMessage(role, content) {
   const msgEl = document.createElement('div');
   msgEl.className = `message ${role}`;
@@ -2528,7 +2571,7 @@ function addMessage(role, content) {
     textEl.textContent = content;
   } else if (role === 'system') {
     textEl.innerHTML = content || '';
-  } else {
+  } else if (!renderSubscribeError(textEl, content)) {
     textEl.innerHTML = content ? formatMarkdown(content) : '';
   }
 
@@ -2619,7 +2662,9 @@ async function continueAgent() {
     if (currentTabId === tabId && res?.content && assistantEl) {
       const textEl = assistantEl.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
-        textEl.innerHTML = formatMarkdown(res.content);
+        if (!renderSubscribeError(textEl, res.content)) {
+          textEl.innerHTML = formatMarkdown(res.content);
+        }
         addMessageCopyButton(assistantEl);
       }
     }

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -1520,6 +1520,35 @@ body {
   color: var(--error-soft);
 }
 
+/* WebBrain Cloud quota / subscribe prompt — bare URL upgraded to a button */
+.message-text.subscribe-error {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.subscribe-error-text {
+  line-height: 1.45;
+}
+
+.subscribe-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 8px 22px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.subscribe-btn:hover {
+  background: var(--accent-hover);
+}
+
 /* Clarify card — agent paused to ask user a question */
 .clarify-card {
   margin: 8px 0;


### PR DESCRIPTION
## What

When WebBrain Cloud hits its free daily limit it returns a `402` whose body ends with a bare line:

```
Daily free WebBrain Cloud allowance used.
Subscribe for more usage: https://webbrain.one/subscribe
```

Previously the user had to read and manually copy that URL out of an error bubble. This PR detects that response shape and renders the message with a **one-click Subscribe button** that opens the subscribe page.

## Why

The 402 quota message is the moment a user is most likely to convert, but the UX dead-ended at a non-clickable URL inside a red/error bubble. A clear button removes that friction.

## How

- Added `parseSubscribeError` / `renderSubscribeError` helpers in `sidepanel.js`. The detector matches `Subscribe for more usage: <url>`, splits off the message text, strips trailing punctuation from the URL, and renders a card with a Subscribe button.
- Wired it into `addMessage` (covers the red **error** bubble) and the two assistant content-render paths (covers the white **"Error communicating with LLM…"** bubble). Both cases from the reported screenshots are handled.
- The button uses the URL from the response, so it respects a backend-provided `subscribe_url` if it differs from the default.
- Styled `.subscribe-btn` to match the existing accent buttons (e.g. the Continue button).

## Notes for reviewer

- Changes are mirrored across the **Chrome** and **Firefox** builds. The only intentional difference: Firefox uses `browser.tabs.create`, Chrome uses `chrome.tabs.create`; both fall back to `window.open(..., '_blank', 'noopener')`.
- English strings (`sp.subscribe.btn`, `sp.subscribe.allowance_used`) added to `en.js`; other locales fall back to English automatically via `t()`.
- No backend/provider changes — `openai.js` already emits the `subscribe_url` shape this consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)