### PR TITLE
[codex] Tune context compaction thresholds

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5063,11 +5063,20 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // would leave too little `oldMessages` history to summarize and we'd send
       // the same over-budget prompt again. Move just enough of the earliest
       // recent turns back into the summary set to make compaction possible.
-      while (oldMessages.length < 4 && recentMessages.length) {
+      const moveOldestRecentToSummary = () => {
         oldMessages.push(recentMessages.shift());
         while (recentMessages.length && recentMessages[0].role === 'tool') {
           oldMessages.push(recentMessages.shift());
         }
+      };
+      while (oldMessages.length < 4 && recentMessages.length) {
+        moveOldestRecentToSummary();
+      }
+      const pinnedChars = this._estimateContextChars([systemMsg, originalTask, scratchpadMsg, progressMsg].filter(Boolean));
+      const compactOverheadChars = 3000; // summary wrapper + ack + manual summary fallback
+      const maxRecentChars = Math.max(0, (tokenBudget * 4) - pinnedChars - compactOverheadChars);
+      while (oldMessages.length >= 4 && recentMessages.length > 1 && this._estimateContextChars(recentMessages) > maxRecentChars) {
+        moveOldestRecentToSummary();
       }
     }
 

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -4842,9 +4842,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * than the jarring _emergencyTrim fallback.
    */
   _contextCompactRatioForWindow(contextWindow) {
-    if (contextWindow <= 32000) return 0.65;
-    if (contextWindow <= 64000) return 0.70;
-    if (contextWindow <= 128000) return this.contextCompactRatio;
+    if (contextWindow <= 32768) return 0.65;
+    if (contextWindow <= 65536) return 0.70;
+    if (contextWindow <= 131072) return this.contextCompactRatio;
     return 0.80;
   }
 

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5066,25 +5066,39 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // would leave too little `oldMessages` history to summarize and we'd send
       // the same over-budget prompt again. Move just enough of the earliest
       // recent turns back into the summary set to make compaction possible.
+      const latestUserRecentIndex = () => {
+        for (let i = recentMessages.length - 1; i >= 0; i--) {
+          if (recentMessages[i]?.role === 'user') return i;
+        }
+        return -1;
+      };
+      const canMoveOldestRecentToSummary = () => {
+        if (!recentMessages.length) return false;
+        const latestUserIdx = latestUserRecentIndex();
+        if (latestUserIdx === 0) return false;
+        if (latestUserIdx < 0 && recentMessages[0]?.role === 'tool') return true;
+        return latestUserIdx > 0 || recentMessages.length > 1;
+      };
       const moveOldestRecentToSummary = () => {
+        if (!canMoveOldestRecentToSummary()) return false;
         oldMessages.push(recentMessages.shift());
-        while (recentMessages.length && recentMessages[0].role === 'tool') {
+        while (recentMessages.length && recentMessages[0].role === 'tool' && canMoveOldestRecentToSummary()) {
           oldMessages.push(recentMessages.shift());
         }
+        return true;
       };
-      while (oldMessages.length < 4 && recentMessages.length) {
-        moveOldestRecentToSummary();
-      }
+      while (oldMessages.length < 4 && moveOldestRecentToSummary()) {}
       const pinnedChars = this._estimateContextChars([systemMsg, originalTask, scratchpadMsg, progressMsg].filter(Boolean));
       const compactOverheadChars = 3000; // summary wrapper + ack + manual summary fallback
       const fixedPromptOverheadChars = fixedPromptOverheadTokens * 4;
       const maxRecentChars = Math.max(0, (tokenBudget * 4) - fixedPromptOverheadChars - pinnedChars - compactOverheadChars);
-      while (oldMessages.length >= 4 && recentMessages.length > 1 && this._estimateContextChars(recentMessages) > maxRecentChars) {
+      while (oldMessages.length >= 4 && canMoveOldestRecentToSummary() && this._estimateContextChars(recentMessages) > maxRecentChars) {
         moveOldestRecentToSummary();
       }
     }
 
-    if (oldMessages.length < 4) {
+    const minSummarizableMessages = tooManyTokens && oldMessages.some(m => m?.role === 'user') ? 1 : 4;
+    if (oldMessages.length < minSummarizableMessages) {
       // Not enough history to summarize. But if the TOKEN budget is what
       // tripped us (e.g. a single huge page/tool result early in a run on a
       // small local model), returning unchanged would re-send the same

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5069,7 +5069,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // recent turns back into the summary set to make compaction possible.
       const latestUserRecentIndex = () => {
         for (let i = recentMessages.length - 1; i >= 0; i--) {
-          if (recentMessages[i]?.role === 'user') return i;
+          const msg = recentMessages[i];
+          if (msg?.role === 'user' && !this._isAgentInjectedUserContent(msg.content)) return i;
         }
         return -1;
       };

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -4988,6 +4988,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     } else {
       usedTokens = Math.max(lastReported, estTokens);
     }
+    const fixedPromptOverheadTokens = lastReported > 0 && lastEstChars != null
+      ? Math.max(0, lastReported - Math.ceil(lastEstChars / 4))
+      : 0;
 
     const tooManyMessages = messages.length > this.maxContextMessages;
     const tooManyChars = totalChars > this.maxContextChars;
@@ -5074,7 +5077,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
       const pinnedChars = this._estimateContextChars([systemMsg, originalTask, scratchpadMsg, progressMsg].filter(Boolean));
       const compactOverheadChars = 3000; // summary wrapper + ack + manual summary fallback
-      const maxRecentChars = Math.max(0, (tokenBudget * 4) - pinnedChars - compactOverheadChars);
+      const fixedPromptOverheadChars = fixedPromptOverheadTokens * 4;
+      const maxRecentChars = Math.max(0, (tokenBudget * 4) - fixedPromptOverheadChars - pinnedChars - compactOverheadChars);
       while (oldMessages.length >= 4 && recentMessages.length > 1 && this._estimateContextChars(recentMessages) > maxRecentChars) {
         moveOldestRecentToSummary();
       }

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -80,10 +80,9 @@ export class Agent {
     this._debugLog = []; // ring buffer for deep verbose (LLM requests/responses)
     this._debugLogMax = 200; // max entries before oldest are dropped
     this.maxContextChars = 80000; // rough char budget (~20k tokens)
-    // Fraction of the model's context window at which we auto-compact. Once
-    // the running input-token count crosses this share of provider.contextWindow,
-    // _manageContext summarizes older turns ("Context automatically compacted")
-    // — leaving headroom for the next request plus the output budget.
+    // Default fraction of the model's context window at which we auto-compact.
+    // _contextCompactRatioForWindow tightens this for small context windows and
+    // relaxes it for very large ones.
     this.contextCompactRatio = 0.75;
     // tabId -> most recent provider-reported input (prompt) token count. Drives
     // the token-aware auto-compaction trigger; updated after each LLM response,
@@ -4837,15 +4836,22 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   /**
    * Token budget at which we proactively auto-compact for the active provider:
-   * a fraction (contextCompactRatio) of the model's context window. Compacting
+   * an adaptive fraction of the model's context window. Compacting
    * here — before the provider hard-errors on overflow — keeps the run smooth
    * and lets us surface a clean "Context automatically compacted" notice rather
    * than the jarring _emergencyTrim fallback.
    */
+  _contextCompactRatioForWindow(contextWindow) {
+    if (contextWindow <= 32000) return 0.65;
+    if (contextWindow <= 64000) return 0.70;
+    if (contextWindow <= 128000) return this.contextCompactRatio;
+    return 0.80;
+  }
+
   _contextTokenBudget() {
     const provider = this.providerManager.getActive();
     const window = (provider && Number(provider.contextWindow)) || 128000;
-    return Math.floor(window * this.contextCompactRatio);
+    return Math.floor(window * this._contextCompactRatioForWindow(window));
   }
 
   // Char-equivalent billed for the single screenshot that survives image

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5060,6 +5060,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     while (recentMessages.length && recentMessages[0].role === 'tool') {
       oldMessages.push(recentMessages.shift());
     }
+    let retainedRecentOverBudget = false;
     if (tooManyTokens) {
       // Small-window runs can exceed the token budget before they have more
       // than 30 post-task messages. In that case, keeping all 30 recent turns
@@ -5095,10 +5096,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       while (oldMessages.length >= 4 && canMoveOldestRecentToSummary() && this._estimateContextChars(recentMessages) > maxRecentChars) {
         moveOldestRecentToSummary();
       }
+      retainedRecentOverBudget = this._estimateContextChars(recentMessages) > maxRecentChars;
     }
 
     const minSummarizableMessages = tooManyTokens && oldMessages.some(m => m?.role === 'user') ? 1 : 4;
-    if (oldMessages.length < minSummarizableMessages) {
+    if (oldMessages.length < minSummarizableMessages || retainedRecentOverBudget) {
       // Not enough history to summarize. But if the TOKEN budget is what
       // tripped us (e.g. a single huge page/tool result early in a run on a
       // small local model), returning unchanged would re-send the same

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5036,8 +5036,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const keepRecent = 30;
     // Exclude the pinned original task from both summary and recent slices.
     const afterPin = originalTaskIdx >= 0 ? originalTaskIdx + 1 : 1;
-    const oldMessagesRaw = messages.slice(afterPin, -keepRecent);
-    const recentMessagesRaw = messages.slice(-keepRecent);
+    const recentStart = Math.max(afterPin, messages.length - keepRecent);
+    const oldMessagesRaw = messages.slice(afterPin, recentStart);
+    const recentMessagesRaw = messages.slice(recentStart);
     // Strip the scratchpad out of both slices — we re-pin a single copy of
     // it in the rebuild step below. Without this we'd either lose it (if it
     // fell into oldMessages and got summarized away) or duplicate it.
@@ -5055,6 +5056,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // parent assistant turn already lives there, so the digest stays intact).
     while (recentMessages.length && recentMessages[0].role === 'tool') {
       oldMessages.push(recentMessages.shift());
+    }
+    if (tooManyTokens) {
+      // Small-window runs can exceed the token budget before they have more
+      // than 30 post-task messages. In that case, keeping all 30 recent turns
+      // would leave too little `oldMessages` history to summarize and we'd send
+      // the same over-budget prompt again. Move just enough of the earliest
+      // recent turns back into the summary set to make compaction possible.
+      while (oldMessages.length < 4 && recentMessages.length) {
+        oldMessages.push(recentMessages.shift());
+        while (recentMessages.length && recentMessages[0].role === 'tool') {
+          oldMessages.push(recentMessages.shift());
+        }
+      }
     }
 
     if (oldMessages.length < 4) {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4245,25 +4245,39 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // would leave too little `oldMessages` history to summarize and we'd send
       // the same over-budget prompt again. Move just enough of the earliest
       // recent turns back into the summary set to make compaction possible.
+      const latestUserRecentIndex = () => {
+        for (let i = recentMessages.length - 1; i >= 0; i--) {
+          if (recentMessages[i]?.role === 'user') return i;
+        }
+        return -1;
+      };
+      const canMoveOldestRecentToSummary = () => {
+        if (!recentMessages.length) return false;
+        const latestUserIdx = latestUserRecentIndex();
+        if (latestUserIdx === 0) return false;
+        if (latestUserIdx < 0 && recentMessages[0]?.role === 'tool') return true;
+        return latestUserIdx > 0 || recentMessages.length > 1;
+      };
       const moveOldestRecentToSummary = () => {
+        if (!canMoveOldestRecentToSummary()) return false;
         oldMessages.push(recentMessages.shift());
-        while (recentMessages.length && recentMessages[0].role === 'tool') {
+        while (recentMessages.length && recentMessages[0].role === 'tool' && canMoveOldestRecentToSummary()) {
           oldMessages.push(recentMessages.shift());
         }
+        return true;
       };
-      while (oldMessages.length < 4 && recentMessages.length) {
-        moveOldestRecentToSummary();
-      }
+      while (oldMessages.length < 4 && moveOldestRecentToSummary()) {}
       const pinnedChars = this._estimateContextChars([systemMsg, originalTask, scratchpadMsg, progressMsg].filter(Boolean));
       const compactOverheadChars = 3000; // summary wrapper + ack + manual summary fallback
       const fixedPromptOverheadChars = fixedPromptOverheadTokens * 4;
       const maxRecentChars = Math.max(0, (tokenBudget * 4) - fixedPromptOverheadChars - pinnedChars - compactOverheadChars);
-      while (oldMessages.length >= 4 && recentMessages.length > 1 && this._estimateContextChars(recentMessages) > maxRecentChars) {
+      while (oldMessages.length >= 4 && canMoveOldestRecentToSummary() && this._estimateContextChars(recentMessages) > maxRecentChars) {
         moveOldestRecentToSummary();
       }
     }
 
-    if (oldMessages.length < 4) {
+    const minSummarizableMessages = tooManyTokens && oldMessages.some(m => m?.role === 'user') ? 1 : 4;
+    if (oldMessages.length < minSummarizableMessages) {
       // Not enough history to summarize. But if the TOKEN budget is what
       // tripped us (e.g. a single huge page/tool result early in a run on a
       // small local model), returning unchanged would re-send the same

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4242,11 +4242,20 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // would leave too little `oldMessages` history to summarize and we'd send
       // the same over-budget prompt again. Move just enough of the earliest
       // recent turns back into the summary set to make compaction possible.
-      while (oldMessages.length < 4 && recentMessages.length) {
+      const moveOldestRecentToSummary = () => {
         oldMessages.push(recentMessages.shift());
         while (recentMessages.length && recentMessages[0].role === 'tool') {
           oldMessages.push(recentMessages.shift());
         }
+      };
+      while (oldMessages.length < 4 && recentMessages.length) {
+        moveOldestRecentToSummary();
+      }
+      const pinnedChars = this._estimateContextChars([systemMsg, originalTask, scratchpadMsg, progressMsg].filter(Boolean));
+      const compactOverheadChars = 3000; // summary wrapper + ack + manual summary fallback
+      const maxRecentChars = Math.max(0, (tokenBudget * 4) - pinnedChars - compactOverheadChars);
+      while (oldMessages.length >= 4 && recentMessages.length > 1 && this._estimateContextChars(recentMessages) > maxRecentChars) {
+        moveOldestRecentToSummary();
       }
     }
 

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4040,9 +4040,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * than the jarring _emergencyTrim fallback.
    */
   _contextCompactRatioForWindow(contextWindow) {
-    if (contextWindow <= 32000) return 0.65;
-    if (contextWindow <= 64000) return 0.70;
-    if (contextWindow <= 128000) return this.contextCompactRatio;
+    if (contextWindow <= 32768) return 0.65;
+    if (contextWindow <= 65536) return 0.70;
+    if (contextWindow <= 131072) return this.contextCompactRatio;
     return 0.80;
   }
 

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4248,7 +4248,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // recent turns back into the summary set to make compaction possible.
       const latestUserRecentIndex = () => {
         for (let i = recentMessages.length - 1; i >= 0; i--) {
-          if (recentMessages[i]?.role === 'user') return i;
+          const msg = recentMessages[i];
+          if (msg?.role === 'user' && !this._isAgentInjectedUserContent(msg.content)) return i;
         }
         return -1;
       };

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4172,6 +4172,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     } else {
       usedTokens = Math.max(lastReported, estTokens);
     }
+    const fixedPromptOverheadTokens = lastReported > 0 && lastEstChars != null
+      ? Math.max(0, lastReported - Math.ceil(lastEstChars / 4))
+      : 0;
 
     const tooManyMessages = messages.length > this.maxContextMessages;
     const tooManyChars = totalChars > this.maxContextChars;
@@ -4253,7 +4256,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
       const pinnedChars = this._estimateContextChars([systemMsg, originalTask, scratchpadMsg, progressMsg].filter(Boolean));
       const compactOverheadChars = 3000; // summary wrapper + ack + manual summary fallback
-      const maxRecentChars = Math.max(0, (tokenBudget * 4) - pinnedChars - compactOverheadChars);
+      const fixedPromptOverheadChars = fixedPromptOverheadTokens * 4;
+      const maxRecentChars = Math.max(0, (tokenBudget * 4) - fixedPromptOverheadChars - pinnedChars - compactOverheadChars);
       while (oldMessages.length >= 4 && recentMessages.length > 1 && this._estimateContextChars(recentMessages) > maxRecentChars) {
         moveOldestRecentToSummary();
       }

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4239,6 +4239,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     while (recentMessages.length && recentMessages[0].role === 'tool') {
       oldMessages.push(recentMessages.shift());
     }
+    let retainedRecentOverBudget = false;
     if (tooManyTokens) {
       // Small-window runs can exceed the token budget before they have more
       // than 30 post-task messages. In that case, keeping all 30 recent turns
@@ -4274,10 +4275,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       while (oldMessages.length >= 4 && canMoveOldestRecentToSummary() && this._estimateContextChars(recentMessages) > maxRecentChars) {
         moveOldestRecentToSummary();
       }
+      retainedRecentOverBudget = this._estimateContextChars(recentMessages) > maxRecentChars;
     }
 
     const minSummarizableMessages = tooManyTokens && oldMessages.some(m => m?.role === 'user') ? 1 : 4;
-    if (oldMessages.length < minSummarizableMessages) {
+    if (oldMessages.length < minSummarizableMessages || retainedRecentOverBudget) {
       // Not enough history to summarize. But if the TOKEN budget is what
       // tripped us (e.g. a single huge page/tool result early in a run on a
       // small local model), returning unchanged would re-send the same

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -72,10 +72,9 @@ export class Agent {
     this._debugLog = []; // ring buffer for deep verbose (LLM requests/responses)
     this._debugLogMax = 200; // max entries before oldest are dropped
     this.maxContextChars = 80000; // rough char budget (~20k tokens)
-    // Fraction of the model's context window at which we auto-compact. Once
-    // the running input-token count crosses this share of provider.contextWindow,
-    // _manageContext summarizes older turns ("Context automatically compacted")
-    // — leaving headroom for the next request plus the output budget.
+    // Default fraction of the model's context window at which we auto-compact.
+    // _contextCompactRatioForWindow tightens this for small context windows and
+    // relaxes it for very large ones.
     this.contextCompactRatio = 0.75;
     // tabId -> most recent provider-reported input (prompt) token count. Drives
     // the token-aware auto-compaction trigger; updated after each LLM response,
@@ -4035,15 +4034,22 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   /**
    * Token budget at which we proactively auto-compact for the active provider:
-   * a fraction (contextCompactRatio) of the model's context window. Compacting
+   * an adaptive fraction of the model's context window. Compacting
    * here — before the provider hard-errors on overflow — keeps the run smooth
    * and lets us surface a clean "Context automatically compacted" notice rather
    * than the jarring _emergencyTrim fallback.
    */
+  _contextCompactRatioForWindow(contextWindow) {
+    if (contextWindow <= 32000) return 0.65;
+    if (contextWindow <= 64000) return 0.70;
+    if (contextWindow <= 128000) return this.contextCompactRatio;
+    return 0.80;
+  }
+
   _contextTokenBudget() {
     const provider = this.providerManager.getActive();
     const window = (provider && Number(provider.contextWindow)) || 128000;
-    return Math.floor(window * this.contextCompactRatio);
+    return Math.floor(window * this._contextCompactRatioForWindow(window));
   }
 
   // Char-equivalent billed for the single screenshot that survives image
@@ -4205,7 +4211,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const scratchpadMsg = scratchpadIdx >= 0 ? messages[scratchpadIdx] : null;
     const progressIdx = this._findProgressLedgerIndex(messages);
     const progressMsg = progressIdx >= 0 ? messages[progressIdx] : null;
-    const keepRecent = 16; // keep last N messages verbatim
+    // Keep last N messages verbatim. Agents doing heavy tool work (scraping,
+    // batch downloads) burn messages fast — each tool call is 2 messages
+    // (assistant + tool result), so 30 ≈ last 15 tool turns. 16 was too tight
+    // for long-horizon tasks and caused the model to "forget" outcomes from
+    // ~8 steps back (e.g. the file list from list_downloads).
+    const keepRecent = 30;
     // Exclude the pinned original task from both summary and recent slices.
     const afterPin = originalTaskIdx >= 0 ? originalTaskIdx + 1 : 1;
     const oldMessagesRaw = messages.slice(afterPin, -keepRecent);

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4219,8 +4219,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const keepRecent = 30;
     // Exclude the pinned original task from both summary and recent slices.
     const afterPin = originalTaskIdx >= 0 ? originalTaskIdx + 1 : 1;
-    const oldMessagesRaw = messages.slice(afterPin, -keepRecent);
-    const recentMessagesRaw = messages.slice(-keepRecent);
+    const recentStart = Math.max(afterPin, messages.length - keepRecent);
+    const oldMessagesRaw = messages.slice(afterPin, recentStart);
+    const recentMessagesRaw = messages.slice(recentStart);
     const oldMessages = oldMessagesRaw.filter(m => !this._isPinnedAgentStateMessage(m));
     const recentMessages = recentMessagesRaw.filter(m => !this._isPinnedAgentStateMessage(m));
 
@@ -4234,6 +4235,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // Move any leading `tool` results back into the summarized set.
     while (recentMessages.length && recentMessages[0].role === 'tool') {
       oldMessages.push(recentMessages.shift());
+    }
+    if (tooManyTokens) {
+      // Small-window runs can exceed the token budget before they have more
+      // than 30 post-task messages. In that case, keeping all 30 recent turns
+      // would leave too little `oldMessages` history to summarize and we'd send
+      // the same over-budget prompt again. Move just enough of the earliest
+      // recent turns back into the summary set to make compaction possible.
+      while (oldMessages.length < 4 && recentMessages.length) {
+        oldMessages.push(recentMessages.shift());
+        while (recentMessages.length && recentMessages[0].role === 'tool') {
+          oldMessages.push(recentMessages.shift());
+        }
+      }
     }
 
     if (oldMessages.length < 4) {

--- a/test/run.js
+++ b/test/run.js
@@ -9673,9 +9673,13 @@ test('context token budget uses adaptive compaction ratios', async () => {
   const cases = [
     [16000, 10400],
     [32000, 20800],
+    [32768, 21299],
     [64000, 44800],
+    [65536, 45875],
     [128000, 96000],
+    [131072, 98304],
     [256000, 204800],
+    [262144, 209715],
   ];
 
   for (const AgentClass of [AgentCh, AgentFx]) {

--- a/test/run.js
+++ b/test/run.js
@@ -9754,6 +9754,41 @@ test('context compaction shrinks recent window when small-window runs exceed tok
   }
 });
 
+test('context compaction preserves the latest user turn while seeding a small summary', async () => {
+  const latestUserTurn = 'CURRENT USER REQUEST: keep this latest turn verbatim';
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getActive: () => ({ contextWindow: 4000, supportsVision: false }) });
+    const tabId = AgentClass === AgentCh ? 196 : 197;
+    const messages = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'keep working on the task' },
+      { role: 'assistant', content: `first exchange ${'x'.repeat(3900)}` },
+      { role: 'user', content: `previous clarification ${'y'.repeat(3900)}` },
+      { role: 'assistant', content: `second exchange ${'z'.repeat(3900)}` },
+      { role: 'user', content: latestUserTurn },
+    ];
+
+    const origLog = console.log;
+    console.log = () => {};
+    let result;
+    try {
+      result = await agent._manageContext(tabId, messages, () => {});
+    } finally {
+      console.log = origLog;
+    }
+
+    assert.equal(result.compacted, true, `${AgentClass.name}: short over-budget history should compact`);
+    assert.equal(result.summarized, 3, `${AgentClass.name}: should summarize only turns before the latest user request`);
+    assert.ok(messages.some(m => m.role === 'user' && m.content === latestUserTurn), `${AgentClass.name}: latest user turn should remain verbatim`);
+    const summary = messages.find(m => /Context window was trimmed/i.test(String(m.content || '')));
+    assert.ok(summary, `${AgentClass.name}: summary message missing`);
+    assert.ok(!String(summary.content || '').includes(latestUserTurn), `${AgentClass.name}: latest user turn should not be folded into the summary`);
+
+    const h = agent.persistTimers?.get?.(tabId);
+    if (h) clearTimeout(h);
+  }
+});
+
 test('context compaction shrinks bulky retained recent history to fit small-window budget', async () => {
   for (const AgentClass of [AgentCh, AgentFx]) {
     const agent = new AgentClass({ getActive: () => ({ contextWindow: 16384, supportsVision: false }) });

--- a/test/run.js
+++ b/test/run.js
@@ -9754,6 +9754,39 @@ test('context compaction shrinks recent window when small-window runs exceed tok
   }
 });
 
+test('context compaction shrinks bulky retained recent history to fit small-window budget', async () => {
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getActive: () => ({ contextWindow: 16384, supportsVision: false }) });
+    const tabId = AgentClass === AgentCh ? 192 : 193;
+    const messages = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'keep working on the task' },
+    ];
+    for (let i = 0; i < 20; i++) {
+      messages.push({ role: 'assistant', content: `step ${i} ${'x'.repeat(2490)}` });
+      messages.push({ role: 'user', content: `ok ${i} ${'y'.repeat(2490)}` });
+    }
+
+    const origLog = console.log;
+    console.log = () => {};
+    let result;
+    try {
+      result = await agent._manageContext(tabId, messages, () => {});
+    } finally {
+      console.log = origLog;
+    }
+
+    assert.equal(result.compacted, true, `${AgentClass.name}: bulky retained history should compact`);
+    assert.ok(result.summarized > 10, `${AgentClass.name}: should summarize some retained recent messages`);
+    assert.ok(agent._estimateContextChars(messages) <= result.budget * 4, `${AgentClass.name}: compacted messages still exceed budget estimate`);
+    assert.ok(messages.some(m => String(m.content || '').includes('ok 19')), `${AgentClass.name}: newest user turn should remain recent`);
+    assert.ok(!messages.some(m => m.role === 'assistant' && String(m.content || '').startsWith('step 5 ')), `${AgentClass.name}: bulky older recent turn should be summarized`);
+
+    const h = agent.persistTimers?.get?.(tabId);
+    if (h) clearTimeout(h);
+  }
+});
+
 test('manual compactConversation reports emergency truncation as compacted', async () => {
   for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
     const agent = new AgentClass({ getActive: () => ({ contextWindow: 4000, supportsVision: false }) });

--- a/test/run.js
+++ b/test/run.js
@@ -9787,6 +9787,42 @@ test('context compaction shrinks bulky retained recent history to fit small-wind
   }
 });
 
+test('context compaction reserves provider-reported fixed prompt overhead', async () => {
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getActive: () => ({ contextWindow: 16384, supportsVision: false }) });
+    const tabId = AgentClass === AgentCh ? 194 : 195;
+    const messages = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'keep working on the task' },
+    ];
+    for (let i = 0; i < 20; i++) {
+      messages.push({ role: 'assistant', content: `step ${i} ${'x'.repeat(2490)}` });
+      messages.push({ role: 'user', content: `ok ${i} ${'y'.repeat(2490)}` });
+    }
+
+    const totalChars = agent._estimateContextChars(messages);
+    const fixedOverheadTokens = 2000;
+    agent._lastEstCharsAtReport.set(tabId, totalChars);
+    agent._lastInputTokens.set(tabId, Math.ceil(totalChars / 4) + fixedOverheadTokens);
+
+    const origLog = console.log;
+    console.log = () => {};
+    let result;
+    try {
+      result = await agent._manageContext(tabId, messages, () => {});
+    } finally {
+      console.log = origLog;
+    }
+
+    assert.equal(result.compacted, true, `${AgentClass.name}: fixed-overhead run should compact`);
+    assert.ok(agent._estimateContextChars(messages) + (fixedOverheadTokens * 4) <= result.budget * 4, `${AgentClass.name}: compacted prompt does not reserve fixed overhead`);
+    assert.ok(messages.some(m => String(m.content || '').includes('ok 19')), `${AgentClass.name}: newest user turn should remain recent`);
+
+    const h = agent.persistTimers?.get?.(tabId);
+    if (h) clearTimeout(h);
+  }
+});
+
 test('manual compactConversation reports emergency truncation as compacted', async () => {
   for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
     const agent = new AgentClass({ getActive: () => ({ contextWindow: 4000, supportsVision: false }) });

--- a/test/run.js
+++ b/test/run.js
@@ -9789,6 +9789,42 @@ test('context compaction preserves the latest user turn while seeding a small su
   }
 });
 
+test('context compaction ignores injected user notes when preserving the latest user turn', async () => {
+  const latestUserTurn = 'CURRENT HUMAN REQUEST: revise the next step with this instruction';
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getActive: () => ({ contextWindow: 4000, supportsVision: false }) });
+    const tabId = AgentClass === AgentCh ? 200 : 201;
+    const messages = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'keep working on the task' },
+      { role: 'assistant', content: `first exchange ${'x'.repeat(3900)}` },
+      { role: 'user', content: `previous clarification ${'y'.repeat(3900)}` },
+      { role: 'assistant', content: `second exchange ${'z'.repeat(3900)}` },
+      { role: 'user', content: latestUserTurn },
+      { role: 'user', content: '[Auto-screenshot after the action above - vision sub-call failed, image omitted.]' },
+    ];
+
+    const origLog = console.log;
+    console.log = () => {};
+    let result;
+    try {
+      result = await agent._manageContext(tabId, messages, () => {});
+    } finally {
+      console.log = origLog;
+    }
+
+    assert.equal(result.compacted, true, `${AgentClass.name}: injected-note history should compact`);
+    assert.equal(result.summarized, 3, `${AgentClass.name}: should preserve the latest real user request`);
+    assert.ok(messages.some(m => m.role === 'user' && m.content === latestUserTurn), `${AgentClass.name}: latest real user turn should remain verbatim`);
+    const summary = messages.find(m => /Context window was trimmed/i.test(String(m.content || '')));
+    assert.ok(summary, `${AgentClass.name}: summary message missing`);
+    assert.ok(!String(summary.content || '').includes(latestUserTurn), `${AgentClass.name}: latest real user turn should not be folded into the summary`);
+
+    const h = agent.persistTimers?.get?.(tabId);
+    if (h) clearTimeout(h);
+  }
+});
+
 test('context compaction truncates when protected recent history still exceeds budget', async () => {
   const latestUserTurn = 'CURRENT USER REQUEST: inspect this large result next';
   const hugeToolResult = 'tool-result '.repeat(900);

--- a/test/run.js
+++ b/test/run.js
@@ -9789,6 +9789,42 @@ test('context compaction preserves the latest user turn while seeding a small su
   }
 });
 
+test('context compaction truncates when protected recent history still exceeds budget', async () => {
+  const latestUserTurn = 'CURRENT USER REQUEST: inspect this large result next';
+  const hugeToolResult = 'tool-result '.repeat(900);
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getActive: () => ({ contextWindow: 4000, supportsVision: false }) });
+    const tabId = AgentClass === AgentCh ? 198 : 199;
+    const messages = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'keep working on the task' },
+      { role: 'assistant', content: `first exchange ${'x'.repeat(3900)}` },
+      { role: 'user', content: `previous clarification ${'y'.repeat(3900)}` },
+      { role: 'assistant', content: `second exchange ${'z'.repeat(3900)}` },
+      { role: 'user', content: latestUserTurn },
+      { role: 'assistant', tool_calls: [{ id: 'tool-protected', function: { name: 'read_page' } }] },
+      { role: 'tool', tool_call_id: 'tool-protected', content: hugeToolResult },
+    ];
+
+    const origLog = console.log;
+    console.log = () => {};
+    let result;
+    try {
+      result = await agent._manageContext(tabId, messages, () => {});
+    } finally {
+      console.log = origLog;
+    }
+
+    assert.equal(result.compacted, true, `${AgentClass.name}: protected oversized recent tail should still compact via truncation`);
+    assert.equal(result.reason, 'truncated_oversized_messages', `${AgentClass.name}: should fall back to truncation instead of rebuilding over budget`);
+    assert.ok(messages.some(m => m.role === 'user' && m.content === latestUserTurn), `${AgentClass.name}: latest user turn should remain verbatim`);
+    assert.match(messages[messages.length - 1].content, /\[\.\.\.truncated to fit context\]/, `${AgentClass.name}: protected recent tool result should be truncated`);
+
+    const h = agent.persistTimers?.get?.(tabId);
+    if (h) clearTimeout(h);
+  }
+});
+
 test('context compaction shrinks bulky retained recent history to fit small-window budget', async () => {
   for (const AgentClass of [AgentCh, AgentFx]) {
     const agent = new AgentClass({ getActive: () => ({ contextWindow: 16384, supportsVision: false }) });

--- a/test/run.js
+++ b/test/run.js
@@ -9669,6 +9669,54 @@ test('manual compactConversation compacts before automatic thresholds', async ()
   }
 });
 
+test('context token budget uses adaptive compaction ratios', async () => {
+  const cases = [
+    [16000, 10400],
+    [32000, 20800],
+    [64000, 44800],
+    [128000, 96000],
+    [256000, 204800],
+  ];
+
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    for (const [contextWindow, expectedBudget] of cases) {
+      const agent = new AgentClass({ getActive: () => ({ contextWindow, supportsVision: false }) });
+      assert.equal(agent._contextTokenBudget(), expectedBudget, `${AgentClass.name}: wrong budget for ${contextWindow}`);
+    }
+  }
+});
+
+test('context compaction keeps the same recent turn window in chrome and firefox', async () => {
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getActive: () => ({ contextWindow: 128000, supportsVision: false }) });
+    const tabId = AgentClass === AgentCh ? 188 : 189;
+    const messages = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'keep working on the task' },
+    ];
+    for (let i = 0; i < 40; i++) {
+      messages.push({ role: 'assistant', content: `step ${i}` });
+      messages.push({ role: 'user', content: `ok ${i}` });
+    }
+    agent.conversations.set(tabId, messages);
+
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await agent.compactConversation(tabId);
+    } finally {
+      console.log = origLog;
+    }
+
+    const compacted = agent.conversations.get(tabId);
+    assert.ok(compacted.some(m => m.role === 'assistant' && m.content === 'step 25'), `${AgentClass.name}: did not keep the last 30 messages`);
+    assert.ok(compacted.some(m => m.role === 'user' && m.content === 'ok 39'), `${AgentClass.name}: lost newest user turn`);
+
+    const h = agent.persistTimers?.get?.(tabId);
+    if (h) clearTimeout(h);
+  }
+});
+
 test('manual compactConversation reports emergency truncation as compacted', async () => {
   for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
     const agent = new AgentClass({ getActive: () => ({ contextWindow: 4000, supportsVision: false }) });

--- a/test/run.js
+++ b/test/run.js
@@ -9721,6 +9721,39 @@ test('context compaction keeps the same recent turn window in chrome and firefox
   }
 });
 
+test('context compaction shrinks recent window when small-window runs exceed token budget early', async () => {
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getActive: () => ({ contextWindow: 32768, supportsVision: false }) });
+    const tabId = AgentClass === AgentCh ? 190 : 191;
+    const messages = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'keep working on the task' },
+    ];
+    for (let i = 0; i < 15; i++) {
+      messages.push({ role: 'assistant', content: `step ${i} ${'x'.repeat(2990)}` });
+      messages.push({ role: 'user', content: `ok ${i} ${'y'.repeat(2990)}` });
+    }
+
+    const origLog = console.log;
+    console.log = () => {};
+    let result;
+    try {
+      result = await agent._manageContext(tabId, messages, () => {});
+    } finally {
+      console.log = origLog;
+    }
+
+    assert.equal(result.compacted, true, `${AgentClass.name}: over-budget small-window history should compact`);
+    assert.ok(result.summarized >= 4, `${AgentClass.name}: should summarize enough early turns`);
+    assert.notEqual(result.reason, 'over_budget_unshrinkable', `${AgentClass.name}: should not leave oversized prompt uncompactable`);
+    assert.ok(messages.some(m => /Context window was trimmed/i.test(String(m.content || ''))), `${AgentClass.name}: summary message missing`);
+    assert.ok(messages.some(m => String(m.content || '').includes('ok 14')), `${AgentClass.name}: newest user turn should remain recent`);
+
+    const h = agent.persistTimers?.get?.(tabId);
+    if (h) clearTimeout(h);
+  }
+});
+
 test('manual compactConversation reports emergency truncation as compacted', async () => {
   for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
     const agent = new AgentClass({ getActive: () => ({ contextWindow: 4000, supportsVision: false }) });


### PR DESCRIPTION
## Summary

- Add adaptive auto-compaction thresholds based on the active provider context window.
- Keep Chrome and Firefox aligned on the recent-message window retained after compaction.
- Add regression coverage for the threshold boundaries and Chrome/Firefox retention parity.

## Why

Small local context windows need compaction earlier to preserve headroom for tool schemas, page context, screenshots, and tool results. Larger context windows can wait longer before summarizing older turns.

## Behavior

- `<= 32k` context windows compact at 65%.
- `<= 64k` context windows compact at 70%.
- `<= 128k` context windows compact at 75%.
- Larger context windows compact at 80%.
- Firefox now retains the same last 30 messages after compaction that Chrome already retained.

## Validation

- `npm test` passed: 484 main tests, 0 failures.
- Security injection corpus passed: 60/60 checks.