### PR TITLE
[codex] Add Edge package docs and zip target

### DIFF
--- a/scripts/build-zip.mjs
+++ b/scripts/build-zip.mjs
@@ -17,6 +17,7 @@
  *
  * Output:
  *   dist/webbrain-chrome-<version>.zip
+ *   dist/webbrain-edge-<version>.zip
  *   dist/webbrain-firefox-<version>.zip
  *
  * <version> is read from package.json so a single npm-version bump
@@ -38,14 +39,21 @@ mkdirSync(distDir, { recursive: true });
 
 console.log(`Building extension zips for v${version} …`);
 
-for (const browser of ['chrome', 'firefox']) {
-  const out = path.join(distDir, `webbrain-${browser}-${version}.zip`);
+const targets = [
+  { packageName: 'chrome', sourceDir: 'chrome' },
+  // Microsoft Edge uses the same Chromium-compatible MV3 source tree.
+  { packageName: 'edge', sourceDir: 'chrome' },
+  { packageName: 'firefox', sourceDir: 'firefox' },
+];
+
+for (const { packageName, sourceDir } of targets) {
+  const out = path.join(distDir, `webbrain-${packageName}-${version}.zip`);
   // -o writes directly to the file; avoids needing shell redirection,
   // so this runs identically on bash, zsh, cmd, and PowerShell.
   execFileSync(
     'git',
-    ['archive', '--format=zip', '-o', out, `HEAD:src/${browser}`],
+    ['archive', '--format=zip', '-o', out, `HEAD:src/${sourceDir}`],
     { stdio: 'inherit', cwd: root }
   );
-  console.log(`  ✓ dist/webbrain-${browser}-${version}.zip`);
+  console.log(`  ✓ dist/webbrain-${packageName}-${version}.zip`);
 }

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -35,9 +35,10 @@
  * automatic — the operator runs `git push --follow-tags origin <branch>`.
  *
  * The pure helpers `bumpSemver`, `rewriteVersionInJsonText`,
- * `rewriteVersionByAnchor`, and `isReleaseBoundary` are exported for unit
- * tests — the CLI side is guarded by an `import.meta.url` check so
- * importing this file doesn't trigger filesystem writes or git calls.
+ * `rewriteVersionByAnchor`, `isReleaseBoundary`, and `submissionZipPaths`
+ * are exported for unit tests — the CLI side is guarded by an
+ * `import.meta.url` check so importing this file doesn't trigger
+ * filesystem writes or git calls.
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -118,6 +119,12 @@ export function isReleaseBoundary(version) {
   const match = SEMVER.exec(version);
   if (!match) throw new Error(`Not MAJOR.MINOR.PATCH: ${version}`);
   return parseInt(match[3], 10) === 0;
+}
+
+export const SUBMISSION_ZIP_PACKAGES = Object.freeze(['chrome', 'edge', 'firefox']);
+
+export function submissionZipPaths(version) {
+  return SUBMISSION_ZIP_PACKAGES.map((browser) => `dist/webbrain-${browser}-${version}.zip`);
 }
 
 /**
@@ -299,9 +306,9 @@ function runCli() {
   if (isReleaseBoundary(newVersion)) {
     console.log(`  git tag -a v${newVersion} -m "Release v${newVersion}"   # ${newVersion} is a release boundary`);
   }
-  console.log('  npm run build:zip       # rebuild dist/webbrain-{chrome,firefox}-' + newVersion + '.zip');
-  console.log('  git rm dist/webbrain-{chrome,firefox}-' + oldVersion + '.zip');
-  console.log('  git add dist/webbrain-{chrome,firefox}-' + newVersion + '.zip');
+  console.log('  npm run build:zip       # rebuild ' + submissionZipPaths(newVersion).join(', '));
+  console.log('  git rm ' + submissionZipPaths(oldVersion).join(' '));
+  console.log('  git add ' + submissionZipPaths(newVersion).join(' '));
   console.log('  git commit -m "dist: rebuild submission zips for v' + newVersion + '"');
 }
 

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -35,10 +35,10 @@
  * automatic — the operator runs `git push --follow-tags origin <branch>`.
  *
  * The pure helpers `bumpSemver`, `rewriteVersionInJsonText`,
- * `rewriteVersionByAnchor`, `isReleaseBoundary`, and `submissionZipPaths`
- * are exported for unit tests — the CLI side is guarded by an
- * `import.meta.url` check so importing this file doesn't trigger
- * filesystem writes or git calls.
+ * `rewriteVersionByAnchor`, `isReleaseBoundary`, `submissionZipPaths`, and
+ * `submissionZipRemoveCommand` are exported for unit tests — the CLI side is
+ * guarded by an `import.meta.url` check so importing this file doesn't
+ * trigger filesystem writes or git calls.
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -125,6 +125,10 @@ export const SUBMISSION_ZIP_PACKAGES = Object.freeze(['chrome', 'edge', 'firefox
 
 export function submissionZipPaths(version) {
   return SUBMISSION_ZIP_PACKAGES.map((browser) => `dist/webbrain-${browser}-${version}.zip`);
+}
+
+export function submissionZipRemoveCommand(version) {
+  return `git rm --ignore-unmatch ${submissionZipPaths(version).join(' ')}`;
 }
 
 /**
@@ -307,7 +311,7 @@ function runCli() {
     console.log(`  git tag -a v${newVersion} -m "Release v${newVersion}"   # ${newVersion} is a release boundary`);
   }
   console.log('  npm run build:zip       # rebuild ' + submissionZipPaths(newVersion).join(', '));
-  console.log('  git rm ' + submissionZipPaths(oldVersion).join(' '));
+  console.log('  ' + submissionZipRemoveCommand(oldVersion));
   console.log('  git add ' + submissionZipPaths(newVersion).join(' '));
   console.log('  git commit -m "dist: rebuild submission zips for v' + newVersion + '"');
 }

--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# WebBrain Chrome Extension — Architecture
+# WebBrain Chrome/Edge Extension — Architecture
 
 > Version 18.1.0 · Manifest V3 · Service Worker background
 
@@ -30,6 +30,9 @@ WebBrain is a browser extension that gives an LLM full control over the browser 
 
 ## Directory Structure
 
+The `src/chrome` tree is also the Microsoft Edge build. Edge supports the same
+Chromium extension APIs and the same `chrome.*` namespace used by this code.
+
 ```
 src/chrome/
 ├── manifest.json              # Manifest V3 config
@@ -43,7 +46,7 @@ src/chrome/
 │   │   ├── adapters.js         # Per-site guidance
 │   │   └── scheduler.js        # ScheduledJobManager — alarms-backed deferred tasks
 │   ├── cdp/
-│   │   └── cdp-client.js       # Chrome DevTools Protocol wrapper
+│   │   └── cdp-client.js       # DevTools Protocol wrapper
 │   ├── content/
 │   │   ├── accessibility-tree.js  # AX tree builder + ref_id registry
 │   │   └── content.js          # Injected DOM reader / typer / clicker
@@ -88,7 +91,7 @@ src/chrome/
 
 | Permission | Why |
 |---|---|
-| `debugger` | CDP access — trusted mouse/keyboard, pixel-perfect screenshots, shadow-DOM piercing. The single most important differentiator vs Firefox. |
+| `debugger` | CDP access — trusted mouse/keyboard, pixel-perfect screenshots, shadow-DOM piercing. The single most important differentiator in the Chrome/Edge build vs Firefox. |
 | `webRequest` | Opt-in, in-memory same-tab XHR/fetch observer for repeated-click API shortcut hints and opaque same-origin replay. Off by default. |
 | `alarms` | Scheduled tasks and scheduled resumes across browser sessions. |
 | `unlimitedStorage` | Optional trace recorder persists agent runs (LLM I/O + screenshots) into IndexedDB. A multi-step run can be 1–10 MB; the default ~10 MB origin cap fills after a few runs. |
@@ -167,7 +170,7 @@ sidepanel listens for recording_update broadcast events:
 
 ### Audio passthrough — the gotcha
 
-By default, when `chrome.tabCapture` is active, Chrome reroutes the tab's
+By default, when `chrome.tabCapture` is active, Chromium browsers reroute the tab's
 audio into the capture stream — the user can no longer hear what's playing
 in the tab. For a meeting recorder this is catastrophic (you can't follow
 the call). `offscreen/recorder.js` works around this with Web Audio:
@@ -183,7 +186,7 @@ that would feed back).
 
 ### Why a shared offscreen document
 
-Chrome MV3 allows exactly one offscreen document per extension. The
+Chrome/Edge MV3 allows exactly one offscreen document per extension. The
 localhost-fetch proxy already needs one for Private Network Access
 workarounds. Rather than fight over it, `offscreen/offscreen.html` loads
 both `offscreen.js` (fetch proxy) and `recorder.js` (tab recorder).
@@ -220,8 +223,8 @@ still saved.
 | Google Meet (browser) | ✓ |
 | Zoom web client (`zoom.us/wc/...`) | ✓ |
 | **Native Zoom desktop app** | ✗ — not in a tab; tabCapture cannot reach it. Would need `desktopCapture` (window picker) — deferred. |
-| DRM-protected video (Netflix, Disney+) | ✗ — Chrome blocks the encoder at the platform level. |
-| chrome:// / chrome-extension:// pages | ✗ — tabCapture is not allowed there. |
+| DRM-protected video (Netflix, Disney+) | ✗ — the browser blocks the encoder at the platform level. |
+| chrome:// / edge:// / chrome-extension:// pages | ✗ — tabCapture is not allowed there. |
 | Background tabs at start time | ⚠ — `getMediaStreamId` requires the target tab to be active; we briefly activate it before capture. The user can switch away after capture starts. |
 
 ### Firefox
@@ -360,7 +363,7 @@ When `click({text})` or `click({selector})` finds multiple matches, the error pa
 ### Interaction
 `click_ax`, `type_ax`, `set_field`, `hover` (CDP-trusted, for reveal-on-hover menus), `drag_drop` (CDP-trusted pointer sequence, for Trello/Linear-style reordering), `click` (by text/selector/index/coords — legacy), `type_text`, `press_keys`, `scroll`, `navigate`, `go_back`, `go_forward`, `new_tab`, `wait_for_element`, `wait_for_stable` (DOM mutations + network idle), `iframe_read`, `iframe_click`, `iframe_type`, `upload_file`
 
-> **Note:** `execute_js` was removed from the Chrome MV3 tool schema — `new Function()` is blocked by the extension_pages CSP and always throws EvalError. The agent uses `read_page`, `click`, `type_text`, `scroll`, and other fine-grained tools instead. `execute_js` is still available on Firefox MV2.
+> **Note:** `execute_js` was removed from the Chrome/Edge MV3 tool schema — `new Function()` is blocked by the extension_pages CSP and always throws EvalError. The agent uses `read_page`, `click`, `type_text`, `scroll`, and other fine-grained tools instead. `execute_js` is still available on Firefox MV2.
 
 ### Network / files
 `fetch_url`, `research_url`, `list_downloads`, `read_downloaded_file`, `download_resource_from_page`, `download_files`
@@ -372,7 +375,7 @@ Mode gating (Ask vs Act) continues as before — Ask mode is read-only.
 
 ---
 
-## Chrome DevTools Protocol (CDP)
+## DevTools Protocol (CDP)
 
 `cdp-client.js` wraps `chrome.debugger`:
 
@@ -393,7 +396,7 @@ CDP events are **trusted** (`event.isTrusted === true`). Many sites reject synth
 | How | `Input.dispatchMouseEvent(x,y)` | `el.click()` |
 | Trusted | Yes | No |
 | Cross-origin | Works | Blocked |
-| Used when | Default in Chrome, or `click({x,y})` / `click({text})` after coord resolution | `click_ax` (focuses the exact element, dispatches in-page) |
+| Used when | Default in Chrome/Edge, or `click({x,y})` / `click({text})` after coord resolution | `click_ax` (focuses the exact element, dispatches in-page) |
 
 ---
 
@@ -432,9 +435,9 @@ OpenAI format → Anthropic blocks: system → separate `system` field; `assista
 
 ## Scheduled Tasks (`scheduler.js`)
 
-`ScheduledJobManager` (Chrome build: `src/chrome/src/agent/scheduler.js`) is instantiated in `background.js` and uses `chrome.alarms` to fire deferred work.
+`ScheduledJobManager` (Chrome/Edge build: `src/chrome/src/agent/scheduler.js`) is instantiated in `background.js` and uses `chrome.alarms` to fire deferred work.
 
-**Chrome-specific behavior vs Firefox:**
+**Chromium/Edge-specific behavior vs Firefox:**
 
 - URL-target tasks open their tab in the **background** (`active: false`) so the user isn't interrupted.
 - A **service-worker keepalive** (`startChromeAlarmKeepAlive`) pings `chrome.runtime.getPlatformInfo` every 20 s while a scheduled job is executing, keeping the MV3 service worker alive for the duration of the run.

--- a/src/chrome/README.md
+++ b/src/chrome/README.md
@@ -33,7 +33,7 @@ git clone https://github.com/webbrain-one/webbrain.git
 
 1. Open Chrome → `chrome://extensions/`
 2. Enable **Developer mode** (top right)
-3. Click **Load unpacked** → select the `webbrain` folder
+3. Click **Load unpacked** → select the `webbrain/src/chrome` folder
 
 ### Microsoft Edge
 
@@ -43,7 +43,7 @@ git clone https://github.com/webbrain-one/webbrain.git
 
 1. Open Edge → `edge://extensions/`
 2. Enable **Developer mode** (left sidebar)
-3. Click **Load unpacked** → select the `webbrain` folder
+3. Click **Load unpacked** → select the `webbrain/src/chrome` folder
 
 The Edge package uses the same Manifest V3 build as Chrome. The extension APIs
 still use the Chromium `chrome.*` namespace in code, which is supported by

--- a/src/chrome/README.md
+++ b/src/chrome/README.md
@@ -1,6 +1,6 @@
 # WebBrain
 
-Open-source AI browser agent for Chrome and Firefox. Chat with any web page, automate browser tasks, and run multi-step agent workflows — powered by your choice of LLM.
+Open-source AI browser agent for Chrome, Microsoft Edge, and Firefox. Chat with any web page, automate browser tasks, and run multi-step agent workflows — powered by your choice of LLM.
 
 ## Features
 
@@ -34,6 +34,20 @@ git clone https://github.com/webbrain-one/webbrain.git
 1. Open Chrome → `chrome://extensions/`
 2. Enable **Developer mode** (top right)
 3. Click **Load unpacked** → select the `webbrain` folder
+
+### Microsoft Edge
+
+```bash
+git clone https://github.com/webbrain-one/webbrain.git
+```
+
+1. Open Edge → `edge://extensions/`
+2. Enable **Developer mode** (left sidebar)
+3. Click **Load unpacked** → select the `webbrain` folder
+
+The Edge package uses the same Manifest V3 build as Chrome. The extension APIs
+still use the Chromium `chrome.*` namespace in code, which is supported by
+Microsoft Edge.
 
 ### Firefox
 
@@ -98,8 +112,8 @@ Click the gear icon or go to the extension's Options page to configure:
 ## Architecture
 
 ```
-webbrain/                          webbrain-firefox/
-├── manifest.json (MV3)            ├── manifest.json (MV2)
+webbrain/ (Chrome/Edge MV3)        webbrain-firefox/
+├── manifest.json                  ├── manifest.json (MV2)
 ├── src/                           ├── src/
 │   ├── background.js              │   ├── background.js (+ background.html)
 │   ├── agent/                     │   ├── agent/
@@ -126,7 +140,7 @@ webbrain/                          webbrain-firefox/
 └── icons/
 ```
 
-Key difference: Chrome uses Manifest V3 (service worker, `chrome.scripting`, `sidePanel` API), Firefox uses Manifest V2 (background page, `browser.tabs.executeScript`, `sidebar_action`).
+Key difference: Chrome and Edge use Manifest V3 (service worker, `chrome.scripting`, `sidePanel` API), Firefox uses Manifest V2 (background page, `browser.tabs.executeScript`, `sidebar_action`).
 
 ## Agent Tools
 
@@ -148,8 +162,8 @@ Key difference: Chrome uses Manifest V3 (service worker, `chrome.scripting`, `si
 
 ## Known Issues
 
-- **No file download/upload support** — The agent cannot download files from pages or upload files to file inputs. This is a limitation of the content script architecture. Planned for a future release via `chrome.downloads` API and CDP integration.
-- **No Chrome DevTools Protocol (CDP) support** — Currently uses content script injection instead of CDP. This means no access to network requests, shadow DOM, cross-origin iframes, or pixel-perfect screenshots. CDP support is planned as an opt-in advanced mode.
+- **No file download/upload support** — The agent cannot download files from pages or upload files to file inputs. This is a limitation of the content script architecture. Planned for a future release via the Chromium `chrome.downloads` API and CDP integration.
+- **No DevTools Protocol (CDP) support** — Currently uses content script injection instead of CDP. This means no access to network requests, shadow DOM, cross-origin iframes, or pixel-perfect screenshots. CDP support is planned as an opt-in advanced mode.
 - **Shadow DOM limitations** — Web components using closed shadow DOM cannot be read or interacted with by the content script.
 - **SPA navigation detection** — Some single-page applications may not trigger content script re-injection after client-side navigation.
 - **Firefox temporary add-on** — Firefox requires the extension to be loaded as a temporary add-on during development, which is removed on restart.
@@ -164,7 +178,7 @@ Key difference: Chrome uses Manifest V3 (service worker, `chrome.scripting`, `si
 - [ ] **Keyboard shortcuts** — Hotkeys for opening panel, sending messages, switching modes
 - [ ] **Context menu integration** — Right-click → "Ask WebBrain about this"
 - [ ] **Screenshot/vision tool** — Send screenshots to multimodal models for visual understanding
-- [ ] **Chrome Web Store / Firefox AMO** — Official store listings
+- [ ] **Chrome Web Store / Microsoft Edge Add-ons / Firefox AMO** — Official store listings
 
 ## Adding a New Provider
 

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -51,10 +51,16 @@ const TOKENS_PER_MILLION = 1_000_000;
 const DEFAULT_INPUT_COST_PER_MILLION_USD = 3;
 const DEFAULT_OUTPUT_COST_PER_MILLION_USD = 15;
 const DONE_OUTCOMES = new Set(['success', 'partial', 'failed']);
+const BROWSER_NEW_TAB_URL_PREFIXES = ['chrome://newtab', 'edge://newtab'];
 
 function normalizeDoneOutcome(value) {
   const outcome = String(value || '').trim().toLowerCase();
   return DONE_OUTCOMES.has(outcome) ? outcome : null;
+}
+
+function isBrowserNewTabUrl(url) {
+  const value = String(url || '').toLowerCase();
+  return BROWSER_NEW_TAB_URL_PREFIXES.some(prefix => value.startsWith(prefix));
 }
 
 /**
@@ -1125,7 +1131,7 @@ export class Agent {
     try {
       let newTab = null;
       // Poll for up to ~900ms — the new tab needs a few ticks to appear
-      // and for Chrome to populate its URL past about:blank.
+      // and for the browser to populate its URL past about:blank/newtab.
       for (let i = 0; i < 9; i++) {
         await new Promise(r => setTimeout(r, 100));
         const all = await chrome.tabs.query({});
@@ -1137,7 +1143,7 @@ export class Agent {
         if (candidate) {
           const url = candidate.pendingUrl || candidate.url || '';
           // Wait a tick more if the URL hasn't resolved past about:blank.
-          if (url && url !== 'about:blank' && !url.startsWith('chrome://newtab')) {
+          if (url && url !== 'about:blank' && !isBrowserNewTabUrl(url)) {
             newTab = candidate;
             break;
           }
@@ -1147,7 +1153,7 @@ export class Agent {
       }
       if (!newTab) return null;
       const targetUrl = newTab.pendingUrl || newTab.url || '';
-      if (!targetUrl || targetUrl === 'about:blank' || targetUrl.startsWith('chrome://newtab')) {
+      if (!targetUrl || targetUrl === 'about:blank' || isBrowserNewTabUrl(targetUrl)) {
         // We saw a new tab but never got a real URL out of it. Close it
         // and move on — redirecting to about:blank would make things worse.
         try { await chrome.tabs.remove(newTab.id); } catch {}

--- a/test/run.js
+++ b/test/run.js
@@ -152,7 +152,7 @@ function allowProgress(agent, tabId, allowedActions = ['follow'], opts = {}) {
 
 // bump-version.mjs is the version-bump CLI but exports its pure helpers
 // for testing. The CLI body is guarded so importing it is side-effect-free.
-const { bumpSemver, rewriteVersionInJsonText, rewriteVersionByAnchor, isReleaseBoundary } = await import(
+const { bumpSemver, rewriteVersionInJsonText, rewriteVersionByAnchor, isReleaseBoundary, submissionZipPaths } = await import(
   'file://' + path.join(ROOT, 'scripts/bump-version.mjs').replace(/\\/g, '/')
 );
 const { normalizeChangelogBody, buildChangelogSection, insertChangelogEntry } = await import(
@@ -2296,6 +2296,14 @@ test('isReleaseBoundary: composes with bumpSemver to classify the next version',
   // Explicit override path also routes through correctly.
   assert.equal(isReleaseBoundary(bumpSemver('7.0.5', '8.2.0')), true);
   assert.equal(isReleaseBoundary(bumpSemver('7.0.5', '8.2.3')), false);
+});
+
+test('submissionZipPaths includes every store package artifact', () => {
+  assert.deepEqual(submissionZipPaths('18.2.0'), [
+    'dist/webbrain-chrome-18.2.0.zip',
+    'dist/webbrain-edge-18.2.0.zip',
+    'dist/webbrain-firefox-18.2.0.zip',
+  ]);
 });
 
 // ────────────────────────────────────────────────────────────────────────

--- a/test/run.js
+++ b/test/run.js
@@ -456,6 +456,40 @@ test('agent URL normalization preserves query and hash for nav change detection'
   }
 });
 
+test('chrome target blank redirect ignores browser new-tab placeholders', async () => {
+  const realChrome = globalThis.chrome;
+  const realSetTimeout = globalThis.setTimeout;
+  try {
+    globalThis.setTimeout = (fn, _delay, ...args) => realSetTimeout(fn, 0, ...args);
+
+    for (const url of ['chrome://newtab/', 'edge://newtab/']) {
+      const removedTabs = [];
+      const updatedTabs = [];
+      globalThis.chrome = {
+        tabs: {
+          query: async () => [
+            { id: 1, url: 'https://example.com/source' },
+            { id: 2, openerTabId: 1, url },
+          ],
+          remove: async (tabId) => { removedTabs.push(tabId); },
+          update: async (tabId, patch) => { updatedTabs.push({ tabId, patch }); },
+        },
+      };
+
+      const agent = new AgentCh({});
+      const result = await agent._redirectTargetBlankClick(1, new Set([1]));
+
+      assert.equal(result, null, `${url} should not be treated as a real target`);
+      assert.deepEqual(updatedTabs, [], `${url} should not navigate the source tab`);
+      assert.deepEqual(removedTabs, [2], `${url} placeholder tab should be closed`);
+    }
+  } finally {
+    if (realChrome === undefined) delete globalThis.chrome;
+    else globalThis.chrome = realChrome;
+    globalThis.setTimeout = realSetTimeout;
+  }
+});
+
 // ────────────────────────────────────────────────────────────────────────
 // Adapter matching tests
 // ────────────────────────────────────────────────────────────────────────

--- a/test/run.js
+++ b/test/run.js
@@ -152,7 +152,7 @@ function allowProgress(agent, tabId, allowedActions = ['follow'], opts = {}) {
 
 // bump-version.mjs is the version-bump CLI but exports its pure helpers
 // for testing. The CLI body is guarded so importing it is side-effect-free.
-const { bumpSemver, rewriteVersionInJsonText, rewriteVersionByAnchor, isReleaseBoundary, submissionZipPaths } = await import(
+const { bumpSemver, rewriteVersionInJsonText, rewriteVersionByAnchor, isReleaseBoundary, submissionZipPaths, submissionZipRemoveCommand } = await import(
   'file://' + path.join(ROOT, 'scripts/bump-version.mjs').replace(/\\/g, '/')
 );
 const { normalizeChangelogBody, buildChangelogSection, insertChangelogEntry } = await import(
@@ -2304,6 +2304,13 @@ test('submissionZipPaths includes every store package artifact', () => {
     'dist/webbrain-edge-18.2.0.zip',
     'dist/webbrain-firefox-18.2.0.zip',
   ]);
+});
+
+test('submissionZipRemoveCommand tolerates missing first Edge artifact', () => {
+  assert.equal(
+    submissionZipRemoveCommand('18.1.0'),
+    'git rm --ignore-unmatch dist/webbrain-chrome-18.1.0.zip dist/webbrain-edge-18.1.0.zip dist/webbrain-firefox-18.1.0.zip'
+  );
 });
 
 // ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Update the Chrome extension README and architecture docs to explicitly cover Microsoft Edge.
- Clarify that the Edge build uses the same Chromium-compatible `src/chrome` MV3 source tree and `chrome.*` extension API namespace.
- Update the zip builder to emit `dist/webbrain-edge-<version>.zip` from the Chrome-compatible source tree alongside the Chrome and Firefox packages.

## Validation

- `node --check scripts/build-zip.mjs`
- `npm test`

## Notes

The build script still archives `HEAD`, so release zips should be built after this branch is checked out or merged.