### PR TITLE
[codex] fix local model load selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to WebBrain are documented in this file.
 
 This changelog was generated from the repository Git history and release tags. Versions without a Git tag are inferred from version-bump commits and the current `package.json` / browser manifest versions.
 
+## [19.0.11] - 2026-07-02
+
+### Changed
+- Updated release metadata, Settings subtitle versions, Chrome / Firefox manifests, package versions, and browser architecture docs for 19.0.11.
+
+### Fixed
+- Fixed Settings -> Providers -> Load Models for local providers so loaded models appear in a centered picker dialog without replacing an existing model value until the user chooses one.
+- Replaced raw HTML 404 model-list errors with the concise local-server status when a local model server is not running.
+- Guarded repeated model-load completions so an already-open loaded-model dialog is not reopened.
+
+### Tests
+- Added Chrome and Firefox regression coverage for loaded-model dialog rendering, localized dialog copy, stale option clearing, concise HTML 404 handling, centered dialog styling, and repeated dialog-open handling.
+
 ## [19.0.0] - 2026-07-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webbrain",
-  "version": "19.0.10",
+  "version": "19.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webbrain",
-      "version": "19.0.10",
+      "version": "19.0.11",
       "license": "MIT",
       "devDependencies": {
         "playwright": "^1.48.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webbrain",
-  "version": "19.0.5",
+  "version": "19.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webbrain",
-      "version": "19.0.5",
+      "version": "19.0.10",
       "license": "MIT",
       "devDependencies": {
         "playwright": "^1.48.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webbrain",
-  "version": "19.0.10",
+  "version": "19.0.11",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webbrain",
-  "version": "19.0.5",
+  "version": "19.0.10",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "private": true,
   "type": "module",

--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Chrome/Edge Extension — Architecture
 
-> Version 19.0.10 · Manifest V3 · Service Worker background
+> Version 19.0.11 · Manifest V3 · Service Worker background
 
 ## High-Level Overview
 

--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Chrome/Edge Extension — Architecture
 
-> Version 19.0.5 · Manifest V3 · Service Worker background
+> Version 19.0.10 · Manifest V3 · Service Worker background
 
 ## High-Level Overview
 

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "19.0.10",
+  "version": "19.0.11",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "19.0.5",
+  "version": "19.0.10",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -657,7 +657,8 @@ export class ProviderManager {
       try {
         const res = await fetchWithFallback(url, { method: 'GET', headers });
         if (!res.ok) {
-          const errBody = await res.text();
+          let errBody = '';
+          try { errBody = await res.text(); } catch {}
           if (res.status === 403) {
             if (!firstFailure) firstFailure = {
               ok: false,
@@ -666,7 +667,7 @@ export class ProviderManager {
             };
             continue;
           }
-          if (!firstFailure) firstFailure = { ok: false, error: `HTTP ${res.status}: ${errBody}` };
+          if (!firstFailure) firstFailure = this._modelListFailure(res.status, errBody, res.statusText);
           continue;
         }
         const data = await res.json();
@@ -694,6 +695,19 @@ export class ProviderManager {
     const apiKey = provider?.config?.apiKey;
     if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
     return headers;
+  }
+
+  _modelListFailure(status, body = '', statusText = '') {
+    const text = String(body || '').trim();
+    if (status === 404 && /<!doctype\s+html|<html[\s>]|file not found/i.test(text)) {
+      return {
+        ok: false,
+        error: 'No local model server was detected.',
+        errorKey: 'ob.tokens.none_status',
+      };
+    }
+    const compact = text.replace(/\s+/g, ' ').slice(0, 300);
+    return { ok: false, error: `HTTP ${status}: ${compact || statusText || 'Request failed'}` };
   }
 
   _baseUrlCandidates(config) {

--- a/src/chrome/src/ui/locales/ar.js
+++ b/src/chrome/src/ui/locales/ar.js
@@ -198,6 +198,7 @@ export default {
   'st.providers.load_models': 'تحميل النماذج',
   'st.providers.loading': 'جارٍ التحميل…',
   'st.providers.models_loaded': 'تم تحميل {count} نموذجًا',
+  'st.providers.select_loaded_model': 'اختر النموذج المحمّل',
 
   'st.provider.field.server_url': 'عنوان الخادم',
   'st.provider.field.api_base_url': 'عنوان API الأساسي',

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -363,6 +363,7 @@ export default {
   'st.providers.load_models': 'Load models',
   'st.providers.loading': 'Loading…',
   'st.providers.models_loaded': '{count} models loaded',
+  'st.providers.select_loaded_model': 'Select loaded model',
   'st.providers.get_api_key': 'Get API key',
   'st.providers.webbrain_note.body': 'Free daily WebBrain Cloud usage is included. Requests go through api.webbrain.one; by default we log metadata for quota and debugging, not prompt text, page content, screenshots, or model responses. {privacyLink}. For more usage, subscribe at {subscribeLink}. Manage billing at {accountLink}.',
   'st.providers.webbrain_note.privacy_link': 'Privacy policy',

--- a/src/chrome/src/ui/locales/es.js
+++ b/src/chrome/src/ui/locales/es.js
@@ -198,6 +198,7 @@ export default {
   'st.providers.load_models': 'Cargar modelos',
   'st.providers.loading': 'Cargando…',
   'st.providers.models_loaded': '{count} modelos cargados',
+  'st.providers.select_loaded_model': 'Seleccionar modelo cargado',
 
   'st.provider.field.server_url': 'URL del servidor',
   'st.provider.field.api_base_url': 'URL base de la API',

--- a/src/chrome/src/ui/locales/fr.js
+++ b/src/chrome/src/ui/locales/fr.js
@@ -198,6 +198,7 @@ export default {
   'st.providers.load_models': 'Charger les modèles',
   'st.providers.loading': 'Chargement…',
   'st.providers.models_loaded': '{count} modèles chargés',
+  'st.providers.select_loaded_model': 'Sélectionner un modèle chargé',
 
   'st.provider.field.server_url': 'URL du serveur',
   'st.provider.field.api_base_url': 'URL de base de l\'API',

--- a/src/chrome/src/ui/locales/id.js
+++ b/src/chrome/src/ui/locales/id.js
@@ -198,6 +198,7 @@ export default {
   'st.providers.load_models': 'Muat model',
   'st.providers.loading': 'Memuat…',
   'st.providers.models_loaded': '{count} model dimuat',
+  'st.providers.select_loaded_model': 'Pilih model yang dimuat',
 
   'st.provider.field.server_url': 'URL server',
   'st.provider.field.api_base_url': 'URL dasar API',

--- a/src/chrome/src/ui/locales/ja.js
+++ b/src/chrome/src/ui/locales/ja.js
@@ -198,6 +198,7 @@ export default {
   'st.providers.load_models': 'モデルを読み込み',
   'st.providers.loading': '読み込み中…',
   'st.providers.models_loaded': '{count} 個のモデルを読み込みました',
+  'st.providers.select_loaded_model': '読み込んだモデルを選択',
 
   'st.provider.field.server_url': 'サーバー URL',
   'st.provider.field.api_base_url': 'API ベース URL',

--- a/src/chrome/src/ui/locales/ko.js
+++ b/src/chrome/src/ui/locales/ko.js
@@ -198,6 +198,7 @@ export default {
   'st.providers.load_models': '모델 불러오기',
   'st.providers.loading': '불러오는 중…',
   'st.providers.models_loaded': '모델 {count}개를 불러왔습니다',
+  'st.providers.select_loaded_model': '불러온 모델 선택',
 
   'st.provider.field.server_url': '서버 URL',
   'st.provider.field.api_base_url': 'API 기본 URL',

--- a/src/chrome/src/ui/locales/ms.js
+++ b/src/chrome/src/ui/locales/ms.js
@@ -198,6 +198,7 @@ export default {
   'st.providers.load_models': 'Muatkan model',
   'st.providers.loading': 'Memuatkan…',
   'st.providers.models_loaded': '{count} model dimuatkan',
+  'st.providers.select_loaded_model': 'Pilih model yang dimuatkan',
 
   'st.provider.field.server_url': 'URL pelayan',
   'st.provider.field.api_base_url': 'URL asas API',

--- a/src/chrome/src/ui/locales/pl.js
+++ b/src/chrome/src/ui/locales/pl.js
@@ -311,6 +311,7 @@ export default {
   'st.providers.load_models': 'Załaduj modele',
   'st.providers.loading': 'Ładowanie…',
   'st.providers.models_loaded': 'Załadowano {count} modeli',
+  'st.providers.select_loaded_model': 'Wybierz załadowany model',
   'st.providers.get_api_key': 'Uzyskaj klucz API',
   'st.providers.webbrain_note.body': 'Darmowe dzienne korzystanie z WebBrain Cloud jest wliczone. Żądania przechodzą przez api.webbrain.one; domyślnie rejestrujemy metadane na potrzeby limitów i debugowania, a nie tekst poleceń, treść stron, zrzuty ekranu ani odpowiedzi modelu. {privacyLink}. Aby korzystać więcej, subskrybuj na {subscribeLink}. Zarządzaj rozliczeniami na {accountLink}.',
   'st.providers.webbrain_note.privacy_link': 'Polityka prywatności',

--- a/src/chrome/src/ui/locales/ru.js
+++ b/src/chrome/src/ui/locales/ru.js
@@ -198,6 +198,7 @@ export default {
   'st.providers.load_models': 'Загрузить модели',
   'st.providers.loading': 'Загрузка…',
   'st.providers.models_loaded': 'Загружено моделей: {count}',
+  'st.providers.select_loaded_model': 'Выберите загруженную модель',
 
   'st.provider.field.server_url': 'URL сервера',
   'st.provider.field.api_base_url': 'Базовый URL API',

--- a/src/chrome/src/ui/locales/th.js
+++ b/src/chrome/src/ui/locales/th.js
@@ -198,6 +198,7 @@ export default {
   'st.providers.load_models': 'โหลดโมเดล',
   'st.providers.loading': 'กำลังโหลด…',
   'st.providers.models_loaded': 'โหลดแล้ว {count} โมเดล',
+  'st.providers.select_loaded_model': 'เลือกโมเดลที่โหลดแล้ว',
 
   'st.provider.field.server_url': 'URL เซิร์ฟเวอร์',
   'st.provider.field.api_base_url': 'URL ฐานของ API',

--- a/src/chrome/src/ui/locales/tl.js
+++ b/src/chrome/src/ui/locales/tl.js
@@ -198,6 +198,7 @@ export default {
   'st.providers.load_models': 'I-load ang mga modelo',
   'st.providers.loading': 'Naglo-load…',
   'st.providers.models_loaded': '{count} na modelo ang na-load',
+  'st.providers.select_loaded_model': 'Piliin ang na-load na modelo',
 
   'st.provider.field.server_url': 'Server URL',
   'st.provider.field.api_base_url': 'API Base URL',

--- a/src/chrome/src/ui/locales/tr.js
+++ b/src/chrome/src/ui/locales/tr.js
@@ -228,6 +228,7 @@ export default {
   'st.providers.load_models': 'Modelleri yükle',
   'st.providers.loading': 'Yükleniyor…',
   'st.providers.models_loaded': '{count} model yüklendi',
+  'st.providers.select_loaded_model': 'Yüklenen modeli seç',
 
   'st.provider.field.server_url': 'Sunucu URL\'si',
   'st.provider.field.api_base_url': 'API temel URL\'si',

--- a/src/chrome/src/ui/locales/uk.js
+++ b/src/chrome/src/ui/locales/uk.js
@@ -198,6 +198,7 @@ export default {
   'st.providers.load_models': 'Завантажити моделі',
   'st.providers.loading': 'Завантаження…',
   'st.providers.models_loaded': 'Завантажено моделей: {count}',
+  'st.providers.select_loaded_model': 'Виберіть завантажену модель',
 
   'st.provider.field.server_url': 'URL сервера',
   'st.provider.field.api_base_url': 'Базовий URL API',

--- a/src/chrome/src/ui/locales/zh.js
+++ b/src/chrome/src/ui/locales/zh.js
@@ -198,6 +198,7 @@ export default {
   'st.providers.load_models': '加载模型',
   'st.providers.loading': '加载中…',
   'st.providers.models_loaded': '已加载 {count} 个模型',
+  'st.providers.select_loaded_model': '选择已加载的模型',
 
   'st.provider.field.server_url': '服务器 URL',
   'st.provider.field.api_base_url': 'API 基础 URL',

--- a/src/chrome/src/ui/settings.html
+++ b/src/chrome/src/ui/settings.html
@@ -326,6 +326,9 @@
     .btn-secondary:hover { background: rgba(255,255,255,0.05); }
 
     .loaded-model-dialog {
+      position: fixed;
+      inset: 0;
+      margin: auto;
       width: min(520px, calc(100vw - 32px));
       max-height: min(680px, calc(100vh - 48px));
       padding: 0;

--- a/src/chrome/src/ui/settings.html
+++ b/src/chrome/src/ui/settings.html
@@ -325,6 +325,62 @@
     }
     .btn-secondary:hover { background: rgba(255,255,255,0.05); }
 
+    .loaded-model-dialog {
+      width: min(520px, calc(100vw - 32px));
+      max-height: min(680px, calc(100vh - 48px));
+      padding: 0;
+      color: var(--text);
+      background: var(--bg2);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      box-shadow: 0 18px 48px rgba(0,0,0,0.42);
+    }
+    .loaded-model-dialog::backdrop { background: rgba(0,0,0,0.58); }
+    .loaded-model-dialog-panel { padding: 14px; }
+    .loaded-model-dialog-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+    .loaded-model-dialog-header h3 {
+      font-size: 14px;
+      font-weight: 700;
+      line-height: 1.3;
+    }
+    .loaded-model-dialog-close {
+      width: 30px;
+      height: 30px;
+      padding: 0;
+      background: var(--bg3);
+      color: var(--text);
+      border: 1px solid var(--border);
+      font-size: 18px;
+      line-height: 1;
+    }
+    .loaded-model-options {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      max-height: min(420px, 58vh);
+      overflow: auto;
+    }
+    .loaded-model-option {
+      width: 100%;
+      padding: 8px 10px;
+      background: var(--bg3);
+      color: var(--text);
+      border: 1px solid var(--border);
+      text-align: left;
+      font-weight: 500;
+      overflow-wrap: anywhere;
+    }
+    .loaded-model-option:hover {
+      border-color: var(--accent);
+      background: rgba(108,99,255,0.12);
+    }
+
     .test-result {
       margin-top: 8px;
       font-size: 11px;

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1714,9 +1714,21 @@ function applyProviderBaseUrl(id, baseUrl) {
   if (input && input.value !== baseUrl) input.value = baseUrl;
 }
 
+function clearProviderLoadedModels(id) {
+  const loadedSelectEl = document.querySelector(`.loaded-model-select[data-loaded-models-for="${id}"]`);
+  if (loadedSelectEl) {
+    loadedSelectEl.innerHTML = '';
+    loadedSelectEl.value = '';
+    loadedSelectEl.style.display = 'none';
+  }
+  const datalistEl = document.getElementById(`models-${id}`);
+  if (datalistEl) datalistEl.innerHTML = '';
+}
+
 async function loadProviderModels(id) {
   let datalistEl = document.getElementById(`models-${id}`);
   if (!datalistEl) return;
+  clearProviderLoadedModels(id);
   // Persist whatever the user has typed in baseUrl/model so the background
   // call uses the current values, not stale storage.
   try {

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -19,7 +19,7 @@ import {
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '19.0.10';
+const EXT_VERSION = '19.0.11';
 
 const providersContainer = document.getElementById('providers');
 const displaySettings = document.getElementById('display-settings');

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1367,6 +1367,11 @@ function renderProviders() {
         const canLoadModels = localModelProviders.includes(id) && field.key === 'model';
         const listAttr = canLoadModels ? `list="models-${id}"` : '';
         const datalistHTML = canLoadModels ? `<datalist id="models-${id}"></datalist>` : '';
+        const loadedModelsSelectHTML = canLoadModels
+          ? `<select class="loaded-model-select" data-loaded-models-for="${id}"
+                    aria-label="${escapeHtml(t('st.providers.select_loaded_model'))}"
+                    style="display:none;margin-top:6px;"></select>`
+          : '';
         const loadBtnHTML = canLoadModels
           ? `<button type="button" class="btn-secondary btn-load-models" data-provider="${id}"
                     style="margin-top:6px;">${escapeHtml(t('st.providers.load_models'))}</button>
@@ -1386,6 +1391,7 @@ function renderProviders() {
                    value="${escapeHtml(value)}" placeholder="${escapeHtml(placeholder)}">
             ${datalistHTML}
             ${loadBtnHTML}
+            ${loadedModelsSelectHTML}
           </div>
         `;
       }
@@ -1469,6 +1475,15 @@ function renderProviders() {
         input.style.display = 'none';
         input.value = sel.value;
       }
+    });
+  });
+  document.querySelectorAll('.loaded-model-select').forEach(sel => {
+    sel.addEventListener('change', () => {
+      if (!sel.value) return;
+      const providerId = sel.dataset.loadedModelsFor;
+      const input = document.querySelector(`input[data-provider="${providerId}"][data-key="model"]`);
+      if (!input) return;
+      input.value = sel.value;
     });
   });
   // OAuth-Claude-specific bindings. These only fire if the OAuth card is
@@ -1724,9 +1739,18 @@ async function loadProviderModels(id) {
   if (!datalistEl) return;
   if (res?.ok) {
     applyProviderBaseUrl(id, res.baseUrl);
+    const loadedSelectEl = document.querySelector(`.loaded-model-select[data-loaded-models-for="${id}"]`);
     datalistEl.innerHTML = res.models
       .map((m) => `<option value="${escapeHtml(m)}"></option>`)
       .join('');
+    if (loadedSelectEl) {
+      loadedSelectEl.innerHTML = `<option value="">${escapeHtml(t('st.providers.select_loaded_model'))}</option>` +
+        res.models
+          .map((m) => `<option value="${escapeHtml(m)}">${escapeHtml(m)}</option>`)
+          .join('');
+      loadedSelectEl.value = '';
+      loadedSelectEl.style.display = res.models.length ? '' : 'none';
+    }
     setProviderLoadModelsStatus(id, t('st.providers.models_loaded', { count: res.models.length }));
   } else {
     setProviderLoadModelsStatus(id, res?.error || 'Failed to load models', 'var(--danger, #c33)');

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1367,10 +1367,11 @@ function renderProviders() {
         const canLoadModels = localModelProviders.includes(id) && field.key === 'model';
         const listAttr = canLoadModels ? `list="models-${id}"` : '';
         const datalistHTML = canLoadModels ? `<datalist id="models-${id}"></datalist>` : '';
-        const loadedModelsSelectHTML = canLoadModels
-          ? `<select class="loaded-model-select" data-loaded-models-for="${id}"
-                    aria-label="${escapeHtml(t('st.providers.select_loaded_model'))}"
-                    style="display:none;margin-top:6px;"></select>`
+        const loadedModelsMenuHTML = canLoadModels
+          ? `<div class="loaded-model-menu" data-loaded-models-for="${id}" role="listbox"
+                  aria-label="${escapeHtml(t('st.providers.select_loaded_model'))}"
+                  style="display:none;margin-top:6px;max-height:180px;overflow:auto;
+                         border:1px solid var(--border);border-radius:6px;background:var(--bg3);"></div>`
           : '';
         const loadBtnHTML = canLoadModels
           ? `<button type="button" class="btn-secondary btn-load-models" data-provider="${id}"
@@ -1391,7 +1392,7 @@ function renderProviders() {
                    value="${escapeHtml(value)}" placeholder="${escapeHtml(placeholder)}">
             ${datalistHTML}
             ${loadBtnHTML}
-            ${loadedModelsSelectHTML}
+            ${loadedModelsMenuHTML}
           </div>
         `;
       }
@@ -1477,13 +1478,15 @@ function renderProviders() {
       }
     });
   });
-  document.querySelectorAll('.loaded-model-select').forEach(sel => {
-    sel.addEventListener('change', () => {
-      if (!sel.value) return;
-      const providerId = sel.dataset.loadedModelsFor;
+  document.querySelectorAll('.loaded-model-menu').forEach(menu => {
+    menu.addEventListener('click', (event) => {
+      const option = event.target.closest('.loaded-model-option');
+      if (!option) return;
+      const providerId = menu.dataset.loadedModelsFor;
       const input = document.querySelector(`input[data-provider="${providerId}"][data-key="model"]`);
       if (!input) return;
-      input.value = sel.value;
+      input.value = option.dataset.model || '';
+      menu.style.display = 'none';
     });
   });
   // OAuth-Claude-specific bindings. These only fire if the OAuth card is
@@ -1715,11 +1718,10 @@ function applyProviderBaseUrl(id, baseUrl) {
 }
 
 function clearProviderLoadedModels(id) {
-  const loadedSelectEl = document.querySelector(`.loaded-model-select[data-loaded-models-for="${id}"]`);
-  if (loadedSelectEl) {
-    loadedSelectEl.innerHTML = '';
-    loadedSelectEl.value = '';
-    loadedSelectEl.style.display = 'none';
+  const loadedMenuEl = document.querySelector(`.loaded-model-menu[data-loaded-models-for="${id}"]`);
+  if (loadedMenuEl) {
+    loadedMenuEl.innerHTML = '';
+    loadedMenuEl.style.display = 'none';
   }
   const datalistEl = document.getElementById(`models-${id}`);
   if (datalistEl) datalistEl.innerHTML = '';
@@ -1751,17 +1753,15 @@ async function loadProviderModels(id) {
   if (!datalistEl) return;
   if (res?.ok) {
     applyProviderBaseUrl(id, res.baseUrl);
-    const loadedSelectEl = document.querySelector(`.loaded-model-select[data-loaded-models-for="${id}"]`);
+    const loadedMenuEl = document.querySelector(`.loaded-model-menu[data-loaded-models-for="${id}"]`);
     datalistEl.innerHTML = res.models
       .map((m) => `<option value="${escapeHtml(m)}"></option>`)
       .join('');
-    if (loadedSelectEl) {
-      loadedSelectEl.innerHTML = `<option value="">${escapeHtml(t('st.providers.select_loaded_model'))}</option>` +
-        res.models
-          .map((m) => `<option value="${escapeHtml(m)}">${escapeHtml(m)}</option>`)
-          .join('');
-      loadedSelectEl.value = '';
-      loadedSelectEl.style.display = res.models.length ? '' : 'none';
+    if (loadedMenuEl) {
+      loadedMenuEl.innerHTML = res.models
+        .map((m) => `<button type="button" class="loaded-model-option" role="option" data-model="${escapeHtml(m)}" style="display:block;width:100%;padding:7px 10px;border:0;border-bottom:1px solid var(--border);background:transparent;color:var(--text);font:inherit;text-align:left;overflow-wrap:anywhere;cursor:pointer;">${escapeHtml(m)}</button>`)
+        .join('');
+      loadedMenuEl.style.display = res.models.length ? '' : 'none';
     }
     setProviderLoadModelsStatus(id, t('st.providers.models_loaded', { count: res.models.length }));
   } else {

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -19,7 +19,7 @@ import {
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '19.0.5';
+const EXT_VERSION = '19.0.10';
 
 const providersContainer = document.getElementById('providers');
 const displaySettings = document.getElementById('display-settings');
@@ -1746,6 +1746,7 @@ function closeLoadedModelDialog(dialog) {
 
 function openLoadedModelDialog(dialog) {
   if (!dialog) return;
+  if (dialog.open) return;
   if (typeof dialog.showModal === 'function') dialog.showModal();
   else dialog.setAttribute('open', '');
 }

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1367,11 +1367,19 @@ function renderProviders() {
         const canLoadModels = localModelProviders.includes(id) && field.key === 'model';
         const listAttr = canLoadModels ? `list="models-${id}"` : '';
         const datalistHTML = canLoadModels ? `<datalist id="models-${id}"></datalist>` : '';
-        const loadedModelsMenuHTML = canLoadModels
-          ? `<div class="loaded-model-menu" data-loaded-models-for="${id}" role="listbox"
-                  aria-label="${escapeHtml(t('st.providers.select_loaded_model'))}"
-                  style="display:none;margin-top:6px;max-height:180px;overflow:auto;
-                         border:1px solid var(--border);border-radius:6px;background:var(--bg3);"></div>`
+        const loadedModelsDialogHTML = canLoadModels
+          ? `<dialog class="loaded-model-dialog" data-loaded-models-for="${id}"
+                     aria-labelledby="loaded-model-dialog-title-${id}">
+              <div class="loaded-model-dialog-panel">
+                <div class="loaded-model-dialog-header">
+                  <h3 id="loaded-model-dialog-title-${id}">${escapeHtml(t('st.providers.select_loaded_model'))}</h3>
+                  <button type="button" class="loaded-model-dialog-close"
+                          aria-label="${escapeHtml(t('sp.schedule_form.cancel'))}">&times;</button>
+                </div>
+                <div class="loaded-model-options" role="listbox"
+                     aria-label="${escapeHtml(t('st.providers.select_loaded_model'))}"></div>
+              </div>
+            </dialog>`
           : '';
         const loadBtnHTML = canLoadModels
           ? `<button type="button" class="btn-secondary btn-load-models" data-provider="${id}"
@@ -1392,7 +1400,7 @@ function renderProviders() {
                    value="${escapeHtml(value)}" placeholder="${escapeHtml(placeholder)}">
             ${datalistHTML}
             ${loadBtnHTML}
-            ${loadedModelsMenuHTML}
+            ${loadedModelsDialogHTML}
           </div>
         `;
       }
@@ -1478,15 +1486,19 @@ function renderProviders() {
       }
     });
   });
-  document.querySelectorAll('.loaded-model-menu').forEach(menu => {
-    menu.addEventListener('click', (event) => {
+  document.querySelectorAll('.loaded-model-dialog').forEach(dialog => {
+    dialog.addEventListener('click', (event) => {
+      if (event.target === dialog || event.target.closest('.loaded-model-dialog-close')) {
+        closeLoadedModelDialog(dialog);
+        return;
+      }
       const option = event.target.closest('.loaded-model-option');
       if (!option) return;
-      const providerId = menu.dataset.loadedModelsFor;
+      const providerId = dialog.dataset.loadedModelsFor;
       const input = document.querySelector(`input[data-provider="${providerId}"][data-key="model"]`);
       if (!input) return;
       input.value = option.dataset.model || '';
-      menu.style.display = 'none';
+      closeLoadedModelDialog(dialog);
     });
   });
   // OAuth-Claude-specific bindings. These only fire if the OAuth card is
@@ -1710,6 +1722,15 @@ function setProviderLoadModelsStatus(id, message, color = 'var(--text2)') {
   return statusEl;
 }
 
+function providerModelLoadErrorMessage(resultOrError) {
+  if (resultOrError?.errorKey) return t(resultOrError.errorKey);
+  const message = String(typeof resultOrError === 'string' ? resultOrError : resultOrError?.error || '').trim();
+  if (/^HTTP\s+404\b/i.test(message) && /<!doctype\s+html|<html[\s>]|file not found/i.test(message)) {
+    return t('ob.tokens.none_status');
+  }
+  return message || 'Failed to load models';
+}
+
 function applyProviderBaseUrl(id, baseUrl) {
   if (!baseUrl) return;
   if (providersData[id]) providersData[id].baseUrl = baseUrl;
@@ -1717,11 +1738,24 @@ function applyProviderBaseUrl(id, baseUrl) {
   if (input && input.value !== baseUrl) input.value = baseUrl;
 }
 
+function closeLoadedModelDialog(dialog) {
+  if (!dialog) return;
+  if (typeof dialog.close === 'function') dialog.close();
+  else dialog.removeAttribute('open');
+}
+
+function openLoadedModelDialog(dialog) {
+  if (!dialog) return;
+  if (typeof dialog.showModal === 'function') dialog.showModal();
+  else dialog.setAttribute('open', '');
+}
+
 function clearProviderLoadedModels(id) {
-  const loadedMenuEl = document.querySelector(`.loaded-model-menu[data-loaded-models-for="${id}"]`);
-  if (loadedMenuEl) {
-    loadedMenuEl.innerHTML = '';
-    loadedMenuEl.style.display = 'none';
+  const loadedDialogEl = document.querySelector(`.loaded-model-dialog[data-loaded-models-for="${id}"]`);
+  if (loadedDialogEl) {
+    const optionsEl = loadedDialogEl.querySelector('.loaded-model-options');
+    if (optionsEl) optionsEl.innerHTML = '';
+    closeLoadedModelDialog(loadedDialogEl);
   }
   const datalistEl = document.getElementById(`models-${id}`);
   if (datalistEl) datalistEl.innerHTML = '';
@@ -1736,7 +1770,7 @@ async function loadProviderModels(id) {
   try {
     await saveProvider(id, { showFlash: false });
   } catch (e) {
-    setProviderLoadModelsStatus(id, e.message, 'var(--danger, #c33)');
+    setProviderLoadModelsStatus(id, providerModelLoadErrorMessage(e.message), 'var(--danger, #c33)');
     return;
   }
 
@@ -1745,7 +1779,7 @@ async function loadProviderModels(id) {
   try {
     res = await sendToBackground('list_provider_models', { providerId: id });
   } catch (e) {
-    setProviderLoadModelsStatus(id, e.message, 'var(--danger, #c33)');
+    setProviderLoadModelsStatus(id, providerModelLoadErrorMessage(e.message), 'var(--danger, #c33)');
     return;
   }
 
@@ -1753,19 +1787,22 @@ async function loadProviderModels(id) {
   if (!datalistEl) return;
   if (res?.ok) {
     applyProviderBaseUrl(id, res.baseUrl);
-    const loadedMenuEl = document.querySelector(`.loaded-model-menu[data-loaded-models-for="${id}"]`);
+    const loadedDialogEl = document.querySelector(`.loaded-model-dialog[data-loaded-models-for="${id}"]`);
     datalistEl.innerHTML = res.models
       .map((m) => `<option value="${escapeHtml(m)}"></option>`)
       .join('');
-    if (loadedMenuEl) {
-      loadedMenuEl.innerHTML = res.models
-        .map((m) => `<button type="button" class="loaded-model-option" role="option" data-model="${escapeHtml(m)}" style="display:block;width:100%;padding:7px 10px;border:0;border-bottom:1px solid var(--border);background:transparent;color:var(--text);font:inherit;text-align:left;overflow-wrap:anywhere;cursor:pointer;">${escapeHtml(m)}</button>`)
-        .join('');
-      loadedMenuEl.style.display = res.models.length ? '' : 'none';
+    if (loadedDialogEl) {
+      const optionsEl = loadedDialogEl.querySelector('.loaded-model-options');
+      if (optionsEl) {
+        optionsEl.innerHTML = res.models
+          .map((m) => `<button type="button" class="loaded-model-option" role="option" data-model="${escapeHtml(m)}">${escapeHtml(m)}</button>`)
+          .join('');
+      }
+      if (res.models.length) openLoadedModelDialog(loadedDialogEl);
     }
     setProviderLoadModelsStatus(id, t('st.providers.models_loaded', { count: res.models.length }));
   } else {
-    setProviderLoadModelsStatus(id, res?.error || 'Failed to load models', 'var(--danger, #c33)');
+    setProviderLoadModelsStatus(id, providerModelLoadErrorMessage(res), 'var(--danger, #c33)');
   }
 }
 

--- a/src/firefox/ARCHITECTURE.md
+++ b/src/firefox/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Firefox Extension — Architecture
 
-> Version 19.0.10 · Manifest V2 · Background Page
+> Version 19.0.11 · Manifest V2 · Background Page
 
 ## How Firefox Differs from Chrome
 

--- a/src/firefox/ARCHITECTURE.md
+++ b/src/firefox/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Firefox Extension — Architecture
 
-> Version 19.0.5 · Manifest V2 · Background Page
+> Version 19.0.10 · Manifest V2 · Background Page
 
 ## How Firefox Differs from Chrome
 

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "WebBrain",
-  "version": "19.0.10",
+  "version": "19.0.11",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "activeTab",

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "WebBrain",
-  "version": "19.0.5",
+  "version": "19.0.10",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "activeTab",

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -638,7 +638,8 @@ export class ProviderManager {
       try {
         const res = await fetch(url, { method: 'GET', headers });
         if (!res.ok) {
-          const errBody = await res.text();
+          let errBody = '';
+          try { errBody = await res.text(); } catch {}
           if (res.status === 403) {
             if (!firstFailure) firstFailure = {
               ok: false,
@@ -647,7 +648,7 @@ export class ProviderManager {
             };
             continue;
           }
-          if (!firstFailure) firstFailure = { ok: false, error: `HTTP ${res.status}: ${errBody}` };
+          if (!firstFailure) firstFailure = this._modelListFailure(res.status, errBody, res.statusText);
           continue;
         }
         const data = await res.json();
@@ -675,6 +676,19 @@ export class ProviderManager {
     const apiKey = provider?.config?.apiKey;
     if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
     return headers;
+  }
+
+  _modelListFailure(status, body = '', statusText = '') {
+    const text = String(body || '').trim();
+    if (status === 404 && /<!doctype\s+html|<html[\s>]|file not found/i.test(text)) {
+      return {
+        ok: false,
+        error: 'No local model server was detected.',
+        errorKey: 'ob.tokens.none_status',
+      };
+    }
+    const compact = text.replace(/\s+/g, ' ').slice(0, 300);
+    return { ok: false, error: `HTTP ${status}: ${compact || statusText || 'Request failed'}` };
   }
 
   _baseUrlCandidates(config) {

--- a/src/firefox/src/ui/locales/ar.js
+++ b/src/firefox/src/ui/locales/ar.js
@@ -196,6 +196,7 @@ export default {
   'st.providers.load_models': 'تحميل النماذج',
   'st.providers.loading': 'جارٍ التحميل…',
   'st.providers.models_loaded': 'تم تحميل {count} نموذجًا',
+  'st.providers.select_loaded_model': 'اختر النموذج المحمّل',
 
   'st.provider.field.server_url': 'عنوان الخادم',
   'st.provider.field.api_base_url': 'عنوان API الأساسي',

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -352,6 +352,7 @@ export default {
   'st.providers.load_models': 'Load models',
   'st.providers.loading': 'Loading…',
   'st.providers.models_loaded': '{count} models loaded',
+  'st.providers.select_loaded_model': 'Select loaded model',
   'st.providers.get_api_key': 'Get API key',
   'st.providers.webbrain_note.body': 'Free daily WebBrain Cloud usage is included. Requests go through api.webbrain.one; by default we log metadata for quota and debugging, not prompt text, page content, screenshots, or model responses. {privacyLink}. For more usage, subscribe at {subscribeLink}. Manage billing at {accountLink}.',
   'st.providers.webbrain_note.privacy_link': 'Privacy policy',

--- a/src/firefox/src/ui/locales/es.js
+++ b/src/firefox/src/ui/locales/es.js
@@ -196,6 +196,7 @@ export default {
   'st.providers.load_models': 'Cargar modelos',
   'st.providers.loading': 'Cargando…',
   'st.providers.models_loaded': '{count} modelos cargados',
+  'st.providers.select_loaded_model': 'Seleccionar modelo cargado',
 
   'st.provider.field.server_url': 'URL del servidor',
   'st.provider.field.api_base_url': 'URL base de la API',

--- a/src/firefox/src/ui/locales/fr.js
+++ b/src/firefox/src/ui/locales/fr.js
@@ -196,6 +196,7 @@ export default {
   'st.providers.load_models': 'Charger les modèles',
   'st.providers.loading': 'Chargement…',
   'st.providers.models_loaded': '{count} modèles chargés',
+  'st.providers.select_loaded_model': 'Sélectionner un modèle chargé',
 
   'st.provider.field.server_url': 'URL du serveur',
   'st.provider.field.api_base_url': 'URL de base de l\'API',

--- a/src/firefox/src/ui/locales/id.js
+++ b/src/firefox/src/ui/locales/id.js
@@ -196,6 +196,7 @@ export default {
   'st.providers.load_models': 'Muat model',
   'st.providers.loading': 'Memuat…',
   'st.providers.models_loaded': '{count} model dimuat',
+  'st.providers.select_loaded_model': 'Pilih model yang dimuat',
 
   'st.provider.field.server_url': 'URL server',
   'st.provider.field.api_base_url': 'URL dasar API',

--- a/src/firefox/src/ui/locales/ja.js
+++ b/src/firefox/src/ui/locales/ja.js
@@ -196,6 +196,7 @@ export default {
   'st.providers.load_models': 'モデルを読み込み',
   'st.providers.loading': '読み込み中…',
   'st.providers.models_loaded': '{count} 個のモデルを読み込みました',
+  'st.providers.select_loaded_model': '読み込んだモデルを選択',
 
   'st.provider.field.server_url': 'サーバー URL',
   'st.provider.field.api_base_url': 'API ベース URL',

--- a/src/firefox/src/ui/locales/ko.js
+++ b/src/firefox/src/ui/locales/ko.js
@@ -196,6 +196,7 @@ export default {
   'st.providers.load_models': '모델 불러오기',
   'st.providers.loading': '불러오는 중…',
   'st.providers.models_loaded': '모델 {count}개를 불러왔습니다',
+  'st.providers.select_loaded_model': '불러온 모델 선택',
 
   'st.provider.field.server_url': '서버 URL',
   'st.provider.field.api_base_url': 'API 기본 URL',

--- a/src/firefox/src/ui/locales/ms.js
+++ b/src/firefox/src/ui/locales/ms.js
@@ -196,6 +196,7 @@ export default {
   'st.providers.load_models': 'Muatkan model',
   'st.providers.loading': 'Memuatkan…',
   'st.providers.models_loaded': '{count} model dimuatkan',
+  'st.providers.select_loaded_model': 'Pilih model yang dimuatkan',
 
   'st.provider.field.server_url': 'URL pelayan',
   'st.provider.field.api_base_url': 'URL asas API',

--- a/src/firefox/src/ui/locales/pl.js
+++ b/src/firefox/src/ui/locales/pl.js
@@ -304,6 +304,7 @@ export default {
   'st.providers.load_models': 'Załaduj modele',
   'st.providers.loading': 'Ładowanie…',
   'st.providers.models_loaded': 'Załadowano {count} modeli',
+  'st.providers.select_loaded_model': 'Wybierz załadowany model',
   'st.providers.get_api_key': 'Uzyskaj klucz API',
   'st.providers.webbrain_note.body': 'Darmowe dzienne korzystanie z WebBrain Cloud jest wliczone. Żądania przechodzą przez api.webbrain.one; domyślnie rejestrujemy metadane na potrzeby limitów i debugowania, a nie tekst poleceń, treść stron, zrzuty ekranu ani odpowiedzi modelu. {privacyLink}. Aby korzystać więcej, subskrybuj na {subscribeLink}. Zarządzaj rozliczeniami na {accountLink}.',
   'st.providers.webbrain_note.privacy_link': 'Polityka prywatności',

--- a/src/firefox/src/ui/locales/ru.js
+++ b/src/firefox/src/ui/locales/ru.js
@@ -196,6 +196,7 @@ export default {
   'st.providers.load_models': 'Загрузить модели',
   'st.providers.loading': 'Загрузка…',
   'st.providers.models_loaded': 'Загружено моделей: {count}',
+  'st.providers.select_loaded_model': 'Выберите загруженную модель',
 
   'st.provider.field.server_url': 'URL сервера',
   'st.provider.field.api_base_url': 'Базовый URL API',

--- a/src/firefox/src/ui/locales/th.js
+++ b/src/firefox/src/ui/locales/th.js
@@ -196,6 +196,7 @@ export default {
   'st.providers.load_models': 'โหลดโมเดล',
   'st.providers.loading': 'กำลังโหลด…',
   'st.providers.models_loaded': 'โหลดแล้ว {count} โมเดล',
+  'st.providers.select_loaded_model': 'เลือกโมเดลที่โหลดแล้ว',
 
   'st.provider.field.server_url': 'URL เซิร์ฟเวอร์',
   'st.provider.field.api_base_url': 'URL ฐานของ API',

--- a/src/firefox/src/ui/locales/tl.js
+++ b/src/firefox/src/ui/locales/tl.js
@@ -196,6 +196,7 @@ export default {
   'st.providers.load_models': 'I-load ang mga modelo',
   'st.providers.loading': 'Naglo-load…',
   'st.providers.models_loaded': '{count} na modelo ang na-load',
+  'st.providers.select_loaded_model': 'Piliin ang na-load na modelo',
 
   'st.provider.field.server_url': 'Server URL',
   'st.provider.field.api_base_url': 'API Base URL',

--- a/src/firefox/src/ui/locales/tr.js
+++ b/src/firefox/src/ui/locales/tr.js
@@ -226,6 +226,7 @@ export default {
   'st.providers.load_models': 'Modelleri yükle',
   'st.providers.loading': 'Yükleniyor…',
   'st.providers.models_loaded': '{count} model yüklendi',
+  'st.providers.select_loaded_model': 'Yüklenen modeli seç',
 
   'st.provider.field.server_url': 'Sunucu URL\'si',
   'st.provider.field.api_base_url': 'API temel URL\'si',

--- a/src/firefox/src/ui/locales/uk.js
+++ b/src/firefox/src/ui/locales/uk.js
@@ -196,6 +196,7 @@ export default {
   'st.providers.load_models': 'Завантажити моделі',
   'st.providers.loading': 'Завантаження…',
   'st.providers.models_loaded': 'Завантажено моделей: {count}',
+  'st.providers.select_loaded_model': 'Виберіть завантажену модель',
 
   'st.provider.field.server_url': 'URL сервера',
   'st.provider.field.api_base_url': 'Базовий URL API',

--- a/src/firefox/src/ui/locales/zh.js
+++ b/src/firefox/src/ui/locales/zh.js
@@ -196,6 +196,7 @@ export default {
   'st.providers.load_models': '加载模型',
   'st.providers.loading': '加载中…',
   'st.providers.models_loaded': '已加载 {count} 个模型',
+  'st.providers.select_loaded_model': '选择已加载的模型',
 
   'st.provider.field.server_url': '服务器 URL',
   'st.provider.field.api_base_url': 'API 基础 URL',

--- a/src/firefox/src/ui/settings.html
+++ b/src/firefox/src/ui/settings.html
@@ -320,6 +320,9 @@
     .btn-secondary:hover { background: rgba(255,255,255,0.05); }
 
     .loaded-model-dialog {
+      position: fixed;
+      inset: 0;
+      margin: auto;
       width: min(520px, calc(100vw - 32px));
       max-height: min(680px, calc(100vh - 48px));
       padding: 0;

--- a/src/firefox/src/ui/settings.html
+++ b/src/firefox/src/ui/settings.html
@@ -319,6 +319,62 @@
     }
     .btn-secondary:hover { background: rgba(255,255,255,0.05); }
 
+    .loaded-model-dialog {
+      width: min(520px, calc(100vw - 32px));
+      max-height: min(680px, calc(100vh - 48px));
+      padding: 0;
+      color: var(--text);
+      background: var(--bg2);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      box-shadow: 0 18px 48px rgba(0,0,0,0.42);
+    }
+    .loaded-model-dialog::backdrop { background: rgba(0,0,0,0.58); }
+    .loaded-model-dialog-panel { padding: 14px; }
+    .loaded-model-dialog-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+    .loaded-model-dialog-header h3 {
+      font-size: 14px;
+      font-weight: 700;
+      line-height: 1.3;
+    }
+    .loaded-model-dialog-close {
+      width: 30px;
+      height: 30px;
+      padding: 0;
+      background: var(--bg3);
+      color: var(--text);
+      border: 1px solid var(--border);
+      font-size: 18px;
+      line-height: 1;
+    }
+    .loaded-model-options {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      max-height: min(420px, 58vh);
+      overflow: auto;
+    }
+    .loaded-model-option {
+      width: 100%;
+      padding: 8px 10px;
+      background: var(--bg3);
+      color: var(--text);
+      border: 1px solid var(--border);
+      text-align: left;
+      font-weight: 500;
+      overflow-wrap: anywhere;
+    }
+    .loaded-model-option:hover {
+      border-color: var(--accent);
+      background: rgba(108,99,255,0.12);
+    }
+
     .test-result {
       margin-top: 8px;
       font-size: 11px;

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1653,9 +1653,21 @@ function applyProviderBaseUrl(id, baseUrl) {
   if (input && input.value !== baseUrl) input.value = baseUrl;
 }
 
+function clearProviderLoadedModels(id) {
+  const loadedSelectEl = document.querySelector(`.loaded-model-select[data-loaded-models-for="${id}"]`);
+  if (loadedSelectEl) {
+    loadedSelectEl.innerHTML = '';
+    loadedSelectEl.value = '';
+    loadedSelectEl.style.display = 'none';
+  }
+  const datalistEl = document.getElementById(`models-${id}`);
+  if (datalistEl) datalistEl.innerHTML = '';
+}
+
 async function loadProviderModels(id) {
   let datalistEl = document.getElementById(`models-${id}`);
   if (!datalistEl) return;
+  clearProviderLoadedModels(id);
   try {
     await saveProvider(id, { showFlash: false });
   } catch (e) {

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -19,7 +19,7 @@ import {
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '19.0.10';
+const EXT_VERSION = '19.0.11';
 
 const providersContainer = document.getElementById('providers');
 const displaySettings = document.getElementById('display-settings');

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1331,10 +1331,11 @@ function renderProviders() {
         const canLoadModels = localModelProviders.includes(id) && field.key === 'model';
         const listAttr = canLoadModels ? `list="models-${id}"` : '';
         const datalistHTML = canLoadModels ? `<datalist id="models-${id}"></datalist>` : '';
-        const loadedModelsSelectHTML = canLoadModels
-          ? `<select class="loaded-model-select" data-loaded-models-for="${id}"
-                    aria-label="${escapeHtml(t('st.providers.select_loaded_model'))}"
-                    style="display:none;margin-top:6px;"></select>`
+        const loadedModelsMenuHTML = canLoadModels
+          ? `<div class="loaded-model-menu" data-loaded-models-for="${id}" role="listbox"
+                  aria-label="${escapeHtml(t('st.providers.select_loaded_model'))}"
+                  style="display:none;margin-top:6px;max-height:180px;overflow:auto;
+                         border:1px solid var(--border);border-radius:6px;background:var(--bg3);"></div>`
           : '';
         const loadBtnHTML = canLoadModels
           ? `<button type="button" class="btn-secondary btn-load-models" data-provider="${id}"
@@ -1355,7 +1356,7 @@ function renderProviders() {
                    value="${escapeHtml(value)}" placeholder="${escapeHtml(placeholder)}">
             ${datalistHTML}
             ${loadBtnHTML}
-            ${loadedModelsSelectHTML}
+            ${loadedModelsMenuHTML}
           </div>
         `;
       }
@@ -1438,13 +1439,15 @@ function renderProviders() {
       }
     });
   });
-  document.querySelectorAll('.loaded-model-select').forEach(sel => {
-    sel.addEventListener('change', () => {
-      if (!sel.value) return;
-      const providerId = sel.dataset.loadedModelsFor;
+  document.querySelectorAll('.loaded-model-menu').forEach(menu => {
+    menu.addEventListener('click', (event) => {
+      const option = event.target.closest('.loaded-model-option');
+      if (!option) return;
+      const providerId = menu.dataset.loadedModelsFor;
       const input = document.querySelector(`input[data-provider="${providerId}"][data-key="model"]`);
       if (!input) return;
-      input.value = sel.value;
+      input.value = option.dataset.model || '';
+      menu.style.display = 'none';
     });
   });
   document.querySelectorAll('.btn-claude-signin').forEach(btn => {
@@ -1654,11 +1657,10 @@ function applyProviderBaseUrl(id, baseUrl) {
 }
 
 function clearProviderLoadedModels(id) {
-  const loadedSelectEl = document.querySelector(`.loaded-model-select[data-loaded-models-for="${id}"]`);
-  if (loadedSelectEl) {
-    loadedSelectEl.innerHTML = '';
-    loadedSelectEl.value = '';
-    loadedSelectEl.style.display = 'none';
+  const loadedMenuEl = document.querySelector(`.loaded-model-menu[data-loaded-models-for="${id}"]`);
+  if (loadedMenuEl) {
+    loadedMenuEl.innerHTML = '';
+    loadedMenuEl.style.display = 'none';
   }
   const datalistEl = document.getElementById(`models-${id}`);
   if (datalistEl) datalistEl.innerHTML = '';
@@ -1688,17 +1690,15 @@ async function loadProviderModels(id) {
   if (!datalistEl) return;
   if (res?.ok) {
     applyProviderBaseUrl(id, res.baseUrl);
-    const loadedSelectEl = document.querySelector(`.loaded-model-select[data-loaded-models-for="${id}"]`);
+    const loadedMenuEl = document.querySelector(`.loaded-model-menu[data-loaded-models-for="${id}"]`);
     datalistEl.innerHTML = res.models
       .map((m) => `<option value="${escapeHtml(m)}"></option>`)
       .join('');
-    if (loadedSelectEl) {
-      loadedSelectEl.innerHTML = `<option value="">${escapeHtml(t('st.providers.select_loaded_model'))}</option>` +
-        res.models
-          .map((m) => `<option value="${escapeHtml(m)}">${escapeHtml(m)}</option>`)
-          .join('');
-      loadedSelectEl.value = '';
-      loadedSelectEl.style.display = res.models.length ? '' : 'none';
+    if (loadedMenuEl) {
+      loadedMenuEl.innerHTML = res.models
+        .map((m) => `<button type="button" class="loaded-model-option" role="option" data-model="${escapeHtml(m)}" style="display:block;width:100%;padding:7px 10px;border:0;border-bottom:1px solid var(--border);background:transparent;color:var(--text);font:inherit;text-align:left;overflow-wrap:anywhere;cursor:pointer;">${escapeHtml(m)}</button>`)
+        .join('');
+      loadedMenuEl.style.display = res.models.length ? '' : 'none';
     }
     setProviderLoadModelsStatus(id, t('st.providers.models_loaded', { count: res.models.length }));
   } else {

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1331,6 +1331,11 @@ function renderProviders() {
         const canLoadModels = localModelProviders.includes(id) && field.key === 'model';
         const listAttr = canLoadModels ? `list="models-${id}"` : '';
         const datalistHTML = canLoadModels ? `<datalist id="models-${id}"></datalist>` : '';
+        const loadedModelsSelectHTML = canLoadModels
+          ? `<select class="loaded-model-select" data-loaded-models-for="${id}"
+                    aria-label="${escapeHtml(t('st.providers.select_loaded_model'))}"
+                    style="display:none;margin-top:6px;"></select>`
+          : '';
         const loadBtnHTML = canLoadModels
           ? `<button type="button" class="btn-secondary btn-load-models" data-provider="${id}"
                     style="margin-top:6px;">${escapeHtml(t('st.providers.load_models'))}</button>
@@ -1350,6 +1355,7 @@ function renderProviders() {
                    value="${escapeHtml(value)}" placeholder="${escapeHtml(placeholder)}">
             ${datalistHTML}
             ${loadBtnHTML}
+            ${loadedModelsSelectHTML}
           </div>
         `;
       }
@@ -1430,6 +1436,15 @@ function renderProviders() {
         input.style.display = 'none';
         input.value = sel.value;
       }
+    });
+  });
+  document.querySelectorAll('.loaded-model-select').forEach(sel => {
+    sel.addEventListener('change', () => {
+      if (!sel.value) return;
+      const providerId = sel.dataset.loadedModelsFor;
+      const input = document.querySelector(`input[data-provider="${providerId}"][data-key="model"]`);
+      if (!input) return;
+      input.value = sel.value;
     });
   });
   document.querySelectorAll('.btn-claude-signin').forEach(btn => {
@@ -1661,9 +1676,18 @@ async function loadProviderModels(id) {
   if (!datalistEl) return;
   if (res?.ok) {
     applyProviderBaseUrl(id, res.baseUrl);
+    const loadedSelectEl = document.querySelector(`.loaded-model-select[data-loaded-models-for="${id}"]`);
     datalistEl.innerHTML = res.models
       .map((m) => `<option value="${escapeHtml(m)}"></option>`)
       .join('');
+    if (loadedSelectEl) {
+      loadedSelectEl.innerHTML = `<option value="">${escapeHtml(t('st.providers.select_loaded_model'))}</option>` +
+        res.models
+          .map((m) => `<option value="${escapeHtml(m)}">${escapeHtml(m)}</option>`)
+          .join('');
+      loadedSelectEl.value = '';
+      loadedSelectEl.style.display = res.models.length ? '' : 'none';
+    }
     setProviderLoadModelsStatus(id, t('st.providers.models_loaded', { count: res.models.length }));
   } else {
     setProviderLoadModelsStatus(id, res?.error || 'Failed to load models', 'var(--danger, #c33)');

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -19,7 +19,7 @@ import {
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '19.0.5';
+const EXT_VERSION = '19.0.10';
 
 const providersContainer = document.getElementById('providers');
 const displaySettings = document.getElementById('display-settings');
@@ -1685,6 +1685,7 @@ function closeLoadedModelDialog(dialog) {
 
 function openLoadedModelDialog(dialog) {
   if (!dialog) return;
+  if (dialog.open) return;
   if (typeof dialog.showModal === 'function') dialog.showModal();
   else dialog.setAttribute('open', '');
 }

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1331,11 +1331,19 @@ function renderProviders() {
         const canLoadModels = localModelProviders.includes(id) && field.key === 'model';
         const listAttr = canLoadModels ? `list="models-${id}"` : '';
         const datalistHTML = canLoadModels ? `<datalist id="models-${id}"></datalist>` : '';
-        const loadedModelsMenuHTML = canLoadModels
-          ? `<div class="loaded-model-menu" data-loaded-models-for="${id}" role="listbox"
-                  aria-label="${escapeHtml(t('st.providers.select_loaded_model'))}"
-                  style="display:none;margin-top:6px;max-height:180px;overflow:auto;
-                         border:1px solid var(--border);border-radius:6px;background:var(--bg3);"></div>`
+        const loadedModelsDialogHTML = canLoadModels
+          ? `<dialog class="loaded-model-dialog" data-loaded-models-for="${id}"
+                     aria-labelledby="loaded-model-dialog-title-${id}">
+              <div class="loaded-model-dialog-panel">
+                <div class="loaded-model-dialog-header">
+                  <h3 id="loaded-model-dialog-title-${id}">${escapeHtml(t('st.providers.select_loaded_model'))}</h3>
+                  <button type="button" class="loaded-model-dialog-close"
+                          aria-label="${escapeHtml(t('sp.schedule_form.cancel'))}">&times;</button>
+                </div>
+                <div class="loaded-model-options" role="listbox"
+                     aria-label="${escapeHtml(t('st.providers.select_loaded_model'))}"></div>
+              </div>
+            </dialog>`
           : '';
         const loadBtnHTML = canLoadModels
           ? `<button type="button" class="btn-secondary btn-load-models" data-provider="${id}"
@@ -1356,7 +1364,7 @@ function renderProviders() {
                    value="${escapeHtml(value)}" placeholder="${escapeHtml(placeholder)}">
             ${datalistHTML}
             ${loadBtnHTML}
-            ${loadedModelsMenuHTML}
+            ${loadedModelsDialogHTML}
           </div>
         `;
       }
@@ -1439,15 +1447,19 @@ function renderProviders() {
       }
     });
   });
-  document.querySelectorAll('.loaded-model-menu').forEach(menu => {
-    menu.addEventListener('click', (event) => {
+  document.querySelectorAll('.loaded-model-dialog').forEach(dialog => {
+    dialog.addEventListener('click', (event) => {
+      if (event.target === dialog || event.target.closest('.loaded-model-dialog-close')) {
+        closeLoadedModelDialog(dialog);
+        return;
+      }
       const option = event.target.closest('.loaded-model-option');
       if (!option) return;
-      const providerId = menu.dataset.loadedModelsFor;
+      const providerId = dialog.dataset.loadedModelsFor;
       const input = document.querySelector(`input[data-provider="${providerId}"][data-key="model"]`);
       if (!input) return;
       input.value = option.dataset.model || '';
-      menu.style.display = 'none';
+      closeLoadedModelDialog(dialog);
     });
   });
   document.querySelectorAll('.btn-claude-signin').forEach(btn => {
@@ -1649,6 +1661,15 @@ function setProviderLoadModelsStatus(id, message, color = 'var(--text2)') {
   return statusEl;
 }
 
+function providerModelLoadErrorMessage(resultOrError) {
+  if (resultOrError?.errorKey) return t(resultOrError.errorKey);
+  const message = String(typeof resultOrError === 'string' ? resultOrError : resultOrError?.error || '').trim();
+  if (/^HTTP\s+404\b/i.test(message) && /<!doctype\s+html|<html[\s>]|file not found/i.test(message)) {
+    return t('ob.tokens.none_status');
+  }
+  return message || 'Failed to load models';
+}
+
 function applyProviderBaseUrl(id, baseUrl) {
   if (!baseUrl) return;
   if (providersData[id]) providersData[id].baseUrl = baseUrl;
@@ -1656,11 +1677,24 @@ function applyProviderBaseUrl(id, baseUrl) {
   if (input && input.value !== baseUrl) input.value = baseUrl;
 }
 
+function closeLoadedModelDialog(dialog) {
+  if (!dialog) return;
+  if (typeof dialog.close === 'function') dialog.close();
+  else dialog.removeAttribute('open');
+}
+
+function openLoadedModelDialog(dialog) {
+  if (!dialog) return;
+  if (typeof dialog.showModal === 'function') dialog.showModal();
+  else dialog.setAttribute('open', '');
+}
+
 function clearProviderLoadedModels(id) {
-  const loadedMenuEl = document.querySelector(`.loaded-model-menu[data-loaded-models-for="${id}"]`);
-  if (loadedMenuEl) {
-    loadedMenuEl.innerHTML = '';
-    loadedMenuEl.style.display = 'none';
+  const loadedDialogEl = document.querySelector(`.loaded-model-dialog[data-loaded-models-for="${id}"]`);
+  if (loadedDialogEl) {
+    const optionsEl = loadedDialogEl.querySelector('.loaded-model-options');
+    if (optionsEl) optionsEl.innerHTML = '';
+    closeLoadedModelDialog(loadedDialogEl);
   }
   const datalistEl = document.getElementById(`models-${id}`);
   if (datalistEl) datalistEl.innerHTML = '';
@@ -1673,7 +1707,7 @@ async function loadProviderModels(id) {
   try {
     await saveProvider(id, { showFlash: false });
   } catch (e) {
-    setProviderLoadModelsStatus(id, e.message, 'var(--danger, #c33)');
+    setProviderLoadModelsStatus(id, providerModelLoadErrorMessage(e.message), 'var(--danger, #c33)');
     return;
   }
 
@@ -1682,7 +1716,7 @@ async function loadProviderModels(id) {
   try {
     res = await sendToBackground('list_provider_models', { providerId: id });
   } catch (e) {
-    setProviderLoadModelsStatus(id, e.message, 'var(--danger, #c33)');
+    setProviderLoadModelsStatus(id, providerModelLoadErrorMessage(e.message), 'var(--danger, #c33)');
     return;
   }
 
@@ -1690,19 +1724,22 @@ async function loadProviderModels(id) {
   if (!datalistEl) return;
   if (res?.ok) {
     applyProviderBaseUrl(id, res.baseUrl);
-    const loadedMenuEl = document.querySelector(`.loaded-model-menu[data-loaded-models-for="${id}"]`);
+    const loadedDialogEl = document.querySelector(`.loaded-model-dialog[data-loaded-models-for="${id}"]`);
     datalistEl.innerHTML = res.models
       .map((m) => `<option value="${escapeHtml(m)}"></option>`)
       .join('');
-    if (loadedMenuEl) {
-      loadedMenuEl.innerHTML = res.models
-        .map((m) => `<button type="button" class="loaded-model-option" role="option" data-model="${escapeHtml(m)}" style="display:block;width:100%;padding:7px 10px;border:0;border-bottom:1px solid var(--border);background:transparent;color:var(--text);font:inherit;text-align:left;overflow-wrap:anywhere;cursor:pointer;">${escapeHtml(m)}</button>`)
-        .join('');
-      loadedMenuEl.style.display = res.models.length ? '' : 'none';
+    if (loadedDialogEl) {
+      const optionsEl = loadedDialogEl.querySelector('.loaded-model-options');
+      if (optionsEl) {
+        optionsEl.innerHTML = res.models
+          .map((m) => `<button type="button" class="loaded-model-option" role="option" data-model="${escapeHtml(m)}">${escapeHtml(m)}</button>`)
+          .join('');
+      }
+      if (res.models.length) openLoadedModelDialog(loadedDialogEl);
     }
     setProviderLoadModelsStatus(id, t('st.providers.models_loaded', { count: res.models.length }));
   } else {
-    setProviderLoadModelsStatus(id, res?.error || 'Failed to load models', 'var(--danger, #c33)');
+    setProviderLoadModelsStatus(id, providerModelLoadErrorMessage(res), 'var(--danger, #c33)');
   }
 }
 

--- a/test/run.js
+++ b/test/run.js
@@ -6087,8 +6087,15 @@ test('settings async test controls surface rejected background results', () => {
       /document\.querySelectorAll\('\.loaded-model-select'\)\.forEach\(sel => \{[\s\S]*?sel\.addEventListener\('change', \(\) => \{[\s\S]*?const providerId = sel\.dataset\.loadedModelsFor;[\s\S]*?input\.value = sel\.value;[\s\S]*?\}\);[\s\S]*?\}\);/,
       `${label}: selecting a loaded model should write it back to the provider model input`,
     );
-    const locale = fs.readFileSync(path.join(ROOT, label === 'chrome' ? 'src/chrome/src/ui/locales/en.js' : 'src/firefox/src/ui/locales/en.js'), 'utf8');
-    assert.match(locale, /'st\.providers\.select_loaded_model': 'Select loaded model'/, `${label}: loaded-model selector copy should be localized`);
+    const localeDir = path.join(ROOT, label === 'chrome' ? 'src/chrome/src/ui/locales' : 'src/firefox/src/ui/locales');
+    for (const filename of fs.readdirSync(localeDir).filter((name) => name.endsWith('.js'))) {
+      const locale = fs.readFileSync(path.join(localeDir, filename), 'utf8');
+      assert.match(
+        locale,
+        /['"]st\.providers\.select_loaded_model['"]:\s*['"][^'"]+['"]/,
+        `${label}/${filename}: loaded-model selector copy should be localized`,
+      );
+    }
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -6069,6 +6069,16 @@ test('settings async test controls surface rejected background results', () => {
     );
     assert.match(
       settings,
+      /function clearProviderLoadedModels\(id\) \{[\s\S]*?loadedSelectEl\.innerHTML = '';[\s\S]*?loadedSelectEl\.value = '';[\s\S]*?loadedSelectEl\.style\.display = 'none';[\s\S]*?if \(datalistEl\) datalistEl\.innerHTML = '';[\s\S]*?\}/,
+      `${label}: model loading should have a helper that clears stale loaded-model choices`,
+    );
+    assert.match(
+      loadBody,
+      /let datalistEl = document\.getElementById\(`models-\$\{id\}`\);[\s\S]*?if \(!datalistEl\) return;[\s\S]*?clearProviderLoadedModels\(id\);[\s\S]*?await saveProvider\(id, \{ showFlash: false \}\);/,
+      `${label}: model loading should clear stale model choices before saving or requesting new models`,
+    );
+    assert.match(
+      settings,
       /const loadedModelsSelectHTML = canLoadModels[\s\S]*class="loaded-model-select" data-loaded-models-for="\$\{id\}"[\s\S]*\$\{loadedModelsSelectHTML\}/,
       `${label}: local model loading should render a separate loaded-model selector`,
     );

--- a/test/run.js
+++ b/test/run.js
@@ -6000,11 +6000,12 @@ test('API mutation observer setting is opt-in and controls the request observer'
 });
 
 test('settings async test controls surface rejected background results', () => {
-  for (const [label, settingsRel] of [
-    ['chrome', 'src/chrome/src/ui/settings.js'],
-    ['firefox', 'src/firefox/src/ui/settings.js'],
+  for (const [label, settingsRel, htmlRel] of [
+    ['chrome', 'src/chrome/src/ui/settings.js', 'src/chrome/src/ui/settings.html'],
+    ['firefox', 'src/firefox/src/ui/settings.js', 'src/firefox/src/ui/settings.html'],
   ]) {
     const settings = fs.readFileSync(path.join(ROOT, settingsRel), 'utf8');
+    const html = fs.readFileSync(path.join(ROOT, htmlRel), 'utf8');
 
     assert.match(
       settings,
@@ -6106,6 +6107,11 @@ test('settings async test controls surface rejected background results', () => {
       settings,
       /document\.querySelectorAll\('\.loaded-model-dialog'\)\.forEach\(dialog => \{[\s\S]*?dialog\.addEventListener\('click', \(event\) => \{[\s\S]*?event\.target === dialog[\s\S]*?closeLoadedModelDialog\(dialog\);[\s\S]*?event\.target\.closest\('\.loaded-model-option'\);[\s\S]*?const providerId = dialog\.dataset\.loadedModelsFor;[\s\S]*?input\.value = option\.dataset\.model \|\| '';[\s\S]*?closeLoadedModelDialog\(dialog\);[\s\S]*?\}\);[\s\S]*?\}\);/,
       `${label}: choosing a loaded model should write it back to the provider model input`,
+    );
+    assert.match(
+      html,
+      /\.loaded-model-dialog \{[\s\S]*?position: fixed;[\s\S]*?inset: 0;[\s\S]*?margin: auto;[\s\S]*?width: min\(520px, calc\(100vw - 32px\)\);/,
+      `${label}: loaded-model dialog should stay centered despite the global margin reset`,
     );
     const localeDir = path.join(ROOT, label === 'chrome' ? 'src/chrome/src/ui/locales' : 'src/firefox/src/ui/locales');
     for (const filename of fs.readdirSync(localeDir).filter((name) => name.endsWith('.js'))) {

--- a/test/run.js
+++ b/test/run.js
@@ -6069,7 +6069,7 @@ test('settings async test controls surface rejected background results', () => {
     );
     assert.match(
       settings,
-      /function clearProviderLoadedModels\(id\) \{[\s\S]*?loadedSelectEl\.innerHTML = '';[\s\S]*?loadedSelectEl\.value = '';[\s\S]*?loadedSelectEl\.style\.display = 'none';[\s\S]*?if \(datalistEl\) datalistEl\.innerHTML = '';[\s\S]*?\}/,
+      /function clearProviderLoadedModels\(id\) \{[\s\S]*?loadedMenuEl\.innerHTML = '';[\s\S]*?loadedMenuEl\.style\.display = 'none';[\s\S]*?if \(datalistEl\) datalistEl\.innerHTML = '';[\s\S]*?\}/,
       `${label}: model loading should have a helper that clears stale loaded-model choices`,
     );
     assert.match(
@@ -6079,13 +6079,18 @@ test('settings async test controls surface rejected background results', () => {
     );
     assert.match(
       settings,
-      /const loadedModelsSelectHTML = canLoadModels[\s\S]*class="loaded-model-select" data-loaded-models-for="\$\{id\}"[\s\S]*\$\{loadedModelsSelectHTML\}/,
-      `${label}: local model loading should render a separate loaded-model selector`,
+      /const loadedModelsMenuHTML = canLoadModels[\s\S]*class="loaded-model-menu" data-loaded-models-for="\$\{id\}"[\s\S]*\$\{loadedModelsMenuHTML\}/,
+      `${label}: local model loading should render a temporary loaded-model menu`,
+    );
+    assert.doesNotMatch(
+      settings,
+      /loaded-model-select|loadedModelsSelectHTML/,
+      `${label}: local model loading should not render a second select control`,
     );
     assert.match(
       loadBody,
-      /const loadedSelectEl = document\.querySelector\(`\.loaded-model-select\[data-loaded-models-for="\$\{id\}"\]`\);[\s\S]*?loadedSelectEl\.innerHTML = `<option value="">\$\{escapeHtml\(t\('st\.providers\.select_loaded_model'\)\)\}<\/option>` \+[\s\S]*?res\.models[\s\S]*?loadedSelectEl\.value = '';[\s\S]*?loadedSelectEl\.style\.display = res\.models\.length \? '' : 'none';/,
-      `${label}: loaded models should populate a visible selector without replacing the current model text`,
+      /const loadedMenuEl = document\.querySelector\(`\.loaded-model-menu\[data-loaded-models-for="\$\{id\}"\]`\);[\s\S]*?loadedMenuEl\.innerHTML = res\.models[\s\S]*?class="loaded-model-option"[\s\S]*?loadedMenuEl\.style\.display = res\.models\.length \? '' : 'none';/,
+      `${label}: loaded models should populate a temporary menu without replacing the current model text`,
     );
     assert.doesNotMatch(
       loadBody,
@@ -6094,8 +6099,8 @@ test('settings async test controls surface rejected background results', () => {
     );
     assert.match(
       settings,
-      /document\.querySelectorAll\('\.loaded-model-select'\)\.forEach\(sel => \{[\s\S]*?sel\.addEventListener\('change', \(\) => \{[\s\S]*?const providerId = sel\.dataset\.loadedModelsFor;[\s\S]*?input\.value = sel\.value;[\s\S]*?\}\);[\s\S]*?\}\);/,
-      `${label}: selecting a loaded model should write it back to the provider model input`,
+      /document\.querySelectorAll\('\.loaded-model-menu'\)\.forEach\(menu => \{[\s\S]*?menu\.addEventListener\('click', \(event\) => \{[\s\S]*?event\.target\.closest\('\.loaded-model-option'\);[\s\S]*?const providerId = menu\.dataset\.loadedModelsFor;[\s\S]*?input\.value = option\.dataset\.model \|\| '';[\s\S]*?menu\.style\.display = 'none';[\s\S]*?\}\);[\s\S]*?\}\);/,
+      `${label}: choosing a loaded model should write it back to the provider model input`,
     );
     const localeDir = path.join(ROOT, label === 'chrome' ? 'src/chrome/src/ui/locales' : 'src/firefox/src/ui/locales');
     for (const filename of fs.readdirSync(localeDir).filter((name) => name.endsWith('.js'))) {

--- a/test/run.js
+++ b/test/run.js
@@ -6067,6 +6067,28 @@ test('settings async test controls surface rejected background results', () => {
       /let datalistEl = document\.getElementById\(`models-\$\{id\}`\);[\s\S]*?setProviderLoadModelsStatus\(id, t\('st\.providers\.loading'\)\);[\s\S]*?try \{[\s\S]*?res = await sendToBackground\('list_provider_models', \{ providerId: id \}\);[\s\S]*?\} catch \(e\) \{[\s\S]*?setProviderLoadModelsStatus\(id, e\.message, 'var\(--danger, #c33\)'\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?datalistEl = document\.getElementById\(`models-\$\{id\}`\);[\s\S]*?if \(!datalistEl\) return;[\s\S]*?setProviderLoadModelsStatus\(id, res\?\.error \|\| 'Failed to load models', 'var\(--danger, #c33\)'\);/,
       `${label}: model loading should report rejected background results and avoid stale datalist writes`,
     );
+    assert.match(
+      settings,
+      /const loadedModelsSelectHTML = canLoadModels[\s\S]*class="loaded-model-select" data-loaded-models-for="\$\{id\}"[\s\S]*\$\{loadedModelsSelectHTML\}/,
+      `${label}: local model loading should render a separate loaded-model selector`,
+    );
+    assert.match(
+      loadBody,
+      /const loadedSelectEl = document\.querySelector\(`\.loaded-model-select\[data-loaded-models-for="\$\{id\}"\]`\);[\s\S]*?loadedSelectEl\.innerHTML = `<option value="">\$\{escapeHtml\(t\('st\.providers\.select_loaded_model'\)\)\}<\/option>` \+[\s\S]*?res\.models[\s\S]*?loadedSelectEl\.value = '';[\s\S]*?loadedSelectEl\.style\.display = res\.models\.length \? '' : 'none';/,
+      `${label}: loaded models should populate a visible selector without replacing the current model text`,
+    );
+    assert.doesNotMatch(
+      loadBody,
+      /input\.value\s*=\s*res\.models/,
+      `${label}: loading models should not overwrite an existing model until the user chooses one`,
+    );
+    assert.match(
+      settings,
+      /document\.querySelectorAll\('\.loaded-model-select'\)\.forEach\(sel => \{[\s\S]*?sel\.addEventListener\('change', \(\) => \{[\s\S]*?const providerId = sel\.dataset\.loadedModelsFor;[\s\S]*?input\.value = sel\.value;[\s\S]*?\}\);[\s\S]*?\}\);/,
+      `${label}: selecting a loaded model should write it back to the provider model input`,
+    );
+    const locale = fs.readFileSync(path.join(ROOT, label === 'chrome' ? 'src/chrome/src/ui/locales/en.js' : 'src/firefox/src/ui/locales/en.js'), 'utf8');
+    assert.match(locale, /'st\.providers\.select_loaded_model': 'Select loaded model'/, `${label}: loaded-model selector copy should be localized`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -6109,6 +6109,11 @@ test('settings async test controls surface rejected background results', () => {
       `${label}: choosing a loaded model should write it back to the provider model input`,
     );
     assert.match(
+      settings,
+      /function openLoadedModelDialog\(dialog\) \{[\s\S]*?if \(!dialog\) return;[\s\S]*?if \(dialog\.open\) return;[\s\S]*?dialog\.showModal/,
+      `${label}: loaded-model dialog opening should tolerate repeated model-load responses`,
+    );
+    assert.match(
       html,
       /\.loaded-model-dialog \{[\s\S]*?position: fixed;[\s\S]*?inset: 0;[\s\S]*?margin: auto;[\s\S]*?width: min\(520px, calc\(100vw - 32px\)\);/,
       `${label}: loaded-model dialog should stay centered despite the global margin reset`,

--- a/test/run.js
+++ b/test/run.js
@@ -5931,7 +5931,7 @@ test('settings provider save and test status updates are DOM-safe', () => {
     const loadBody = settings.slice(loadStart, settings.indexOf('\n}\n\nfunction setProviderTestResult', loadStart) + 2);
     assert.match(
       loadBody,
-      /try \{[\s\S]*?await saveProvider\(id, \{ showFlash: false \}\);[\s\S]*?\} catch \(e\) \{[\s\S]*?setProviderLoadModelsStatus\(id, e\.message, 'var\(--danger, #c33\)'\);[\s\S]*?return;[\s\S]*?\}/,
+      /try \{[\s\S]*?await saveProvider\(id, \{ showFlash: false \}\);[\s\S]*?\} catch \(e\) \{[\s\S]*?setProviderLoadModelsStatus\(id, providerModelLoadErrorMessage\(e\.message\), 'var\(--danger, #c33\)'\);[\s\S]*?return;[\s\S]*?\}/,
       `${label}: model loading should stop and report if the pre-save fails`,
     );
   }
@@ -6064,12 +6064,17 @@ test('settings async test controls surface rejected background results', () => {
     const loadBody = settings.slice(loadStart, settings.indexOf('\n}\n\nfunction setProviderTestResult', loadStart) + 2);
     assert.match(
       loadBody,
-      /let datalistEl = document\.getElementById\(`models-\$\{id\}`\);[\s\S]*?setProviderLoadModelsStatus\(id, t\('st\.providers\.loading'\)\);[\s\S]*?try \{[\s\S]*?res = await sendToBackground\('list_provider_models', \{ providerId: id \}\);[\s\S]*?\} catch \(e\) \{[\s\S]*?setProviderLoadModelsStatus\(id, e\.message, 'var\(--danger, #c33\)'\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?datalistEl = document\.getElementById\(`models-\$\{id\}`\);[\s\S]*?if \(!datalistEl\) return;[\s\S]*?setProviderLoadModelsStatus\(id, res\?\.error \|\| 'Failed to load models', 'var\(--danger, #c33\)'\);/,
+      /let datalistEl = document\.getElementById\(`models-\$\{id\}`\);[\s\S]*?await saveProvider\(id, \{ showFlash: false \}\);[\s\S]*?\} catch \(e\) \{[\s\S]*?setProviderLoadModelsStatus\(id, providerModelLoadErrorMessage\(e\.message\), 'var\(--danger, #c33\)'\);[\s\S]*?return;[\s\S]*?setProviderLoadModelsStatus\(id, t\('st\.providers\.loading'\)\);[\s\S]*?try \{[\s\S]*?res = await sendToBackground\('list_provider_models', \{ providerId: id \}\);[\s\S]*?\} catch \(e\) \{[\s\S]*?setProviderLoadModelsStatus\(id, providerModelLoadErrorMessage\(e\.message\), 'var\(--danger, #c33\)'\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?datalistEl = document\.getElementById\(`models-\$\{id\}`\);[\s\S]*?if \(!datalistEl\) return;[\s\S]*?setProviderLoadModelsStatus\(id, providerModelLoadErrorMessage\(res\), 'var\(--danger, #c33\)'\);/,
       `${label}: model loading should report rejected background results and avoid stale datalist writes`,
     );
     assert.match(
       settings,
-      /function clearProviderLoadedModels\(id\) \{[\s\S]*?loadedMenuEl\.innerHTML = '';[\s\S]*?loadedMenuEl\.style\.display = 'none';[\s\S]*?if \(datalistEl\) datalistEl\.innerHTML = '';[\s\S]*?\}/,
+      /function providerModelLoadErrorMessage\(resultOrError\) \{[\s\S]*?resultOrError\?\.errorKey[\s\S]*?t\(resultOrError\.errorKey\)[\s\S]*?\^HTTP\\s\+404\\b[\s\S]*?<!doctype\\s\+html\|<html\[\\s>\]\|file not found[\s\S]*?t\('ob\.tokens\.none_status'\)[\s\S]*?\}/,
+      `${label}: HTML 404 model-list failures should be shown as a concise local-server status`,
+    );
+    assert.match(
+      settings,
+      /function clearProviderLoadedModels\(id\) \{[\s\S]*?loadedDialogEl\.querySelector\('\.loaded-model-options'\);[\s\S]*?optionsEl\.innerHTML = '';[\s\S]*?closeLoadedModelDialog\(loadedDialogEl\);[\s\S]*?if \(datalistEl\) datalistEl\.innerHTML = '';[\s\S]*?\}/,
       `${label}: model loading should have a helper that clears stale loaded-model choices`,
     );
     assert.match(
@@ -6079,18 +6084,18 @@ test('settings async test controls surface rejected background results', () => {
     );
     assert.match(
       settings,
-      /const loadedModelsMenuHTML = canLoadModels[\s\S]*class="loaded-model-menu" data-loaded-models-for="\$\{id\}"[\s\S]*\$\{loadedModelsMenuHTML\}/,
-      `${label}: local model loading should render a temporary loaded-model menu`,
+      /const loadedModelsDialogHTML = canLoadModels[\s\S]*<dialog class="loaded-model-dialog" data-loaded-models-for="\$\{id\}"[\s\S]*class="loaded-model-options"[\s\S]*\$\{loadedModelsDialogHTML\}/,
+      `${label}: local model loading should render a loaded-model dialog`,
     );
     assert.doesNotMatch(
       settings,
-      /loaded-model-select|loadedModelsSelectHTML/,
-      `${label}: local model loading should not render a second select control`,
+      /loaded-model-select|loadedModelsSelectHTML|loaded-model-menu|loadedModelsMenuHTML/,
+      `${label}: local model loading should not render a second select control or inline menu`,
     );
     assert.match(
       loadBody,
-      /const loadedMenuEl = document\.querySelector\(`\.loaded-model-menu\[data-loaded-models-for="\$\{id\}"\]`\);[\s\S]*?loadedMenuEl\.innerHTML = res\.models[\s\S]*?class="loaded-model-option"[\s\S]*?loadedMenuEl\.style\.display = res\.models\.length \? '' : 'none';/,
-      `${label}: loaded models should populate a temporary menu without replacing the current model text`,
+      /const loadedDialogEl = document\.querySelector\(`\.loaded-model-dialog\[data-loaded-models-for="\$\{id\}"\]`\);[\s\S]*?const optionsEl = loadedDialogEl\.querySelector\('\.loaded-model-options'\);[\s\S]*?optionsEl\.innerHTML = res\.models[\s\S]*?class="loaded-model-option"[\s\S]*?if \(res\.models\.length\) openLoadedModelDialog\(loadedDialogEl\);/,
+      `${label}: loaded models should populate and open a dialog without replacing the current model text`,
     );
     assert.doesNotMatch(
       loadBody,
@@ -6099,7 +6104,7 @@ test('settings async test controls surface rejected background results', () => {
     );
     assert.match(
       settings,
-      /document\.querySelectorAll\('\.loaded-model-menu'\)\.forEach\(menu => \{[\s\S]*?menu\.addEventListener\('click', \(event\) => \{[\s\S]*?event\.target\.closest\('\.loaded-model-option'\);[\s\S]*?const providerId = menu\.dataset\.loadedModelsFor;[\s\S]*?input\.value = option\.dataset\.model \|\| '';[\s\S]*?menu\.style\.display = 'none';[\s\S]*?\}\);[\s\S]*?\}\);/,
+      /document\.querySelectorAll\('\.loaded-model-dialog'\)\.forEach\(dialog => \{[\s\S]*?dialog\.addEventListener\('click', \(event\) => \{[\s\S]*?event\.target === dialog[\s\S]*?closeLoadedModelDialog\(dialog\);[\s\S]*?event\.target\.closest\('\.loaded-model-option'\);[\s\S]*?const providerId = dialog\.dataset\.loadedModelsFor;[\s\S]*?input\.value = option\.dataset\.model \|\| '';[\s\S]*?closeLoadedModelDialog\(dialog\);[\s\S]*?\}\);[\s\S]*?\}\);/,
       `${label}: choosing a loaded model should write it back to the provider model input`,
     );
     const localeDir = path.join(ROOT, label === 'chrome' ? 'src/chrome/src/ui/locales' : 'src/firefox/src/ui/locales');
@@ -9110,6 +9115,43 @@ test('listProviderModels does not persist stale base URL repairs', async () => {
     else globalThis.chrome = originalChrome;
     if (originalBrowser === undefined) delete globalThis.browser;
     else globalThis.browser = originalBrowser;
+  }
+});
+
+test('listProviderModels normalizes HTML 404 model-list failures', async () => {
+  const originalFetch = globalThis.fetch;
+  const html404 = `<!DOCTYPE HTML>
+<html lang="en">
+<head><title>Error response</title></head>
+<body><h1>Error response</h1><p>Error code: 404</p><p>Message: File not found.</p></body>
+</html>`;
+
+  try {
+    for (const [label, PM] of [
+      ['chrome', ProviderManagerCh],
+      ['firefox', ProviderManagerFx],
+    ]) {
+      globalThis.fetch = async () => new Response(html404, {
+        status: 404,
+        statusText: 'File not found',
+        headers: { 'Content-Type': 'text/html' },
+      });
+
+      const mgr = new PM();
+      const config = {
+        ...mgr._defaultConfigs().vllm,
+        baseUrl: 'http://127.0.0.1:8000',
+      };
+      mgr.providers.set('vllm', mgr._createProvider('vllm', config));
+
+      const result = await mgr.listProviderModels('vllm');
+      assert.equal(result.ok, false, `${label}: HTML 404 should fail`);
+      assert.equal(result.errorKey, 'ob.tokens.none_status', `${label}: HTML 404 should carry a localizable error key`);
+      assert.equal(result.error, 'No local model server was detected.', `${label}: HTML 404 should use concise fallback text`);
+      assert.doesNotMatch(result.error, /<!DOCTYPE|<html|File not found/, `${label}: HTML body should not leak into the UI error`);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
   }
 });
 


### PR DESCRIPTION
## Summary

Fixes the Settings > Providers Load models flow for local providers when a model is already typed or saved in the model field.

## Root Cause

The UI populated only a datalist attached to the existing model text input. Browsers filter datalist suggestions against the current input value, so a stale or different saved model could make freshly loaded models appear missing.

## Changes

- Adds a separate loaded-model selector for local providers in both Chrome and Firefox settings.
- Keeps the existing model text value unchanged after loading models.
- Writes the selected loaded model back into the normal model input only when the user chooses it.
- Adds English copy and source-level regression coverage for the Chrome and Firefox settings implementations.

## Validation

- `node test/run.js` passed: 552/552
- `npm test` passed, including injection corpus: 60/60