### PR TITLE
[codex] Add sidepanel message queue

### DIFF
--- a/src/chrome/src/ui/locales/ar.js
+++ b/src/chrome/src/ui/locales/ar.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'تمت الموافقة على الخطة — جارٍ التشغيل…',
   'sp.plan.cancelled': 'تم إلغاء الخطة.',
   'sp.plan.expired': 'لم تعد هذه الخطة قيد المراجعة — تم إلغاء التشغيل.',
-  'sp.slash.busy_only_oob': 'يمكن فقط لـ /help و /show-scratchpad و /list-schedules و /screenshot و /export و /verbose العمل بينما WebBrain مشغول. أوقف التشغيل أو حاول مرة أخرى عندما ينتهي.',
+  'sp.slash.busy_only_oob': 'تُضاف الرسائل إلى قائمة الانتظار بينما يكون WebBrain مشغولًا. يمكن فقط لـ /help و /show-scratchpad و /list-schedules و /screenshot و /export و /verbose العمل فورًا كأوامر slash.',
   'tool.go_back': 'العودة للخلف',
   'tool.go_forward': 'التقدم للأمام',
   'st.display.search.placeholder': 'البحث في الإعدادات العامة',

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -24,6 +24,10 @@ export default {
   'sp.btn.send': 'Send',
   'sp.btn.stop.title': 'Stop agent',
   'sp.btn.stop.label': 'Stop',
+  'sp.queue.label': 'Queued',
+  'sp.queue.label_numbered': 'Queued {index}',
+  'sp.queue.edit': 'Edit queued message',
+  'sp.queue.delete': 'Delete queued message',
 
   'sp.inspection': 'WebBrain started inspecting this page',
 
@@ -180,7 +184,7 @@ export default {
   'sp.api.badge_html': '<span>🔓 API mutations allowed</span>',
 
   'sp.help_html': '<strong>Slash Commands</strong><br><code>/help</code> — Show this list<br><code>/schedule</code> — Create a scheduled task<br><code>/list-schedules</code> — Show scheduled tasks<br><code>/show-scratchpad</code> — Show current scratchpad<br><code>/edit-scratchpad &lt;text&gt;</code> — Append text to the current scratchpad<br><code>/clear-scratchpad</code> — Clear the current scratchpad<br><code>/allow-api</code> — Allow API mutations for this conversation<br><code>/compact</code> — Compact this conversation context<br><code>/verbose</code> — Toggle verbose/compact tool display<br><code>/reset</code> — Clear conversation<br><code>/screenshot</code> — Capture current tab<br><code>/full-page-screenshot</code> — Capture the full page (Chrome only)<br><code>/record</code> — Start recording the current tab<br><code>/export</code> — Download conversation as Markdown<br><code>/profile</code> — Toggle profile auto-fill<br><code>/vision</code> — Toggle vision mode on active provider<br><br><strong>Keyboard Shortcuts</strong><br><code>Ctrl/Cmd+/</code> — Focus the input<br><code>Ctrl/Cmd+Shift+A</code> — Switch to Ask mode<br><code>Ctrl/Cmd+Shift+X</code> — Switch to Act mode<br><code>Escape</code> — Stop the active run',
-  'sp.slash.busy_only_oob': 'Only /help, /show-scratchpad, /list-schedules, /screenshot, /export, and /verbose can run while WebBrain is busy. Stop the run or try again when it finishes.',
+  'sp.slash.busy_only_oob': 'Messages are queued while WebBrain is busy. Only /help, /show-scratchpad, /list-schedules, /screenshot, /export, and /verbose can run immediately as slash commands.',
   'sp.compact.nothing_to_compact': 'Nothing to compact yet — there is not enough older context.',
   'sp.compact.busy': 'Cannot compact while a run is in progress — wait for it to finish.',
   'sp.compact.failed': 'Context compaction failed: {error}',

--- a/src/chrome/src/ui/locales/es.js
+++ b/src/chrome/src/ui/locales/es.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'Plan aprobado — ejecutando…',
   'sp.plan.cancelled': 'Plan cancelado.',
   'sp.plan.expired': 'Este plan ya no está en espera de revisión — la ejecución fue cancelada.',
-  'sp.slash.busy_only_oob': 'Solo /help, /show-scratchpad, /list-schedules, /screenshot, /export y /verbose pueden ejecutarse mientras WebBrain está ocupado. Detén la ejecución o inténtalo de nuevo cuando termine.',
+  'sp.slash.busy_only_oob': 'Los mensajes se ponen en cola mientras WebBrain está ocupado. Solo /help, /show-scratchpad, /list-schedules, /screenshot, /export y /verbose pueden ejecutarse de inmediato como comandos slash.',
   'tool.go_back': 'Volviendo atrás',
   'tool.go_forward': 'Avanzando',
   'st.display.search.placeholder': 'Buscar en ajustes generales',

--- a/src/chrome/src/ui/locales/fr.js
+++ b/src/chrome/src/ui/locales/fr.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'Plan approuvé — exécution…',
   'sp.plan.cancelled': 'Plan annulé.',
   'sp.plan.expired': 'Ce plan n\'est plus en attente de révision — l\'exécution a été annulée.',
-  'sp.slash.busy_only_oob': 'Seuls /help, /show-scratchpad, /list-schedules, /screenshot, /export et /verbose peuvent fonctionner pendant que WebBrain est occupé. Arrêtez l\'exécution ou réessayez quand il a terminé.',
+  'sp.slash.busy_only_oob': 'Les messages sont mis en file d\'attente pendant que WebBrain est occupé. Seuls /help, /show-scratchpad, /list-schedules, /screenshot, /export et /verbose peuvent s\'exécuter immédiatement comme commandes slash.',
   'tool.go_back': 'Revenir en arrière',
   'tool.go_forward': 'Aller en avant',
   'st.display.search.placeholder': 'Rechercher dans les paramètres généraux',

--- a/src/chrome/src/ui/locales/id.js
+++ b/src/chrome/src/ui/locales/id.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'Rencana disetujui — menjalankan…',
   'sp.plan.cancelled': 'Rencana dibatalkan.',
   'sp.plan.expired': 'Rencana ini tidak lagi menunggu peninjauan — proses dibatalkan.',
-  'sp.slash.busy_only_oob': 'Hanya /help, /show-scratchpad, /list-schedules, /screenshot, /export, dan /verbose yang dapat berjalan saat WebBrain sibuk. Hentikan proses atau coba lagi setelah selesai.',
+  'sp.slash.busy_only_oob': 'Pesan dimasukkan ke antrean saat WebBrain sibuk. Hanya /help, /show-scratchpad, /list-schedules, /screenshot, /export, dan /verbose yang dapat langsung berjalan sebagai perintah slash.',
   'tool.go_back': 'Kembali',
   'tool.go_forward': 'Maju',
   'st.display.search.placeholder': 'Cari pengaturan Umum',

--- a/src/chrome/src/ui/locales/ja.js
+++ b/src/chrome/src/ui/locales/ja.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': '計画承認済み — 実行中…',
   'sp.plan.cancelled': '計画がキャンセルされました。',
   'sp.plan.expired': 'この計画はレビュー待ちではなくなりました — 実行はキャンセルされました。',
-  'sp.slash.busy_only_oob': 'WebBrain がビジーの間は、/help、/show-scratchpad、/list-schedules、/screenshot、/export、/verbose のみ実行できます。実行を停止するか、終了してもう一度お試しください。',
+  'sp.slash.busy_only_oob': 'WebBrain がビジーの間、メッセージはキューに入ります。/help、/show-scratchpad、/list-schedules、/screenshot、/export、/verbose だけがスラッシュコマンドとしてすぐに実行できます。',
   'tool.go_back': '戻る',
   'tool.go_forward': '進む',
   'st.display.search.placeholder': '一般設定を検索',

--- a/src/chrome/src/ui/locales/ko.js
+++ b/src/chrome/src/ui/locales/ko.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': '계획 승인됨 — 실행 중…',
   'sp.plan.cancelled': '계획이 취소되었습니다.',
   'sp.plan.expired': '이 계획은 더 이상 검토 대기 중이 아닙니다 — 실행이 취소되었습니다.',
-  'sp.slash.busy_only_oob': 'WebBrain이 사용 중인 동안에는 /help, /show-scratchpad, /list-schedules, /screenshot, /export, /verbose만 실행할 수 있습니다. 실행을 중지하거나 완료되면 다시 시도하세요.',
+  'sp.slash.busy_only_oob': 'WebBrain이 사용 중일 때 메시지는 대기열에 추가됩니다. /help, /show-scratchpad, /list-schedules, /screenshot, /export, /verbose만 슬래시 명령으로 즉시 실행할 수 있습니다.',
   'tool.go_back': '뒤로 가기',
   'tool.go_forward': '앞으로 가기',
   'st.display.search.placeholder': '일반 설정 검색',

--- a/src/chrome/src/ui/locales/ms.js
+++ b/src/chrome/src/ui/locales/ms.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'Rancangan diluluskan — berjalan…',
   'sp.plan.cancelled': 'Rancangan dibatalkan.',
   'sp.plan.expired': 'Rancangan ini tidak lagi menunggu semakan — pelaksanaan dibatalkan.',
-  'sp.slash.busy_only_oob': 'Hanya /help, /show-scratchpad, /list-schedules, /screenshot, /export, dan /verbose boleh berjalan semasa WebBrain sibuk. Hentikan larian atau cuba semula apabila ia selesai.',
+  'sp.slash.busy_only_oob': 'Mesej dimasukkan ke giliran semasa WebBrain sibuk. Hanya /help, /show-scratchpad, /list-schedules, /screenshot, /export, dan /verbose boleh berjalan serta-merta sebagai arahan slash.',
   'tool.go_back': 'Kembali',
   'tool.go_forward': 'Maju',
   'st.display.search.placeholder': 'Cari tetapan Umum',

--- a/src/chrome/src/ui/locales/pl.js
+++ b/src/chrome/src/ui/locales/pl.js
@@ -476,7 +476,7 @@ export default {
   'sp.plan.approved': 'Plan zatwierdzony — uruchamianie…',
   'sp.plan.cancelled': 'Plan anulowany.',
   'sp.plan.expired': 'Ten plan nie oczekuje już na przegląd — uruchomienie zostało anulowane.',
-  'sp.slash.busy_only_oob': 'Tylko /help, /show-scratchpad, /list-schedules, /screenshot, /export i /verbose mogą działać, gdy WebBrain jest zajęty. Zatrzymaj działanie lub spróbuj ponownie, gdy zakończy.',
+  'sp.slash.busy_only_oob': 'Wiadomości są kolejkowane, gdy WebBrain jest zajęty. Tylko /help, /show-scratchpad, /list-schedules, /screenshot, /export i /verbose mogą uruchamiać się od razu jako polecenia slash.',
   'tool.go_back': 'Cofanie',
   'tool.go_forward': 'Przechodzenie do przodu',
   'st.display.search.placeholder': 'Szukaj w ustawieniach ogólnych',

--- a/src/chrome/src/ui/locales/ru.js
+++ b/src/chrome/src/ui/locales/ru.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'План утверждён — выполняется…',
   'sp.plan.cancelled': 'План отменён.',
   'sp.plan.expired': 'Этот план больше не ожидает рассмотрения — запуск отменён.',
-  'sp.slash.busy_only_oob': 'Только /help, /show-scratchpad, /list-schedules, /screenshot, /export и /verbose могут работать, пока WebBrain занят. Остановите выполнение или повторите попытку, когда он закончит.',
+  'sp.slash.busy_only_oob': 'Пока WebBrain занят, сообщения ставятся в очередь. Только /help, /show-scratchpad, /list-schedules, /screenshot, /export и /verbose могут запускаться сразу как slash-команды.',
   'tool.go_back': 'Назад',
   'tool.go_forward': 'Вперёд',
   'st.display.search.placeholder': 'Поиск в общих настройках',

--- a/src/chrome/src/ui/locales/th.js
+++ b/src/chrome/src/ui/locales/th.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'แผนได้รับการอนุมัติ — กำลังดำเนินการ…',
   'sp.plan.cancelled': 'แผนถูกยกเลิก',
   'sp.plan.expired': 'แผนนี้ไม่ได้รอการตรวจสอบอีกต่อไป — การดำเนินการถูกยกเลิก',
-  'sp.slash.busy_only_oob': 'เฉพาะ /help, /show-scratchpad, /list-schedules, /screenshot, /export และ /verbose เท่านั้นที่ทำงานได้ขณะที่ WebBrain ไม่ว่าง หยุดการทำงานหรือลองอีกครั้งเมื่อเสร็จสิ้น',
+  'sp.slash.busy_only_oob': 'ข้อความจะถูกเข้าคิวขณะที่ WebBrain ไม่ว่าง เฉพาะ /help, /show-scratchpad, /list-schedules, /screenshot, /export และ /verbose เท่านั้นที่เรียกใช้ได้ทันทีในฐานะคำสั่ง slash',
   'tool.go_back': 'กำลังย้อนกลับ',
   'tool.go_forward': 'กำลังไปข้างหน้า',
   'st.display.search.placeholder': 'ค้นหาการตั้งค่าทั่วไป',

--- a/src/chrome/src/ui/locales/tl.js
+++ b/src/chrome/src/ui/locales/tl.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'Naaprubahan ang plano — tumatakbo…',
   'sp.plan.cancelled': 'Kinansela ang plano.',
   'sp.plan.expired': 'Ang planong ito ay hindi na naghihintay ng pagsusuri — ang pagtakbo ay kinansela.',
-  'sp.slash.busy_only_oob': 'Tanging /help, /show-scratchpad, /list-schedules, /screenshot, /export, at /verbose ang maaaring tumakbo habang abala ang WebBrain. Itigil ang pagtakbo o subukan muli kapag natapos na.',
+  'sp.slash.busy_only_oob': 'Nakapila ang mga mensahe habang abala ang WebBrain. Tanging /help, /show-scratchpad, /list-schedules, /screenshot, /export, at /verbose ang maaaring tumakbo agad bilang mga slash command.',
   'tool.go_back': 'Bumabalik',
   'tool.go_forward': 'Sumusulong',
   'st.display.search.placeholder': 'Maghanap sa General na mga setting',

--- a/src/chrome/src/ui/locales/tr.js
+++ b/src/chrome/src/ui/locales/tr.js
@@ -517,7 +517,7 @@ export default {
   'sp.plan.approved': 'Plan onaylandı — çalıştırılıyor…',
   'sp.plan.cancelled': 'Plan iptal edildi.',
   'sp.plan.expired': 'Bu plan artık inceleme beklenmiyor — çalıştırma iptal edildi.',
-  'sp.slash.busy_only_oob': 'WebBrain meşgulken yalnızca /help, /show-scratchpad, /list-schedules, /screenshot, /export ve /verbose çalışabilir. Çalıştırmayı durdurun veya bittiğinde tekrar deneyin.',
+  'sp.slash.busy_only_oob': 'WebBrain meşgulken mesajlar kuyruğa alınır. Yalnızca /help, /show-scratchpad, /list-schedules, /screenshot, /export ve /verbose slash komutları olarak hemen çalışabilir.',
   'tool.go_back': 'Geri gidiliyor',
   'tool.go_forward': 'İleri gidiliyor',
   'st.display.search.placeholder': 'Genel ayarları ara',

--- a/src/chrome/src/ui/locales/uk.js
+++ b/src/chrome/src/ui/locales/uk.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'План схвалено — виконується…',
   'sp.plan.cancelled': 'План скасовано.',
   'sp.plan.expired': 'Цей план більше не очікує розгляду — запуск скасовано.',
-  'sp.slash.busy_only_oob': 'Лише /help, /show-scratchpad, /list-schedules, /screenshot, /export та /verbose можуть працювати, поки WebBrain зайнятий. Зупиніть виконання або спробуйте ще раз, коли він закінчить.',
+  'sp.slash.busy_only_oob': 'Поки WebBrain зайнятий, повідомлення ставляться в чергу. Лише /help, /show-scratchpad, /list-schedules, /screenshot, /export та /verbose можуть запускатися одразу як slash-команди.',
   'tool.go_back': 'Назад',
   'tool.go_forward': 'Вперед',
   'st.display.search.placeholder': 'Пошук у загальних налаштуваннях',

--- a/src/chrome/src/ui/locales/zh.js
+++ b/src/chrome/src/ui/locales/zh.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': '计划已批准 — 正在运行…',
   'sp.plan.cancelled': '计划已取消。',
   'sp.plan.expired': '该计划不再等待审查 — 运行已取消。',
-  'sp.slash.busy_only_oob': '当 WebBrain 忙碌时，只有 /help、/show-scratchpad、/list-schedules、/screenshot、/export 和 /verbose 可以运行。停止运行或等待其完成后再试。',
+  'sp.slash.busy_only_oob': 'WebBrain 忙碌时，消息会排队。只有 /help、/show-scratchpad、/list-schedules、/screenshot、/export 和 /verbose 可以作为斜杠命令立即运行。',
   'tool.go_back': '返回',
   'tool.go_forward': '前进',
   'st.display.search.placeholder': '搜索通用设置',

--- a/src/chrome/src/ui/sidepanel.html
+++ b/src/chrome/src/ui/sidepanel.html
@@ -209,6 +209,7 @@
         <button id="btn-mode-ask" class="mode-btn active" data-i18n="sp.mode.ask" data-i18n-title="sp.mode.ask.title"></button>
         <button id="btn-mode-act" class="mode-btn" data-i18n="sp.mode.act" data-i18n-title="sp.mode.act.title"></button>
       </div>
+      <div id="queued-messages" class="queued-messages hidden" role="list" aria-live="polite"></div>
       <div id="slash-command-menu" class="slash-command-menu hidden" role="listbox" data-i18n-aria-label="sp.slash.commands_label"></div>
       <div id="input-wrapper">
         <div id="input-text-layer">

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -317,6 +317,7 @@ const modeActBtn = document.getElementById('btn-mode-act');
 const actWarning = document.getElementById('act-warning');
 const inputArea = document.getElementById('input-area');
 const slashCommandMenuEl = document.getElementById('slash-command-menu');
+const queuedMessagesEl = document.getElementById('queued-messages');
 const recommendedActionsEl = document.getElementById('recommended-actions');
 const recommendedActionsToggleEl = document.getElementById('recommended-actions-toggle');
 const recommendedActionsListEl = document.getElementById('recommended-actions-list');
@@ -560,6 +561,8 @@ const tabChats = new Map();
 const TAB_CHAT_PREFIX = 'tabChat:';
 const tabChatOperations = new Map();
 const tabInputDrafts = new Map();
+const queuedComposerMessagesByTab = new Map();
+let queuedComposerMessageSeq = 0;
 
 function enqueueTabChatOperation(tabId, fn) {
   const numericTabId = Number(tabId);
@@ -659,9 +662,159 @@ function restoreInputDraftForTab(tabId) {
   syncSendButtonState();
 }
 
+function getQueuedComposerMessages(tabId) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return [];
+  return queuedComposerMessagesByTab.get(numericTabId) || [];
+}
+
+function setQueuedComposerMessages(tabId, messages) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return;
+  if (messages.length) {
+    queuedComposerMessagesByTab.set(numericTabId, messages);
+  } else {
+    queuedComposerMessagesByTab.delete(numericTabId);
+  }
+  if (currentTabId === numericTabId) renderQueuedComposerMessages(numericTabId);
+}
+
+function queuedComposerButton(className, action, queueId, labelKey, svgPath) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = `queued-message-action ${className}`;
+  btn.dataset.queueAction = action;
+  btn.dataset.queueId = queueId;
+  btn.title = t(labelKey);
+  btn.setAttribute('aria-label', t(labelKey));
+  btn.innerHTML = `<svg viewBox="0 0 24 24" aria-hidden="true">${svgPath}</svg>`;
+  return btn;
+}
+
+function renderQueuedComposerMessages(tabId = currentTabId) {
+  if (!queuedMessagesEl) return;
+  const messages = getQueuedComposerMessages(tabId);
+  queuedMessagesEl.replaceChildren();
+  queuedMessagesEl.classList.toggle('hidden', messages.length === 0);
+  if (!messages.length) return;
+
+  messages.forEach((item, index) => {
+    const row = document.createElement('div');
+    row.className = 'queued-message';
+    row.dataset.queueId = item.id;
+    row.setAttribute('role', 'listitem');
+
+    const label = document.createElement('span');
+    label.className = 'queued-message-label';
+    label.textContent = messages.length > 1
+      ? t('sp.queue.label_numbered', { index: index + 1 })
+      : t('sp.queue.label');
+
+    const text = document.createElement('span');
+    text.className = 'queued-message-text';
+    text.textContent = item.text;
+    text.title = item.text;
+
+    const edit = queuedComposerButton(
+      'queued-message-edit',
+      'edit',
+      item.id,
+      'sp.queue.edit',
+      '<path d="M12 19V5"></path><path d="M5 12l7-7 7 7"></path>',
+    );
+    const remove = queuedComposerButton(
+      'queued-message-delete',
+      'delete',
+      item.id,
+      'sp.queue.delete',
+      '<path d="M18 6L6 18"></path><path d="M6 6l12 12"></path>',
+    );
+
+    row.append(label, text, edit, remove);
+    queuedMessagesEl.appendChild(row);
+  });
+}
+
+function shiftQueuedComposerMessage(tabId) {
+  const queue = getQueuedComposerMessages(tabId);
+  if (!queue.length) return null;
+  const [item, ...remaining] = queue;
+  setQueuedComposerMessages(tabId, remaining);
+  return item;
+}
+
+function removeQueuedComposerMessage(tabId, queueId) {
+  const queue = getQueuedComposerMessages(tabId);
+  const index = queue.findIndex((item) => item.id === queueId);
+  if (index === -1) return null;
+  const nextQueue = queue.slice();
+  const [item] = nextQueue.splice(index, 1);
+  setQueuedComposerMessages(tabId, nextQueue);
+  return item;
+}
+
+function enqueueQueuedComposerMessage(tabId, text) {
+  const numericTabId = Number(tabId);
+  const queuedText = String(text || '').trim();
+  if (!Number.isFinite(numericTabId) || !queuedText) return false;
+  const queue = getQueuedComposerMessages(numericTabId).slice();
+  queue.push({
+    id: `queued-${Date.now()}-${++queuedComposerMessageSeq}`,
+    text: queuedText,
+  });
+  setQueuedComposerMessages(numericTabId, queue);
+  if (currentTabId === numericTabId) {
+    saveInputDraftForTab(numericTabId, '');
+    hideSlashCommandAutocomplete();
+    inputEl.value = '';
+    autoResizeInput();
+    syncSendButtonState();
+  }
+  return true;
+}
+
+function editQueuedComposerMessage(tabId, queueId) {
+  const item = removeQueuedComposerMessage(tabId, queueId);
+  if (!item || currentTabId !== Number(tabId)) return;
+  inputEl.value = item.text;
+  saveInputDraftForTab(tabId, item.text);
+  autoResizeInput();
+  updateSlashCommandAutocomplete();
+  syncSendButtonState();
+  inputEl.focus();
+  inputEl.setSelectionRange(inputEl.value.length, inputEl.value.length);
+}
+
+function deleteQueuedComposerMessage(tabId, queueId) {
+  removeQueuedComposerMessage(tabId, queueId);
+}
+
+function clearQueuedComposerMessagesForTab(tabId) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return;
+  queuedComposerMessagesByTab.delete(numericTabId);
+  if (currentTabId === numericTabId) renderQueuedComposerMessages(numericTabId);
+}
+
+function drainQueuedComposerMessageForCurrentTab() {
+  if (isProcessing || currentTabId == null || renderedTabId !== currentTabId) return false;
+  if (inputEl.value.trim()) return false;
+  const item = shiftQueuedComposerMessage(currentTabId);
+  if (!item) return false;
+  inputEl.value = item.text;
+  autoResizeInput();
+  updateSlashCommandAutocomplete();
+  syncSendButtonState();
+  Promise.resolve().then(() => sendMessage()).catch((e) => {
+    addMessage('error', t('sp.error_prefix', { msg: e?.message || String(e) }));
+  });
+  return true;
+}
+
 function renderClearedConversationForTab(tabId) {
   clearCachedTabChat(tabId);
   saveInputDraftForTab(tabId, '');
+  clearQueuedComposerMessagesForTab(tabId);
   setApiMutationsAllowedForTab(tabId, false);
   if (currentTabId !== tabId) return;
   renderedTabId = tabId;
@@ -977,6 +1130,7 @@ async function scheduledJobAction(action, jobId) {
 }
 
 async function drainQueuedContextMenuPromptsAfterPendingTabSwitch() {
+  if (drainQueuedComposerMessageForCurrentTab()) return;
   if (pendingTabSwitch == null) {
     drainQueuedContextMenuPrompts();
     return;
@@ -989,6 +1143,7 @@ async function drainQueuedContextMenuPromptsAfterPendingTabSwitch() {
     // Still drain any queued prompt for the current tab; tab activation can fail
     // when the underlying browser tab disappears during run settlement.
   }
+  if (drainQueuedComposerMessageForCurrentTab()) return;
   drainQueuedContextMenuPrompts();
 }
 
@@ -1620,6 +1775,7 @@ async function switchToTab(newTabId) {
       addMessage('system', t('sp.help_message'));
     }
     restoreInputDraftForTab(newTabId);
+    renderQueuedComposerMessages(newTabId);
     scrollToBottom();
     refreshScheduledJobs({ tabId: newTabId });
     refreshRecommendedActions();
@@ -2205,8 +2361,12 @@ function syncSendButtonState() {
     sendBtn.disabled = false;
     return;
   }
-  const draft = normalizeScreenshotCommandText(inputEl?.value || '');
-  sendBtn.disabled = !isOutOfBandSlashDraft(draft);
+  const draft = normalizeScreenshotCommandText(inputEl?.value || '').trim();
+  if (!draft) {
+    sendBtn.disabled = true;
+    return;
+  }
+  sendBtn.disabled = draft.startsWith('/') && !isOutOfBandSlashDraft(draft);
 }
 
 function showBusySlashCommandNotice() {
@@ -2477,24 +2637,27 @@ async function sendMessage(extraChatParams) {
   const tabId = currentTabId;
   text = normalizeScreenshotCommandText(text);
   if (isProcessing) {
-    if (!isOutOfBandSlashDraft(text)) {
+    if (isOutOfBandSlashDraft(text)) {
+      saveInputDraftForTab(tabId, '');
+      hideSlashCommandAutocomplete();
+      inputEl.value = '';
+      autoResizeInput();
+      syncSendButtonState();
+      await parseSlashCommands(text, tabId);
+      if (currentTabId === tabId) {
+        if (!inputEl.value.trim() || inputEl.value.trim() === text) {
+          inputEl.value = '';
+          autoResizeInput();
+        }
+        syncSendButtonState();
+      }
+      return true;
+    }
+    if (text.startsWith('/')) {
       showBusySlashCommandNotice();
       return false;
     }
-    saveInputDraftForTab(tabId, '');
-    hideSlashCommandAutocomplete();
-    inputEl.value = '';
-    autoResizeInput();
-    syncSendButtonState();
-    await parseSlashCommands(text, tabId);
-    if (currentTabId === tabId) {
-      if (!inputEl.value.trim() || inputEl.value.trim() === text) {
-        inputEl.value = '';
-        autoResizeInput();
-      }
-      syncSendButtonState();
-    }
-    return true;
+    return enqueueQueuedComposerMessage(tabId, text);
   }
   const modeForSend = /^\/(?:ask|plan)\b/i.test(text) ? 'ask' : agentMode;
   const apiMutationsAllowedForSend = isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);
@@ -4053,6 +4216,18 @@ sendBtn.addEventListener('click', sendMessage);
 
 document.addEventListener('keydown', handleGlobalKeydown);
 
+queuedMessagesEl?.addEventListener('click', (e) => {
+  const btn = e.target.closest('button[data-queue-action][data-queue-id]');
+  if (!btn) return;
+  const action = btn.dataset.queueAction;
+  const queueId = btn.dataset.queueId;
+  if (action === 'edit') {
+    editQueuedComposerMessage(currentTabId, queueId);
+  } else if (action === 'delete') {
+    deleteQueuedComposerMessage(currentTabId, queueId);
+  }
+});
+
 inputEl.addEventListener('keydown', (e) => {
   if (handleSlashCommandKeydown(e)) return;
   if (e.key === 'Enter' && !e.shiftKey) {
@@ -4068,6 +4243,7 @@ inputEl.addEventListener('focus', updateSlashCommandAutocomplete);
 inputEl.addEventListener('blur', () => setTimeout(hideSlashCommandAutocomplete, 120));
 document.addEventListener('wb-locale-changed', () => {
   if (slashCommandMatches.length) renderSlashCommandAutocomplete();
+  renderQueuedComposerMessages();
 });
 
 clearBtn.addEventListener('click', async () => {

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -1239,6 +1239,76 @@ body {
   display: none;
 }
 
+.queued-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0 0 8px;
+}
+
+.queued-messages.hidden {
+  display: none;
+}
+
+.queued-message {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 32px;
+  padding: 6px 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.queued-message-label {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.queued-message-text {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queued-message-action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.queued-message-action:hover {
+  color: var(--text-primary);
+  background: rgba(91, 82, 232, 0.12);
+  border-color: var(--border);
+}
+
+.queued-message-action svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
 .slash-command-option {
   display: grid;
   grid-template-columns: minmax(112px, max-content) minmax(0, 1fr);

--- a/src/firefox/src/ui/locales/ar.js
+++ b/src/firefox/src/ui/locales/ar.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'تمت الموافقة على الخطة — جارٍ التشغيل…',
   'sp.plan.cancelled': 'تم إلغاء الخطة.',
   'sp.plan.expired': 'لم تعد هذه الخطة قيد المراجعة — تم إلغاء التشغيل.',
-  'sp.slash.busy_only_oob': 'يمكن فقط لـ /help و /show-scratchpad و /list-schedules و /screenshot و /export و /verbose العمل بينما WebBrain مشغول. أوقف التشغيل أو حاول مرة أخرى عندما ينتهي.',
+  'sp.slash.busy_only_oob': 'تُضاف الرسائل إلى قائمة الانتظار بينما يكون WebBrain مشغولًا. يمكن فقط لـ /help و /show-scratchpad و /list-schedules و /screenshot و /export و /verbose العمل فورًا كأوامر slash.',
   'tool.go_back': 'العودة للخلف',
   'tool.go_forward': 'التقدم للأمام',
   'st.display.search.placeholder': 'البحث في الإعدادات العامة',

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -15,6 +15,10 @@ export default {
   'sp.btn.send': 'Send',
   'sp.btn.stop.title': 'Stop agent',
   'sp.btn.stop.label': 'Stop',
+  'sp.queue.label': 'Queued',
+  'sp.queue.label_numbered': 'Queued {index}',
+  'sp.queue.edit': 'Edit queued message',
+  'sp.queue.delete': 'Delete queued message',
 
   'sp.inspection': 'WebBrain started inspecting this page',
 
@@ -168,7 +172,7 @@ export default {
   'sp.api.badge_html': '<span>🔓 API mutations allowed</span>',
 
   'sp.help_html': '<strong>Slash Commands</strong><br><code>/help</code> — Show this list<br><code>/schedule</code> — Create a scheduled task<br><code>/list-schedules</code> — Show scheduled tasks<br><code>/show-scratchpad</code> — Show current scratchpad<br><code>/edit-scratchpad &lt;text&gt;</code> — Append text to the current scratchpad<br><code>/clear-scratchpad</code> — Clear the current scratchpad<br><code>/allow-api</code> — Allow API mutations for this conversation<br><code>/compact</code> — Compact this conversation context<br><code>/verbose</code> — Toggle verbose/compact tool display<br><code>/reset</code> — Clear conversation<br><code>/screenshot</code> — Capture current tab<br><code>/export</code> — Download conversation as Markdown<br><code>/profile</code> — Toggle profile auto-fill<br><code>/vision</code> — Toggle vision mode on active provider',
-  'sp.slash.busy_only_oob': 'Only /help, /show-scratchpad, /list-schedules, /screenshot, /export, and /verbose can run while WebBrain is busy. Stop the run or try again when it finishes.',
+  'sp.slash.busy_only_oob': 'Messages are queued while WebBrain is busy. Only /help, /show-scratchpad, /list-schedules, /screenshot, /export, and /verbose can run immediately as slash commands.',
   'sp.compact.nothing_to_compact': 'Nothing to compact yet — there is not enough older context.',
   'sp.compact.busy': 'Cannot compact while a run is in progress — wait for it to finish.',
   'sp.compact.failed': 'Context compaction failed: {error}',

--- a/src/firefox/src/ui/locales/es.js
+++ b/src/firefox/src/ui/locales/es.js
@@ -518,7 +518,7 @@ export default {
   'sp.plan.approved': 'Plan aprobado — ejecutando…',
   'sp.plan.cancelled': 'Plan cancelado.',
   'sp.plan.expired': 'Este plan ya no está en espera de revisión — la ejecución fue cancelada.',
-  'sp.slash.busy_only_oob': 'Solo /help, /show-scratchpad, /list-schedules, /screenshot, /export y /verbose pueden ejecutarse mientras WebBrain está ocupado. Detén la ejecución o inténtalo de nuevo cuando termine.',
+  'sp.slash.busy_only_oob': 'Los mensajes se ponen en cola mientras WebBrain está ocupado. Solo /help, /show-scratchpad, /list-schedules, /screenshot, /export y /verbose pueden ejecutarse de inmediato como comandos slash.',
   'tool.go_back': 'Volviendo atrás',
   'tool.go_forward': 'Avanzando',
   'st.display.search.placeholder': 'Buscar en ajustes generales',

--- a/src/firefox/src/ui/locales/fr.js
+++ b/src/firefox/src/ui/locales/fr.js
@@ -518,7 +518,7 @@ export default {
   'sp.plan.approved': 'Plan approuvé — exécution…',
   'sp.plan.cancelled': 'Plan annulé.',
   'sp.plan.expired': 'Ce plan n\'est plus en attente de révision — l\'exécution a été annulée.',
-  'sp.slash.busy_only_oob': 'Seuls /help, /show-scratchpad, /list-schedules, /screenshot, /export et /verbose peuvent fonctionner pendant que WebBrain est occupé. Arrêtez l\'exécution ou réessayez quand il a terminé.',
+  'sp.slash.busy_only_oob': 'Les messages sont mis en file d\'attente pendant que WebBrain est occupé. Seuls /help, /show-scratchpad, /list-schedules, /screenshot, /export et /verbose peuvent s\'exécuter immédiatement comme commandes slash.',
   'tool.go_back': 'Revenir en arrière',
   'tool.go_forward': 'Aller en avant',
   'st.display.search.placeholder': 'Rechercher dans les paramètres généraux',

--- a/src/firefox/src/ui/locales/id.js
+++ b/src/firefox/src/ui/locales/id.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'Rencana disetujui — menjalankan…',
   'sp.plan.cancelled': 'Rencana dibatalkan.',
   'sp.plan.expired': 'Rencana ini tidak lagi menunggu peninjauan — proses dibatalkan.',
-  'sp.slash.busy_only_oob': 'Hanya /help, /show-scratchpad, /list-schedules, /screenshot, /export, dan /verbose yang dapat berjalan saat WebBrain sibuk. Hentikan proses atau coba lagi setelah selesai.',
+  'sp.slash.busy_only_oob': 'Pesan dimasukkan ke antrean saat WebBrain sibuk. Hanya /help, /show-scratchpad, /list-schedules, /screenshot, /export, dan /verbose yang dapat langsung berjalan sebagai perintah slash.',
   'tool.go_back': 'Kembali',
   'tool.go_forward': 'Maju',
   'st.display.search.placeholder': 'Cari pengaturan Umum',

--- a/src/firefox/src/ui/locales/ja.js
+++ b/src/firefox/src/ui/locales/ja.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': '計画承認済み — 実行中…',
   'sp.plan.cancelled': '計画がキャンセルされました。',
   'sp.plan.expired': 'この計画はレビュー待ちではなくなりました — 実行はキャンセルされました。',
-  'sp.slash.busy_only_oob': 'WebBrain がビジーの間は、/help、/show-scratchpad、/list-schedules、/screenshot、/export、/verbose のみ実行できます。実行を停止するか、終了してもう一度お試しください。',
+  'sp.slash.busy_only_oob': 'WebBrain がビジーの間、メッセージはキューに入ります。/help、/show-scratchpad、/list-schedules、/screenshot、/export、/verbose だけがスラッシュコマンドとしてすぐに実行できます。',
   'tool.go_back': '戻る',
   'tool.go_forward': '進む',
   'st.display.search.placeholder': '一般設定を検索',

--- a/src/firefox/src/ui/locales/ko.js
+++ b/src/firefox/src/ui/locales/ko.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': '계획 승인됨 — 실행 중…',
   'sp.plan.cancelled': '계획이 취소되었습니다.',
   'sp.plan.expired': '이 계획은 더 이상 검토 대기 중이 아닙니다 — 실행이 취소되었습니다.',
-  'sp.slash.busy_only_oob': 'WebBrain이 사용 중인 동안에는 /help, /show-scratchpad, /list-schedules, /screenshot, /export, /verbose만 실행할 수 있습니다. 실행을 중지하거나 완료되면 다시 시도하세요.',
+  'sp.slash.busy_only_oob': 'WebBrain이 사용 중일 때 메시지는 대기열에 추가됩니다. /help, /show-scratchpad, /list-schedules, /screenshot, /export, /verbose만 슬래시 명령으로 즉시 실행할 수 있습니다.',
   'tool.go_back': '뒤로 가기',
   'tool.go_forward': '앞으로 가기',
   'st.display.search.placeholder': '일반 설정 검색',

--- a/src/firefox/src/ui/locales/ms.js
+++ b/src/firefox/src/ui/locales/ms.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'Rancangan diluluskan — berjalan…',
   'sp.plan.cancelled': 'Rancangan dibatalkan.',
   'sp.plan.expired': 'Rancangan ini tidak lagi menunggu semakan — pelaksanaan dibatalkan.',
-  'sp.slash.busy_only_oob': 'Hanya /help, /show-scratchpad, /list-schedules, /screenshot, /export, dan /verbose boleh berjalan semasa WebBrain sibuk. Hentikan larian atau cuba semula apabila ia selesai.',
+  'sp.slash.busy_only_oob': 'Mesej dimasukkan ke giliran semasa WebBrain sibuk. Hanya /help, /show-scratchpad, /list-schedules, /screenshot, /export, dan /verbose boleh berjalan serta-merta sebagai arahan slash.',
   'tool.go_back': 'Kembali',
   'tool.go_forward': 'Maju',
   'st.display.search.placeholder': 'Cari tetapan Umum',

--- a/src/firefox/src/ui/locales/pl.js
+++ b/src/firefox/src/ui/locales/pl.js
@@ -476,7 +476,7 @@ export default {
   'sp.plan.approved': 'Plan zatwierdzony — uruchamianie…',
   'sp.plan.cancelled': 'Plan anulowany.',
   'sp.plan.expired': 'Ten plan nie oczekuje już na przegląd — uruchomienie zostało anulowane.',
-  'sp.slash.busy_only_oob': 'Tylko /help, /show-scratchpad, /list-schedules, /screenshot, /export i /verbose mogą działać, gdy WebBrain jest zajęty. Zatrzymaj działanie lub spróbuj ponownie, gdy zakończy.',
+  'sp.slash.busy_only_oob': 'Wiadomości są kolejkowane, gdy WebBrain jest zajęty. Tylko /help, /show-scratchpad, /list-schedules, /screenshot, /export i /verbose mogą uruchamiać się od razu jako polecenia slash.',
   'tool.go_back': 'Cofanie',
   'tool.go_forward': 'Przechodzenie do przodu',
   'st.display.search.placeholder': 'Szukaj w ustawieniach ogólnych',

--- a/src/firefox/src/ui/locales/ru.js
+++ b/src/firefox/src/ui/locales/ru.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'План утверждён — выполняется…',
   'sp.plan.cancelled': 'План отменён.',
   'sp.plan.expired': 'Этот план больше не ожидает рассмотрения — запуск отменён.',
-  'sp.slash.busy_only_oob': 'Только /help, /show-scratchpad, /list-schedules, /screenshot, /export и /verbose могут работать, пока WebBrain занят. Остановите выполнение или повторите попытку, когда он закончит.',
+  'sp.slash.busy_only_oob': 'Пока WebBrain занят, сообщения ставятся в очередь. Только /help, /show-scratchpad, /list-schedules, /screenshot, /export и /verbose могут запускаться сразу как slash-команды.',
   'tool.go_back': 'Назад',
   'tool.go_forward': 'Вперёд',
   'st.display.search.placeholder': 'Поиск в общих настройках',

--- a/src/firefox/src/ui/locales/th.js
+++ b/src/firefox/src/ui/locales/th.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'แผนได้รับการอนุมัติ — กำลังดำเนินการ…',
   'sp.plan.cancelled': 'แผนถูกยกเลิก',
   'sp.plan.expired': 'แผนนี้ไม่ได้รอการตรวจสอบอีกต่อไป — การดำเนินการถูกยกเลิก',
-  'sp.slash.busy_only_oob': 'เฉพาะ /help, /show-scratchpad, /list-schedules, /screenshot, /export และ /verbose เท่านั้นที่ทำงานได้ขณะที่ WebBrain ไม่ว่าง หยุดการทำงานหรือลองอีกครั้งเมื่อเสร็จสิ้น',
+  'sp.slash.busy_only_oob': 'ข้อความจะถูกเข้าคิวขณะที่ WebBrain ไม่ว่าง เฉพาะ /help, /show-scratchpad, /list-schedules, /screenshot, /export และ /verbose เท่านั้นที่เรียกใช้ได้ทันทีในฐานะคำสั่ง slash',
   'tool.go_back': 'กำลังย้อนกลับ',
   'tool.go_forward': 'กำลังไปข้างหน้า',
   'st.display.search.placeholder': 'ค้นหาการตั้งค่าทั่วไป',

--- a/src/firefox/src/ui/locales/tl.js
+++ b/src/firefox/src/ui/locales/tl.js
@@ -516,7 +516,7 @@ export default {
   'sp.plan.approved': 'Naaprubahan ang plano — tumatakbo…',
   'sp.plan.cancelled': 'Kinansela ang plano.',
   'sp.plan.expired': 'Ang planong ito ay hindi na naghihintay ng pagsusuri — ang pagtakbo ay kinansela.',
-  'sp.slash.busy_only_oob': 'Tanging /help, /show-scratchpad, /list-schedules, /screenshot, /export, at /verbose ang maaaring tumakbo habang abala ang WebBrain. Itigil ang pagtakbo o subukan muli kapag natapos na.',
+  'sp.slash.busy_only_oob': 'Nakapila ang mga mensahe habang abala ang WebBrain. Tanging /help, /show-scratchpad, /list-schedules, /screenshot, /export, at /verbose ang maaaring tumakbo agad bilang mga slash command.',
   'tool.go_back': 'Bumabalik',
   'tool.go_forward': 'Sumusulong',
   'st.display.search.placeholder': 'Maghanap sa General na mga setting',

--- a/src/firefox/src/ui/locales/tr.js
+++ b/src/firefox/src/ui/locales/tr.js
@@ -517,7 +517,7 @@ export default {
   'sp.plan.approved': 'Plan onaylandı — çalıştırılıyor…',
   'sp.plan.cancelled': 'Plan iptal edildi.',
   'sp.plan.expired': 'Bu plan artık inceleme beklenmiyor — çalıştırma iptal edildi.',
-  'sp.slash.busy_only_oob': 'WebBrain meşgulken yalnızca /help, /show-scratchpad, /list-schedules, /screenshot, /export ve /verbose çalışabilir. Çalıştırmayı durdurun veya bittiğinde tekrar deneyin.',
+  'sp.slash.busy_only_oob': 'WebBrain meşgulken mesajlar kuyruğa alınır. Yalnızca /help, /show-scratchpad, /list-schedules, /screenshot, /export ve /verbose slash komutları olarak hemen çalışabilir.',
   'tool.go_back': 'Geri gidiliyor',
   'tool.go_forward': 'İleri gidiliyor',
   'st.display.search.placeholder': 'Genel ayarları ara',

--- a/src/firefox/src/ui/locales/uk.js
+++ b/src/firefox/src/ui/locales/uk.js
@@ -517,7 +517,7 @@ export default {
   'sp.plan.approved': 'План схвалено — виконується…',
   'sp.plan.cancelled': 'План скасовано.',
   'sp.plan.expired': 'Цей план більше не очікує розгляду — запуск скасовано.',
-  'sp.slash.busy_only_oob': 'Лише /help, /show-scratchpad, /list-schedules, /screenshot, /export та /verbose можуть працювати, поки WebBrain зайнятий. Зупиніть виконання або спробуйте ще раз, коли він закінчить.',
+  'sp.slash.busy_only_oob': 'Поки WebBrain зайнятий, повідомлення ставляться в чергу. Лише /help, /show-scratchpad, /list-schedules, /screenshot, /export та /verbose можуть запускатися одразу як slash-команди.',
   'tool.go_back': 'Назад',
   'tool.go_forward': 'Вперед',
   'st.display.search.placeholder': 'Пошук у загальних налаштуваннях',

--- a/src/firefox/src/ui/locales/zh.js
+++ b/src/firefox/src/ui/locales/zh.js
@@ -518,7 +518,7 @@ export default {
   'sp.plan.approved': '计划已批准 — 正在运行…',
   'sp.plan.cancelled': '计划已取消。',
   'sp.plan.expired': '该计划不再等待审查 — 运行已取消。',
-  'sp.slash.busy_only_oob': '当 WebBrain 忙碌时，只有 /help、/show-scratchpad、/list-schedules、/screenshot、/export 和 /verbose 可以运行。停止运行或等待其完成后再试。',
+  'sp.slash.busy_only_oob': 'WebBrain 忙碌时，消息会排队。只有 /help、/show-scratchpad、/list-schedules、/screenshot、/export 和 /verbose 可以作为斜杠命令立即运行。',
   'tool.go_back': '返回',
   'tool.go_forward': '前进',
   'st.display.search.placeholder': '搜索通用设置',

--- a/src/firefox/src/ui/sidepanel.html
+++ b/src/firefox/src/ui/sidepanel.html
@@ -194,6 +194,7 @@
         <button id="btn-mode-ask" class="mode-btn active" data-i18n="sp.mode.ask" data-i18n-title="sp.mode.ask.title"></button>
         <button id="btn-mode-act" class="mode-btn" data-i18n="sp.mode.act" data-i18n-title="sp.mode.act.title"></button>
       </div>
+      <div id="queued-messages" class="queued-messages hidden" role="list" aria-live="polite"></div>
       <div id="slash-command-menu" class="slash-command-menu hidden" role="listbox" data-i18n-aria-label="sp.slash.commands_label"></div>
       <div id="input-wrapper">
         <div id="input-text-layer">

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -313,6 +313,7 @@ const modeActBtn = document.getElementById('btn-mode-act');
 const actWarning = document.getElementById('act-warning');
 const inputArea = document.getElementById('input-area');
 const slashCommandMenuEl = document.getElementById('slash-command-menu');
+const queuedMessagesEl = document.getElementById('queued-messages');
 const recommendedActionsEl = document.getElementById('recommended-actions');
 const recommendedActionsToggleEl = document.getElementById('recommended-actions-toggle');
 const recommendedActionsListEl = document.getElementById('recommended-actions-list');
@@ -536,6 +537,8 @@ const tabChats = new Map();
 const TAB_CHAT_PREFIX = 'tabChat:';
 const tabChatOperations = new Map();
 const tabInputDrafts = new Map();
+const queuedComposerMessagesByTab = new Map();
+let queuedComposerMessageSeq = 0;
 
 function enqueueTabChatOperation(tabId, fn) {
   const numericTabId = Number(tabId);
@@ -655,9 +658,159 @@ function restoreInputDraftForTab(tabId) {
   syncSendButtonState();
 }
 
+function getQueuedComposerMessages(tabId) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return [];
+  return queuedComposerMessagesByTab.get(numericTabId) || [];
+}
+
+function setQueuedComposerMessages(tabId, messages) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return;
+  if (messages.length) {
+    queuedComposerMessagesByTab.set(numericTabId, messages);
+  } else {
+    queuedComposerMessagesByTab.delete(numericTabId);
+  }
+  if (currentTabId === numericTabId) renderQueuedComposerMessages(numericTabId);
+}
+
+function queuedComposerButton(className, action, queueId, labelKey, svgPath) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = `queued-message-action ${className}`;
+  btn.dataset.queueAction = action;
+  btn.dataset.queueId = queueId;
+  btn.title = t(labelKey);
+  btn.setAttribute('aria-label', t(labelKey));
+  btn.innerHTML = `<svg viewBox="0 0 24 24" aria-hidden="true">${svgPath}</svg>`;
+  return btn;
+}
+
+function renderQueuedComposerMessages(tabId = currentTabId) {
+  if (!queuedMessagesEl) return;
+  const messages = getQueuedComposerMessages(tabId);
+  queuedMessagesEl.replaceChildren();
+  queuedMessagesEl.classList.toggle('hidden', messages.length === 0);
+  if (!messages.length) return;
+
+  messages.forEach((item, index) => {
+    const row = document.createElement('div');
+    row.className = 'queued-message';
+    row.dataset.queueId = item.id;
+    row.setAttribute('role', 'listitem');
+
+    const label = document.createElement('span');
+    label.className = 'queued-message-label';
+    label.textContent = messages.length > 1
+      ? t('sp.queue.label_numbered', { index: index + 1 })
+      : t('sp.queue.label');
+
+    const text = document.createElement('span');
+    text.className = 'queued-message-text';
+    text.textContent = item.text;
+    text.title = item.text;
+
+    const edit = queuedComposerButton(
+      'queued-message-edit',
+      'edit',
+      item.id,
+      'sp.queue.edit',
+      '<path d="M12 19V5"></path><path d="M5 12l7-7 7 7"></path>',
+    );
+    const remove = queuedComposerButton(
+      'queued-message-delete',
+      'delete',
+      item.id,
+      'sp.queue.delete',
+      '<path d="M18 6L6 18"></path><path d="M6 6l12 12"></path>',
+    );
+
+    row.append(label, text, edit, remove);
+    queuedMessagesEl.appendChild(row);
+  });
+}
+
+function shiftQueuedComposerMessage(tabId) {
+  const queue = getQueuedComposerMessages(tabId);
+  if (!queue.length) return null;
+  const [item, ...remaining] = queue;
+  setQueuedComposerMessages(tabId, remaining);
+  return item;
+}
+
+function removeQueuedComposerMessage(tabId, queueId) {
+  const queue = getQueuedComposerMessages(tabId);
+  const index = queue.findIndex((item) => item.id === queueId);
+  if (index === -1) return null;
+  const nextQueue = queue.slice();
+  const [item] = nextQueue.splice(index, 1);
+  setQueuedComposerMessages(tabId, nextQueue);
+  return item;
+}
+
+function enqueueQueuedComposerMessage(tabId, text) {
+  const numericTabId = Number(tabId);
+  const queuedText = String(text || '').trim();
+  if (!Number.isFinite(numericTabId) || !queuedText) return false;
+  const queue = getQueuedComposerMessages(numericTabId).slice();
+  queue.push({
+    id: `queued-${Date.now()}-${++queuedComposerMessageSeq}`,
+    text: queuedText,
+  });
+  setQueuedComposerMessages(numericTabId, queue);
+  if (currentTabId === numericTabId) {
+    saveInputDraftForTab(numericTabId, '');
+    hideSlashCommandAutocomplete();
+    inputEl.value = '';
+    autoResizeInput();
+    syncSendButtonState();
+  }
+  return true;
+}
+
+function editQueuedComposerMessage(tabId, queueId) {
+  const item = removeQueuedComposerMessage(tabId, queueId);
+  if (!item || currentTabId !== Number(tabId)) return;
+  inputEl.value = item.text;
+  saveInputDraftForTab(tabId, item.text);
+  autoResizeInput();
+  updateSlashCommandAutocomplete();
+  syncSendButtonState();
+  inputEl.focus();
+  inputEl.setSelectionRange(inputEl.value.length, inputEl.value.length);
+}
+
+function deleteQueuedComposerMessage(tabId, queueId) {
+  removeQueuedComposerMessage(tabId, queueId);
+}
+
+function clearQueuedComposerMessagesForTab(tabId) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return;
+  queuedComposerMessagesByTab.delete(numericTabId);
+  if (currentTabId === numericTabId) renderQueuedComposerMessages(numericTabId);
+}
+
+function drainQueuedComposerMessageForCurrentTab() {
+  if (isProcessing || currentTabId == null || renderedTabId !== currentTabId) return false;
+  if (inputEl.value.trim()) return false;
+  const item = shiftQueuedComposerMessage(currentTabId);
+  if (!item) return false;
+  inputEl.value = item.text;
+  autoResizeInput();
+  updateSlashCommandAutocomplete();
+  syncSendButtonState();
+  Promise.resolve().then(() => sendMessage()).catch((e) => {
+    addMessage('error', t('sp.error_prefix', { msg: e?.message || String(e) }));
+  });
+  return true;
+}
+
 function renderClearedConversationForTab(tabId) {
   clearCachedTabChat(tabId);
   saveInputDraftForTab(tabId, '');
+  clearQueuedComposerMessagesForTab(tabId);
   setApiMutationsAllowedForTab(tabId, false);
   if (currentTabId !== tabId) return;
   renderedTabId = tabId;
@@ -954,6 +1107,7 @@ async function scheduledJobAction(action, jobId) {
 }
 
 async function drainQueuedContextMenuPromptsAfterPendingTabSwitch() {
+  if (drainQueuedComposerMessageForCurrentTab()) return;
   if (pendingTabSwitch == null) {
     drainQueuedContextMenuPrompts();
     return;
@@ -966,6 +1120,7 @@ async function drainQueuedContextMenuPromptsAfterPendingTabSwitch() {
     // Still drain any queued prompt for the current tab; tab activation can fail
     // when the underlying browser tab disappears during run settlement.
   }
+  if (drainQueuedComposerMessageForCurrentTab()) return;
   drainQueuedContextMenuPrompts();
 }
 
@@ -1585,6 +1740,7 @@ async function switchToTab(newTabId) {
       addMessage('system', t('sp.help_message'));
     }
     restoreInputDraftForTab(newTabId);
+    renderQueuedComposerMessages(newTabId);
     scrollToBottom();
     refreshScheduledJobs({ tabId: newTabId });
     refreshRecommendedActions();
@@ -2168,8 +2324,12 @@ function syncSendButtonState() {
     sendBtn.disabled = false;
     return;
   }
-  const draft = normalizeScreenshotCommandText(inputEl?.value || '');
-  sendBtn.disabled = !isOutOfBandSlashDraft(draft);
+  const draft = normalizeScreenshotCommandText(inputEl?.value || '').trim();
+  if (!draft) {
+    sendBtn.disabled = true;
+    return;
+  }
+  sendBtn.disabled = draft.startsWith('/') && !isOutOfBandSlashDraft(draft);
 }
 
 function showBusySlashCommandNotice() {
@@ -2400,24 +2560,27 @@ async function sendMessage(extraChatParams) {
   const tabId = currentTabId;
   text = normalizeScreenshotCommandText(text);
   if (isProcessing) {
-    if (!isOutOfBandSlashDraft(text)) {
+    if (isOutOfBandSlashDraft(text)) {
+      saveInputDraftForTab(tabId, '');
+      hideSlashCommandAutocomplete();
+      inputEl.value = '';
+      autoResizeInput();
+      syncSendButtonState();
+      await parseSlashCommands(text, tabId);
+      if (currentTabId === tabId) {
+        if (!inputEl.value.trim() || inputEl.value.trim() === text) {
+          inputEl.value = '';
+          autoResizeInput();
+        }
+        syncSendButtonState();
+      }
+      return true;
+    }
+    if (text.startsWith('/')) {
       showBusySlashCommandNotice();
       return false;
     }
-    saveInputDraftForTab(tabId, '');
-    hideSlashCommandAutocomplete();
-    inputEl.value = '';
-    autoResizeInput();
-    syncSendButtonState();
-    await parseSlashCommands(text, tabId);
-    if (currentTabId === tabId) {
-      if (!inputEl.value.trim() || inputEl.value.trim() === text) {
-        inputEl.value = '';
-        autoResizeInput();
-      }
-      syncSendButtonState();
-    }
-    return true;
+    return enqueueQueuedComposerMessage(tabId, text);
   }
   const modeForSend = /^\/(?:ask|plan)\b/i.test(text) ? 'ask' : agentMode;
   const apiMutationsAllowedForSend = isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);
@@ -3679,6 +3842,18 @@ stopBtn.addEventListener('click', async () => {
 
 sendBtn.addEventListener('click', sendMessage);
 
+queuedMessagesEl?.addEventListener('click', (e) => {
+  const btn = e.target.closest('button[data-queue-action][data-queue-id]');
+  if (!btn) return;
+  const action = btn.dataset.queueAction;
+  const queueId = btn.dataset.queueId;
+  if (action === 'edit') {
+    editQueuedComposerMessage(currentTabId, queueId);
+  } else if (action === 'delete') {
+    deleteQueuedComposerMessage(currentTabId, queueId);
+  }
+});
+
 inputEl.addEventListener('keydown', (e) => {
   if (handleSlashCommandKeydown(e)) return;
   if (e.key === 'Enter' && !e.shiftKey) {
@@ -3693,6 +3868,7 @@ inputEl.addEventListener('focus', updateSlashCommandAutocomplete);
 inputEl.addEventListener('blur', () => setTimeout(hideSlashCommandAutocomplete, 120));
 document.addEventListener('wb-locale-changed', () => {
   if (slashCommandMatches.length) renderSlashCommandAutocomplete();
+  renderQueuedComposerMessages();
 });
 
 clearBtn.addEventListener('click', async () => {

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -1238,6 +1238,76 @@ body {
   display: none;
 }
 
+.queued-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0 0 8px;
+}
+
+.queued-messages.hidden {
+  display: none;
+}
+
+.queued-message {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 32px;
+  padding: 6px 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.queued-message-label {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.queued-message-text {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queued-message-action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.queued-message-action:hover {
+  color: var(--text-primary);
+  background: rgba(91, 82, 232, 0.12);
+  border-color: var(--border);
+}
+
+.queued-message-action svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
 .slash-command-option {
   display: grid;
   grid-template-columns: minmax(112px, max-content) minmax(0, 1fr);

--- a/test/run.js
+++ b/test/run.js
@@ -6411,7 +6411,7 @@ test('sidepanel preserves stale residual slash-command prompts without hidden ru
   }
 });
 
-test('sidepanel allows only safe slash commands while busy', () => {
+test('sidepanel allows safe slash commands and queues normal messages while busy', () => {
   for (const [label, panelRel, localeRel] of [
     ['chrome', 'src/chrome/src/ui/sidepanel.js', 'src/chrome/src/ui/locales/en.js'],
     ['firefox', 'src/firefox/src/ui/sidepanel.js', 'src/firefox/src/ui/locales/en.js'],
@@ -6434,8 +6434,8 @@ test('sidepanel allows only safe slash commands while busy', () => {
     assert.doesNotMatch(oobBlock, /'\/full-page-screenshot'/, `${label}: /full-page-screenshot should not be allowed while busy`);
     assert.match(
       panel,
-      /function syncSendButtonState\(\) \{[\s\S]*?if \(!isProcessing\) \{[\s\S]*?sendBtn\.disabled = false;[\s\S]*?\}[\s\S]*?const draft = normalizeScreenshotCommandText\(inputEl\?\.value \|\| ''\);[\s\S]*?sendBtn\.disabled = !isOutOfBandSlashDraft\(draft\);[\s\S]*?\}/,
-      `${label}: send button state should normalize screenshot requests and permit only out-of-band slash drafts while busy`,
+      /function syncSendButtonState\(\) \{[\s\S]*?if \(!isProcessing\) \{[\s\S]*?sendBtn\.disabled = false;[\s\S]*?\}[\s\S]*?const draft = normalizeScreenshotCommandText\(inputEl\?\.value \|\| ''\)\.trim\(\);[\s\S]*?if \(!draft\) \{[\s\S]*?sendBtn\.disabled = true;[\s\S]*?\}[\s\S]*?sendBtn\.disabled = draft\.startsWith\('\/'\) && !isOutOfBandSlashDraft\(draft\);[\s\S]*?\}/,
+      `${label}: send button state should permit normal queued drafts and only safe slash drafts while busy`,
     );
     assert.match(
       panel,
@@ -6444,8 +6444,8 @@ test('sidepanel allows only safe slash commands while busy', () => {
     );
     assert.match(
       panel,
-      /text = normalizeScreenshotCommandText\(text\);[\s\S]*?if \(isProcessing\) \{[\s\S]*?if \(!isOutOfBandSlashDraft\(text\)\) \{[\s\S]*?showBusySlashCommandNotice\(\);[\s\S]*?return false;[\s\S]*?\}[\s\S]*?await parseSlashCommands\(text, tabId\);[\s\S]*?return true;[\s\S]*?\}/,
-      `${label}: busy send preflight should run safe slash commands without starting chat`,
+      /text = normalizeScreenshotCommandText\(text\);[\s\S]*?if \(isProcessing\) \{[\s\S]*?if \(isOutOfBandSlashDraft\(text\)\) \{[\s\S]*?await parseSlashCommands\(text, tabId\);[\s\S]*?return true;[\s\S]*?\}[\s\S]*?if \(text\.startsWith\('\/'\)\) \{[\s\S]*?showBusySlashCommandNotice\(\);[\s\S]*?return false;[\s\S]*?\}[\s\S]*?return enqueueQueuedComposerMessage\(tabId, text\);[\s\S]*?\}/,
+      `${label}: busy send preflight should run safe slash commands and queue normal drafts`,
     );
     assert.match(
       panel,
@@ -6454,9 +6454,87 @@ test('sidepanel allows only safe slash commands while busy', () => {
     );
     assert.match(
       locale,
-      /'sp\.slash\.busy_only_oob': 'Only \/help, \/show-scratchpad, \/list-schedules, \/screenshot, \/export, and \/verbose can run while WebBrain is busy\./,
-      `${label}: busy slash notice should be localized`,
+      /'sp\.slash\.busy_only_oob': 'Messages are queued while WebBrain is busy\. Only \/help, \/show-scratchpad, \/list-schedules, \/screenshot, \/export, and \/verbose can run immediately as slash commands\./,
+      `${label}: busy slash notice should explain queued messages and safe slash commands`,
     );
+  }
+});
+
+test('sidepanel queued composer messages expose edit and delete controls', () => {
+  for (const [label, panelRel, htmlRel, cssRel, localeRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js', 'src/chrome/src/ui/sidepanel.html', 'src/chrome/styles/sidepanel.css', 'src/chrome/src/ui/locales/en.js'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js', 'src/firefox/src/ui/sidepanel.html', 'src/firefox/styles/sidepanel.css', 'src/firefox/src/ui/locales/en.js'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    const html = fs.readFileSync(path.join(ROOT, htmlRel), 'utf8');
+    const css = fs.readFileSync(path.join(ROOT, cssRel), 'utf8');
+    const locale = fs.readFileSync(path.join(ROOT, localeRel), 'utf8');
+
+    assert.match(html, /id="queued-messages" class="queued-messages hidden" role="list"/, `${label}: queued message strip should exist above the composer`);
+    assert.match(panel, /const queuedComposerMessagesByTab = new Map\(\);/, `${label}: queued composer messages should be tracked per tab`);
+    assert.match(panel, /function enqueueQueuedComposerMessage\(tabId, text\) \{[\s\S]*?queue\.push\(\{[\s\S]*?text: queuedText,[\s\S]*?inputEl\.value = '';[\s\S]*?syncSendButtonState\(\);[\s\S]*?return true;[\s\S]*?\}/, `${label}: busy drafts should be queued and clear the composer`);
+    assert.match(panel, /function editQueuedComposerMessage\(tabId, queueId\) \{[\s\S]*?removeQueuedComposerMessage\(tabId, queueId\);[\s\S]*?inputEl\.value = item\.text;[\s\S]*?inputEl\.setSelectionRange\(inputEl\.value\.length, inputEl\.value\.length\);[\s\S]*?\}/, `${label}: queued message edit should move text back into the composer`);
+    assert.match(panel, /function deleteQueuedComposerMessage\(tabId, queueId\) \{[\s\S]*?removeQueuedComposerMessage\(tabId, queueId\);[\s\S]*?\}/, `${label}: queued message delete should remove the queued item`);
+    assert.match(panel, /queued-message-edit/, `${label}: queued item should render an edit button`);
+    assert.match(panel, /queued-message-delete/, `${label}: queued item should render a delete button`);
+    const drainStart = panel.indexOf('function drainQueuedComposerMessageForCurrentTab()');
+    const drainEnd = panel.indexOf('function renderClearedConversationForTab', drainStart);
+    assert.notEqual(drainStart, -1, `${label}: queued composer drain helper should exist`);
+    assert.notEqual(drainEnd, -1, `${label}: queued composer drain helper boundary should exist`);
+    const drainBody = panel.slice(drainStart, drainEnd);
+    const draftGuardIdx = drainBody.indexOf('if (inputEl.value.trim()) return false;');
+    const queueShiftIdx = drainBody.indexOf('const item = shiftQueuedComposerMessage(currentTabId);');
+    assert.notEqual(draftGuardIdx, -1, `${label}: queued composer drain should preserve newly typed drafts`);
+    assert.notEqual(queueShiftIdx, -1, `${label}: queued composer drain should shift the next queued message`);
+    assert.equal(draftGuardIdx < queueShiftIdx, true, `${label}: queued composer drain must preserve drafts before removing queued messages`);
+    assert.match(panel, /if \(drainQueuedComposerMessageForCurrentTab\(\)\) return;[\s\S]*?drainQueuedContextMenuPrompts\(\);/, `${label}: run settlement should drain queued composer messages before context-menu recovery prompts`);
+    const helperStart = panel.indexOf('async function drainQueuedContextMenuPromptsAfterPendingTabSwitch()');
+    const helperEnd = panel.indexOf('function queueAgentUpdateDuringTabSwitch', helperStart);
+    assert.notEqual(helperStart, -1, `${label}: queued drain helper should exist`);
+    assert.notEqual(helperEnd, -1, `${label}: queued drain helper boundary should exist`);
+    const helperBody = panel.slice(helperStart, helperEnd);
+    const composerDrainIdx = helperBody.indexOf('if (drainQueuedComposerMessageForCurrentTab()) return;');
+    const pendingSwitchIdx = helperBody.indexOf('const pending = pendingTabSwitch;');
+    assert.notEqual(composerDrainIdx, -1, `${label}: completed-tab queued composer drain should run in the drain helper`);
+    assert.notEqual(pendingSwitchIdx, -1, `${label}: pending tab switch should still be applied in the drain helper`);
+    assert.equal(composerDrainIdx < pendingSwitchIdx, true, `${label}: queued composer messages for the completed tab must drain before applying a pending tab switch`);
+    assert.match(css, /\.queued-messages/, `${label}: queued message strip should be styled`);
+    assert.match(css, /\.queued-message-action/, `${label}: queued message controls should be styled`);
+    assert.match(locale, /'sp\.queue\.edit': 'Edit queued message'/, `${label}: queued edit label should have an English fallback`);
+    assert.match(locale, /'sp\.queue\.delete': 'Delete queued message'/, `${label}: queued delete label should have an English fallback`);
+  }
+});
+
+test('sidepanel busy slash notice is updated in every locale', () => {
+  const expected = {
+    en: 'Messages are queued while WebBrain is busy. Only /help, /show-scratchpad, /list-schedules, /screenshot, /export, and /verbose can run immediately as slash commands.',
+    es: 'Los mensajes se ponen en cola mientras WebBrain está ocupado. Solo /help, /show-scratchpad, /list-schedules, /screenshot, /export y /verbose pueden ejecutarse de inmediato como comandos slash.',
+    fr: "Les messages sont mis en file d'attente pendant que WebBrain est occupé. Seuls /help, /show-scratchpad, /list-schedules, /screenshot, /export et /verbose peuvent s'exécuter immédiatement comme commandes slash.",
+    tr: 'WebBrain meşgulken mesajlar kuyruğa alınır. Yalnızca /help, /show-scratchpad, /list-schedules, /screenshot, /export ve /verbose slash komutları olarak hemen çalışabilir.',
+    zh: 'WebBrain 忙碌时，消息会排队。只有 /help、/show-scratchpad、/list-schedules、/screenshot、/export 和 /verbose 可以作为斜杠命令立即运行。',
+    ru: 'Пока WebBrain занят, сообщения ставятся в очередь. Только /help, /show-scratchpad, /list-schedules, /screenshot, /export и /verbose могут запускаться сразу как slash-команды.',
+    uk: 'Поки WebBrain зайнятий, повідомлення ставляться в чергу. Лише /help, /show-scratchpad, /list-schedules, /screenshot, /export та /verbose можуть запускатися одразу як slash-команди.',
+    ar: 'تُضاف الرسائل إلى قائمة الانتظار بينما يكون WebBrain مشغولًا. يمكن فقط لـ /help و /show-scratchpad و /list-schedules و /screenshot و /export و /verbose العمل فورًا كأوامر slash.',
+    ja: 'WebBrain がビジーの間、メッセージはキューに入ります。/help、/show-scratchpad、/list-schedules、/screenshot、/export、/verbose だけがスラッシュコマンドとしてすぐに実行できます。',
+    ko: 'WebBrain이 사용 중일 때 메시지는 대기열에 추가됩니다. /help, /show-scratchpad, /list-schedules, /screenshot, /export, /verbose만 슬래시 명령으로 즉시 실행할 수 있습니다.',
+    id: 'Pesan dimasukkan ke antrean saat WebBrain sibuk. Hanya /help, /show-scratchpad, /list-schedules, /screenshot, /export, dan /verbose yang dapat langsung berjalan sebagai perintah slash.',
+    th: 'ข้อความจะถูกเข้าคิวขณะที่ WebBrain ไม่ว่าง เฉพาะ /help, /show-scratchpad, /list-schedules, /screenshot, /export และ /verbose เท่านั้นที่เรียกใช้ได้ทันทีในฐานะคำสั่ง slash',
+    ms: 'Mesej dimasukkan ke giliran semasa WebBrain sibuk. Hanya /help, /show-scratchpad, /list-schedules, /screenshot, /export, dan /verbose boleh berjalan serta-merta sebagai arahan slash.',
+    tl: 'Nakapila ang mga mensahe habang abala ang WebBrain. Tanging /help, /show-scratchpad, /list-schedules, /screenshot, /export, at /verbose ang maaaring tumakbo agad bilang mga slash command.',
+    pl: 'Wiadomości są kolejkowane, gdy WebBrain jest zajęty. Tylko /help, /show-scratchpad, /list-schedules, /screenshot, /export i /verbose mogą uruchamiać się od razu jako polecenia slash.',
+  };
+
+  for (const [label, localeDir] of [
+    ['chrome', 'src/chrome/src/ui/locales'],
+    ['firefox', 'src/firefox/src/ui/locales'],
+  ]) {
+    for (const [code, message] of Object.entries(expected)) {
+      const locale = fs.readFileSync(path.join(ROOT, localeDir, `${code}.js`), 'utf8');
+      const match = locale.match(/'sp\.slash\.busy_only_oob': '((?:\\'|[^'])*)'/);
+      assert.ok(match, `${label}/${code}: busy slash notice key missing`);
+      const actual = match[1].replace(/\\'/g, "'");
+      assert.equal(actual, message, `${label}/${code}: busy slash notice should match queued-send behavior`);
+    }
   }
 });
 


### PR DESCRIPTION
## What changed

- Added a per-tab queued message strip above the sidepanel composer in Chrome and Firefox.
- Normal text submitted while WebBrain is busy is queued instead of being rejected.
- Queued items can be pulled back into the composer with the up-arrow edit button or removed with the delete button.
- Safe out-of-band slash commands still run immediately while busy; unsafe slash commands remain blocked.

## Why

Previously, sidepanel sends during an active run were mostly blocked. That made it easy to lose the next thought or instruction while waiting for the current run to finish.

## Validation

- `npm test`
- `git diff --check`