### PR TITLE
[codex] Add sidepanel slash output retry UX

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5691,7 +5691,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   _augmentScheduledResumeMessage(tabId, userMessage) {
     if (typeof userMessage !== 'string') return userMessage;
-    if ((this.conversationModes.get(tabId) || 'ask') !== 'act') return userMessage;
+    if (!this._isActionMode(this.conversationModes.get(tabId) || 'ask')) return userMessage;
     if (!this._isScheduledResumeTurn(userMessage)) return userMessage;
     const { rows } = this._progressRowsForResumeGuard(tabId);
     if (!rows.length) return userMessage;

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -184,6 +184,9 @@ export default {
   'sp.copy': 'Copy',
   'sp.copied': 'Copied!',
   'sp.copy.code.title': 'Copy code',
+  'sp.retry': 'Retry',
+  'sp.retry.busy': 'Wait for the current run to finish before retrying.',
+  'sp.retry.attachments_unavailable': 'Attachments from the failed attempt are no longer available; retrying the text only.',
 
   'sp.error_prefix': 'Error: {msg}',
   'sp.subscribe.allowance_used': 'Daily free WebBrain Cloud allowance used.',

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -455,6 +455,7 @@ let composerToastTimer = null;
 let retryPayloadSeq = 0;
 const activeChatPayloadsByTab = new Map();
 const retryAttachmentPayloads = new Map();
+const retryAttachmentIdsByTab = new Map();
 const {
   acceptContextMenuPrompt,
   drainQueuedContextMenuPrompts,
@@ -852,6 +853,51 @@ function sameTabId(a, b) {
   return a != null && b != null && String(a) === String(b);
 }
 
+function normalizeRetryAttachmentTabId(tabId = renderedTabId ?? currentTabId) {
+  const numericTabId = Number(tabId);
+  return Number.isFinite(numericTabId) ? numericTabId : null;
+}
+
+function trackRetryAttachmentId(tabId, retryId) {
+  if (!retryId) return;
+  const numericTabId = normalizeRetryAttachmentTabId(tabId);
+  if (numericTabId == null) return;
+  let ids = retryAttachmentIdsByTab.get(numericTabId);
+  if (!ids) {
+    ids = new Set();
+    retryAttachmentIdsByTab.set(numericTabId, ids);
+  }
+  ids.add(retryId);
+}
+
+function releaseRetryAttachmentPayload(retryId) {
+  if (!retryId) return;
+  retryAttachmentPayloads.delete(retryId);
+  for (const [tabId, ids] of retryAttachmentIdsByTab) {
+    ids.delete(retryId);
+    if (!ids.size) retryAttachmentIdsByTab.delete(tabId);
+  }
+}
+
+function releaseRetryAttachmentsInTree(root) {
+  if (!root) return;
+  if (root.matches?.('.error-retry-btn[data-retry-id]')) {
+    releaseRetryAttachmentPayload(root.dataset.retryId);
+  }
+  root.querySelectorAll?.('.error-retry-btn[data-retry-id]').forEach((btn) => {
+    releaseRetryAttachmentPayload(btn.dataset.retryId);
+  });
+}
+
+function clearRetryAttachmentsForTab(tabId) {
+  const numericTabId = normalizeRetryAttachmentTabId(tabId);
+  if (numericTabId == null) return;
+  const ids = retryAttachmentIdsByTab.get(numericTabId);
+  if (!ids) return;
+  ids.forEach((retryId) => retryAttachmentPayloads.delete(retryId));
+  retryAttachmentIdsByTab.delete(numericTabId);
+}
+
 function getQueuedComposerMessages(tabId) {
   const numericTabId = Number(tabId);
   if (!Number.isFinite(numericTabId)) return [];
@@ -1018,6 +1064,8 @@ function renderClearedConversationForTab(tabId) {
   saveInputDraftForTab(tabId, '');
   clearPendingAttachmentsForTab(tabId);
   clearQueuedComposerMessagesForTab(tabId);
+  if (sameTabId(currentTabId, tabId)) releaseRetryAttachmentsInTree(messagesEl);
+  clearRetryAttachmentsForTab(tabId);
   setApiMutationsAllowedForTab(tabId, false);
   if (currentTabId !== tabId) return;
   renderedTabId = tabId;
@@ -4239,7 +4287,10 @@ function addErrorRetryButton(msgEl, retryPayload) {
   if (!msgEl || !retryPayload?.text || msgEl.querySelector('.error-retry-btn')) return;
   const retryId = `retry-${Date.now()}-${++retryPayloadSeq}`;
   const attachments = Array.isArray(retryPayload.attachments) ? retryPayload.attachments.slice() : [];
-  if (attachments.length) retryAttachmentPayloads.set(retryId, attachments);
+  if (attachments.length) {
+    retryAttachmentPayloads.set(retryId, attachments);
+    trackRetryAttachmentId(renderedTabId ?? currentTabId, retryId);
+  }
   msgEl.classList.add('retryable');
   const btn = document.createElement('button');
   btn.type = 'button';

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -2336,6 +2336,40 @@ function rebindRetryButtons() {
   document.querySelectorAll('.error-retry-btn').forEach(bindErrorRetryButton);
 }
 
+function createActiveChatPayloadState(retryPayload) {
+  return { retryPayload, renderedErrorMessages: new Set() };
+}
+
+function errorMessageKey(message) {
+  return String(message || '').trim() || 'unknown error';
+}
+
+function takeActiveRetryPayloadForError(tabId, message) {
+  const state = activeChatPayloadsByTab.get(tabId);
+  if (!state?.retryPayload) return { retryPayload: null, duplicate: false };
+  const key = errorMessageKey(message);
+  if (state.renderedErrorMessages?.has(key)) {
+    return { retryPayload: state.retryPayload, duplicate: true };
+  }
+  state.renderedErrorMessages?.add(key);
+  return { retryPayload: state.retryPayload, duplicate: false };
+}
+
+function scheduleActiveChatPayloadCleanup(tabId, state) {
+  setTimeout(() => {
+    if (activeChatPayloadsByTab.get(tabId) === state) {
+      activeChatPayloadsByTab.delete(tabId);
+    }
+  }, 30000);
+}
+
+function renderAgentErrorUpdate(data, tabId = currentTabId) {
+  const message = data?.message || data?.error || 'unknown error';
+  const active = abortRequested ? { retryPayload: null, duplicate: false } : takeActiveRetryPayloadForError(tabId, message);
+  if (active.duplicate) return;
+  addMessage('error', t('sp.error_prefix', { msg: message }), { retryPayload: active.retryPayload });
+}
+
 function rebindRestoredMessageControls() {
   rebindCopyButtons();
   rebindRetryButtons();
@@ -3151,7 +3185,8 @@ async function sendMessage(extraChatParams = {}) {
     assistantEl = addMessage('assistant', '');
     currentAssistantEl = assistantEl;
   }
-  activeChatPayloadsByTab.set(tabId, retryPayload);
+  const activePayloadState = createActiveChatPayloadState(retryPayload);
+  activeChatPayloadsByTab.set(tabId, activePayloadState);
 
   let accepted = false;
   let completedSuccessfully = false;
@@ -3168,6 +3203,12 @@ async function sendMessage(extraChatParams = {}) {
     accepted = true;
     completedSuccessfully = updatesContainSuccessfulDone(res?.updates);
     promptEligibleCompletion = completedSuccessfully || isSuccessfulAskCompletion(modeForSend, res);
+    const returnedErrorUpdate = Array.isArray(res?.updates)
+      ? res.updates.find(u => u?.type === 'error')
+      : null;
+    if (returnedErrorUpdate && renderToCurrentTab && currentTabId === tabId && !abortRequested) {
+      renderAgentErrorUpdate(returnedErrorUpdate.data, tabId);
+    }
 
     // An unsupported-attachment rejection never records the turn in history;
     // the agent signals it via a structured 'attachment_rejected' update (not
@@ -3211,11 +3252,12 @@ async function sendMessage(extraChatParams = {}) {
     }
   } catch (e) {
     if (renderToCurrentTab && currentTabId === tabId && !abortRequested) {
+      takeActiveRetryPayloadForError(tabId, e.message);
       addMessage('error', t('sp.error_prefix', { msg: e.message }), { retryPayload });
     }
   } finally {
-    if (activeChatPayloadsByTab.get(tabId) === retryPayload) {
-      activeChatPayloadsByTab.delete(tabId);
+    if (activeChatPayloadsByTab.get(tabId) === activePayloadState) {
+      scheduleActiveChatPayloadCleanup(tabId, activePayloadState);
     }
     if (renderToCurrentTab && currentTabId === tabId) finalizeSteps(assistantEl);
     clearAssistantTextStreamState(assistantEl);
@@ -3542,9 +3584,7 @@ function handleAgentUpdateMessage(msg) {
     case 'error':
       hideActivity();
       if (currentAssistantEl) markLastStepFailed();
-      addMessage('error', t('sp.error_prefix', { msg: data.message }), {
-        retryPayload: abortRequested ? null : activeChatPayloadsByTab.get(currentTabId),
-      });
+      renderAgentErrorUpdate(data, currentTabId);
       break;
 
     case 'max_steps_reached':

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -1412,6 +1412,7 @@ async function handleScheduledJobEvent(data, tabId) {
   if (event === 'created') {
     addMessage('system', systemHtml(tSystemHtml('sp.scheduled.created', { title, time: formatScheduledTime(job.nextRunAt || job.scheduledAt) })));
   } else if (event === 'running') {
+    clearActiveChatPayloadForTab(tabId ?? currentTabId);
     isProcessing = true;
     abortRequested = false;
     syncSendButtonState();
@@ -1429,6 +1430,7 @@ async function handleScheduledJobEvent(data, tabId) {
     hideActivity();
     abortRequested = false;
     if (currentAssistantEl) {
+      clearActiveChatPayloadForTab(tabId ?? currentTabId);
       isProcessing = true;
       syncSendButtonState();
     } else {
@@ -2247,6 +2249,7 @@ function bindPlanReviewCard(card) {
 function reattachPlanReviewActiveRun(card) {
   const assistantEl = card?.closest?.('.message.assistant');
   if (!assistantEl) return null;
+  clearActiveChatPayloadForTab(currentTabId);
   currentAssistantEl = assistantEl;
   isProcessing = true;
   abortRequested = false;
@@ -2319,6 +2322,9 @@ function bindErrorRetryButton(btn) {
       showComposerToast(t('sp.retry.attachments_unavailable'), { duration: 5000 });
     }
     setMode(payload.mode);
+    if (payload.apiMutationsAllowed) {
+      setApiMutationsAllowedForTab(currentTabId, true);
+    }
     inputEl.value = payload.text;
     autoResizeInput();
     hideSlashCommandAutocomplete();
@@ -2338,6 +2344,10 @@ function rebindRetryButtons() {
 
 function createActiveChatPayloadState(retryPayload) {
   return { retryPayload, renderedErrorMessages: new Set() };
+}
+
+function clearActiveChatPayloadForTab(tabId) {
+  if (tabId != null) activeChatPayloadsByTab.delete(tabId);
 }
 
 function errorMessageKey(message) {
@@ -3922,6 +3932,7 @@ function submitClarify(card, tabId, clarifyId, answer, source) {
   // so the target field is always injected.
   const isScheduledClarify = !!card.dataset.scheduledJobId;
   if (isScheduledClarify) {
+    clearActiveChatPayloadForTab(tabId);
     const msgEl = card.closest('.message.assistant');
     const scheduledJobId = card.dataset.scheduledJobId;
     if (msgEl && (!currentAssistantEl || currentAssistantEl.dataset?.scheduledJobId === scheduledJobId)) {
@@ -4344,6 +4355,7 @@ function showContinueButton() {
 async function continueAgent() {
   const tabId = currentTabId;
   const modeForSend = agentMode;
+  clearActiveChatPayloadForTab(tabId);
   // Remove the continue bar
   document.querySelectorAll('.continue-bar').forEach(el => el.remove());
 

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -451,6 +451,10 @@ let recommendedActionsCollapsed = false;
 let slashCommandMatches = [];
 let slashCommandSelectedIndex = 0;
 let busySlashNoticeLastShownAt = 0;
+let composerToastTimer = null;
+let retryPayloadSeq = 0;
+const activeChatPayloadsByTab = new Map();
+const retryAttachmentPayloads = new Map();
 const {
   acceptContextMenuPrompt,
   drainQueuedContextMenuPrompts,
@@ -1772,14 +1776,14 @@ async function showScratchpad(tabId = currentTabId) {
     if (currentTabId !== tabId) return;
     const body = String(res?.body || '').trim();
     if (!res?.exists || !body || body === '(empty)') {
-      addMessage('system', t('sp.scratchpad.empty'));
+      addPersistentSlashMessage(t('sp.scratchpad.empty'));
       return;
     }
-    const msgEl = addMessage('system', systemHtml(`${t('sp.scratchpad.title_html')}<pre class="scratchpad-dump">${escapeHtml(body)}</pre>`));
+    const msgEl = addPersistentSlashMessage(systemHtml(`${t('sp.scratchpad.title_html')}<pre class="scratchpad-dump">${escapeHtml(body)}</pre>`));
     addScratchpadCopyButton(msgEl);
   } catch (e) {
     if (currentTabId !== tabId) return;
-    addMessage('system', systemHtml(tSystemHtml('sp.scratchpad.error', { msg: e.message })));
+    addPersistentSlashMessage(systemHtml(tSystemHtml('sp.scratchpad.error', { msg: e.message })));
   }
 }
 
@@ -1788,13 +1792,13 @@ async function showProgress(tabId = currentTabId) {
     const res = await sendToBackground('get_progress', { tabId });
     if (currentTabId !== tabId) return;
     if (!res?.ok && !res?.success) {
-      addMessage('system', systemHtml(tSystemHtml('sp.progress.error', { msg: res?.error || 'unknown error' })));
+      addPersistentSlashMessage(systemHtml(tSystemHtml('sp.progress.error', { msg: res?.error || 'unknown error' })));
       return;
     }
     const rows = Array.isArray(res.rows) ? res.rows : [];
     const counts = res.counts || {};
     if (!rows.length) {
-      addMessage('system', t('sp.progress.empty'));
+      addPersistentSlashMessage(t('sp.progress.empty'));
       return;
     }
     const summary = [
@@ -1808,10 +1812,10 @@ async function showProgress(tabId = currentTabId) {
       `unresolved: ${counts.unresolved ?? 0}`,
     ].join('\n');
     const body = JSON.stringify(rows, null, 2);
-    addMessage('system', systemHtml(`${t('sp.progress.title_html')}<pre class="scratchpad-dump">${escapeHtml(summary)}\n\n${escapeHtml(body)}</pre>`));
+    addPersistentSlashMessage(systemHtml(`${t('sp.progress.title_html')}<pre class="scratchpad-dump">${escapeHtml(summary)}\n\n${escapeHtml(body)}</pre>`));
   } catch (e) {
     if (currentTabId !== tabId) return;
-    addMessage('system', systemHtml(tSystemHtml('sp.progress.error', { msg: e.message })));
+    addPersistentSlashMessage(systemHtml(tSystemHtml('sp.progress.error', { msg: e.message })));
   }
 }
 
@@ -1819,20 +1823,20 @@ async function editScratchpad(note, tabId = currentTabId) {
   const text = String(note || '').trim();
   if (!text) {
     if (currentTabId !== tabId) return;
-    addMessage('system', t('sp.scratchpad.edit_empty'));
+    showComposerToast(t('sp.scratchpad.edit_empty'), { duration: 5000 });
     return;
   }
   try {
     const res = await sendToBackground('write_scratchpad', { tabId, text });
     if (currentTabId !== tabId) return;
     if (!res?.ok && !res?.success) {
-      addMessage('system', systemHtml(tSystemHtml('sp.scratchpad.error', { msg: res?.error || 'unknown error' })));
+      showComposerToast(t('sp.scratchpad.error', { msg: res?.error || 'unknown error' }), { duration: 5000 });
       return;
     }
-    addMessage('system', t('sp.scratchpad.updated'));
+    showComposerToast(t('sp.scratchpad.updated'));
   } catch (e) {
     if (currentTabId !== tabId) return;
-    addMessage('system', systemHtml(tSystemHtml('sp.scratchpad.error', { msg: e.message })));
+    showComposerToast(t('sp.scratchpad.error', { msg: e.message }), { duration: 5000 });
   }
 }
 
@@ -1841,14 +1845,14 @@ function clearScratchpad(tabId = currentTabId) {
     .then((res) => {
       if (currentTabId !== tabId) return;
       if (!res?.ok && !res?.success) {
-        addMessage('system', systemHtml(tSystemHtml('sp.scratchpad.error', { msg: res?.error || 'unknown error' })));
+        showComposerToast(t('sp.scratchpad.error', { msg: res?.error || 'unknown error' }), { duration: 5000 });
         return;
       }
-      addMessage('system', t('sp.scratchpad.cleared'));
+      showComposerToast(t('sp.scratchpad.cleared'));
     })
     .catch((e) => {
       if (currentTabId !== tabId) return;
-      addMessage('system', systemHtml(tSystemHtml('sp.scratchpad.error', { msg: e.message })));
+      showComposerToast(t('sp.scratchpad.error', { msg: e.message }), { duration: 5000 });
     });
 }
 
@@ -2281,8 +2285,60 @@ function rebindSubscribeButtons() {
   });
 }
 
+function retryPayloadFromButton(btn) {
+  const text = String(btn?.dataset?.retryText || '').trim();
+  if (!text) return null;
+  const mode = ['ask', 'act', 'dev'].includes(btn.dataset.retryMode)
+    ? btn.dataset.retryMode
+    : agentMode;
+  const retryId = btn.dataset.retryId || '';
+  const attachments = retryAttachmentPayloads.get(retryId) || [];
+  const attachmentCount = Number(btn.dataset.retryAttachmentCount || 0) || 0;
+  return {
+    text,
+    mode,
+    apiMutationsAllowed: btn.dataset.retryApiMutationsAllowed === 'true',
+    attachments,
+    missingAttachments: attachmentCount > 0 && attachments.length === 0,
+  };
+}
+
+function bindErrorRetryButton(btn) {
+  if (!btn || btn.dataset.bound) return;
+  btn.dataset.bound = 'true';
+  btn.addEventListener('click', async (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (isProcessing) {
+      showComposerToast(t('sp.retry.busy'), { duration: 4000 });
+      return;
+    }
+    const payload = retryPayloadFromButton(btn);
+    if (!payload) return;
+    if (payload.missingAttachments) {
+      showComposerToast(t('sp.retry.attachments_unavailable'), { duration: 5000 });
+    }
+    setMode(payload.mode);
+    inputEl.value = payload.text;
+    autoResizeInput();
+    hideSlashCommandAutocomplete();
+    await sendMessage({
+      __retry: {
+        mode: payload.mode,
+        apiMutationsAllowed: payload.apiMutationsAllowed,
+        attachments: payload.attachments,
+      },
+    });
+  });
+}
+
+function rebindRetryButtons() {
+  document.querySelectorAll('.error-retry-btn').forEach(bindErrorRetryButton);
+}
+
 function rebindRestoredMessageControls() {
   rebindCopyButtons();
+  rebindRetryButtons();
   rebindContinueButtons();
   rebindClarifyCards();
   rebindPlanReviewCards();
@@ -2613,7 +2669,30 @@ function showBusySlashCommandNotice() {
   const now = Date.now();
   if (now - busySlashNoticeLastShownAt < BUSY_SLASH_NOTICE_COOLDOWN_MS) return;
   busySlashNoticeLastShownAt = now;
-  addMessage('system', t('sp.slash.busy_only_oob'));
+  showComposerToast(t('sp.slash.busy_only_oob'), { duration: 5000 });
+}
+
+function showComposerToast(message, { duration = 2600 } = {}) {
+  if (!message) return;
+  let toast = document.getElementById('composer-toast');
+  if (!toast) {
+    toast = document.createElement('div');
+    toast.id = 'composer-toast';
+    toast.className = 'composer-toast';
+    toast.setAttribute('role', 'status');
+    toast.setAttribute('aria-live', 'polite');
+    inputArea?.parentNode?.insertBefore(toast, inputArea);
+  }
+  toast.textContent = message;
+  toast.classList.remove('hidden');
+  clearTimeout(composerToastTimer);
+  composerToastTimer = setTimeout(() => {
+    toast.classList.add('hidden');
+  }, duration);
+}
+
+function addPersistentSlashMessage(content) {
+  return addMessage('system', content, { beforeCurrentAssistant: true });
 }
 
 function resolvePendingPermissionPromptsForTab(tabId) {
@@ -2639,7 +2718,7 @@ function resolvePendingPermissionPromptsForTab(tabId) {
 async function parseSlashCommands(text, tabId = currentTabId) {
   // /help — list all available slash commands
   if (/^\/help\b\s*/i.test(text)) {
-    addMessage('system', systemHtml(t('sp.help_html')));
+    addPersistentSlashMessage(systemHtml(t('sp.help_html')));
     return '';
   }
 
@@ -2647,7 +2726,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
   if (/^\/list-schedules\b\s*/i.test(text)) {
     const jobs = await refreshScheduledJobs({ tabId });
     if (currentTabId !== tabId) return '';
-    addMessage('system', visibleScheduledJobs(jobs).length
+    addPersistentSlashMessage(visibleScheduledJobs(jobs).length
       ? t('sp.schedule_form.list_refreshed')
       : t('sp.schedule_form.none'));
     return '';
@@ -2691,7 +2770,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     const wasAlreadyAllowed = isApiMutationsAllowedForTab(tabId);
     setApiMutationsAllowedForTab(tabId, true);
     if (!wasAlreadyAllowed) {
-      addMessage('system', systemHtml(t('sp.api.enabled_html')));
+      addPersistentSlashMessage(systemHtml(t('sp.api.enabled_html')));
     }
     return text.slice(mApi[0].length).trim();
   }
@@ -2703,7 +2782,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     askBeforeConsequential = false;
     updateActWarning();
     resolvePendingPermissionPromptsForTab(tabId);
-    addMessage('system', systemHtml(t('sp.permissions.disabled_html')));
+    addPersistentSlashMessage(systemHtml(t('sp.permissions.disabled_html')));
     return text.slice(mSkipPermissions[0].length).trim();
   }
 
@@ -2716,11 +2795,11 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     if (res?.ok && res.compacted) {
       addContextCompactedNote({ ...res, manual: true });
     } else if (res?.ok && res.reason === 'busy') {
-      addMessage('system', t('sp.compact.busy'));
+      showComposerToast(t('sp.compact.busy'), { duration: 5000 });
     } else if (res?.ok) {
-      addMessage('system', t('sp.compact.nothing_to_compact'));
+      showComposerToast(t('sp.compact.nothing_to_compact'), { duration: 5000 });
     } else {
-      addMessage('system', systemHtml(tSystemHtml('sp.compact.failed', { error: res?.error || 'unknown error' })));
+      showComposerToast(tSystemHtml('sp.compact.failed', { error: res?.error || 'unknown error' }), { duration: 5000 });
     }
     return remainder;
   }
@@ -2731,7 +2810,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     if (verboseBtn) verboseBtn.classList.toggle('active', verboseMode);
     await chrome.storage.local.set({ verboseMode }).catch(() => {});
     if (currentTabId !== tabId) return '';
-    addMessage('system', verboseMode
+    showComposerToast(verboseMode
       ? t('sp.compact.verbose_on')
       : t('sp.compact.verbose_off'));
     return '';
@@ -2754,11 +2833,11 @@ async function parseSlashCommands(text, tabId = currentTabId) {
         const dataUrl = await chrome.tabs.captureVisibleTab(windowId, { format: 'png' });
         if (currentTabId !== tabId) return '';
         const imgHtml = `<img src="${dataUrl}" style="max-width:100%;border-radius:6px;margin:4px 0;" alt="Screenshot"/>`;
-        addMessage('system', systemHtml(imgHtml));
+        addPersistentSlashMessage(systemHtml(imgHtml));
       }
     } catch (e) {
       if (currentTabId !== tabId) return '';
-      addMessage('system', systemHtml(tSystemHtml('sp.screenshot.error', { msg: e.message })));
+      addPersistentSlashMessage(systemHtml(tSystemHtml('sp.screenshot.error', { msg: e.message })));
     }
     return '';
   }
@@ -2769,14 +2848,14 @@ async function parseSlashCommands(text, tabId = currentTabId) {
       const res = await sendToBackground('capture_full_page_screenshot', { tabId });
       if (currentTabId !== tabId) return '';
       if (!res?.ok || !res.dataUrl) {
-        addMessage('system', systemHtml(tSystemHtml('sp.screenshot.error', { msg: res?.error || 'unknown error' })));
+        addPersistentSlashMessage(systemHtml(tSystemHtml('sp.screenshot.error', { msg: res?.error || 'unknown error' })));
         return '';
       }
       const imgHtml = `<img src="${res.dataUrl}" style="max-width:100%;max-height:70vh;object-fit:contain;object-position:top;border-radius:6px;margin:4px 0;" alt="Full-page screenshot"/>`;
-      addMessage('system', systemHtml(imgHtml));
+      addPersistentSlashMessage(systemHtml(imgHtml));
     } catch (e) {
       if (currentTabId !== tabId) return '';
-      addMessage('system', systemHtml(tSystemHtml('sp.screenshot.error', { msg: e.message })));
+      addPersistentSlashMessage(systemHtml(tSystemHtml('sp.screenshot.error', { msg: e.message })));
     }
     return '';
   }
@@ -2804,13 +2883,13 @@ async function parseSlashCommands(text, tabId = currentTabId) {
       });
       if (currentTabId !== tabId) return '';
       if (!res?.ok) {
-        addMessage('system', systemHtml(tSystemHtml('sp.record.error', { error: res?.error || 'unknown' })));
+        addPersistentSlashMessage(systemHtml(tSystemHtml('sp.record.error', { error: res?.error || 'unknown' })));
       } else if (res.state && res.state.hasMic === false && res.state.micError) {
-        addMessage('system', systemHtml(tSystemHtml('sp.record.mic_unavailable', { error: res.state.micError })));
+        addPersistentSlashMessage(systemHtml(tSystemHtml('sp.record.mic_unavailable', { error: res.state.micError })));
       }
     } catch (e) {
       if (currentTabId !== tabId) return '';
-      addMessage('system', systemHtml(tSystemHtml('sp.record.error', { error: e.message })));
+      addPersistentSlashMessage(systemHtml(tSystemHtml('sp.record.error', { error: e.message })));
     }
     return '';
   }
@@ -2844,7 +2923,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
       a.remove();
       setTimeout(() => URL.revokeObjectURL(url), 7000);
     }
-    addMessage('system', t('sp.export.done'));
+    addPersistentSlashMessage(t('sp.export.done'));
     return '';
   }
 
@@ -2854,7 +2933,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     const newState = !stored.profileEnabled;
     await chrome.storage.local.set({ profileEnabled: newState });
     if (currentTabId !== tabId) return '';
-    addMessage('system', newState
+    showComposerToast(newState
       ? t('sp.profile.on')
       : t('sp.profile.off'));
     return '';
@@ -2901,13 +2980,13 @@ async function parseSlashCommands(text, tabId = currentTabId) {
           config: { ...config, supportsVision: newVision },
         });
         if (currentTabId !== tabId) return '';
-        addMessage('system', newVision
+        showComposerToast(newVision
           ? t('sp.vision.on')
           : t('sp.vision.off'));
       }
     } catch (e) {
       if (currentTabId !== tabId) return '';
-      addMessage('system', systemHtml(tSystemHtml('sp.vision.error', { msg: e.message })));
+      showComposerToast(tSystemHtml('sp.vision.error', { msg: e.message }), { duration: 5000 });
     }
     return '';
   }
@@ -2933,7 +3012,7 @@ async function startFullScreenRecording(tabId = currentTabId, recordOptions = {}
   try {
     const prep = await sendToBackground('prepare_recording_host');
     if (!prep?.ok) {
-      addMessage('system', systemHtml(tSystemHtml('sp.record.error', { error: prep?.error || 'unknown' })));
+      addPersistentSlashMessage(systemHtml(tSystemHtml('sp.record.error', { error: prep?.error || 'unknown' })));
       return;
     }
     const res = await sendToBackground('start_display_recording', {
@@ -2948,18 +3027,18 @@ async function startFullScreenRecording(tabId = currentTabId, recordOptions = {}
     });
     if (currentTabId !== tabId) return;
     if (!res?.ok) {
-      addMessage('system', systemHtml(tSystemHtml('sp.record.error', { error: res?.error || 'unknown' })));
+      addPersistentSlashMessage(systemHtml(tSystemHtml('sp.record.error', { error: res?.error || 'unknown' })));
       return;
     }
     recordingStartedAt = res.state?.startedAt || Date.now();
     setRecordingUI(true, res.state || { source: 'display', showBanner: false });
-    addMessage('system', systemHtml(t('sp.record.full_screen_started_html')));
+    addPersistentSlashMessage(systemHtml(t('sp.record.full_screen_started_html')));
     if (res.state?.hasMic === false && res.state?.micError) {
-      addMessage('system', systemHtml(tSystemHtml('sp.record.mic_unavailable', { error: res.state.micError })));
+      addPersistentSlashMessage(systemHtml(tSystemHtml('sp.record.mic_unavailable', { error: res.state.micError })));
     }
   } catch (e) {
     if (currentTabId !== tabId) return;
-    addMessage('system', systemHtml(tSystemHtml('sp.record.error', { error: e?.message || 'unknown' })));
+    addPersistentSlashMessage(systemHtml(tSystemHtml('sp.record.error', { error: e?.message || 'unknown' })));
   }
 }
 
@@ -2979,13 +3058,16 @@ function updateApiBadge() {
   }
 }
 
-async function sendMessage(extraChatParams) {
+async function sendMessage(extraChatParams = {}) {
+  const retryOptions = extraChatParams?.__retry || null;
+  const chatExtraParams = { ...(extraChatParams || {}) };
+  delete chatExtraParams.__retry;
   stopListening();
   let text = inputEl.value.trim();
   if (!text) return;
   const tabId = currentTabId;
   text = normalizeScreenshotCommandText(text);
-  if (!isProcessing && isAttachmentReadPendingForTab(tabId)) {
+  if (!retryOptions && !isProcessing && isAttachmentReadPendingForTab(tabId)) {
     syncSendButtonState();
     return false;
   }
@@ -3012,13 +3094,15 @@ async function sendMessage(extraChatParams) {
     }
     return enqueueQueuedComposerMessage(tabId, text);
   }
-  const modeForSend = modeForMessageText(text);
-  const apiMutationsAllowedForSend = isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);
+  const modeForSend = retryOptions?.mode || modeForMessageText(text);
+  const apiMutationsAllowedForSend = retryOptions
+    ? !!retryOptions.apiMutationsAllowed
+    : isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);
   saveInputDraftForTab(tabId, '');
   hideSlashCommandAutocomplete();
 
   // Clear input early so slash commands don't linger visually.
-  if (text.startsWith('/')) {
+  if (!retryOptions && text.startsWith('/')) {
     inputEl.value = '';
     autoResizeInput();
     syncSendButtonState();
@@ -3026,7 +3110,7 @@ async function sendMessage(extraChatParams) {
 
   // Parse any leading slash command. parseSlashCommands may strip the
   // command from `text` and toggle apiMutationsAllowed as a side effect.
-  text = await parseSlashCommands(text, tabId);
+  if (!retryOptions) text = await parseSlashCommands(text, tabId);
   const renderToCurrentTab = currentTabId === tabId;
   if (!renderToCurrentTab) {
     if (text) saveInputDraftForTab(tabId, text);
@@ -3042,7 +3126,15 @@ async function sendMessage(extraChatParams) {
   }
 
   let assistantEl = null;
-  const attachmentsForSend = getPendingAttachmentsForTab(tabId, { create: false }).slice();
+  const attachmentsForSend = retryOptions
+    ? (Array.isArray(retryOptions.attachments) ? retryOptions.attachments.slice() : [])
+    : getPendingAttachmentsForTab(tabId, { create: false }).slice();
+  const retryPayload = {
+    text,
+    mode: modeForSend,
+    apiMutationsAllowed: apiMutationsAllowedForSend,
+    attachments: attachmentsForSend,
+  };
   if (renderToCurrentTab) {
     isProcessing = true;
     abortRequested = false;
@@ -3050,13 +3142,16 @@ async function sendMessage(extraChatParams) {
     autoResizeInput();
     syncSendButtonState();
     hideRecommendedActions();
-    clearPendingAttachmentsForTab(tabId);
-    renderAttachmentPreviews();
+    if (!retryOptions) {
+      clearPendingAttachmentsForTab(tabId);
+      renderAttachmentPreviews();
+    }
     addMessage('user', text);
     showActivity(t('sp.activity.thinking'));
     assistantEl = addMessage('assistant', '');
     currentAssistantEl = assistantEl;
   }
+  activeChatPayloadsByTab.set(tabId, retryPayload);
 
   let accepted = false;
   let completedSuccessfully = false;
@@ -3068,7 +3163,7 @@ async function sendMessage(extraChatParams) {
       mode: modeForSend,
       apiMutationsAllowed: apiMutationsAllowedForSend,
       ...(attachmentsForSend.length ? { attachments: attachmentsForSend } : {}),
-      ...extraChatParams,
+      ...chatExtraParams,
     });
     accepted = true;
     completedSuccessfully = updatesContainSuccessfulDone(res?.updates);
@@ -3116,9 +3211,12 @@ async function sendMessage(extraChatParams) {
     }
   } catch (e) {
     if (renderToCurrentTab && currentTabId === tabId && !abortRequested) {
-      addMessage('error', t('sp.error_prefix', { msg: e.message }));
+      addMessage('error', t('sp.error_prefix', { msg: e.message }), { retryPayload });
     }
   } finally {
+    if (activeChatPayloadsByTab.get(tabId) === retryPayload) {
+      activeChatPayloadsByTab.delete(tabId);
+    }
     if (renderToCurrentTab && currentTabId === tabId) finalizeSteps(assistantEl);
     clearAssistantTextStreamState(assistantEl);
     // Chime the user when the agent finishes. We play on both success and
@@ -3444,7 +3542,9 @@ function handleAgentUpdateMessage(msg) {
     case 'error':
       hideActivity();
       if (currentAssistantEl) markLastStepFailed();
-      addMessage('error', t('sp.error_prefix', { msg: data.message }));
+      addMessage('error', t('sp.error_prefix', { msg: data.message }), {
+        retryPayload: abortRequested ? null : activeChatPayloadsByTab.get(currentTabId),
+      });
       break;
 
     case 'max_steps_reached':
@@ -4084,7 +4184,32 @@ function renderSubscribeError(textEl, content) {
   return true;
 }
 
-function addMessage(role, content) {
+function addErrorRetryButton(msgEl, retryPayload) {
+  if (!msgEl || !retryPayload?.text || msgEl.querySelector('.error-retry-btn')) return;
+  const retryId = `retry-${Date.now()}-${++retryPayloadSeq}`;
+  const attachments = Array.isArray(retryPayload.attachments) ? retryPayload.attachments.slice() : [];
+  if (attachments.length) retryAttachmentPayloads.set(retryId, attachments);
+  msgEl.classList.add('retryable');
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'error-retry-btn';
+  btn.title = t('sp.retry');
+  btn.setAttribute('aria-label', t('sp.retry'));
+  btn.dataset.retryId = retryId;
+  btn.dataset.retryText = String(retryPayload.text || '');
+  btn.dataset.retryMode = retryPayload.mode || 'ask';
+  btn.dataset.retryApiMutationsAllowed = retryPayload.apiMutationsAllowed ? 'true' : 'false';
+  btn.dataset.retryAttachmentCount = String(attachments.length);
+  btn.innerHTML = `
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <polyline points="23 4 23 10 17 10"></polyline>
+      <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
+    </svg>`;
+  bindErrorRetryButton(btn);
+  msgEl.querySelector('.message-content')?.appendChild(btn);
+}
+
+function addMessage(role, content, options = {}) {
   const msgEl = document.createElement('div');
   msgEl.className = `message ${role}`;
 
@@ -4104,7 +4229,15 @@ function addMessage(role, content) {
 
   contentEl.appendChild(textEl);
   msgEl.appendChild(contentEl);
-  messagesEl.appendChild(msgEl);
+  if (options.beforeCurrentAssistant && currentAssistantEl?.parentNode === messagesEl) {
+    messagesEl.insertBefore(msgEl, currentAssistantEl);
+  } else {
+    messagesEl.appendChild(msgEl);
+  }
+
+  if (role === 'error' && options.retryPayload) {
+    addErrorRetryButton(msgEl, options.retryPayload);
+  }
 
   // Add copy button to assistant messages
   if (role === 'assistant' && content) {

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -485,6 +485,22 @@ body {
 }
 .api-badge span { font-weight: 600; }
 
+.composer-toast {
+  margin: 0 12px 6px 12px;
+  padding: 7px 11px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+  box-shadow: var(--shadow);
+}
+
+.composer-toast.hidden {
+  display: none;
+}
+
 /* Page Inspection Banner */
 #inspection-banner {
   display: flex;
@@ -1876,6 +1892,46 @@ body {
   background: rgba(244, 67, 54, 0.1);
   border: 1px solid rgba(244, 67, 54, 0.3);
   color: var(--error-soft);
+}
+
+.message.error.retryable .message-content {
+  position: relative;
+  padding-right: 42px;
+  min-height: 42px;
+}
+
+.error-retry-btn {
+  position: absolute;
+  right: 8px;
+  bottom: 7px;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(244, 67, 54, 0.35);
+  border-radius: 6px;
+  background: rgba(244, 67, 54, 0.08);
+  color: var(--error-soft);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.error-retry-btn svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.error-retry-btn:hover,
+.error-retry-btn:focus-visible {
+  background: rgba(244, 67, 54, 0.18);
+  border-color: rgba(244, 67, 54, 0.55);
+  color: var(--text-primary);
 }
 
 /* WebBrain Cloud quota / subscribe prompt — bare URL upgraded to a button */

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4934,7 +4934,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   _augmentScheduledResumeMessage(tabId, userMessage) {
     if (typeof userMessage !== 'string') return userMessage;
-    if ((this.conversationModes.get(tabId) || 'ask') !== 'act') return userMessage;
+    if (!this._isActionMode(this.conversationModes.get(tabId) || 'ask')) return userMessage;
     if (!this._isScheduledResumeTurn(userMessage)) return userMessage;
     const { rows } = this._progressRowsForResumeGuard(tabId);
     if (!rows.length) return userMessage;

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -169,6 +169,9 @@ export default {
   'sp.copy': 'Copy',
   'sp.copied': 'Copied!',
   'sp.copy.code.title': 'Copy code',
+  'sp.retry': 'Retry',
+  'sp.retry.busy': 'Wait for the current run to finish before retrying.',
+  'sp.retry.attachments_unavailable': 'Attachments from the failed attempt are no longer available; retrying the text only.',
 
   'sp.error_prefix': 'Error: {msg}',
   'sp.subscribe.allowance_used': 'Daily free WebBrain Cloud allowance used.',

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -423,6 +423,7 @@ let composerToastTimer = null;
 let retryPayloadSeq = 0;
 const activeChatPayloadsByTab = new Map();
 const retryAttachmentPayloads = new Map();
+const retryAttachmentIdsByTab = new Map();
 const {
   acceptContextMenuPrompt,
   drainQueuedContextMenuPrompts,
@@ -847,6 +848,51 @@ function sameTabId(a, b) {
   return a != null && b != null && String(a) === String(b);
 }
 
+function normalizeRetryAttachmentTabId(tabId = renderedTabId ?? currentTabId) {
+  const numericTabId = Number(tabId);
+  return Number.isFinite(numericTabId) ? numericTabId : null;
+}
+
+function trackRetryAttachmentId(tabId, retryId) {
+  if (!retryId) return;
+  const numericTabId = normalizeRetryAttachmentTabId(tabId);
+  if (numericTabId == null) return;
+  let ids = retryAttachmentIdsByTab.get(numericTabId);
+  if (!ids) {
+    ids = new Set();
+    retryAttachmentIdsByTab.set(numericTabId, ids);
+  }
+  ids.add(retryId);
+}
+
+function releaseRetryAttachmentPayload(retryId) {
+  if (!retryId) return;
+  retryAttachmentPayloads.delete(retryId);
+  for (const [tabId, ids] of retryAttachmentIdsByTab) {
+    ids.delete(retryId);
+    if (!ids.size) retryAttachmentIdsByTab.delete(tabId);
+  }
+}
+
+function releaseRetryAttachmentsInTree(root) {
+  if (!root) return;
+  if (root.matches?.('.error-retry-btn[data-retry-id]')) {
+    releaseRetryAttachmentPayload(root.dataset.retryId);
+  }
+  root.querySelectorAll?.('.error-retry-btn[data-retry-id]').forEach((btn) => {
+    releaseRetryAttachmentPayload(btn.dataset.retryId);
+  });
+}
+
+function clearRetryAttachmentsForTab(tabId) {
+  const numericTabId = normalizeRetryAttachmentTabId(tabId);
+  if (numericTabId == null) return;
+  const ids = retryAttachmentIdsByTab.get(numericTabId);
+  if (!ids) return;
+  ids.forEach((retryId) => retryAttachmentPayloads.delete(retryId));
+  retryAttachmentIdsByTab.delete(numericTabId);
+}
+
 function getQueuedComposerMessages(tabId) {
   const numericTabId = Number(tabId);
   if (!Number.isFinite(numericTabId)) return [];
@@ -1013,6 +1059,8 @@ function renderClearedConversationForTab(tabId) {
   saveInputDraftForTab(tabId, '');
   clearPendingAttachmentsForTab(tabId);
   clearQueuedComposerMessagesForTab(tabId);
+  if (sameTabId(currentTabId, tabId)) releaseRetryAttachmentsInTree(messagesEl);
+  clearRetryAttachmentsForTab(tabId);
   setApiMutationsAllowedForTab(tabId, false);
   if (currentTabId !== tabId) return;
   renderedTabId = tabId;
@@ -3901,7 +3949,10 @@ function addErrorRetryButton(msgEl, retryPayload) {
   if (!msgEl || !retryPayload?.text || msgEl.querySelector('.error-retry-btn')) return;
   const retryId = `retry-${Date.now()}-${++retryPayloadSeq}`;
   const attachments = Array.isArray(retryPayload.attachments) ? retryPayload.attachments.slice() : [];
-  if (attachments.length) retryAttachmentPayloads.set(retryId, attachments);
+  if (attachments.length) {
+    retryAttachmentPayloads.set(retryId, attachments);
+    trackRetryAttachmentId(renderedTabId ?? currentTabId, retryId);
+  }
   msgEl.classList.add('retryable');
   const btn = document.createElement('button');
   btn.type = 'button';

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -1388,6 +1388,7 @@ function handleScheduledJobEvent(data, tabId) {
   if (event === 'created') {
     addMessage('system', systemHtml(tSystemHtml('sp.scheduled.created', { title, time: formatScheduledTime(job.nextRunAt || job.scheduledAt) })));
   } else if (event === 'running') {
+    clearActiveChatPayloadForTab(tabId ?? currentTabId);
     isProcessing = true;
     abortRequested = false;
     syncSendButtonState();
@@ -1405,6 +1406,7 @@ function handleScheduledJobEvent(data, tabId) {
     hideActivity();
     abortRequested = false;
     if (currentAssistantEl) {
+      clearActiveChatPayloadForTab(tabId ?? currentTabId);
       isProcessing = true;
       syncSendButtonState();
     } else {
@@ -2211,6 +2213,7 @@ function bindPlanReviewCard(card) {
 function reattachPlanReviewActiveRun(card) {
   const assistantEl = card?.closest?.('.message.assistant');
   if (!assistantEl) return null;
+  clearActiveChatPayloadForTab(currentTabId);
   currentAssistantEl = assistantEl;
   isProcessing = true;
   abortRequested = false;
@@ -2283,6 +2286,9 @@ function bindErrorRetryButton(btn) {
       showComposerToast(t('sp.retry.attachments_unavailable'), { duration: 5000 });
     }
     setMode(payload.mode);
+    if (payload.apiMutationsAllowed) {
+      setApiMutationsAllowedForTab(currentTabId, true);
+    }
     inputEl.value = payload.text;
     autoResizeInput();
     hideSlashCommandAutocomplete();
@@ -2302,6 +2308,10 @@ function rebindRetryButtons() {
 
 function createActiveChatPayloadState(retryPayload) {
   return { retryPayload, renderedErrorMessages: new Set() };
+}
+
+function clearActiveChatPayloadForTab(tabId) {
+  if (tabId != null) activeChatPayloadsByTab.delete(tabId);
 }
 
 function errorMessageKey(message) {
@@ -3584,6 +3594,7 @@ function submitClarify(card, tabId, clarifyId, answer, source) {
   // injected.
   const isScheduledClarify = !!card.dataset.scheduledJobId;
   if (isScheduledClarify) {
+    clearActiveChatPayloadForTab(tabId);
     const msgEl = card.closest('.message.assistant');
     const scheduledJobId = card.dataset.scheduledJobId;
     if (msgEl && (!currentAssistantEl || currentAssistantEl.dataset?.scheduledJobId === scheduledJobId)) {
@@ -4006,6 +4017,7 @@ function showContinueButton() {
 async function continueAgent() {
   const tabId = currentTabId;
   const modeForSend = agentMode;
+  clearActiveChatPayloadForTab(tabId);
   document.querySelectorAll('.continue-bar').forEach(el => el.remove());
 
   isProcessing = true;

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -2300,6 +2300,40 @@ function rebindRetryButtons() {
   document.querySelectorAll('.error-retry-btn').forEach(bindErrorRetryButton);
 }
 
+function createActiveChatPayloadState(retryPayload) {
+  return { retryPayload, renderedErrorMessages: new Set() };
+}
+
+function errorMessageKey(message) {
+  return String(message || '').trim() || 'unknown error';
+}
+
+function takeActiveRetryPayloadForError(tabId, message) {
+  const state = activeChatPayloadsByTab.get(tabId);
+  if (!state?.retryPayload) return { retryPayload: null, duplicate: false };
+  const key = errorMessageKey(message);
+  if (state.renderedErrorMessages?.has(key)) {
+    return { retryPayload: state.retryPayload, duplicate: true };
+  }
+  state.renderedErrorMessages?.add(key);
+  return { retryPayload: state.retryPayload, duplicate: false };
+}
+
+function scheduleActiveChatPayloadCleanup(tabId, state) {
+  setTimeout(() => {
+    if (activeChatPayloadsByTab.get(tabId) === state) {
+      activeChatPayloadsByTab.delete(tabId);
+    }
+  }, 30000);
+}
+
+function renderAgentErrorUpdate(data, tabId = currentTabId) {
+  const message = data?.message || data?.error || 'unknown error';
+  const active = abortRequested ? { retryPayload: null, duplicate: false } : takeActiveRetryPayloadForError(tabId, message);
+  if (active.duplicate) return;
+  addMessage('error', t('sp.error_prefix', { msg: message }), { retryPayload: active.retryPayload });
+}
+
 function rebindRestoredMessageControls() {
   rebindCopyButtons();
   rebindRetryButtons();
@@ -3019,7 +3053,8 @@ async function sendMessage(extraChatParams = {}) {
     assistantEl = addMessage('assistant', '');
     currentAssistantEl = assistantEl;
   }
-  activeChatPayloadsByTab.set(tabId, retryPayload);
+  const activePayloadState = createActiveChatPayloadState(retryPayload);
+  activeChatPayloadsByTab.set(tabId, activePayloadState);
 
   let accepted = false;
   let completedSuccessfully = false;
@@ -3036,6 +3071,12 @@ async function sendMessage(extraChatParams = {}) {
     accepted = true;
     completedSuccessfully = updatesContainSuccessfulDone(res?.updates);
     promptEligibleCompletion = completedSuccessfully || isSuccessfulAskCompletion(modeForSend, res);
+    const returnedErrorUpdate = Array.isArray(res?.updates)
+      ? res.updates.find(u => u?.type === 'error')
+      : null;
+    if (returnedErrorUpdate && renderToCurrentTab && currentTabId === tabId && !abortRequested) {
+      renderAgentErrorUpdate(returnedErrorUpdate.data, tabId);
+    }
 
     // An unsupported-attachment rejection never records the turn in history;
     // the agent signals it via a structured 'attachment_rejected' update (not
@@ -3079,11 +3120,12 @@ async function sendMessage(extraChatParams = {}) {
     }
   } catch (e) {
     if (renderToCurrentTab && currentTabId === tabId && !abortRequested) {
+      takeActiveRetryPayloadForError(tabId, e.message);
       addMessage('error', t('sp.error_prefix', { msg: e.message }), { retryPayload });
     }
   } finally {
-    if (activeChatPayloadsByTab.get(tabId) === retryPayload) {
-      activeChatPayloadsByTab.delete(tabId);
+    if (activeChatPayloadsByTab.get(tabId) === activePayloadState) {
+      scheduleActiveChatPayloadCleanup(tabId, activePayloadState);
     }
     if (renderToCurrentTab && currentTabId === tabId) finalizeSteps(assistantEl);
     clearAssistantTextStreamState(assistantEl);
@@ -3212,9 +3254,7 @@ function handleAgentUpdateMessage(msg) {
     case 'error':
       hideActivity();
       if (currentAssistantEl) markLastStepFailed();
-      addMessage('error', t('sp.error_prefix', { msg: data.message }), {
-        retryPayload: abortRequested ? null : activeChatPayloadsByTab.get(currentTabId),
-      });
+      renderAgentErrorUpdate(data, currentTabId);
       break;
 
     case 'max_steps_reached':

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -419,6 +419,10 @@ let recommendedActionsCollapsed = false;
 let slashCommandMatches = [];
 let slashCommandSelectedIndex = 0;
 let busySlashNoticeLastShownAt = 0;
+let composerToastTimer = null;
+let retryPayloadSeq = 0;
+const activeChatPayloadsByTab = new Map();
+const retryAttachmentPayloads = new Map();
 const {
   acceptContextMenuPrompt,
   drainQueuedContextMenuPrompts,
@@ -1748,14 +1752,14 @@ async function showScratchpad(tabId = currentTabId) {
     if (currentTabId !== tabId) return;
     const body = String(res?.body || '').trim();
     if (!res?.exists || !body || body === '(empty)') {
-      addMessage('system', t('sp.scratchpad.empty'));
+      addPersistentSlashMessage(t('sp.scratchpad.empty'));
       return;
     }
-    const msgEl = addMessage('system', systemHtml(`${t('sp.scratchpad.title_html')}<pre class="scratchpad-dump">${escapeHtml(body)}</pre>`));
+    const msgEl = addPersistentSlashMessage(systemHtml(`${t('sp.scratchpad.title_html')}<pre class="scratchpad-dump">${escapeHtml(body)}</pre>`));
     addScratchpadCopyButton(msgEl);
   } catch (e) {
     if (currentTabId !== tabId) return;
-    addMessage('system', systemHtml(tSystemHtml('sp.scratchpad.error', { msg: e.message })));
+    addPersistentSlashMessage(systemHtml(tSystemHtml('sp.scratchpad.error', { msg: e.message })));
   }
 }
 
@@ -1764,13 +1768,13 @@ async function showProgress(tabId = currentTabId) {
     const res = await sendToBackground('get_progress', { tabId });
     if (currentTabId !== tabId) return;
     if (!res?.ok && !res?.success) {
-      addMessage('system', systemHtml(tSystemHtml('sp.progress.error', { msg: res?.error || 'unknown error' })));
+      addPersistentSlashMessage(systemHtml(tSystemHtml('sp.progress.error', { msg: res?.error || 'unknown error' })));
       return;
     }
     const rows = Array.isArray(res.rows) ? res.rows : [];
     const counts = res.counts || {};
     if (!rows.length) {
-      addMessage('system', t('sp.progress.empty'));
+      addPersistentSlashMessage(t('sp.progress.empty'));
       return;
     }
     const summary = [
@@ -1784,10 +1788,10 @@ async function showProgress(tabId = currentTabId) {
       `unresolved: ${counts.unresolved ?? 0}`,
     ].join('\n');
     const body = JSON.stringify(rows, null, 2);
-    addMessage('system', systemHtml(`${t('sp.progress.title_html')}<pre class="scratchpad-dump">${escapeHtml(summary)}\n\n${escapeHtml(body)}</pre>`));
+    addPersistentSlashMessage(systemHtml(`${t('sp.progress.title_html')}<pre class="scratchpad-dump">${escapeHtml(summary)}\n\n${escapeHtml(body)}</pre>`));
   } catch (e) {
     if (currentTabId !== tabId) return;
-    addMessage('system', systemHtml(tSystemHtml('sp.progress.error', { msg: e.message })));
+    addPersistentSlashMessage(systemHtml(tSystemHtml('sp.progress.error', { msg: e.message })));
   }
 }
 
@@ -1795,20 +1799,20 @@ async function editScratchpad(note, tabId = currentTabId) {
   const text = String(note || '').trim();
   if (!text) {
     if (currentTabId !== tabId) return;
-    addMessage('system', t('sp.scratchpad.edit_empty'));
+    showComposerToast(t('sp.scratchpad.edit_empty'), { duration: 5000 });
     return;
   }
   try {
     const res = await sendToBackground('write_scratchpad', { tabId, text });
     if (currentTabId !== tabId) return;
     if (!res?.ok && !res?.success) {
-      addMessage('system', systemHtml(tSystemHtml('sp.scratchpad.error', { msg: res?.error || 'unknown error' })));
+      showComposerToast(t('sp.scratchpad.error', { msg: res?.error || 'unknown error' }), { duration: 5000 });
       return;
     }
-    addMessage('system', t('sp.scratchpad.updated'));
+    showComposerToast(t('sp.scratchpad.updated'));
   } catch (e) {
     if (currentTabId !== tabId) return;
-    addMessage('system', systemHtml(tSystemHtml('sp.scratchpad.error', { msg: e.message })));
+    showComposerToast(t('sp.scratchpad.error', { msg: e.message }), { duration: 5000 });
   }
 }
 
@@ -1817,14 +1821,14 @@ function clearScratchpad(tabId = currentTabId) {
     .then((res) => {
       if (currentTabId !== tabId) return;
       if (!res?.ok && !res?.success) {
-        addMessage('system', systemHtml(tSystemHtml('sp.scratchpad.error', { msg: res?.error || 'unknown error' })));
+        showComposerToast(t('sp.scratchpad.error', { msg: res?.error || 'unknown error' }), { duration: 5000 });
         return;
       }
-      addMessage('system', t('sp.scratchpad.cleared'));
+      showComposerToast(t('sp.scratchpad.cleared'));
     })
     .catch((e) => {
       if (currentTabId !== tabId) return;
-      addMessage('system', systemHtml(tSystemHtml('sp.scratchpad.error', { msg: e.message })));
+      showComposerToast(t('sp.scratchpad.error', { msg: e.message }), { duration: 5000 });
     });
 }
 
@@ -2245,8 +2249,60 @@ function rebindSubscribeButtons() {
   });
 }
 
+function retryPayloadFromButton(btn) {
+  const text = String(btn?.dataset?.retryText || '').trim();
+  if (!text) return null;
+  const mode = ['ask', 'act', 'dev'].includes(btn.dataset.retryMode)
+    ? btn.dataset.retryMode
+    : agentMode;
+  const retryId = btn.dataset.retryId || '';
+  const attachments = retryAttachmentPayloads.get(retryId) || [];
+  const attachmentCount = Number(btn.dataset.retryAttachmentCount || 0) || 0;
+  return {
+    text,
+    mode,
+    apiMutationsAllowed: btn.dataset.retryApiMutationsAllowed === 'true',
+    attachments,
+    missingAttachments: attachmentCount > 0 && attachments.length === 0,
+  };
+}
+
+function bindErrorRetryButton(btn) {
+  if (!btn || btn.dataset.bound) return;
+  btn.dataset.bound = 'true';
+  btn.addEventListener('click', async (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (isProcessing) {
+      showComposerToast(t('sp.retry.busy'), { duration: 4000 });
+      return;
+    }
+    const payload = retryPayloadFromButton(btn);
+    if (!payload) return;
+    if (payload.missingAttachments) {
+      showComposerToast(t('sp.retry.attachments_unavailable'), { duration: 5000 });
+    }
+    setMode(payload.mode);
+    inputEl.value = payload.text;
+    autoResizeInput();
+    hideSlashCommandAutocomplete();
+    await sendMessage({
+      __retry: {
+        mode: payload.mode,
+        apiMutationsAllowed: payload.apiMutationsAllowed,
+        attachments: payload.attachments,
+      },
+    });
+  });
+}
+
+function rebindRetryButtons() {
+  document.querySelectorAll('.error-retry-btn').forEach(bindErrorRetryButton);
+}
+
 function rebindRestoredMessageControls() {
   rebindCopyButtons();
+  rebindRetryButtons();
   rebindContinueButtons();
   rebindClarifyCards();
   rebindPlanReviewCards();
@@ -2575,7 +2631,30 @@ function showBusySlashCommandNotice() {
   const now = Date.now();
   if (now - busySlashNoticeLastShownAt < BUSY_SLASH_NOTICE_COOLDOWN_MS) return;
   busySlashNoticeLastShownAt = now;
-  addMessage('system', t('sp.slash.busy_only_oob'));
+  showComposerToast(t('sp.slash.busy_only_oob'), { duration: 5000 });
+}
+
+function showComposerToast(message, { duration = 2600 } = {}) {
+  if (!message) return;
+  let toast = document.getElementById('composer-toast');
+  if (!toast) {
+    toast = document.createElement('div');
+    toast.id = 'composer-toast';
+    toast.className = 'composer-toast';
+    toast.setAttribute('role', 'status');
+    toast.setAttribute('aria-live', 'polite');
+    inputArea?.parentNode?.insertBefore(toast, inputArea);
+  }
+  toast.textContent = message;
+  toast.classList.remove('hidden');
+  clearTimeout(composerToastTimer);
+  composerToastTimer = setTimeout(() => {
+    toast.classList.add('hidden');
+  }, duration);
+}
+
+function addPersistentSlashMessage(content) {
+  return addMessage('system', content, { beforeCurrentAssistant: true });
 }
 
 function resolvePendingPermissionPromptsForTab(tabId) {
@@ -2596,7 +2675,7 @@ function resolvePendingPermissionPromptsForTab(tabId) {
 async function parseSlashCommands(text, tabId = currentTabId) {
   // /help — list all available slash commands
   if (/^\/help\b\s*/i.test(text)) {
-    addMessage('system', systemHtml(t('sp.help_html')));
+    addPersistentSlashMessage(systemHtml(t('sp.help_html')));
     return '';
   }
 
@@ -2604,7 +2683,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
   if (/^\/list-schedules\b\s*/i.test(text)) {
     const jobs = await refreshScheduledJobs({ tabId });
     if (currentTabId !== tabId) return '';
-    addMessage('system', visibleScheduledJobs(jobs).length
+    addPersistentSlashMessage(visibleScheduledJobs(jobs).length
       ? t('sp.schedule_form.list_refreshed')
       : t('sp.schedule_form.none'));
     return '';
@@ -2648,7 +2727,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     const wasAlreadyAllowed = isApiMutationsAllowedForTab(tabId);
     setApiMutationsAllowedForTab(tabId, true);
     if (!wasAlreadyAllowed) {
-      addMessage('system', systemHtml(t('sp.api.enabled_html')));
+      addPersistentSlashMessage(systemHtml(t('sp.api.enabled_html')));
     }
     return text.slice(mApi[0].length).trim();
   }
@@ -2660,7 +2739,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     askBeforeConsequential = false;
     updateActWarning();
     resolvePendingPermissionPromptsForTab(tabId);
-    addMessage('system', systemHtml(t('sp.permissions.disabled_html')));
+    addPersistentSlashMessage(systemHtml(t('sp.permissions.disabled_html')));
     return text.slice(mSkipPermissions[0].length).trim();
   }
 
@@ -2673,11 +2752,11 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     if (res?.ok && res.compacted) {
       addContextCompactedNote({ ...res, manual: true });
     } else if (res?.ok && res.reason === 'busy') {
-      addMessage('system', t('sp.compact.busy'));
+      showComposerToast(t('sp.compact.busy'), { duration: 5000 });
     } else if (res?.ok) {
-      addMessage('system', t('sp.compact.nothing_to_compact'));
+      showComposerToast(t('sp.compact.nothing_to_compact'), { duration: 5000 });
     } else {
-      addMessage('system', systemHtml(tSystemHtml('sp.compact.failed', { error: res?.error || 'unknown error' })));
+      showComposerToast(tSystemHtml('sp.compact.failed', { error: res?.error || 'unknown error' }), { duration: 5000 });
     }
     return remainder;
   }
@@ -2688,7 +2767,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     if (verboseBtn) verboseBtn.classList.toggle('active', verboseMode);
     await browser.storage.local.set({ verboseMode }).catch(() => {});
     if (currentTabId !== tabId) return '';
-    addMessage('system', verboseMode
+    showComposerToast(verboseMode
       ? t('sp.compact.verbose_on')
       : t('sp.compact.verbose_off'));
     return '';
@@ -2709,23 +2788,23 @@ async function parseSlashCommands(text, tabId = currentTabId) {
       const dataUrl = await browser.tabs.captureVisibleTab(tab.windowId, { format: 'png' });
       if (currentTabId !== tabId) return '';
       const imgHtml = `<img src="${dataUrl}" style="max-width:100%;border-radius:6px;margin:4px 0;" alt="Screenshot"/>`;
-      addMessage('system', systemHtml(imgHtml));
+      addPersistentSlashMessage(systemHtml(imgHtml));
     } catch (e) {
       if (currentTabId !== tabId) return '';
-      addMessage('system', systemHtml(tSystemHtml('sp.screenshot.error', { msg: e.message })));
+      addPersistentSlashMessage(systemHtml(tSystemHtml('sp.screenshot.error', { msg: e.message })));
     }
     return '';
   }
 
   // /record-full-screen — not supported in Firefox
   if (/^\/record-full-screen(?:\s|$)/i.test(text)) {
-    addMessage('system', systemHtml(tSystemHtml('sp.record.error', { error: 'Full-screen recording is not supported in Firefox.' })));
+    addPersistentSlashMessage(systemHtml(tSystemHtml('sp.record.error', { error: 'Full-screen recording is not supported in Firefox.' })));
     return '';
   }
 
   // /record — not supported in Firefox
   if (/^\/record(?:\s|$)/i.test(text)) {
-    addMessage('system', systemHtml(tSystemHtml('sp.record.error', { error: 'Tab recording is not supported in Firefox.' })));
+    addPersistentSlashMessage(systemHtml(tSystemHtml('sp.record.error', { error: 'Tab recording is not supported in Firefox.' })));
     return '';
   }
 
@@ -2758,7 +2837,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
       a.remove();
       setTimeout(() => URL.revokeObjectURL(url), 7000);
     }
-    addMessage('system', t('sp.export.done'));
+    addPersistentSlashMessage(t('sp.export.done'));
     return '';
   }
 
@@ -2768,7 +2847,7 @@ async function parseSlashCommands(text, tabId = currentTabId) {
     const newState = !stored.profileEnabled;
     await browser.storage.local.set({ profileEnabled: newState });
     if (currentTabId !== tabId) return '';
-    addMessage('system', newState
+    showComposerToast(newState
       ? t('sp.profile.on')
       : t('sp.profile.off'));
     return '';
@@ -2815,13 +2894,13 @@ async function parseSlashCommands(text, tabId = currentTabId) {
           config: { ...config, supportsVision: newVision },
         });
         if (currentTabId !== tabId) return '';
-        addMessage('system', newVision
+        showComposerToast(newVision
           ? t('sp.vision.on')
           : t('sp.vision.off'));
       }
     } catch (e) {
       if (currentTabId !== tabId) return '';
-      addMessage('system', systemHtml(tSystemHtml('sp.vision.error', { msg: e.message })));
+      showComposerToast(tSystemHtml('sp.vision.error', { msg: e.message }), { duration: 5000 });
     }
     return '';
   }
@@ -2852,13 +2931,16 @@ function updateApiBadge() {
   }
 }
 
-async function sendMessage(extraChatParams) {
+async function sendMessage(extraChatParams = {}) {
+  const retryOptions = extraChatParams?.__retry || null;
+  const chatExtraParams = { ...(extraChatParams || {}) };
+  delete chatExtraParams.__retry;
   stopListening();
   let text = inputEl.value.trim();
   if (!text) return;
   const tabId = currentTabId;
   text = normalizeScreenshotCommandText(text);
-  if (!isProcessing && isAttachmentReadPendingForTab(tabId)) {
+  if (!retryOptions && !isProcessing && isAttachmentReadPendingForTab(tabId)) {
     syncSendButtonState();
     return false;
   }
@@ -2885,18 +2967,20 @@ async function sendMessage(extraChatParams) {
     }
     return enqueueQueuedComposerMessage(tabId, text);
   }
-  const modeForSend = modeForMessageText(text);
-  const apiMutationsAllowedForSend = isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);
+  const modeForSend = retryOptions?.mode || modeForMessageText(text);
+  const apiMutationsAllowedForSend = retryOptions
+    ? !!retryOptions.apiMutationsAllowed
+    : isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);
   saveInputDraftForTab(tabId, '');
   hideSlashCommandAutocomplete();
 
-  if (text.startsWith('/')) {
+  if (!retryOptions && text.startsWith('/')) {
     inputEl.value = '';
     autoResizeInput();
     syncSendButtonState();
   }
 
-  text = await parseSlashCommands(text, tabId);
+  if (!retryOptions) text = await parseSlashCommands(text, tabId);
   const renderToCurrentTab = currentTabId === tabId;
   if (!renderToCurrentTab) {
     if (text) saveInputDraftForTab(tabId, text);
@@ -2910,7 +2994,15 @@ async function sendMessage(extraChatParams) {
   }
 
   let assistantEl = null;
-  const attachmentsForSend = getPendingAttachmentsForTab(tabId, { create: false }).slice();
+  const attachmentsForSend = retryOptions
+    ? (Array.isArray(retryOptions.attachments) ? retryOptions.attachments.slice() : [])
+    : getPendingAttachmentsForTab(tabId, { create: false }).slice();
+  const retryPayload = {
+    text,
+    mode: modeForSend,
+    apiMutationsAllowed: apiMutationsAllowedForSend,
+    attachments: attachmentsForSend,
+  };
   if (renderToCurrentTab) {
     isProcessing = true;
     abortRequested = false;
@@ -2918,13 +3010,16 @@ async function sendMessage(extraChatParams) {
     autoResizeInput();
     syncSendButtonState();
     hideRecommendedActions();
-    clearPendingAttachmentsForTab(tabId);
-    renderAttachmentPreviews();
+    if (!retryOptions) {
+      clearPendingAttachmentsForTab(tabId);
+      renderAttachmentPreviews();
+    }
     addMessage('user', text);
     showActivity(t('sp.activity.thinking'));
     assistantEl = addMessage('assistant', '');
     currentAssistantEl = assistantEl;
   }
+  activeChatPayloadsByTab.set(tabId, retryPayload);
 
   let accepted = false;
   let completedSuccessfully = false;
@@ -2936,7 +3031,7 @@ async function sendMessage(extraChatParams) {
       mode: modeForSend,
       apiMutationsAllowed: apiMutationsAllowedForSend,
       ...(attachmentsForSend.length ? { attachments: attachmentsForSend } : {}),
-      ...extraChatParams,
+      ...chatExtraParams,
     });
     accepted = true;
     completedSuccessfully = updatesContainSuccessfulDone(res?.updates);
@@ -2984,9 +3079,12 @@ async function sendMessage(extraChatParams) {
     }
   } catch (e) {
     if (renderToCurrentTab && currentTabId === tabId && !abortRequested) {
-      addMessage('error', t('sp.error_prefix', { msg: e.message }));
+      addMessage('error', t('sp.error_prefix', { msg: e.message }), { retryPayload });
     }
   } finally {
+    if (activeChatPayloadsByTab.get(tabId) === retryPayload) {
+      activeChatPayloadsByTab.delete(tabId);
+    }
     if (renderToCurrentTab && currentTabId === tabId) finalizeSteps(assistantEl);
     clearAssistantTextStreamState(assistantEl);
     const wasAborted = abortRequested;
@@ -3114,7 +3212,9 @@ function handleAgentUpdateMessage(msg) {
     case 'error':
       hideActivity();
       if (currentAssistantEl) markLastStepFailed();
-      addMessage('error', t('sp.error_prefix', { msg: data.message }));
+      addMessage('error', t('sp.error_prefix', { msg: data.message }), {
+        retryPayload: abortRequested ? null : activeChatPayloadsByTab.get(currentTabId),
+      });
       break;
 
     case 'max_steps_reached':
@@ -3746,7 +3846,32 @@ function renderSubscribeError(textEl, content) {
   return true;
 }
 
-function addMessage(role, content) {
+function addErrorRetryButton(msgEl, retryPayload) {
+  if (!msgEl || !retryPayload?.text || msgEl.querySelector('.error-retry-btn')) return;
+  const retryId = `retry-${Date.now()}-${++retryPayloadSeq}`;
+  const attachments = Array.isArray(retryPayload.attachments) ? retryPayload.attachments.slice() : [];
+  if (attachments.length) retryAttachmentPayloads.set(retryId, attachments);
+  msgEl.classList.add('retryable');
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'error-retry-btn';
+  btn.title = t('sp.retry');
+  btn.setAttribute('aria-label', t('sp.retry'));
+  btn.dataset.retryId = retryId;
+  btn.dataset.retryText = String(retryPayload.text || '');
+  btn.dataset.retryMode = retryPayload.mode || 'ask';
+  btn.dataset.retryApiMutationsAllowed = retryPayload.apiMutationsAllowed ? 'true' : 'false';
+  btn.dataset.retryAttachmentCount = String(attachments.length);
+  btn.innerHTML = `
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <polyline points="23 4 23 10 17 10"></polyline>
+      <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
+    </svg>`;
+  bindErrorRetryButton(btn);
+  msgEl.querySelector('.message-content')?.appendChild(btn);
+}
+
+function addMessage(role, content, options = {}) {
   const msgEl = document.createElement('div');
   msgEl.className = `message ${role}`;
 
@@ -3766,7 +3891,15 @@ function addMessage(role, content) {
 
   contentEl.appendChild(textEl);
   msgEl.appendChild(contentEl);
-  messagesEl.appendChild(msgEl);
+  if (options.beforeCurrentAssistant && currentAssistantEl?.parentNode === messagesEl) {
+    messagesEl.insertBefore(msgEl, currentAssistantEl);
+  } else {
+    messagesEl.appendChild(msgEl);
+  }
+
+  if (role === 'error' && options.retryPayload) {
+    addErrorRetryButton(msgEl, options.retryPayload);
+  }
 
   // Add copy button to assistant messages, and to user messages too (Firefox
   // only — manual select-and-copy is unreliable in the Firefox sidebar panel).

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -484,6 +484,22 @@ body {
 }
 .api-badge span { font-weight: 600; }
 
+.composer-toast {
+  margin: 0 12px 6px 12px;
+  padding: 7px 11px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+  box-shadow: var(--shadow);
+}
+
+.composer-toast.hidden {
+  display: none;
+}
+
 /* Page Inspection Banner */
 #inspection-banner {
   display: flex;
@@ -1882,6 +1898,46 @@ body {
   background: rgba(244, 67, 54, 0.1);
   border: 1px solid rgba(244, 67, 54, 0.3);
   color: var(--error-soft);
+}
+
+.message.error.retryable .message-content {
+  position: relative;
+  padding-right: 42px;
+  min-height: 42px;
+}
+
+.error-retry-btn {
+  position: absolute;
+  right: 8px;
+  bottom: 7px;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(244, 67, 54, 0.35);
+  border-radius: 6px;
+  background: rgba(244, 67, 54, 0.08);
+  color: var(--error-soft);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.error-retry-btn svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.error-retry-btn:hover,
+.error-retry-btn:focus-visible {
+  background: rgba(244, 67, 54, 0.18);
+  border-color: rgba(244, 67, 54, 0.55);
+  color: var(--text-primary);
 }
 
 /* WebBrain Cloud quota / subscribe prompt — bare URL upgraded to a button */

--- a/test/run.js
+++ b/test/run.js
@@ -7153,6 +7153,26 @@ test('sidepanel keeps retry metadata long enough for returned error updates', ()
     );
     assert.match(
       source,
+      /const retryAttachmentIdsByTab = new Map\(\);/,
+      `${label}: retry attachment payloads should be indexed by tab for cleanup`,
+    );
+    assert.match(
+      source,
+      /function clearRetryAttachmentsForTab\(tabId\) \{[\s\S]*?retryAttachmentPayloads\.delete\(retryId\)[\s\S]*?retryAttachmentIdsByTab\.delete\(numericTabId\);[\s\S]*?\}/,
+      `${label}: clearing a conversation should release retry attachment payloads for that tab`,
+    );
+    assert.match(
+      source,
+      /function renderClearedConversationForTab\(tabId\) \{[\s\S]*?releaseRetryAttachmentsInTree\(messagesEl\);[\s\S]*?clearRetryAttachmentsForTab\(tabId\);[\s\S]*?messagesEl\.innerHTML = '';/,
+      `${label}: reset should release retry attachment payloads before removing retry buttons from the DOM`,
+    );
+    assert.match(
+      source,
+      /retryAttachmentPayloads\.set\(retryId, attachments\);[\s\S]*?trackRetryAttachmentId\(renderedTabId \?\? currentTabId, retryId\);/,
+      `${label}: retry attachment payload IDs should be associated with the rendered tab`,
+    );
+    assert.match(
+      source,
       /if \(payload\.apiMutationsAllowed\) \{[\s\S]*?setApiMutationsAllowedForTab\(currentTabId, true\);[\s\S]*?\}[\s\S]*?await sendMessage\(\{/,
       `${label}: restored retries that replay API mutation permission should resync the visible per-tab API state`,
     );

--- a/test/run.js
+++ b/test/run.js
@@ -7153,6 +7153,11 @@ test('sidepanel keeps retry metadata long enough for returned error updates', ()
     );
     assert.match(
       source,
+      /if \(payload\.apiMutationsAllowed\) \{[\s\S]*?setApiMutationsAllowedForTab\(currentTabId, true\);[\s\S]*?\}[\s\S]*?await sendMessage\(\{/,
+      `${label}: restored retries that replay API mutation permission should resync the visible per-tab API state`,
+    );
+    assert.match(
+      source,
       /const activePayloadState = createActiveChatPayloadState\(retryPayload\);[\s\S]*?activeChatPayloadsByTab\.set\(tabId, activePayloadState\);/,
       `${label}: sendMessage should store retry metadata as an active run state`,
     );
@@ -7170,6 +7175,31 @@ test('sidepanel keeps retry metadata long enough for returned error updates', ()
       source,
       /function scheduleActiveChatPayloadCleanup\(tabId, state\) \{[\s\S]*?setTimeout\(\(\) => \{[\s\S]*?activeChatPayloadsByTab\.delete\(tabId\);[\s\S]*?\}, 30000\);/,
       `${label}: active retry metadata should be cleaned up after late broadcasts have had a chance to drain`,
+    );
+    assert.match(
+      source,
+      /function clearActiveChatPayloadForTab\(tabId\) \{[\s\S]*?activeChatPayloadsByTab\.delete\(tabId\);[\s\S]*?\}/,
+      `${label}: non-chat runs should be able to clear stale chat retry metadata`,
+    );
+    assert.match(
+      source,
+      /else if \(event === 'running'\) \{[\s\S]*?clearActiveChatPayloadForTab\(tabId \?\? currentTabId\);[\s\S]*?isProcessing = true;/,
+      `${label}: scheduled runs should clear stale chat retry metadata before starting`,
+    );
+    assert.match(
+      source,
+      /function reattachPlanReviewActiveRun\(card\) \{[\s\S]*?clearActiveChatPayloadForTab\(currentTabId\);[\s\S]*?isProcessing = true;/,
+      `${label}: plan review resumes should clear stale chat retry metadata before starting`,
+    );
+    assert.match(
+      source,
+      /const isScheduledClarify = !!card\.dataset\.scheduledJobId;[\s\S]*?if \(isScheduledClarify\) \{[\s\S]*?clearActiveChatPayloadForTab\(tabId\);[\s\S]*?isProcessing = true;/,
+      `${label}: scheduled clarify resumes should clear stale chat retry metadata before starting`,
+    );
+    assert.match(
+      source,
+      /async function continueAgent\(\) \{[\s\S]*?const tabId = currentTabId;[\s\S]*?clearActiveChatPayloadForTab\(tabId\);[\s\S]*?isProcessing = true;/,
+      `${label}: Continue runs should clear stale chat retry metadata before starting`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -7140,6 +7140,40 @@ test('sidepanel preserves stale residual slash-command prompts without hidden ru
   }
 });
 
+test('sidepanel keeps retry metadata long enough for returned error updates', () => {
+  for (const [label, panelRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js'],
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    assert.match(
+      source,
+      /function createActiveChatPayloadState\(retryPayload\) \{[\s\S]*?renderedErrorMessages: new Set\(\)[\s\S]*?\}/,
+      `${label}: active retry metadata should track rendered error messages`,
+    );
+    assert.match(
+      source,
+      /const activePayloadState = createActiveChatPayloadState\(retryPayload\);[\s\S]*?activeChatPayloadsByTab\.set\(tabId, activePayloadState\);/,
+      `${label}: sendMessage should store retry metadata as an active run state`,
+    );
+    assert.match(
+      source,
+      /const returnedErrorUpdate = Array\.isArray\(res\?\.updates\)[\s\S]*?res\.updates\.find\(u => u\?\.type === 'error'\)[\s\S]*?renderAgentErrorUpdate\(returnedErrorUpdate\.data, tabId\);/,
+      `${label}: returned agent error updates should render with retry metadata even if the broadcast is late`,
+    );
+    assert.match(
+      source,
+      /case 'error':[\s\S]*?renderAgentErrorUpdate\(data, currentTabId\);[\s\S]*?break;/,
+      `${label}: broadcast agent errors should share the retry-aware renderer`,
+    );
+    assert.match(
+      source,
+      /function scheduleActiveChatPayloadCleanup\(tabId, state\) \{[\s\S]*?setTimeout\(\(\) => \{[\s\S]*?activeChatPayloadsByTab\.delete\(tabId\);[\s\S]*?\}, 30000\);/,
+      `${label}: active retry metadata should be cleaned up after late broadcasts have had a chance to drain`,
+    );
+  }
+});
+
 test('sidepanel allows safe slash commands and queues normal messages while busy', () => {
   for (const [label, panelRel, localeRel] of [
     ['chrome', 'src/chrome/src/ui/sidepanel.js', 'src/chrome/src/ui/locales/en.js'],

--- a/test/run.js
+++ b/test/run.js
@@ -15296,6 +15296,10 @@ test('scheduled resume turns get a fresh untrusted ledger snapshot appended', as
     assert.ok(hostileIdx > untrustedIdx, `${AgentClass.name}: hostile row labels must only appear inside the untrusted wrapper`);
     assert.doesNotMatch(augmented.slice(0, untrustedIdx), /steal secrets|Ignore previous instructions/, `${AgentClass.name}: hostile row labels must not leak into the trusted preamble`);
 
+    agent.conversationModes.set(tabId, 'dev');
+    const devAugmented = agent._augmentScheduledResumeMessage(tabId, resumeMessage);
+    assert.match(devAugmented, /Fresh progress ledger snapshot at resume time: 2 row\(s\), 1 unresolved/, `${AgentClass.name}: Dev scheduled resumes should get the action-mode snapshot`);
+
     assert.equal(agent._augmentScheduledResumeMessage(tabId, 'hello there'), 'hello there', `${AgentClass.name}: non-resume turns must pass through unchanged`);
 
     agent._progressUpdate(tabId, {

--- a/test/run.js
+++ b/test/run.js
@@ -6989,14 +6989,14 @@ test('sidepanel scopes async tab commands to the original tab', () => {
     const screenshotIdx = panel.indexOf('// /screenshot');
     const screenshotEnd = panel.indexOf('// /record', screenshotIdx);
     const screenshotBody = panel.slice(screenshotIdx, screenshotEnd);
-    assert.match(screenshotBody, /if \(currentTabId !== tabId \|\| !tab\?\.active\) return '';[\s\S]*?captureVisibleTab[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?addMessage\('system', systemHtml\(imgHtml\)\);/, `${label}: /screenshot should not render a captured image into a different tab`);
+    assert.match(screenshotBody, /if \(currentTabId !== tabId \|\| !tab\?\.active\) return '';[\s\S]*?captureVisibleTab[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?(?:addMessage\('system', systemHtml\(imgHtml\)\)|addPersistentSlashMessage\(systemHtml\(imgHtml\)\));/, `${label}: /screenshot should not render a captured image into a different tab`);
     const fullPageIdx = panel.indexOf('// /full-page-screenshot');
     assert.match(panel, /function normalizeScreenshotRequestText\(text\) \{[\s\S]*?\.normalize\('NFKD'\)[\s\S]*?\.replace\(\/\[\\u0300-\\u036f\]\/g, ''\)[\s\S]*?\.replace\(\/\\u0131\/g, 'i'\)/, `${label}: plain screenshot request normalization should handle accented Turkish text`);
     assert.match(panel, /function isPlainScreenshotRequest\(text\) \{[\s\S]*?const s = normalizeScreenshotRequestText\(text\);[\s\S]*?s\.startsWith\('\/'\)[\s\S]*?ekran goruntusu[\s\S]*?ekran goruntusunu/, `${label}: plain screenshot request routing should cover English and Turkish screenshot-only requests`);
     if (label === 'chrome') {
       assert.notEqual(fullPageIdx, -1, `${label}: /full-page-screenshot parser missing`);
       const fullPageBody = panel.slice(fullPageIdx, panel.indexOf('// /record', fullPageIdx));
-      assert.match(fullPageBody, /sendToBackground\('capture_full_page_screenshot', \{ tabId \}\);[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?addMessage\('system', systemHtml\(imgHtml\)\);/, `${label}: /full-page-screenshot should render only into the initiating tab`);
+      assert.match(fullPageBody, /sendToBackground\('capture_full_page_screenshot', \{ tabId \}\);[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?(?:addMessage\('system', systemHtml\(imgHtml\)\)|addPersistentSlashMessage\(systemHtml\(imgHtml\)\));/, `${label}: /full-page-screenshot should render only into the initiating tab`);
       assert.match(panel, /function isPlainFullPageScreenshotRequest\(text\) \{[\s\S]*?full\|whole\|entire\|complete[\s\S]*?tam sayfa[\s\S]*?ekran goruntusu/, `${label}: plain full-page screenshot request routing should cover English and Turkish requests`);
       assert.match(panel, /function normalizeScreenshotCommandText\(text\) \{[\s\S]*?isPlainFullPageScreenshotRequest\(text\)[\s\S]*?return '\/full-page-screenshot';[\s\S]*?isPlainScreenshotRequest\(text\)[\s\S]*?return '\/screenshot';/, `${label}: screenshot normalization should route full-page requests before viewport screenshots`);
     } else {
@@ -7005,7 +7005,7 @@ test('sidepanel scopes async tab commands to the original tab', () => {
       assert.doesNotMatch(panel, /isPlainFullPageScreenshotRequest/, `${label}: should not normalize full-page screenshot text into an unsupported slash command`);
       assert.match(panel, /function normalizeScreenshotCommandText\(text\) \{[\s\S]*?if \(isPlainScreenshotRequest\(text\)\) return '\/screenshot';[\s\S]*?return text;[\s\S]*?\}/, `${label}: screenshot normalization should only route viewport screenshots`);
     }
-    const sendIdx = panel.indexOf('async function sendMessage(extraChatParams)');
+    const sendIdx = panel.search(/async function sendMessage\(extraChatParams(?: = \{\})?\)/);
     assert.notEqual(sendIdx, -1, `${label}: sendMessage missing`);
     const sendBody = panel.slice(sendIdx, panel.indexOf('let assistantEl = null;', sendIdx));
     assert.match(sendBody, /const tabId = currentTabId;[\s\S]*?text = normalizeScreenshotCommandText\(text\);[\s\S]*?if \(isProcessing\)/, `${label}: plain screenshot requests should route to slash commands before busy gating`);
@@ -7025,11 +7025,11 @@ test('sidepanel scopes async tab commands to the original tab', () => {
 
     const profileIdx = panel.indexOf('// /profile');
     const profileBody = panel.slice(profileIdx, panel.indexOf('// /ask', profileIdx));
-    assert.match(profileBody, /storage\.local\.get\(\['profileEnabled', 'profileText'\]\);[\s\S]*?storage\.local\.set\(\{ profileEnabled: newState \}\);[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?addMessage\('system'/, `${label}: /profile should not render a result into a different tab`);
+    assert.match(profileBody, /storage\.local\.get\(\['profileEnabled', 'profileText'\]\);[\s\S]*?storage\.local\.set\(\{ profileEnabled: newState \}\);[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?(?:addMessage\('system'|showComposerToast\()/, `${label}: /profile should not render a result into a different tab`);
 
     const visionIdx = panel.indexOf('// /vision');
     const visionBody = panel.slice(visionIdx, panel.indexOf('return text;', visionIdx));
-    assert.match(visionBody, /sendToBackground\('get_providers'\);[\s\S]*?sendToBackground\('update_provider'[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?addMessage\('system'/, `${label}: /vision should not render a result into a different tab`);
+    assert.match(visionBody, /sendToBackground\('get_providers'\);[\s\S]*?sendToBackground\('update_provider'[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?(?:addMessage\('system'|showComposerToast\()/, `${label}: /vision should not render a result into a different tab`);
   }
 });
 
@@ -7046,7 +7046,7 @@ test('sidepanel awaits immediate verbose preference writes', () => {
     );
     assert.match(
       panel,
-      /if \(\s*\/\^\\\/verbose\\b\\s\*\/i\.test\(text\)\s*\) \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ verboseMode \}\)\.catch\(\(\) => \{\}\);[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?addMessage\('system', verboseMode/,
+      /if \(\s*\/\^\\\/verbose\\b\\s\*\/i\.test\(text\)\s*\) \{[\s\S]*?await (chrome|browser)\.storage\.local\.set\(\{ verboseMode \}\)\.catch\(\(\) => \{\}\);[\s\S]*?if \(currentTabId !== tabId\) return '';[\s\S]*?showComposerToast\(verboseMode/,
       `${label}: /verbose should guard against stale tabs after persisting the mode change`,
     );
   }
@@ -7095,7 +7095,7 @@ test('sidepanel preserves stale residual slash-command prompts without hidden ru
     const switchBody = panel.slice(switchStart, panel.indexOf('refreshScheduledJobs({', switchStart));
     assert.match(switchBody, /captureInputDraftForTab\(renderedTabId\);[\s\S]*?restoreInputDraftForTab\(newTabId\);/, `${label}: tab switches should capture and restore per-tab composer drafts`);
 
-    const sendMatch = panel.match(/async function sendMessage\(extraChatParams\) \{[\s\S]*?\n  return accepted;\n\}/);
+    const sendMatch = panel.match(/async function sendMessage\(extraChatParams(?: = \{\})?\) \{[\s\S]*?\n  return accepted;\n\}/);
     assert.ok(sendMatch, `${label}: sendMessage missing`);
     const sendBody = sendMatch[0];
     const modeHelperStart = panel.indexOf('function modeForMessageText(text) {');
@@ -7109,8 +7109,8 @@ test('sidepanel preserves stale residual slash-command prompts without hidden ru
     ]) {
       assert.ok(modeHelper.includes(snippet), `${label}: modeForMessageText should handle ${commandLabel}`);
     }
-    const modeCapture = "const modeForSend = modeForMessageText(text);";
-    const apiCapture = "const apiMutationsAllowedForSend = isApiMutationsAllowedForTab(tabId) || /^\\/allow-api\\b/i.test(text);";
+    const modeCapture = "const modeForSend = retryOptions?.mode || modeForMessageText(text);";
+    const apiCapture = 'const apiMutationsAllowedForSend = retryOptions';
     const modeCaptureIdx = sendBody.indexOf(modeCapture);
     const apiCaptureIdx = sendBody.indexOf(apiCapture);
     const parseIdx = sendBody.indexOf('text = await parseSlashCommands(text, tabId);');
@@ -17838,7 +17838,7 @@ test('sidepanel: pending attachments are tab-scoped and send-gated while loading
     assert.ok(source.includes('const pendingAttachmentsByTab = new Map()'), `${label} should store pending attachments by tab`);
     assert.ok(source.includes('const attachmentReadCountsByTab = new Map()'), `${label} should track in-flight attachment reads by tab`);
     assert.ok(source.includes('function isAttachmentReadPendingForTab'), `${label} should expose a read-pending helper`);
-    assert.ok(source.includes('if (!isProcessing && isAttachmentReadPendingForTab(tabId))'), `${label} should block keyboard sends while files load`);
+    assert.ok(source.includes('if (!retryOptions && !isProcessing && isAttachmentReadPendingForTab(tabId))'), `${label} should block normal sends while files load without blocking retries`);
     assert.ok(source.includes('clearPendingAttachmentsForTab(tabId);'), `${label} should clear pending files with the conversation`);
     assert.match(
       source,


### PR DESCRIPTION
## Summary

- Keep useful persistent slash-command output in the transcript while inserting it before any in-flight assistant bubble so live/newer assistant turns remain bottom-most.
- Move tiny slash state flips such as `/verbose`, `/profile`, and `/vision` to transient composer toasts instead of transcript bubbles.
- Add retry metadata and an icon-only retry action for eligible red chat error bubbles in both Chrome and Firefox side panels.
- Preserve failed-history auditability by appending retries as fresh attempts, with text-only retry fallback after restore when attachments are no longer available.

## Validation

- `npm test` passed: `636 passed, 0 failed`.
- Injection corpus passed: `60/60 checks passed`.
- `git diff --check` passed.