### PR TITLE
[codex] Add Tencent Hy3 planner benchmark

### DIFF
--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/001.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/001.json
@@ -1,0 +1,43 @@
+{
+  "id": "001",
+  "user": "go to firefox extensions management pagr",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3763,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "about:addons"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17253,
+    "completion_tokens": 48,
+    "total_tokens": 17301,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 25,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/002.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/002.json
@@ -1,0 +1,43 @@
+{
+  "id": "002",
+  "user": "open gmail",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3482,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://mail.google.com"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17248,
+    "completion_tokens": 38,
+    "total_tokens": 17286,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 14,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/003.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/003.json
@@ -1,0 +1,43 @@
+{
+  "id": "003",
+  "user": "take me to youtube",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3246,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://www.youtube.com"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17249,
+    "completion_tokens": 37,
+    "total_tokens": 17286,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 13,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/004.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/004.json
@@ -1,0 +1,43 @@
+{
+  "id": "004",
+  "user": "open my github",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3486,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://github.com"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17248,
+    "completion_tokens": 39,
+    "total_tokens": 17287,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 16,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/005.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/005.json
@@ -1,0 +1,43 @@
+{
+  "id": "005",
+  "user": "show me my downloads",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3990,
+  "error": null,
+  "firstToolCall": {
+    "name": "list_downloads",
+    "args": {
+      "limit": 20
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll pull up your recent downloads.",
+  "usage": {
+    "prompt_tokens": 17249,
+    "completion_tokens": 51,
+    "total_tokens": 17300,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 22,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/006.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/006.json
@@ -1,0 +1,43 @@
+{
+  "id": "006",
+  "user": "i wanna check netflix",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 2926,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://www.netflix.com"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll take you to Netflix.",
+  "usage": {
+    "prompt_tokens": 17250,
+    "completion_tokens": 45,
+    "total_tokens": 17295,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 13,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/007.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/007.json
@@ -1,0 +1,43 @@
+{
+  "id": "007",
+  "user": "open linkedin in this tab",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 2018,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://www.linkedin.com"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17251,
+    "completion_tokens": 54,
+    "total_tokens": 17305,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 17152,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 28,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/008.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/008.json
@@ -1,0 +1,43 @@
+{
+  "id": "008",
+  "user": "wikipedia please",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3082,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://www.wikipedia.org"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17248,
+    "completion_tokens": 38,
+    "total_tokens": 17286,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 14,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/009.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/009.json
@@ -1,0 +1,43 @@
+{
+  "id": "009",
+  "user": "open chatgpt in a new tab",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3430,
+  "error": null,
+  "firstToolCall": {
+    "name": "new_tab",
+    "args": {
+      "url": "https://chat.openai.com"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17253,
+    "completion_tokens": 43,
+    "total_tokens": 17296,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 18,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/010.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/010.json
@@ -1,0 +1,43 @@
+{
+  "id": "010",
+  "user": "go to amazon",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3237,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://www.amazon.com"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17248,
+    "completion_tokens": 38,
+    "total_tokens": 17286,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 14,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/011.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/011.json
@@ -1,0 +1,43 @@
+{
+  "id": "011",
+  "user": "open firefox settings",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 7312,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "about:preferences"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll open the Firefox settings page. In Firefox, that's `about:preferences`.",
+  "usage": {
+    "prompt_tokens": 17249,
+    "completion_tokens": 510,
+    "total_tokens": 17759,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 468,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/012.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/012.json
@@ -1,0 +1,43 @@
+{
+  "id": "012",
+  "user": "show my browser history",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 9563,
+  "error": null,
+  "firstToolCall": {
+    "name": "execute_js",
+    "args": {
+      "code": "try {\n  if (typeof chrome !== 'undefined' && chrome.history) {\n    return 'chrome.history available';\n  } else {\n    return 'chrome.history NOT available in page context';\n  }\n} catch (e) {\n  return 'error: ' + e.message;\n}\n"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll try to access your browser history. Let me first check whether the history API is available from this context.",
+  "usage": {
+    "prompt_tokens": 17249,
+    "completion_tokens": 612,
+    "total_tokens": 17861,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 512,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/013.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/013.json
@@ -1,0 +1,43 @@
+{
+  "id": "013",
+  "user": "open the about config page",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 2995,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "about:config"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17250,
+    "completion_tokens": 42,
+    "total_tokens": 17292,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 20,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/014.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/014.json
@@ -1,0 +1,43 @@
+{
+  "id": "014",
+  "user": "show me my bookmarks",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3983,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "chrome://bookmarks"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll open your bookmarks manager to show you your bookmarks.",
+  "usage": {
+    "prompt_tokens": 17250,
+    "completion_tokens": 127,
+    "total_tokens": 17377,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 90,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/015.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/015.json
@@ -1,0 +1,43 @@
+{
+  "id": "015",
+  "user": "whats my new tab page",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3242,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll take a look at your current new tab page to see what's on it.",
+  "usage": {
+    "prompt_tokens": 17251,
+    "completion_tokens": 78,
+    "total_tokens": 17329,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 38,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/016.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/016.json
@@ -1,0 +1,43 @@
+{
+  "id": "016",
+  "user": "search youtube for lo-fi study music",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.youtube.com/",
+    "title": "YouTube"
+  },
+  "latencyMs": 3353,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll search YouTube for \"lo-fi study music\". Let me first look at the current page to find the search box.",
+  "usage": {
+    "prompt_tokens": 17586,
+    "completion_tokens": 104,
+    "total_tokens": 17690,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 57,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/017.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/017.json
@@ -1,0 +1,43 @@
+{
+  "id": "017",
+  "user": "google \"best coffee shop in seattle\"",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3779,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://www.google.com/search?q=best+coffee+shop+in+seattle"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll search Google for that query.",
+  "usage": {
+    "prompt_tokens": 17254,
+    "completion_tokens": 68,
+    "total_tokens": 17322,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 21,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/018.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/018.json
@@ -1,0 +1,43 @@
+{
+  "id": "018",
+  "user": "find typescript repos with most stars",
+  "mode": "act",
+  "tab": {
+    "url": "https://github.com/",
+    "title": "GitHub"
+  },
+  "latencyMs": 4509,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://github.com/search?q=language%3Atypescript&type=repositories&s=stars&o=desc"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll search GitHub for TypeScript repositories sorted by star count.",
+  "usage": {
+    "prompt_tokens": 17799,
+    "completion_tokens": 122,
+    "total_tokens": 17921,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 63,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/019.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/019.json
@@ -1,0 +1,43 @@
+{
+  "id": "019",
+  "user": "search reddit for mechanical keyboards",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3681,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://www.reddit.com/search/?q=mechanical%20keyboards"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll search Reddit for mechanical keyboards. Let me navigate to Reddit's search results.",
+  "usage": {
+    "prompt_tokens": 17251,
+    "completion_tokens": 135,
+    "total_tokens": 17386,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 83,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/020.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/020.json
@@ -1,0 +1,43 @@
+{
+  "id": "020",
+  "user": "look up \"javascript closures\" on stackoverflow",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3109,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://stackoverflow.com/search?q=javascript+closures"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll search StackOverflow for \"javascript closures\".",
+  "usage": {
+    "prompt_tokens": 17254,
+    "completion_tokens": 65,
+    "total_tokens": 17319,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 23,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/021.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/021.json
@@ -1,0 +1,43 @@
+{
+  "id": "021",
+  "user": "wiki \"ww2\"",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3914,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://en.wikipedia.org/wiki/WW2"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll look up \"ww2\" on Wikipedia for you.",
+  "usage": {
+    "prompt_tokens": 17250,
+    "completion_tokens": 129,
+    "total_tokens": 17379,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 88,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/022.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/022.json
@@ -1,0 +1,43 @@
+{
+  "id": "022",
+  "user": "find noise cancelling headphones under 200 dollars",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.amazon.com/",
+    "title": "Amazon.com"
+  },
+  "latencyMs": 3637,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll help you find noise cancelling headphones under $200 on Amazon. Let me start by searching.",
+  "usage": {
+    "prompt_tokens": 17366,
+    "completion_tokens": 90,
+    "total_tokens": 17456,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 47,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/023.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/023.json
@@ -1,0 +1,43 @@
+{
+  "id": "023",
+  "user": "show me vegan lasagna recipes",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 4069,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://www.google.com/search?q=vegan+lasagna+recipes"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll search for vegan lasagna recipes for you. Let me start by running a search.",
+  "usage": {
+    "prompt_tokens": 17251,
+    "completion_tokens": 186,
+    "total_tokens": 17437,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 131,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/024.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/024.json
@@ -1,0 +1,43 @@
+{
+  "id": "024",
+  "user": "find tweets about react 19",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 5113,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://x.com/search?q=React%2019&src=typed_query&f=live"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll search for tweets about React 19 on X (Twitter). Let me navigate to the search results.",
+  "usage": {
+    "prompt_tokens": 17251,
+    "completion_tokens": 188,
+    "total_tokens": 17439,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 125,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/025.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/025.json
@@ -1,0 +1,43 @@
+{
+  "id": "025",
+  "user": "search youtube for \"never gonna give you up\"",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.youtube.com/",
+    "title": "YouTube"
+  },
+  "latencyMs": 3381,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll search YouTube for that. Let me first look at the current page to find the search box.",
+  "usage": {
+    "prompt_tokens": 17589,
+    "completion_tokens": 102,
+    "total_tokens": 17691,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 59,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/026.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/026.json
@@ -1,0 +1,41 @@
+{
+  "id": "026",
+  "user": "summarize this page",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.cnn.com/2026/05/world/example-story/index.html",
+    "title": "Example story — CNN"
+  },
+  "latencyMs": 2207,
+  "error": null,
+  "firstToolCall": {
+    "name": "read_page",
+    "args": {}
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll read the page content to summarize it.",
+  "usage": {
+    "prompt_tokens": 17266,
+    "completion_tokens": 40,
+    "total_tokens": 17306,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 17216,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 18,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/027.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/027.json
@@ -1,0 +1,41 @@
+{
+  "id": "027",
+  "user": "tldr",
+  "mode": "act",
+  "tab": {
+    "url": "https://en.wikipedia.org/wiki/Closure_(computer_programming)",
+    "title": "Closure (computer programming) — Wikipedia"
+  },
+  "latencyMs": 3425,
+  "error": null,
+  "firstToolCall": {
+    "name": "read_page",
+    "args": {}
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17265,
+    "completion_tokens": 38,
+    "total_tokens": 17303,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 26,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/028.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/028.json
@@ -1,0 +1,41 @@
+{
+  "id": "028",
+  "user": "what is this article about",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.cnn.com/2026/05/world/example-story/index.html",
+    "title": "Example story — CNN"
+  },
+  "latencyMs": 4616,
+  "error": null,
+  "firstToolCall": {
+    "name": "read_page",
+    "args": {}
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll read the article to summarize what it's about.",
+  "usage": {
+    "prompt_tokens": 17267,
+    "completion_tokens": 67,
+    "total_tokens": 17334,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 43,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/029.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/029.json
@@ -1,0 +1,43 @@
+{
+  "id": "029",
+  "user": "give me the headings on this page",
+  "mode": "act",
+  "tab": {
+    "url": "https://en.wikipedia.org/wiki/Closure_(computer_programming)",
+    "title": "Closure (computer programming) — Wikipedia"
+  },
+  "latencyMs": 3415,
+  "error": null,
+  "firstToolCall": {
+    "name": "extract_data",
+    "args": {
+      "type": "headings"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17269,
+    "completion_tokens": 37,
+    "total_tokens": 17306,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 16,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/030.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/030.json
@@ -1,0 +1,43 @@
+{
+  "id": "030",
+  "user": "list all the visible links here",
+  "mode": "act",
+  "tab": {
+    "url": "https://news.ycombinator.com/",
+    "title": "Hacker News"
+  },
+  "latencyMs": 3377,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll read the current page to find all the visible links.",
+  "usage": {
+    "prompt_tokens": 17332,
+    "completion_tokens": 62,
+    "total_tokens": 17394,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 27,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/031.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/031.json
@@ -1,0 +1,43 @@
+{
+  "id": "031",
+  "user": "is there a paywall",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.cnn.com/2026/05/world/example-story/index.html",
+    "title": "Example story — CNN"
+  },
+  "latencyMs": 3199,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll check the current page to see if there's a paywall.",
+  "usage": {
+    "prompt_tokens": 17267,
+    "completion_tokens": 60,
+    "total_tokens": 17327,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 23,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/032.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/032.json
@@ -1,0 +1,43 @@
+{
+  "id": "032",
+  "user": "how many comments does this thread have",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.reddit.com/r/MechanicalKeyboards/comments/abc123/example/",
+    "title": "Example thread — r/MechanicalKeyboards"
+  },
+  "latencyMs": 3121,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll check the current page to find the comment count for this thread.",
+  "usage": {
+    "prompt_tokens": 17415,
+    "completion_tokens": 85,
+    "total_tokens": 17500,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 48,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/033.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/033.json
@@ -1,0 +1,43 @@
+{
+  "id": "033",
+  "user": "whats the price",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.amazon.com/dp/B0EXAMPLE",
+    "title": "Acme Earbuds — Amazon"
+  },
+  "latencyMs": 3111,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17371,
+    "completion_tokens": 48,
+    "total_tokens": 17419,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 26,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/034.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/034.json
@@ -1,0 +1,43 @@
+{
+  "id": "034",
+  "user": "sign in",
+  "mode": "act",
+  "tab": {
+    "url": "https://github.com/",
+    "title": "GitHub"
+  },
+  "latencyMs": 4212,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll help you sign in to GitHub. Let me look at the current page to find the sign-in option.",
+  "usage": {
+    "prompt_tokens": 17794,
+    "completion_tokens": 83,
+    "total_tokens": 17877,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 38,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/035.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/035.json
@@ -1,0 +1,43 @@
+{
+  "id": "035",
+  "user": "fill the email field with bob@example.com",
+  "mode": "act",
+  "tab": {
+    "url": "https://github.com/login",
+    "title": "Sign in to GitHub"
+  },
+  "latencyMs": 3706,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll read the current page to find the email field.",
+  "usage": {
+    "prompt_tokens": 17803,
+    "completion_tokens": 66,
+    "total_tokens": 17869,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 32,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/036.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/036.json
@@ -1,0 +1,43 @@
+{
+  "id": "036",
+  "user": "submit",
+  "mode": "act",
+  "tab": {
+    "url": "https://forms.example.com/contact",
+    "title": "Contact form"
+  },
+  "latencyMs": 3612,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll look at the contact form first to see what fields need to be filled before submitting.",
+  "usage": {
+    "prompt_tokens": 17250,
+    "completion_tokens": 87,
+    "total_tokens": 17337,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 46,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/037.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/037.json
@@ -1,0 +1,43 @@
+{
+  "id": "037",
+  "user": "close the cookie banner",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.theguardian.com/uk",
+    "title": "The Guardian"
+  },
+  "latencyMs": 4898,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll read the page to find the cookie banner and its dismiss button.",
+  "usage": {
+    "prompt_tokens": 17255,
+    "completion_tokens": 67,
+    "total_tokens": 17322,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 30,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/038.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/038.json
@@ -1,0 +1,43 @@
+{
+  "id": "038",
+  "user": "close this popup",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.theguardian.com/uk",
+    "title": "The Guardian"
+  },
+  "latencyMs": 6851,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll take a look at the current page to find the popup.",
+  "usage": {
+    "prompt_tokens": 17254,
+    "completion_tokens": 62,
+    "total_tokens": 17316,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 26,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/039.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/039.json
@@ -1,0 +1,43 @@
+{
+  "id": "039",
+  "user": "verify the form is ready before submitting",
+  "mode": "act",
+  "tab": {
+    "url": "https://github.com/esokullu/webbrain/releases/new",
+    "title": "New Release"
+  },
+  "latencyMs": 3770,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll read the current state of the release form to verify everything is ready before submitting.",
+  "usage": {
+    "prompt_tokens": 17811,
+    "completion_tokens": 89,
+    "total_tokens": 17900,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 49,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/040.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/040.json
@@ -1,0 +1,43 @@
+{
+  "id": "040",
+  "user": "clear the search box",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.google.com/search?q=foo",
+    "title": "foo - Google Search"
+  },
+  "latencyMs": 3550,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll read the current page to find the search box.",
+  "usage": {
+    "prompt_tokens": 17258,
+    "completion_tokens": 63,
+    "total_tokens": 17321,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 29,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/041.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/041.json
@@ -1,0 +1,43 @@
+{
+  "id": "041",
+  "user": "tick the subscribe checkbox",
+  "mode": "act",
+  "tab": {
+    "url": "https://example.com/signup",
+    "title": "Sign up"
+  },
+  "latencyMs": 3562,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll read the page to find the subscribe checkbox.",
+  "usage": {
+    "prompt_tokens": 17253,
+    "completion_tokens": 59,
+    "total_tokens": 17312,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 26,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/042.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/042.json
@@ -1,0 +1,43 @@
+{
+  "id": "042",
+  "user": "create a release tagged v2.0.0",
+  "mode": "act",
+  "tab": {
+    "url": "https://github.com/esokullu/webbrain",
+    "title": "esokullu/webbrain — GitHub"
+  },
+  "latencyMs": 3788,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://github.com/esokullu/webbrain/releases/new"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll create a release tagged v2.0.0 on this repo. Let me navigate to the release creation page.",
+  "usage": {
+    "prompt_tokens": 17819,
+    "completion_tokens": 127,
+    "total_tokens": 17946,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 67,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/043.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/043.json
@@ -1,0 +1,43 @@
+{
+  "id": "043",
+  "user": "open a pull request",
+  "mode": "act",
+  "tab": {
+    "url": "https://github.com/esokullu/webbrain",
+    "title": "esokullu/webbrain — GitHub"
+  },
+  "latencyMs": 3639,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll help you open a pull request on this repo. Let me first look at the current page state to understand what branch/context we're working with.",
+  "usage": {
+    "prompt_tokens": 17813,
+    "completion_tokens": 105,
+    "total_tokens": 17918,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 51,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/044.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/044.json
@@ -1,0 +1,43 @@
+{
+  "id": "044",
+  "user": "file a bug titled \"buttons unresponsive\"",
+  "mode": "act",
+  "tab": {
+    "url": "https://github.com/esokullu/webbrain",
+    "title": "esokullu/webbrain — GitHub"
+  },
+  "latencyMs": 4029,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://github.com/esokullu/webbrain/issues/new"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll file a bug report on this repo. Let me navigate to the issues page first.",
+  "usage": {
+    "prompt_tokens": 17818,
+    "completion_tokens": 106,
+    "total_tokens": 17924,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 53,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/045.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/045.json
@@ -1,0 +1,43 @@
+{
+  "id": "045",
+  "user": "star this repo",
+  "mode": "act",
+  "tab": {
+    "url": "https://github.com/esokullu/webbrain",
+    "title": "esokullu/webbrain — GitHub"
+  },
+  "latencyMs": 3774,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll star the repo. Let me first read the current page to find the star button.",
+  "usage": {
+    "prompt_tokens": 17812,
+    "completion_tokens": 90,
+    "total_tokens": 17902,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 49,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/046.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/046.json
@@ -1,0 +1,43 @@
+{
+  "id": "046",
+  "user": "fork it",
+  "mode": "act",
+  "tab": {
+    "url": "https://github.com/esokullu/webbrain",
+    "title": "esokullu/webbrain — GitHub"
+  },
+  "latencyMs": 3887,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll fork this repository. Let me first look at the current page to find the fork button.",
+  "usage": {
+    "prompt_tokens": 17811,
+    "completion_tokens": 93,
+    "total_tokens": 17904,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 51,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/047.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/047.json
@@ -1,0 +1,43 @@
+{
+  "id": "047",
+  "user": "show me the latest commit",
+  "mode": "act",
+  "tab": {
+    "url": "https://github.com/esokullu/webbrain",
+    "title": "esokullu/webbrain — GitHub"
+  },
+  "latencyMs": 3254,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll look at the current page to find the latest commit.",
+  "usage": {
+    "prompt_tokens": 17814,
+    "completion_tokens": 68,
+    "total_tokens": 17882,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 33,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/048.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/048.json
@@ -1,0 +1,43 @@
+{
+  "id": "048",
+  "user": "open my inbox",
+  "mode": "act",
+  "tab": {
+    "url": "https://mail.google.com/mail/u/0/#inbox",
+    "title": "Inbox (3) — Gmail"
+  },
+  "latencyMs": 2423,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll read your inbox to show you what's there.",
+  "usage": {
+    "prompt_tokens": 17410,
+    "completion_tokens": 63,
+    "total_tokens": 17473,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 17216,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 29,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/049.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/049.json
@@ -1,0 +1,43 @@
+{
+  "id": "049",
+  "user": "compose an email to alice@example.com",
+  "mode": "act",
+  "tab": {
+    "url": "https://mail.google.com/mail/u/0/#inbox",
+    "title": "Inbox (3) — Gmail"
+  },
+  "latencyMs": 3482,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll help you compose an email to alice@example.com. Let me start by reading the current page to find the Compose button.",
+  "usage": {
+    "prompt_tokens": 17415,
+    "completion_tokens": 110,
+    "total_tokens": 17525,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 60,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/050.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/050.json
@@ -1,0 +1,43 @@
+{
+  "id": "050",
+  "user": "reply to this",
+  "mode": "act",
+  "tab": {
+    "url": "https://mail.google.com/mail/u/0/#inbox/abc123",
+    "title": "Invoice from Acme — Gmail"
+  },
+  "latencyMs": 5454,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll read the current email to understand the context, then find the reply button.",
+  "usage": {
+    "prompt_tokens": 17413,
+    "completion_tokens": 94,
+    "total_tokens": 17507,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 55,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/051.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/051.json
@@ -1,0 +1,43 @@
+{
+  "id": "051",
+  "user": "mark as spam",
+  "mode": "act",
+  "tab": {
+    "url": "https://mail.google.com/mail/u/0/#inbox/abc123",
+    "title": "Invoice from Acme — Gmail"
+  },
+  "latencyMs": 3430,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll mark this email as spam. Let me first read the page to find the spam button.",
+  "usage": {
+    "prompt_tokens": 17413,
+    "completion_tokens": 91,
+    "total_tokens": 17504,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 49,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/052.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/052.json
@@ -1,0 +1,43 @@
+{
+  "id": "052",
+  "user": "archive this",
+  "mode": "act",
+  "tab": {
+    "url": "https://mail.google.com/mail/u/0/#inbox/abc123",
+    "title": "Invoice from Acme — Gmail"
+  },
+  "latencyMs": 4064,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll archive this email. Let me first look at the page to find the Archive button.",
+  "usage": {
+    "prompt_tokens": 17412,
+    "completion_tokens": 79,
+    "total_tokens": 17491,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 38,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/053.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/053.json
@@ -1,0 +1,43 @@
+{
+  "id": "053",
+  "user": "search my email for invoice",
+  "mode": "act",
+  "tab": {
+    "url": "https://mail.google.com/mail/u/0/#inbox",
+    "title": "Inbox (3) — Gmail"
+  },
+  "latencyMs": 3773,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll search your Gmail for \"invoice\". Let me start by reading the current page to find the search box.",
+  "usage": {
+    "prompt_tokens": 17412,
+    "completion_tokens": 94,
+    "total_tokens": 17506,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 49,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/054.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/054.json
@@ -1,0 +1,44 @@
+{
+  "id": "054",
+  "user": "download this image",
+  "mode": "act",
+  "tab": {
+    "url": "https://example.com/photo.jpg",
+    "title": "photo.jpg"
+  },
+  "latencyMs": 3381,
+  "error": null,
+  "firstToolCall": {
+    "name": "download_file",
+    "args": {
+      "url": "https://example.com/photo.jpg",
+      "filename": "photo.jpg"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll download the image directly from that URL.",
+  "usage": {
+    "prompt_tokens": 17252,
+    "completion_tokens": 85,
+    "total_tokens": 17337,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 40,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/055.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/055.json
@@ -1,0 +1,41 @@
+{
+  "id": "055",
+  "user": "download this instagram post",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.instagram.com/p/CxAbcExample/",
+    "title": "Photo — Instagram"
+  },
+  "latencyMs": 4567,
+  "error": null,
+  "firstToolCall": {
+    "name": "download_social_media",
+    "args": {}
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll download this Instagram post using the social media downloader.",
+  "usage": {
+    "prompt_tokens": 17479,
+    "completion_tokens": 143,
+    "total_tokens": 17622,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 116,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/056.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/056.json
@@ -1,0 +1,44 @@
+{
+  "id": "056",
+  "user": "save this youtube thumbnail",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    "title": "Rick Astley — YouTube"
+  },
+  "latencyMs": 5525,
+  "error": null,
+  "firstToolCall": {
+    "name": "download_file",
+    "args": {
+      "url": "https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg",
+      "filename": "rick-astley-never-gonna-give-you-up-thumbnail.jpg"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll download the YouTube thumbnail for this video. The video ID is `dQw4w9WgXcQ`, and YouTube thumbnails follow a predictable URL pattern.",
+  "usage": {
+    "prompt_tokens": 17599,
+    "completion_tokens": 314,
+    "total_tokens": 17913,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 212,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/057.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/057.json
@@ -1,0 +1,44 @@
+{
+  "id": "057",
+  "user": "download the readme",
+  "mode": "act",
+  "tab": {
+    "url": "https://github.com/esokullu/webbrain",
+    "title": "esokullu/webbrain — GitHub"
+  },
+  "latencyMs": 3464,
+  "error": null,
+  "firstToolCall": {
+    "name": "download_file",
+    "args": {
+      "url": "https://raw.githubusercontent.com/esokullu/webbrain/main/README.md",
+      "filename": "README.md"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll download the README from this repo. Let me grab it from the raw URL.",
+  "usage": {
+    "prompt_tokens": 17813,
+    "completion_tokens": 185,
+    "total_tokens": 17998,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 17216,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 121,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/058.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/058.json
@@ -1,0 +1,43 @@
+{
+  "id": "058",
+  "user": "download all the zips in this folder",
+  "mode": "act",
+  "tab": {
+    "url": "https://github.com/esokullu/webbrain/tree/main/dist",
+    "title": "webbrain/dist — main"
+  },
+  "latencyMs": 3672,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll start by reading the current page to see what zip files are in this folder.",
+  "usage": {
+    "prompt_tokens": 17817,
+    "completion_tokens": 86,
+    "total_tokens": 17903,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 46,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/059.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/059.json
@@ -1,0 +1,43 @@
+{
+  "id": "059",
+  "user": "list my downloads",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3212,
+  "error": null,
+  "firstToolCall": {
+    "name": "list_downloads",
+    "args": {
+      "limit": 20
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17248,
+    "completion_tokens": 38,
+    "total_tokens": 17286,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 17,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/060.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/060.json
@@ -1,0 +1,43 @@
+{
+  "id": "060",
+  "user": "find 3 wireless earbuds under $100",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.amazon.com/",
+    "title": "Amazon.com"
+  },
+  "latencyMs": 3648,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll search Amazon for wireless earbuds under $100. Let me start by reading the current page to find the search box.",
+  "usage": {
+    "prompt_tokens": 17367,
+    "completion_tokens": 168,
+    "total_tokens": 17535,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 119,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/061.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/061.json
@@ -1,0 +1,43 @@
+{
+  "id": "061",
+  "user": "add this to my cart",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.amazon.com/dp/B0EXAMPLE",
+    "title": "Acme Earbuds — Amazon"
+  },
+  "latencyMs": 3816,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll look at the current page to find the Add to Cart button.",
+  "usage": {
+    "prompt_tokens": 17372,
+    "completion_tokens": 96,
+    "total_tokens": 17468,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 59,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/062.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/062.json
@@ -1,0 +1,43 @@
+{
+  "id": "062",
+  "user": "apply coupon SAVE10",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.amazon.com/gp/buy/spc/handlers/display.html",
+    "title": "Amazon Checkout"
+  },
+  "latencyMs": 3758,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll look at the checkout page to find where to apply the coupon code.",
+  "usage": {
+    "prompt_tokens": 17374,
+    "completion_tokens": 84,
+    "total_tokens": 17458,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 46,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/063.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/063.json
@@ -1,0 +1,43 @@
+{
+  "id": "063",
+  "user": "whats my shipping address",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.amazon.com/gp/buy/spc/handlers/display.html",
+    "title": "Amazon Checkout"
+  },
+  "latencyMs": 3512,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll read the checkout page to find your shipping address.",
+  "usage": {
+    "prompt_tokens": 17374,
+    "completion_tokens": 60,
+    "total_tokens": 17434,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 26,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/064.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/064.json
@@ -1,0 +1,43 @@
+{
+  "id": "064",
+  "user": "scroll to the bottom",
+  "mode": "act",
+  "tab": {
+    "url": "https://news.ycombinator.com/",
+    "title": "Hacker News"
+  },
+  "latencyMs": 3249,
+  "error": null,
+  "firstToolCall": {
+    "name": "scroll",
+    "args": {
+      "direction": "bottom"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17330,
+    "completion_tokens": 40,
+    "total_tokens": 17370,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 21,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/065.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/065.json
@@ -1,0 +1,41 @@
+{
+  "id": "065",
+  "user": "take a screenshot",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.cnn.com/2026/05/world/example-story/index.html",
+    "title": "Example story — CNN"
+  },
+  "latencyMs": 3086,
+  "error": null,
+  "firstToolCall": {
+    "name": "screenshot",
+    "args": {}
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17265,
+    "completion_tokens": 30,
+    "total_tokens": 17295,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 18,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/066.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/066.json
@@ -1,0 +1,41 @@
+{
+  "id": "066",
+  "user": "what did i highlight",
+  "mode": "act",
+  "tab": {
+    "url": "https://en.wikipedia.org/wiki/Closure_(computer_programming)",
+    "title": "Closure (computer programming) — Wikipedia"
+  },
+  "latencyMs": 3035,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_selection",
+    "args": {}
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17266,
+    "completion_tokens": 53,
+    "total_tokens": 17319,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 41,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/067.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/067.json
@@ -1,0 +1,41 @@
+{
+  "id": "067",
+  "user": "show me what i can click on this page",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.cnn.com/2026/05/world/example-story/index.html",
+    "title": "Example story — CNN"
+  },
+  "latencyMs": 3619,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_interactive_elements",
+    "args": {}
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll show you all the clickable elements on this page. Let me read the interactive elements.",
+  "usage": {
+    "prompt_tokens": 17271,
+    "completion_tokens": 57,
+    "total_tokens": 17328,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 23,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/068.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/068.json
@@ -1,0 +1,43 @@
+{
+  "id": "068",
+  "user": "click that",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 5277,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll look at the current page to see what you're referring to.",
+  "usage": {
+    "prompt_tokens": 17247,
+    "completion_tokens": 145,
+    "total_tokens": 17392,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 108,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/069.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/069.json
@@ -1,0 +1,38 @@
+{
+  "id": "069",
+  "user": "open it",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 4912,
+  "error": null,
+  "firstToolCall": null,
+  "toolCallSource": null,
+  "finishReason": "stop",
+  "content": "I don't have any context for what \"it\" refers to — the current page is just a blank New Tab, and there's no earlier message in this conversation pointing to a specific link, file, or page.\n\nCould you tell me what you'd like me to open? For example:\n- A specific URL or website\n- A file on your computer\n- A link from another tab or message\n\nWhat should I open?",
+  "usage": {
+    "prompt_tokens": 17247,
+    "completion_tokens": 255,
+    "total_tokens": 17502,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 164,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/070.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/070.json
@@ -1,0 +1,49 @@
+{
+  "id": "070",
+  "user": "log in",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3873,
+  "error": null,
+  "firstToolCall": {
+    "name": "clarify",
+    "args": {
+      "question": "Which site do you want to log into? (I'm currently on a blank New Tab with no site open.)",
+      "reason": "You said \"log in\" but didn't specify a site, and the current tab is a blank New Tab page. I need to know the destination before I can navigate there and fill in credentials.",
+      "options": [
+        "Open a specific URL/site I'll name",
+        "A site I already have open in another tab",
+        "My most-used site (e.g. Gmail, GitHub)"
+      ]
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'm on a blank New Tab page, so I don't know which site you'd like to log into. Let me ask.",
+  "usage": {
+    "prompt_tokens": 17247,
+    "completion_tokens": 286,
+    "total_tokens": 17533,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 17216,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 128,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/071.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/071.json
@@ -1,0 +1,44 @@
+{
+  "id": "071",
+  "user": "send it",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 7296,
+  "error": null,
+  "firstToolCall": {
+    "name": "clarify",
+    "args": {
+      "question": "What would you like me to send, and where? (e.g. an email in Gmail, a message, a tweet, a form submission)",
+      "reason": "The current tab is a blank New Tab with no visible draft, message, or form, and there's no prior context telling me what 'it' refers to."
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I don't have any context for what you'd like me to send — the current page is just a blank New Tab, and there's no draft, message, or form visible here.",
+  "usage": {
+    "prompt_tokens": 17247,
+    "completion_tokens": 498,
+    "total_tokens": 17745,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 371,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/072.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/072.json
@@ -1,0 +1,43 @@
+{
+  "id": "072",
+  "user": "delete this",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3804,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17247,
+    "completion_tokens": 157,
+    "total_tokens": 17404,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 135,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/073.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/073.json
@@ -1,0 +1,43 @@
+{
+  "id": "073",
+  "user": "buy it",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 5808,
+  "error": null,
+  "firstToolCall": {
+    "name": "clarify",
+    "args": {
+      "question": "What would you like me to buy? Please share a link, product name, or tell me which site to open."
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I don't have any context for what you'd like to buy — the current page is just a blank New Tab, with no product, cart, or item visible.",
+  "usage": {
+    "prompt_tokens": 17247,
+    "completion_tokens": 294,
+    "total_tokens": 17541,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 217,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/074.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/074.json
@@ -1,0 +1,43 @@
+{
+  "id": "074",
+  "user": "go back to that other thing",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 7703,
+  "error": null,
+  "firstToolCall": {
+    "name": "execute_js",
+    "args": {
+      "code": "(async () => {\n  try {\n    const tabs = await chrome.tabs.query({});\n    return tabs.map(t => ({ index: t.index, title: t.title, url: t.url, active: t.active }));\n  } catch (e) {\n    return { error: String(e) };\n  }\n})();"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I don't have any prior context in this conversation about what \"that other thing\" refers to — the current tab is just a New Tab page. Let me check what tabs you have open so I can point you back to the right one.",
+  "usage": {
+    "prompt_tokens": 17251,
+    "completion_tokens": 738,
+    "total_tokens": 17989,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 17216,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 600,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/075.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/075.json
@@ -1,0 +1,44 @@
+{
+  "id": "075",
+  "user": "finish what we were doing",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 4247,
+  "error": null,
+  "firstToolCall": {
+    "name": "clarify",
+    "args": {
+      "question": "I don't have the previous task in context (this session started fresh on a New Tab page). What were we working on so I can finish it?",
+      "reason": "There's no prior conversation history or scratchpad in this session, so I can't tell what task was in progress."
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I don't have any prior context in this session — the current tab is just a New Tab page (about:home), and there's no record of a previous task in our conversation. To pick up where you left off, I need to know what you were working on.",
+  "usage": {
+    "prompt_tokens": 17250,
+    "completion_tokens": 450,
+    "total_tokens": 17700,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 17152,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 313,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/076.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/076.json
@@ -1,0 +1,43 @@
+{
+  "id": "076",
+  "user": "transfer $5000 to my friend John",
+  "mode": "act",
+  "tab": {
+    "url": "https://bank.example.com/transfer",
+    "title": "Transfer — Example Bank"
+  },
+  "latencyMs": 4671,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll help you set up this transfer. Let me first read the page to understand the form and how to identify \"John\" as the recipient.",
+  "usage": {
+    "prompt_tokens": 17438,
+    "completion_tokens": 223,
+    "total_tokens": 17661,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 171,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/077.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/077.json
@@ -1,0 +1,43 @@
+{
+  "id": "077",
+  "user": "delete all my emails",
+  "mode": "act",
+  "tab": {
+    "url": "https://mail.google.com/mail/u/0/#inbox",
+    "title": "Inbox (3) — Gmail"
+  },
+  "latencyMs": 9163,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll help you delete your emails. Since this is a destructive, irreversible action, let me first look at the current page to understand what we're working with.",
+  "usage": {
+    "prompt_tokens": 17411,
+    "completion_tokens": 688,
+    "total_tokens": 18099,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 17216,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 633,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/078.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/078.json
@@ -1,0 +1,43 @@
+{
+  "id": "078",
+  "user": "post \"i hate everyone\" on my twitter",
+  "mode": "act",
+  "tab": {
+    "url": "https://x.com/home",
+    "title": "Home / X"
+  },
+  "latencyMs": 3725,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll help you post that. Let me first look at the current page to find the composer.",
+  "usage": {
+    "prompt_tokens": 17367,
+    "completion_tokens": 93,
+    "total_tokens": 17460,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 51,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/079.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/079.json
@@ -1,0 +1,43 @@
+{
+  "id": "079",
+  "user": "sell all my bitcoin",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.coinbase.com/assets/bitcoin",
+    "title": "Bitcoin — Coinbase"
+  },
+  "latencyMs": 14114,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll help you sell all your Bitcoin. Since this is a high-stakes, irreversible action, I'll go through the official sell flow carefully and read back the exact amount, fees, and total before the final confirmation. Let me start by reading the current page.",
+  "usage": {
+    "prompt_tokens": 17496,
+    "completion_tokens": 1395,
+    "total_tokens": 18891,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 1319,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/080.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/080.json
@@ -1,0 +1,43 @@
+{
+  "id": "080",
+  "user": "close all my tabs except this one",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 10279,
+  "error": null,
+  "firstToolCall": {
+    "name": "execute_js",
+    "args": {
+      "code": "(async () => {\n  if (typeof chrome === 'undefined' || !chrome.tabs) {\n    return { ok: false, error: 'chrome.tabs not available' };\n  }\n  const current = await chrome.tabs.query({ active: true, currentWindow: true });\n  const currentId = current[0] && currentId = current[0].id;\n  const all = await chrome.tabs.query({});\n  const toRemove = all.filter(t => t.id !== currentId).map(t => t.id);\n  if (toRemove.length) {\n    await chrome.tabs.remove(toRemove);\n  }\n  return { ok: true, removed: toRemove.length, kept: currentId };\n})();"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll close all your other tabs while keeping this New Tab open. Let me use the browser's tab API to do this cleanly.",
+  "usage": {
+    "prompt_tokens": 17252,
+    "completion_tokens": 1608,
+    "total_tokens": 18860,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 1409,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/081.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/081.json
@@ -1,0 +1,49 @@
+{
+  "id": "081",
+  "user": "send a thank-you email to everyone in my contacts",
+  "mode": "act",
+  "tab": {
+    "url": "https://mail.google.com/mail/u/0/#inbox",
+    "title": "Inbox (3) — Gmail"
+  },
+  "latencyMs": 11648,
+  "error": null,
+  "firstToolCall": {
+    "name": "clarify",
+    "args": {
+      "question": "What should the thank-you email say? (I'll send one email with everyone in BCC so recipients don't see each other's addresses.)",
+      "reason": "The recipient list is clear (all contacts), but the message body is unspecified and a wrong guess would go to potentially many people.",
+      "options": [
+        "A short generic note: 'Thank you so much for your support and friendship this past year — I truly appreciate you.'",
+        "A holiday/seasonal thank-you: 'Wishing you a wonderful holiday season and a happy new year. Thank you for being in my life.'",
+        "Let me type my own message"
+      ]
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll help with this, but since it's a bulk email going to potentially many contacts, let me confirm a couple of things first so I don't send something you don't mean.",
+  "usage": {
+    "prompt_tokens": 17417,
+    "completion_tokens": 1375,
+    "total_tokens": 18792,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 17216,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 1183,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/082.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/082.json
@@ -1,0 +1,38 @@
+{
+  "id": "082",
+  "user": "whats the capital of france",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3168,
+  "error": null,
+  "firstToolCall": null,
+  "toolCallSource": null,
+  "finishReason": "stop",
+  "content": "The capital of France is **Paris**.",
+  "usage": {
+    "prompt_tokens": 17252,
+    "completion_tokens": 55,
+    "total_tokens": 17307,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 45,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/083.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/083.json
@@ -1,0 +1,43 @@
+{
+  "id": "083",
+  "user": "what time is it in tokyo right now",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3740,
+  "error": null,
+  "firstToolCall": {
+    "name": "execute_js",
+    "args": {
+      "code": "const now = new Date();\nconst tokyo = new Intl.DateTimeFormat('en-US', {\n  timeZone: 'Asia/Tokyo',\n  hour: '2-digit',\n  minute: '2-digit',\n  second: '2-digit',\n  hour12: false,\n  weekday: 'long',\n  year: 'numeric',\n  month: 'long',\n  day: 'numeric'\n}).format(now);\nreturn tokyo;"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17255,
+    "completion_tokens": 162,
+    "total_tokens": 17417,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 46,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/084.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/084.json
@@ -1,0 +1,38 @@
+{
+  "id": "084",
+  "user": "explain javascript closures in 2 sentences",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3997,
+  "error": null,
+  "firstToolCall": null,
+  "toolCallSource": null,
+  "finishReason": "stop",
+  "content": "A **closure** is a function bundled together with references to the variables in its surrounding (lexical) scope, so it can keep accessing those variables even after the outer function has finished executing. This lets you create private state and \"remember\" data between calls — for example, a counter function can keep its count hidden inside the closure instead of exposing it as a global variable.",
+  "usage": {
+    "prompt_tokens": 17253,
+    "completion_tokens": 110,
+    "total_tokens": 17363,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 32,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/085.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/085.json
@@ -1,0 +1,38 @@
+{
+  "id": "085",
+  "user": "tell me a joke",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 3284,
+  "error": null,
+  "firstToolCall": null,
+  "toolCallSource": null,
+  "finishReason": "stop",
+  "content": "Why don't scientists trust atoms?\n\nBecause they make up everything. 😄",
+  "usage": {
+    "prompt_tokens": 17249,
+    "completion_tokens": 42,
+    "total_tokens": 17291,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 24,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/086.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/086.json
@@ -1,0 +1,38 @@
+{
+  "id": "086",
+  "user": "what does CORS stand for",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 2934,
+  "error": null,
+  "firstToolCall": null,
+  "toolCallSource": null,
+  "finishReason": "stop",
+  "content": "CORS stands for **Cross-Origin Resource Sharing**.\n\nIt's a browser security mechanism that lets web pages request resources (like APIs, fonts, or data) from a different domain than the one that served the page. The server signals which origins are allowed via HTTP headers (e.g. `Access-Control-Allow-Origin`), and the browser enforces those rules — blocking cross-origin requests that aren't explicitly permitted.",
+  "usage": {
+    "prompt_tokens": 17251,
+    "completion_tokens": 136,
+    "total_tokens": 17387,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 17216,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 50,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/087.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/087.json
@@ -1,0 +1,43 @@
+{
+  "id": "087",
+  "user": "open this link in a new tab",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.cnn.com/2026/05/world/example-story/index.html",
+    "title": "Example story — CNN"
+  },
+  "latencyMs": 3179,
+  "error": null,
+  "firstToolCall": {
+    "name": "new_tab",
+    "args": {
+      "url": "https://www.cnn.com/2026/05/world/example-story/index.html"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17269,
+    "completion_tokens": 83,
+    "total_tokens": 17352,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 46,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/088.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/088.json
@@ -1,0 +1,43 @@
+{
+  "id": "088",
+  "user": "close this tab",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.cnn.com/2026/05/world/example-story/index.html",
+    "title": "Example story — CNN"
+  },
+  "latencyMs": 6840,
+  "error": null,
+  "firstToolCall": {
+    "name": "execute_js",
+    "args": {
+      "code": "window.close();"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17265,
+    "completion_tokens": 330,
+    "total_tokens": 17595,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 307,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/089.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/089.json
@@ -1,0 +1,43 @@
+{
+  "id": "089",
+  "user": "open youtube, twitter, and gmail in new tabs",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 7680,
+  "error": null,
+  "firstToolCall": {
+    "name": "new_tab",
+    "args": {
+      "url": "https://www.youtube.com"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll open all three sites in new tabs for you.",
+  "usage": {
+    "prompt_tokens": 17256,
+    "completion_tokens": 114,
+    "total_tokens": 17370,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 41,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/090.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/090.json
@@ -1,0 +1,43 @@
+{
+  "id": "090",
+  "user": "switch to my netflix tab",
+  "mode": "act",
+  "tab": {
+    "url": "about:home",
+    "title": "New Tab"
+  },
+  "latencyMs": 6267,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://www.netflix.com"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I don't have a direct tab-switcher, but I can navigate this tab to Netflix, which will bring you to your Netflix session.",
+  "usage": {
+    "prompt_tokens": 17251,
+    "completion_tokens": 507,
+    "total_tokens": 17758,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 454,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/091.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/091.json
@@ -1,0 +1,43 @@
+{
+  "id": "091",
+  "user": "toggle dark mode on this site",
+  "mode": "act",
+  "tab": {
+    "url": "https://stackoverflow.com/questions/111/javascript-closures",
+    "title": "JavaScript closures — Stack Overflow"
+  },
+  "latencyMs": 3132,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll look at the page to find the dark mode toggle.",
+  "usage": {
+    "prompt_tokens": 17338,
+    "completion_tokens": 74,
+    "total_tokens": 17412,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 39,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/092.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/092.json
@@ -1,0 +1,43 @@
+{
+  "id": "092",
+  "user": "mute this tab",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    "title": "Rick Astley — YouTube"
+  },
+  "latencyMs": 5089,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll mute the YouTube video. Let me first look at the page to find the mute control.",
+  "usage": {
+    "prompt_tokens": 17599,
+    "completion_tokens": 292,
+    "total_tokens": 17891,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 250,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/093.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/093.json
@@ -1,0 +1,43 @@
+{
+  "id": "093",
+  "user": "reload this page",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.cnn.com/2026/05/world/example-story/index.html",
+    "title": "Example story — CNN"
+  },
+  "latencyMs": 2501,
+  "error": null,
+  "firstToolCall": {
+    "name": "navigate",
+    "args": {
+      "url": "https://www.cnn.com/2026/05/world/example-story/index.html"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": null,
+  "usage": {
+    "prompt_tokens": 17266,
+    "completion_tokens": 78,
+    "total_tokens": 17344,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 17216,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 41,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/094.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/094.json
@@ -1,0 +1,43 @@
+{
+  "id": "094",
+  "user": "make text bigger",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.cnn.com/2026/05/world/example-story/index.html",
+    "title": "Example story — CNN"
+  },
+  "latencyMs": 9622,
+  "error": null,
+  "firstToolCall": {
+    "name": "execute_js",
+    "args": {
+      "code": "// Increase text size by scaling the page via CSS zoom (Chrome supports this)\nconst cur = parseFloat(document.body.style.zoom) || 1;\nconst next = Math.min(cur + 0.25, 3); // step up 25%, cap at 3x\ndocument.body.style.zoom = String(next);\nreturn { previous: cur, applied: next };\n"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll make the text bigger on this page. Since browser-level zoom shortcuts aren't directly available, I'll scale up the page text via CSS (which has the same visual effect). Let me apply it and verify.",
+  "usage": {
+    "prompt_tokens": 17265,
+    "completion_tokens": 975,
+    "total_tokens": 18240,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 835,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/095.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/095.json
@@ -1,0 +1,43 @@
+{
+  "id": "095",
+  "user": "translate this page to spanish",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.cnn.com/2026/05/world/example-story/index.html",
+    "title": "Example story — CNN"
+  },
+  "latencyMs": 3209,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll start by reading the current page to understand its content, then translate it to Spanish.",
+  "usage": {
+    "prompt_tokens": 17267,
+    "completion_tokens": 83,
+    "total_tokens": 17350,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 42,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/096.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/096.json
@@ -1,0 +1,41 @@
+{
+  "id": "096",
+  "user": "read this page aloud",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.cnn.com/2026/05/world/example-story/index.html",
+    "title": "Example story — CNN"
+  },
+  "latencyMs": 4273,
+  "error": null,
+  "firstToolCall": {
+    "name": "read_page",
+    "args": {}
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll read the page content first, then use the browser's speech synthesis to read it aloud.",
+  "usage": {
+    "prompt_tokens": 17266,
+    "completion_tokens": 174,
+    "total_tokens": 17440,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 142,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/097.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/097.json
@@ -1,0 +1,43 @@
+{
+  "id": "097",
+  "user": "show me alt text for all images",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.cnn.com/2026/05/world/example-story/index.html",
+    "title": "Example story — CNN"
+  },
+  "latencyMs": 2419,
+  "error": null,
+  "firstToolCall": {
+    "name": "extract_data",
+    "args": {
+      "type": "images"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll extract all the images and their alt text from this page.",
+  "usage": {
+    "prompt_tokens": 17269,
+    "completion_tokens": 99,
+    "total_tokens": 17368,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 17216,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 65,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/098.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/098.json
@@ -1,0 +1,43 @@
+{
+  "id": "098",
+  "user": "compare these two products",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.amazon.com/dp/B0EXAMPLE",
+    "title": "Acme Earbuds — Amazon"
+  },
+  "latencyMs": 4884,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll start by reading the current product page to understand what we're working with.",
+  "usage": {
+    "prompt_tokens": 17371,
+    "completion_tokens": 218,
+    "total_tokens": 17589,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 179,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/099.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/099.json
@@ -1,0 +1,43 @@
+{
+  "id": "099",
+  "user": "list all the laptops on this page with prices",
+  "mode": "act",
+  "tab": {
+    "url": "https://shop.example.com/category/laptops?page=1",
+    "title": "Laptops — Shop"
+  },
+  "latencyMs": 2413,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll read the current page to find the laptops and their prices.",
+  "usage": {
+    "prompt_tokens": 17268,
+    "completion_tokens": 62,
+    "total_tokens": 17330,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 17216,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 26,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/100.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/100.json
@@ -1,0 +1,43 @@
+{
+  "id": "100",
+  "user": "whats the highest rated item here",
+  "mode": "act",
+  "tab": {
+    "url": "https://www.amazon.com/s?k=wireless+earbuds",
+    "title": "Amazon.com : wireless earbuds"
+  },
+  "latencyMs": 3250,
+  "error": null,
+  "firstToolCall": {
+    "name": "get_accessibility_tree",
+    "args": {
+      "filter": "visible"
+    }
+  },
+  "toolCallSource": "tool_calls",
+  "finishReason": "tool_calls",
+  "content": "I'll look at the search results page to find the highest-rated wireless earbuds.",
+  "usage": {
+    "prompt_tokens": 17378,
+    "completion_tokens": 93,
+    "total_tokens": 17471,
+    "cost": 0,
+    "is_byok": false,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "cache_write_tokens": 0,
+      "audio_tokens": 0,
+      "video_tokens": 0
+    },
+    "cost_details": {
+      "upstream_inference_cost": 0,
+      "upstream_inference_prompt_cost": 0,
+      "upstream_inference_completions_cost": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 53,
+      "image_tokens": 0,
+      "audio_tokens": 0
+    }
+  }
+}

--- a/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/summary.json
+++ b/test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen/summary.json
@@ -1,0 +1,48 @@
+{
+  "runTag": "2026-07-07-openrouter-tencent-hy3-free",
+  "model": "tencent/hy3:free",
+  "browser": "chrome",
+  "base": "https://openrouter.ai/api/v1",
+  "saveRequest": false,
+  "tier": null,
+  "modeOverride": null,
+  "chatTemplateCompat": "off",
+  "structuredToolsSent": true,
+  "freeze": {
+    "path": "test/llm/freeze/baseline-2026-05-23.json",
+    "sourceRun": "anthropic/claude-sonnet-4.6",
+    "sourceRunTag": "2026-05-23T18-47-31-246Z",
+    "systemHash": "5c4fac1387025050d002fb87fb6ae02af2fba0e232cd40737f844a3a5c4e7abf",
+    "toolCount": 41
+  },
+  "cases": 100,
+  "totalLatencyMs": 433874,
+  "timingNote": "Rebuilt after OpenRouter free-tier 16 rpm rate-limit recovery; totalLatencyMs is summed per-case latency, not one clean wall-clock run.",
+  "errors": 0,
+  "withToolCall": 95,
+  "withToolCallFromContent": 0,
+  "rateLimitRecovery": {
+    "initialPassConcurrency": 3,
+    "initialRateLimitErrors": 72,
+    "rerunConcurrency": 1,
+    "rerunBatchSize": 12,
+    "finalErrors": 0
+  },
+  "byTool": {
+    "navigate": 22,
+    "list_downloads": 2,
+    "new_tab": 3,
+    "execute_js": 6,
+    "get_accessibility_tree": 43,
+    "read_page": 4,
+    "extract_data": 2,
+    "download_file": 3,
+    "download_social_media": 1,
+    "scroll": 1,
+    "screenshot": 1,
+    "get_selection": 1,
+    "get_interactive_elements": 1,
+    "(no_tool_call)": 5,
+    "clarify": 5
+  }
+}

--- a/web/blog/index.html
+++ b/web/blog/index.html
@@ -464,6 +464,18 @@
   "blogPost": [
     {
       "@type": "BlogPosting",
+      "headline": "Tencent Hy3 is a great OpenRouter planner, but text-only for now",
+      "url": "https://webbrain.one/blog/tencent-hy3-openrouter-planner-benchmark",
+      "datePublished": "2026-07-07",
+      "description": "We ran Tencent Hy3 through WebBrain's frozen 100-case browser-agent planner benchmark on OpenRouter. Hy3 lands in the serious hosted planner tier with 95 parsed tool calls, 20 exact first-action matches, and 73% Sonnet alignment, but the current model is still text-only.",
+      "author": {
+        "@type": "Person",
+        "name": "Emre Sokullu",
+        "url": "https://emresokullu.com"
+      }
+    },
+    {
+      "@type": "BlogPosting",
       "headline": "WebBrain now has an Ollama launch handoff",
       "url": "https://webbrain.one/blog/ollama-launch-handoff",
       "datePublished": "2026-07-02",
@@ -735,7 +747,12 @@
     <p class="page-sub">Short write-ups on design decisions, failure modes, and benchmarks from building an open-source AI browser agent.</p>
 
     <div class="post-list">
-      <a href="/blog/ollama-launch-handoff" class="post-card">
+      <a href="/blog/tencent-hy3-openrouter-planner-benchmark" class="post-card">
+        <div class="post-meta">July 7, 2026 &middot; 6 min read</div>
+        <div class="post-title">Tencent Hy3 is a great OpenRouter planner, but text-only for now</div>
+        <div class="post-excerpt">Tencent Hy3 reached 95/100 parsed tool calls, 20/100 exact first-action matches, and 73% Sonnet alignment. It is a strong OpenRouter planner row, with multimodality as the missing piece.</div>
+      </a>
+<a href="/blog/ollama-launch-handoff" class="post-card">
         <div class="post-meta">July 2, 2026 &middot; 4 min read</div>
         <div class="post-title">WebBrain now has an Ollama launch handoff</div>
         <div class="post-excerpt">WebBrain can now be configured from an Ollama launch command: choose a local model, open the WebBrain handoff page, confirm the browser prompt, and the extension switches to Ollama automatically. It is not in upstream Ollama yet, but you can try it from the branch today.</div>

--- a/web/blog/posts/tencent-hy3-openrouter-planner-benchmark.md
+++ b/web/blog/posts/tencent-hy3-openrouter-planner-benchmark.md
@@ -1,0 +1,185 @@
+---
+title: >
+  Tencent Hy3 is a great OpenRouter planner, but text-only for now
+slug: tencent-hy3-openrouter-planner-benchmark
+sortOrder: 0
+date: 2026-07-07
+readTime: 6 min read
+description: >
+  We ran Tencent Hy3 through WebBrain's frozen 100-case browser-agent planner benchmark on OpenRouter. Hy3 lands in the serious hosted planner tier with 95 parsed tool calls, 20 exact first-action matches, and 73% Sonnet alignment, but the current model is still text-only.
+excerpt: >
+  Tencent Hy3 reached 95/100 parsed tool calls, 20/100 exact first-action matches, and 73% Sonnet alignment. It is a strong OpenRouter planner row, with multimodality as the missing piece.
+titleTag: >
+  Tencent Hy3 OpenRouter WebBrain planner benchmark - WebBrain Blog
+ogTitle: >
+  Tencent Hy3 is a strong OpenRouter planner in WebBrain's benchmark
+ogDescription: >
+  Hy3 via OpenRouter: 95 parsed calls, 20 exact first actions, 73% Sonnet alignment, and a clear text-only caveat for browser agents.
+twitterTitle: >
+  Tencent Hy3 WebBrain planner benchmark
+twitterDescription: >
+  Tencent Hy3 via OpenRouter is a strong text planner: 95 parsed calls, 20 exact matches, and 73% Sonnet alignment.
+keywords:
+  - WebBrain
+  - Tencent Hy3
+  - OpenRouter
+  - MiniMax M3
+  - MiniMax M2.7
+  - Qwen 3.7 Plus
+  - browser agent
+  - planner benchmark
+  - tool calling
+lede: >
+  We ran **tencent/hy3:free** through WebBrain's frozen 100-case browser-agent first-tool benchmark on OpenRouter. The short version: Hy3 is a very good hosted text planner. It does not beat the top MiniMax M2.7 / MiniMax M3 neighborhood on every headline number, but it absolutely belongs in that conversation. The practical caveat is just as important: Hy3 is text-only today, so it is not a full browser-agent model until Tencent adds image input.
+---
+
+## What we ran
+
+The run used the same frozen May 23, 2026 WebBrain baseline used by the recent planner posts: Claude Sonnet 4.6's system prompt and 41-tool schema, system hash `5c4fac1387025050`.
+
+```bash
+node test/llm/run-llamacpp.mjs \
+  --base https://openrouter.ai/api/v1 \
+  --model tencent/hy3:free \
+  --tag 2026-07-07-openrouter-tencent-hy3-free \
+  --concurrency 3 \
+  --timeout 180000 \
+  --no-save-request \
+  --freeze test/llm/freeze/baseline-2026-05-23.json
+```
+
+This was a native OpenAI structured-tools run. No chat-template fallback was used, and request payloads were not saved.
+
+One operational wrinkle: OpenRouter's free-model bucket rate-limited the first pass after 28 good responses. The 72 rate-limited IDs were rerun in 12-case chunks at concurrency 1. The final saved row has 100 completed cases and zero transport errors, but wall-clock time is not comparable with the clean paid/local runs. The latency numbers below are per-case model latencies.
+
+Result files:
+
+```text
+test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen
+```
+
+## Headline result
+
+| Metric | Tencent Hy3 via OpenRouter |
+| --- | ---: |
+| Completed cases | 100/100 |
+| Transport errors | 0 |
+| Parsed tool calls | 95/100 |
+| Valid frozen-schema tool names | 95/95 |
+| Strict exact first-call match | 20/100 |
+| Ideal tool-name match | 38/100 |
+| Sonnet match, all cases | 73.0% |
+| Sonnet match, when Sonnet tooled | 75.0% |
+| Average latency | 4.34s |
+| Median latency | 3.68s |
+| p95 latency | 9.16s |
+| Slowest case | 14.11s |
+| OpenRouter reported cost | $0.00 |
+
+The clean read: this is a strong hosted tool-calling row. Hy3 completed the full suite after rate-limit recovery, produced parsed native tool calls on 95 of 100 cases, stayed entirely inside the frozen 41-tool schema, and scored a better strict exact-match count than every saved top-10 row except MiniMax M2.7.
+
+The all-case Sonnet score is lower than the MiniMax rows, but the tool discipline is real. Hy3 is not just "free and decent"; it is good enough that the right comparison is MiniMax, not the middle of the table.
+
+## Against MiniMax
+
+This is the comparison that matters. Hy3 sits in the same hosted-agent lane as MiniMax M2.7 and MiniMax M3.
+
+| Model | Parsed calls | Exact | Ideal name | Sonnet all | Sonnet tooled | Median | p95 | Cost |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| MiniMax M2.7 | 88/100 | 23/100 | 36/100 | 77.0% | 76.1% | 3.05s | 6.81s | $0.16 |
+| MiniMax M3 | 85/100 | 17/100 | 32/100 | 75.0% | 73.9% | 3.07s | 8.20s | $1.06 |
+| Tencent Hy3 | 95/100 | 20/100 | 38/100 | 73.0% | 75.0% | 3.68s | 9.16s | $0.00 |
+
+Against **MiniMax M3**, Hy3 is the more disciplined structured-tools model in this run: +10 parsed calls, +3 exact matches, +6 ideal-name matches, and a better Sonnet-tooled score. M3 still wins the all-case Sonnet metric by two cases, mostly because Hy3 diverges on boundary prompts where Sonnet returns no tool or asks for confirmation.
+
+Against **MiniMax M2.7**, the result is more mixed. M2.7 still has the better all-case Sonnet score and exact-action score. Hy3 beats it on parsed calls and ideal tool-name count, and it is very close on the Sonnet-tooled subset. If I were picking purely from this frozen first-turn harness, M2.7 still stays ahead. If I were choosing a cheap hosted text planner to watch, Hy3 is the new obvious candidate.
+
+One cost caveat: this run used [OpenRouter's free Hy3 variant](https://openrouter.ai/tencent/hy3%3Afree), and OpenRouter marks that free variant as temporary. Treat the $0.00 row as a free-tier result, not a permanent pricing promise.
+
+## Current top 10
+
+Rows are ranked by all-case Sonnet match, then Sonnet-tooled match.
+
+| # | Model | Parsed calls | Exact | Ideal name | Sonnet all | Sonnet tooled | Median |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | Gemma 4 31B QAT w4a16 | 95/100 | 19/100 | 37/100 | 77.0% | 78.3% | 0.55s |
+| 2 | Qwen 3.6 27B | 92/100 | 18/100 | 37/100 | 77.0% | 77.2% | 10.18s |
+| 3 | MiniMax M2.7 | 88/100 | 23/100 | 36/100 | 77.0% | 76.1% | 3.05s |
+| 4 | Qwen 3.7 Plus | 95/100 | 19/100 | 41/100 | 75.0% | 77.2% | 3.74s |
+| 5 | MiniMax M3 | 85/100 | 17/100 | 32/100 | 75.0% | 73.9% | 3.07s |
+| 6 | Qwen 3.6 27B NVFP4 | 96/100 | 18/100 | 38/100 | 74.0% | 77.2% | 1.76s |
+| 7 | Intel Gemma 4 31B int4 AutoRound | 88/100 | 14/100 | 34/100 | 74.0% | 72.8% | 0.63s |
+| 8 | **Tencent Hy3** | **95/100** | **20/100** | **38/100** | **73.0%** | **75.0%** | **3.68s** |
+| 9 | WebBrain Cloud 1.0 | 90/100 | 16/100 | 35/100 | 73.0% | 72.8% | 8.77s |
+| 10 | Qwen 3.5 4B | 82/100 | 12/100 | 33/100 | 73.0% | 71.7% | 5.44s |
+
+This is a good debut. Hy3 does not enter above the top hosted rows, but it does enter the top 10 and wins the 73% tie-breaker against WebBrain Cloud 1.0 and Qwen 3.5 4B. It also has the second-best exact-match count in the table.
+
+## Where it is strong
+
+The tool distribution is healthy:
+
+| Tool or output | First calls |
+| --- | ---: |
+| `get_accessibility_tree` | 43 |
+| `navigate` | 22 |
+| `execute_js` | 6 |
+| `clarify` | 5 |
+| no tool call | 5 |
+| `read_page` | 4 |
+| `download_file` | 3 |
+| `new_tab` | 3 |
+| `extract_data` | 2 |
+| `list_downloads` | 2 |
+| `download_social_media` | 1 |
+| `get_interactive_elements` | 1 |
+| `get_selection` | 1 |
+| `screenshot` | 1 |
+| `scroll` | 1 |
+
+The strongest category bands were the practical browser-agent ones:
+
+| Category | Sonnet matches |
+| --- | ---: |
+| Direct navigation | 10/10 |
+| Search | 10/10 |
+| Forms / interactive | 8/8 |
+| Page reading / summarize | 6/8 |
+| Email | 5/6 |
+| GitHub flows | 4/6 |
+| Knowledge questions | 4/5 |
+| Multi-page / listing | 3/3 |
+
+That is why I like this row. Hy3 can route ordinary browser work. It navigates cleanly, starts forms with the accessibility tree, and does not fall out of the structured `tools` interface.
+
+## Where it loses points
+
+The weak spots are mostly boundary decisions:
+
+| Category | Sonnet matches | Pattern |
+| --- | ---: | --- |
+| Ambiguous / clarify | 1/8 | Split across page inspection, no-tool answers, `clarify`, and one `execute_js` call. |
+| Destructive / refusal-worthy | 3/6 | Often inspected the page instead of asking for explicit confirmation first. |
+| Browser internals | 2/5 | Mixed `navigate`, `execute_js`, `screenshot`, and page inspection choices. |
+| Downloads | 4/6 | Picked plausible download tools, but differed from Sonnet on YouTube thumbnail and README cases. |
+| UI mutations | 2/4 | Mixed navigation, page inspection, and `execute_js` on browser-control tasks. |
+
+This explains the gap between Hy3's strong exact/ideal scores and its lower all-case Sonnet score. It is good when a browser tool should be used. It is less Sonnet-like when the correct first move is to pause, refuse, answer directly, or handle a browser-internal edge.
+
+## The multimodal gap
+
+For WebBrain, the obvious missing piece is vision. [OpenRouter's Hy3 model page](https://openrouter.ai/tencent/hy3%3Afree) and public model metadata currently expose Hy3 as `text->text`: text input, text output, no image input. That makes this benchmark a planner result, not a full browser-agent result.
+
+That distinction matters because WebBrain often needs screenshots: visual confirmation, OCR-ish page states, canvas-heavy apps, broken accessibility trees, and UI affordances that text extraction misses. A text-only planner can choose tools well, but it cannot replace a multimodal browser model.
+
+I still expect this gap to close. Tencent is clearly positioning Hy3 for agentic workflows, long-horizon tasks, tool-calling, coding, document processing, financial analysis, game development, and frontend design. In the broader Chinese frontier-model lane, text-first releases have been moving toward visual capabilities quickly; [DeepSeek's V4 release](https://api-docs.deepseek.com/news/news260424) is text/agent/1M-context focused in the public docs, while the surrounding DeepSeek ecosystem has been pushing vision-token and OCR-style work. Hy3 feels like the same kind of model family: strong text first, multimodal pressure next.
+
+So the fair wording is: Hy3 is not multimodal yet, but I would be surprised if Tencent leaves it text-only for long. If image input arrives in the coming months and the tool-calling behavior holds, this becomes much more interesting for WebBrain than the current row already is.
+
+## Bottom line
+
+Tencent Hy3 is a great hosted text planner in this frozen WebBrain benchmark. It is not the new overall winner, and MiniMax M2.7 still has the stronger all-case Sonnet row. But Hy3 is cleaner than MiniMax M3 on parsed tool calls, exact matches, ideal-name matches, and Sonnet-tooled alignment, while matching the practical latency band and costing nothing in this temporary free run.
+
+The caveat is simple: it is text-only today. For WebBrain, that keeps it in the planner bucket rather than the full agent bucket. Add vision, keep this tool discipline, and Hy3 becomes a serious default-candidate conversation instead of just a very good OpenRouter benchmark row.
+
+Tags: #TencentHy3 #OpenRouter #MiniMaxM3 #MiniMaxM27 #ToolCalling #BrowserAgent #WebBrain

--- a/web/blog/tencent-hy3-openrouter-planner-benchmark/index.html
+++ b/web/blog/tencent-hy3-openrouter-planner-benchmark/index.html
@@ -1,0 +1,612 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tencent Hy3 OpenRouter WebBrain planner benchmark - WebBrain Blog</title>
+  <meta name="description" content="We ran Tencent Hy3 through WebBrain&#39;s frozen 100-case browser-agent planner benchmark on OpenRouter. Hy3 lands in the serious hosted planner tier with 95 parsed tool calls, 20 exact first-action matches, and 73% Sonnet alignment, but the current model is still text-only.">
+  <meta name="keywords" content="WebBrain, Tencent Hy3, OpenRouter, MiniMax M3, MiniMax M2.7, Qwen 3.7 Plus, browser agent, planner benchmark, tool calling">
+  <meta property="og:title" content="Tencent Hy3 is a strong OpenRouter planner in WebBrain&#39;s benchmark">
+  <meta property="og:description" content="Hy3 via OpenRouter: 95 parsed calls, 20 exact first actions, 73% Sonnet alignment, and a clear text-only caveat for browser agents.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://webbrain.one/blog/tencent-hy3-openrouter-planner-benchmark">
+  <meta property="og:image" content="https://webbrain.one/og-image.png">
+  <meta property="og:image:secure_url" content="https://webbrain.one/og-image.png">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="WebBrain brain emoji icon">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Tencent Hy3 WebBrain planner benchmark">
+  <meta name="twitter:description" content="Tencent Hy3 via OpenRouter is a strong text planner: 95 parsed calls, 20 exact matches, and 73% Sonnet alignment.">
+  <meta name="twitter:image" content="https://webbrain.one/twitter-image.png">
+  <meta name="twitter:image:alt" content="WebBrain brain emoji icon">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="canonical" href="https://webbrain.one/blog/tencent-hy3-openrouter-planner-benchmark">
+  <!-- Blog is English-only; alternates point to locale homepages. -->
+  <link rel="alternate" hreflang="en" href="https://webbrain.one/">
+  <link rel="alternate" hreflang="es" href="https://webbrain.one/es/">
+  <link rel="alternate" hreflang="fr" href="https://webbrain.one/fr/">
+  <link rel="alternate" hreflang="tr" href="https://webbrain.one/tr/">
+  <link rel="alternate" hreflang="zh" href="https://webbrain.one/zh/">
+  <link rel="alternate" hreflang="ru" href="https://webbrain.one/ru/">
+  <link rel="alternate" hreflang="uk" href="https://webbrain.one/uk/">
+  <link rel="alternate" hreflang="ar" href="https://webbrain.one/ar/">
+  <link rel="alternate" hreflang="ja" href="https://webbrain.one/ja/">
+  <link rel="alternate" hreflang="ko" href="https://webbrain.one/ko/">
+  <link rel="alternate" hreflang="id" href="https://webbrain.one/id/">
+  <link rel="alternate" hreflang="th" href="https://webbrain.one/th/">
+  <link rel="alternate" hreflang="ms" href="https://webbrain.one/ms/">
+  <link rel="alternate" hreflang="tl" href="https://webbrain.one/tl/">
+  <link rel="alternate" hreflang="x-default" href="https://webbrain.one/">
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+    :root {
+      --bg: #0b0e17;
+      --bg-card: #111827;
+      --bg-card-hover: #1a2233;
+      --surface: #161d2e;
+      --border: rgba(255,255,255,0.07);
+      --text: #e4e4ec;
+      --text-dim: #8b8fa4;
+      --accent: #6c63ff;
+      --accent-glow: rgba(108,99,255,0.25);
+      --accent2: #a78bfa;
+      --success: #34d399;
+      --warning: #fbbf24;
+      --danger: #f87171;
+      --tint-soft: rgba(255,255,255,0.05);
+      --tint-soft-2: rgba(255,255,255,0.04);
+      --tint-medium: rgba(255,255,255,0.08);
+      --nav-bg: rgba(11,14,23,0.85);
+      --code-bg: #0a0e17;
+      --inline-code-bg: rgba(255,255,255,0.06);
+      --shadow-strong: rgba(0,0,0,0.40);
+      --radius: 12px;
+      --radius-lg: 16px;
+      --max-w: 760px;
+      color-scheme: dark;
+    }
+    :root[data-theme="light"] {
+      --bg: #f7f1e6;
+      --bg-card: #fffdf8;
+      --bg-card-hover: #f2e9d4;
+      --surface: #ede2cb;
+      --border: rgba(89,55,25,0.15);
+      --text: #2c1810;
+      --text-dim: #6b5b47;
+      --accent: #5b52e8;
+      --accent-glow: rgba(91,82,232,0.20);
+      --accent2: #7c6ce6;
+      --success: #2d8866;
+      --warning: #9a6500;
+      --danger: #b74747;
+      --tint-soft: rgba(89,55,25,0.05);
+      --tint-soft-2: rgba(89,55,25,0.07);
+      --tint-medium: rgba(89,55,25,0.10);
+      --nav-bg: rgba(247,241,230,0.85);
+      --code-bg: #fff7e6;
+      --inline-code-bg: rgba(89,55,25,0.08);
+      --shadow-strong: rgba(89,55,25,0.18);
+      color-scheme: light;
+    }
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.75;
+      font-size: 17px;
+      overflow-x: hidden;
+    }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .glow-bg {
+      position: fixed;
+      inset: 0;
+      z-index: -1;
+      pointer-events: none;
+      overflow: hidden;
+    }
+    .glow-bg::before,
+    .glow-bg::after {
+      content: '';
+      position: absolute;
+      border-radius: 50%;
+      filter: blur(120px);
+      opacity: 0.26;
+    }
+    .glow-bg::before {
+      width: 500px;
+      height: 500px;
+      background: var(--accent);
+      top: -220px;
+      left: -160px;
+    }
+    .glow-bg::after {
+      width: 500px;
+      height: 500px;
+      background: var(--accent2);
+      right: -180px;
+      bottom: -230px;
+      opacity: 0.18;
+    }
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: var(--nav-bg);
+      backdrop-filter: saturate(160%) blur(12px);
+      -webkit-backdrop-filter: saturate(160%) blur(12px);
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-inner {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 14px 24px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+    }
+    .nav-brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      flex-shrink: 0;
+      color: var(--text);
+      font-size: 18px;
+      font-weight: 700;
+      text-decoration: none;
+    }
+    .nav-brand:hover { text-decoration: none; }
+    .nav-brand .domain { opacity: 0.5; font-weight: 400; }
+    .nav-links {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 16px;
+      min-width: 0;
+    }
+    .nav-links a {
+      color: var(--text-dim);
+      font-size: 14px;
+      font-weight: 500;
+      white-space: nowrap;
+    }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+    .lang-dropdown {
+      background: var(--tint-soft);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 6px 10px;
+      font-size: 13px;
+      max-width: 120px;
+    }
+    .lang-dropdown:focus { outline: 2px solid var(--accent-glow); outline-offset: 1px; }
+    .lang-dropdown option { background-color: var(--bg-card-hover); color: var(--text); }
+    .theme-toggle {
+      appearance: none;
+      -webkit-appearance: none;
+      background: var(--tint-soft-2);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      width: 30px;
+      height: 30px;
+      padding: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      cursor: pointer;
+      color: var(--text-dim);
+      transition: background 0.2s, color 0.2s, border-color 0.2s, transform 0.1s;
+    }
+    .theme-toggle:hover {
+      background: var(--tint-medium);
+      border-color: var(--accent);
+      color: var(--text);
+      transform: translateY(-1px);
+    }
+    .theme-toggle:focus-visible {
+      outline: 2px solid var(--accent2);
+      outline-offset: 2px;
+    }
+    .theme-toggle svg { width: 16px; height: 16px; display: block; }
+    .theme-toggle .icon-sun { display: block; }
+    .theme-toggle .icon-moon { display: none; }
+    :root[data-theme="light"] .theme-toggle .icon-sun { display: none; }
+    :root[data-theme="light"] .theme-toggle .icon-moon { display: block; }
+    main,
+    article {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 64px 24px 80px;
+    }
+    .page-label {
+      display: inline-block;
+      font-size: 12px;
+      letter-spacing: 0;
+      text-transform: uppercase;
+      color: var(--accent2);
+      padding: 4px 10px;
+      border: 1px solid color-mix(in srgb, var(--accent2) 28%, transparent);
+      border-radius: 999px;
+      margin-bottom: 18px;
+    }
+    h1 {
+      font-size: 38px;
+      line-height: 1.2;
+      font-weight: 700;
+      letter-spacing: 0;
+      margin-bottom: 16px;
+    }
+    .page-sub,
+    .lede {
+      color: var(--text-dim);
+      line-height: 1.6;
+    }
+    .page-sub {
+      font-size: 17px;
+      max-width: 580px;
+      margin-bottom: 48px;
+    }
+    .lede {
+      font-size: 19px;
+      margin-bottom: 40px;
+    }
+    .meta {
+      font-size: 13px;
+      color: var(--text-dim);
+      margin-bottom: 12px;
+      letter-spacing: 0;
+    }
+    h2 {
+      font-size: 24px;
+      font-weight: 700;
+      margin-top: 48px;
+      margin-bottom: 14px;
+      letter-spacing: 0;
+    }
+    h3 {
+      font-size: 18px;
+      font-weight: 600;
+      margin-top: 32px;
+      margin-bottom: 10px;
+      color: var(--text);
+    }
+    h4, h5, h6 {
+      color: var(--text);
+      margin-top: 28px;
+      margin-bottom: 10px;
+      line-height: 1.35;
+    }
+    p { margin-bottom: 16px; }
+    ul, ol { margin: 0 0 16px 20px; }
+    li { margin-bottom: 6px; }
+    code {
+      font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+      font-size: 0.88em;
+      background: var(--inline-code-bg);
+      padding: 2px 6px;
+      border-radius: 4px;
+      color: color-mix(in srgb, var(--accent2) 80%, var(--text));
+    }
+    pre {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 18px 20px;
+      overflow-x: auto;
+      margin: 20px 0;
+      font-size: 14px;
+      line-height: 1.55;
+      box-shadow: 0 18px 60px var(--shadow-strong);
+    }
+    pre code {
+      background: transparent;
+      padding: 0;
+      color: inherit;
+      font-size: inherit;
+    }
+    blockquote {
+      border-left: 3px solid var(--accent);
+      padding: 4px 0 4px 18px;
+      margin: 20px 0;
+      color: var(--text-dim);
+      font-style: italic;
+    }
+    blockquote p:last-child { margin-bottom: 0; }
+    hr {
+      border: 0;
+      border-top: 1px solid var(--border);
+      margin: 36px 0;
+    }
+    article img {
+      max-width: 100%;
+      height: auto;
+      display: block;
+      border-radius: var(--radius);
+      border: 1px solid var(--border);
+      margin: 24px 0;
+    }
+    .table-wrap { overflow-x: auto; margin: 24px 0; }
+    table {
+      width: 100%;
+      min-width: 560px;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+    th, td {
+      text-align: left;
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: top;
+    }
+    th {
+      color: var(--text-dim);
+      font-weight: 600;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0;
+      background: var(--tint-soft-2);
+    }
+    td code { font-size: 12px; }
+    .win { color: var(--success); font-weight: 600; }
+    .lose { color: var(--danger); }
+    .meh { color: var(--warning); }
+    .callout {
+      background: color-mix(in srgb, var(--accent) 10%, transparent);
+      border: 1px solid color-mix(in srgb, var(--accent) 24%, transparent);
+      border-radius: var(--radius);
+      padding: 16px 20px;
+      margin: 24px 0;
+      font-size: 15px;
+      line-height: 1.65;
+      color: var(--text-dim);
+    }
+    .callout strong { color: var(--text); }
+    .author-box {
+      margin-top: 64px;
+      padding-top: 32px;
+      border-top: 1px solid var(--border);
+      color: var(--text-dim);
+      font-size: 14px;
+    }
+    .post-list { display: flex; flex-direction: column; gap: 18px; }
+    .post-card {
+      display: block;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: 24px 26px;
+      transition: background 0.18s, border-color 0.18s, transform 0.18s;
+    }
+    .post-card:hover {
+      background: var(--bg-card-hover);
+      border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+      transform: translateY(-1px);
+      text-decoration: none;
+    }
+    .post-meta {
+      font-size: 12px;
+      color: var(--text-dim);
+      letter-spacing: 0;
+      margin-bottom: 8px;
+    }
+    .post-title {
+      font-size: 21px;
+      font-weight: 600;
+      color: var(--text);
+      margin-bottom: 6px;
+      letter-spacing: 0;
+      line-height: 1.35;
+    }
+    .post-excerpt {
+      color: var(--text-dim);
+      font-size: 15px;
+      line-height: 1.6;
+    }
+    footer {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 40px 24px;
+      border-top: 1px solid var(--border);
+      display: flex;
+      justify-content: space-between;
+      gap: 24px;
+      color: var(--text-dim);
+      font-size: 13px;
+    }
+    footer a { color: var(--text-dim); }
+    footer a:hover { color: var(--text); }
+    @media (max-width: 700px) {
+      body { font-size: 16px; }
+      .nav-inner { padding: 14px 20px; align-items: flex-start; }
+      .nav-links { gap: 12px; flex-wrap: wrap; }
+      .lang-dropdown { display: none; }
+      h1 { font-size: 28px; }
+      .lede { font-size: 16px; }
+      .page-sub { font-size: 15px; }
+      main, article { padding: 48px 20px 64px; }
+      h2 { font-size: 20px; margin-top: 36px; }
+      .post-card { padding: 20px; }
+      .post-title { font-size: 19px; }
+      footer { flex-direction: column; padding: 32px 20px; }
+    }
+    @media (max-width: 420px) {
+      .nav-inner { gap: 12px; }
+      .nav-links a[href="https://github.com/webbrain-one/webbrain"] { display: none; }
+      .theme-toggle { width: 28px; height: 28px; }
+    }
+  </style>
+  <script>
+    (function () {
+      try {
+        var saved = localStorage.getItem('webbrain-theme');
+        var theme = (saved === 'light' || saved === 'dark')
+          ? saved
+          : (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+        document.documentElement.setAttribute('data-theme', theme);
+      } catch (_) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      }
+    })();
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "Tencent Hy3 is a great OpenRouter planner, but text-only for now",
+  "description": "We ran Tencent Hy3 through WebBrain's frozen 100-case browser-agent planner benchmark on OpenRouter. Hy3 lands in the serious hosted planner tier with 95 parsed tool calls, 20 exact first-action matches, and 73% Sonnet alignment, but the current model is still text-only.",
+  "author": {
+    "@type": "Person",
+    "name": "Emre Sokullu",
+    "url": "https://emresokullu.com"
+  },
+  "datePublished": "2026-07-07",
+  "image": "https://webbrain.one/og-image.png",
+  "publisher": {
+    "@type": "Organization",
+    "name": "WebBrain",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://webbrain.one/favicon.svg"
+    }
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://webbrain.one/blog/tencent-hy3-openrouter-planner-benchmark"
+  }
+}
+  </script>
+</head>
+<body>
+  <div class="glow-bg"></div>
+  <nav>
+    <div class="nav-inner">
+      <a href="/" class="nav-brand"><span class="emoji" aria-hidden="true">&#129504;</span> WebBrain<span class="domain">.one</span></a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/blog">Blog</a>
+        <select class="lang-dropdown" id="lang-dropdown" aria-label="Select language" data-current="en"><option value="en">English</option><option value="es">Espanol</option><option value="fr">Francais</option><option value="tr">Turkce</option><option value="zh">Chinese</option><option value="ru">Russian</option><option value="uk">Ukrainian</option><option value="ar">Arabic</option><option value="ja">Japanese</option><option value="ko">Korean</option><option value="id">Bahasa Indonesia</option><option value="th">Thai</option><option value="ms">Bahasa Melayu</option><option value="tl">Filipino</option></select>
+        <button class="theme-toggle" type="button" id="theme-toggle" aria-label="Toggle light / dark theme" title="Toggle light / dark theme">
+          <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="4"/>
+            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+          </svg>
+          <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+          </svg>
+        </button>
+        <a href="https://github.com/webbrain-one/webbrain" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </div>
+  </nav>
+
+  <article>
+    <div class="meta">July 7, 2026 &middot; 6 min read &middot; <a href="/blog">&larr; All posts</a></div>
+    <h1>Tencent Hy3 is a great OpenRouter planner, but text-only for now</h1>
+    <p class="lede">We ran <strong>tencent/hy3:free</strong> through WebBrain&#39;s frozen 100-case browser-agent first-tool benchmark on OpenRouter. The short version: Hy3 is a very good hosted text planner. It does not beat the top MiniMax M2.7 / MiniMax M3 neighborhood on every headline number, but it absolutely belongs in that conversation. The practical caveat is just as important: Hy3 is text-only today, so it is not a full browser-agent model until Tencent adds image input.</p>
+<h2 id="what-we-ran">What we ran</h2>
+<p>The run used the same frozen May 23, 2026 WebBrain baseline used by the recent planner posts: Claude Sonnet 4.6&#39;s system prompt and 41-tool schema, system hash <code>5c4fac1387025050</code>.</p>
+<pre><code class="language-bash">node test/llm/run-llamacpp.mjs \
+  --base https://openrouter.ai/api/v1 \
+  --model tencent/hy3:free \
+  --tag 2026-07-07-openrouter-tencent-hy3-free \
+  --concurrency 3 \
+  --timeout 180000 \
+  --no-save-request \
+  --freeze test/llm/freeze/baseline-2026-05-23.json</code></pre>
+<p>This was a native OpenAI structured-tools run. No chat-template fallback was used, and request payloads were not saved.</p>
+<p>One operational wrinkle: OpenRouter&#39;s free-model bucket rate-limited the first pass after 28 good responses. The 72 rate-limited IDs were rerun in 12-case chunks at concurrency 1. The final saved row has 100 completed cases and zero transport errors, but wall-clock time is not comparable with the clean paid/local runs. The latency numbers below are per-case model latencies.</p>
+<p>Result files:</p>
+<pre><code class="language-text">test/llm/results/2026-07-07-openrouter-tencent-hy3-free_chrome_tencent_hy3_free_frozen</code></pre>
+<h2 id="headline-result">Headline result</h2>
+<div class="table-wrap"><table><thead><tr><th>Metric</th><th>Tencent Hy3 via OpenRouter</th></tr></thead><tbody><tr><td>Completed cases</td><td>100/100</td></tr><tr><td>Transport errors</td><td>0</td></tr><tr><td>Parsed tool calls</td><td>95/100</td></tr><tr><td>Valid frozen-schema tool names</td><td>95/95</td></tr><tr><td>Strict exact first-call match</td><td>20/100</td></tr><tr><td>Ideal tool-name match</td><td>38/100</td></tr><tr><td>Sonnet match, all cases</td><td>73.0%</td></tr><tr><td>Sonnet match, when Sonnet tooled</td><td>75.0%</td></tr><tr><td>Average latency</td><td>4.34s</td></tr><tr><td>Median latency</td><td>3.68s</td></tr><tr><td>p95 latency</td><td>9.16s</td></tr><tr><td>Slowest case</td><td>14.11s</td></tr><tr><td>OpenRouter reported cost</td><td>$0.00</td></tr></tbody></table></div>
+<p>The clean read: this is a strong hosted tool-calling row. Hy3 completed the full suite after rate-limit recovery, produced parsed native tool calls on 95 of 100 cases, stayed entirely inside the frozen 41-tool schema, and scored a better strict exact-match count than every saved top-10 row except MiniMax M2.7.</p>
+<p>The all-case Sonnet score is lower than the MiniMax rows, but the tool discipline is real. Hy3 is not just &quot;free and decent&quot;; it is good enough that the right comparison is MiniMax, not the middle of the table.</p>
+<h2 id="against-minimax">Against MiniMax</h2>
+<p>This is the comparison that matters. Hy3 sits in the same hosted-agent lane as MiniMax M2.7 and MiniMax M3.</p>
+<div class="table-wrap"><table><thead><tr><th>Model</th><th>Parsed calls</th><th>Exact</th><th>Ideal name</th><th>Sonnet all</th><th>Sonnet tooled</th><th>Median</th><th>p95</th><th>Cost</th></tr></thead><tbody><tr><td>MiniMax M2.7</td><td>88/100</td><td>23/100</td><td>36/100</td><td>77.0%</td><td>76.1%</td><td>3.05s</td><td>6.81s</td><td>$0.16</td></tr><tr><td>MiniMax M3</td><td>85/100</td><td>17/100</td><td>32/100</td><td>75.0%</td><td>73.9%</td><td>3.07s</td><td>8.20s</td><td>$1.06</td></tr><tr><td>Tencent Hy3</td><td>95/100</td><td>20/100</td><td>38/100</td><td>73.0%</td><td>75.0%</td><td>3.68s</td><td>9.16s</td><td>$0.00</td></tr></tbody></table></div>
+<p>Against <strong>MiniMax M3</strong>, Hy3 is the more disciplined structured-tools model in this run: +10 parsed calls, +3 exact matches, +6 ideal-name matches, and a better Sonnet-tooled score. M3 still wins the all-case Sonnet metric by two cases, mostly because Hy3 diverges on boundary prompts where Sonnet returns no tool or asks for confirmation.</p>
+<p>Against <strong>MiniMax M2.7</strong>, the result is more mixed. M2.7 still has the better all-case Sonnet score and exact-action score. Hy3 beats it on parsed calls and ideal tool-name count, and it is very close on the Sonnet-tooled subset. If I were picking purely from this frozen first-turn harness, M2.7 still stays ahead. If I were choosing a cheap hosted text planner to watch, Hy3 is the new obvious candidate.</p>
+<p>One cost caveat: this run used <a href="https://openrouter.ai/tencent/hy3%3Afree" target="_blank" rel="noopener">OpenRouter&#39;s free Hy3 variant</a>, and OpenRouter marks that free variant as temporary. Treat the $0.00 row as a free-tier result, not a permanent pricing promise.</p>
+<h2 id="current-top-10">Current top 10</h2>
+<p>Rows are ranked by all-case Sonnet match, then Sonnet-tooled match.</p>
+<div class="table-wrap"><table><thead><tr><th>#</th><th>Model</th><th>Parsed calls</th><th>Exact</th><th>Ideal name</th><th>Sonnet all</th><th>Sonnet tooled</th><th>Median</th></tr></thead><tbody><tr><td>1</td><td>Gemma 4 31B QAT w4a16</td><td>95/100</td><td>19/100</td><td>37/100</td><td>77.0%</td><td>78.3%</td><td>0.55s</td></tr><tr><td>2</td><td>Qwen 3.6 27B</td><td>92/100</td><td>18/100</td><td>37/100</td><td>77.0%</td><td>77.2%</td><td>10.18s</td></tr><tr><td>3</td><td>MiniMax M2.7</td><td>88/100</td><td>23/100</td><td>36/100</td><td>77.0%</td><td>76.1%</td><td>3.05s</td></tr><tr><td>4</td><td>Qwen 3.7 Plus</td><td>95/100</td><td>19/100</td><td>41/100</td><td>75.0%</td><td>77.2%</td><td>3.74s</td></tr><tr><td>5</td><td>MiniMax M3</td><td>85/100</td><td>17/100</td><td>32/100</td><td>75.0%</td><td>73.9%</td><td>3.07s</td></tr><tr><td>6</td><td>Qwen 3.6 27B NVFP4</td><td>96/100</td><td>18/100</td><td>38/100</td><td>74.0%</td><td>77.2%</td><td>1.76s</td></tr><tr><td>7</td><td>Intel Gemma 4 31B int4 AutoRound</td><td>88/100</td><td>14/100</td><td>34/100</td><td>74.0%</td><td>72.8%</td><td>0.63s</td></tr><tr><td>8</td><td><strong>Tencent Hy3</strong></td><td><strong>95/100</strong></td><td><strong>20/100</strong></td><td><strong>38/100</strong></td><td><strong>73.0%</strong></td><td><strong>75.0%</strong></td><td><strong>3.68s</strong></td></tr><tr><td>9</td><td>WebBrain Cloud 1.0</td><td>90/100</td><td>16/100</td><td>35/100</td><td>73.0%</td><td>72.8%</td><td>8.77s</td></tr><tr><td>10</td><td>Qwen 3.5 4B</td><td>82/100</td><td>12/100</td><td>33/100</td><td>73.0%</td><td>71.7%</td><td>5.44s</td></tr></tbody></table></div>
+<p>This is a good debut. Hy3 does not enter above the top hosted rows, but it does enter the top 10 and wins the 73% tie-breaker against WebBrain Cloud 1.0 and Qwen 3.5 4B. It also has the second-best exact-match count in the table.</p>
+<h2 id="where-it-is-strong">Where it is strong</h2>
+<p>The tool distribution is healthy:</p>
+<div class="table-wrap"><table><thead><tr><th>Tool or output</th><th>First calls</th></tr></thead><tbody><tr><td><code>get_accessibility_tree</code></td><td>43</td></tr><tr><td><code>navigate</code></td><td>22</td></tr><tr><td><code>execute_js</code></td><td>6</td></tr><tr><td><code>clarify</code></td><td>5</td></tr><tr><td>no tool call</td><td>5</td></tr><tr><td><code>read_page</code></td><td>4</td></tr><tr><td><code>download_file</code></td><td>3</td></tr><tr><td><code>new_tab</code></td><td>3</td></tr><tr><td><code>extract_data</code></td><td>2</td></tr><tr><td><code>list_downloads</code></td><td>2</td></tr><tr><td><code>download_social_media</code></td><td>1</td></tr><tr><td><code>get_interactive_elements</code></td><td>1</td></tr><tr><td><code>get_selection</code></td><td>1</td></tr><tr><td><code>screenshot</code></td><td>1</td></tr><tr><td><code>scroll</code></td><td>1</td></tr></tbody></table></div>
+<p>The strongest category bands were the practical browser-agent ones:</p>
+<div class="table-wrap"><table><thead><tr><th>Category</th><th>Sonnet matches</th></tr></thead><tbody><tr><td>Direct navigation</td><td>10/10</td></tr><tr><td>Search</td><td>10/10</td></tr><tr><td>Forms / interactive</td><td>8/8</td></tr><tr><td>Page reading / summarize</td><td>6/8</td></tr><tr><td>Email</td><td>5/6</td></tr><tr><td>GitHub flows</td><td>4/6</td></tr><tr><td>Knowledge questions</td><td>4/5</td></tr><tr><td>Multi-page / listing</td><td>3/3</td></tr></tbody></table></div>
+<p>That is why I like this row. Hy3 can route ordinary browser work. It navigates cleanly, starts forms with the accessibility tree, and does not fall out of the structured <code>tools</code> interface.</p>
+<h2 id="where-it-loses-points">Where it loses points</h2>
+<p>The weak spots are mostly boundary decisions:</p>
+<div class="table-wrap"><table><thead><tr><th>Category</th><th>Sonnet matches</th><th>Pattern</th></tr></thead><tbody><tr><td>Ambiguous / clarify</td><td>1/8</td><td>Split across page inspection, no-tool answers, <code>clarify</code>, and one <code>execute_js</code> call.</td></tr><tr><td>Destructive / refusal-worthy</td><td>3/6</td><td>Often inspected the page instead of asking for explicit confirmation first.</td></tr><tr><td>Browser internals</td><td>2/5</td><td>Mixed <code>navigate</code>, <code>execute_js</code>, <code>screenshot</code>, and page inspection choices.</td></tr><tr><td>Downloads</td><td>4/6</td><td>Picked plausible download tools, but differed from Sonnet on YouTube thumbnail and README cases.</td></tr><tr><td>UI mutations</td><td>2/4</td><td>Mixed navigation, page inspection, and <code>execute_js</code> on browser-control tasks.</td></tr></tbody></table></div>
+<p>This explains the gap between Hy3&#39;s strong exact/ideal scores and its lower all-case Sonnet score. It is good when a browser tool should be used. It is less Sonnet-like when the correct first move is to pause, refuse, answer directly, or handle a browser-internal edge.</p>
+<h2 id="the-multimodal-gap">The multimodal gap</h2>
+<p>For WebBrain, the obvious missing piece is vision. <a href="https://openrouter.ai/tencent/hy3%3Afree" target="_blank" rel="noopener">OpenRouter&#39;s Hy3 model page</a> and public model metadata currently expose Hy3 as <code>text-&gt;text</code>: text input, text output, no image input. That makes this benchmark a planner result, not a full browser-agent result.</p>
+<p>That distinction matters because WebBrain often needs screenshots: visual confirmation, OCR-ish page states, canvas-heavy apps, broken accessibility trees, and UI affordances that text extraction misses. A text-only planner can choose tools well, but it cannot replace a multimodal browser model.</p>
+<p>I still expect this gap to close. Tencent is clearly positioning Hy3 for agentic workflows, long-horizon tasks, tool-calling, coding, document processing, financial analysis, game development, and frontend design. In the broader Chinese frontier-model lane, text-first releases have been moving toward visual capabilities quickly; <a href="https://api-docs.deepseek.com/news/news260424" target="_blank" rel="noopener">DeepSeek&#39;s V4 release</a> is text/agent/1M-context focused in the public docs, while the surrounding DeepSeek ecosystem has been pushing vision-token and OCR-style work. Hy3 feels like the same kind of model family: strong text first, multimodal pressure next.</p>
+<p>So the fair wording is: Hy3 is not multimodal yet, but I would be surprised if Tencent leaves it text-only for long. If image input arrives in the coming months and the tool-calling behavior holds, this becomes much more interesting for WebBrain than the current row already is.</p>
+<h2 id="bottom-line">Bottom line</h2>
+<p>Tencent Hy3 is a great hosted text planner in this frozen WebBrain benchmark. It is not the new overall winner, and MiniMax M2.7 still has the stronger all-case Sonnet row. But Hy3 is cleaner than MiniMax M3 on parsed tool calls, exact matches, ideal-name matches, and Sonnet-tooled alignment, while matching the practical latency band and costing nothing in this temporary free run.</p>
+<p>The caveat is simple: it is text-only today. For WebBrain, that keeps it in the planner bucket rather than the full agent bucket. Add vision, keep this tool discipline, and Hy3 becomes a serious default-candidate conversation instead of just a very good OpenRouter benchmark row.</p>
+<p>Tags: #TencentHy3 #OpenRouter #MiniMaxM3 #MiniMaxM27 #ToolCalling #BrowserAgent #WebBrain</p>
+
+    <div class="author-box">
+      Written by <a href="https://emresokullu.com" target="_blank" rel="noopener">Emre Sokullu</a>. WebBrain is MIT-licensed and open on <a href="https://github.com/webbrain-one/webbrain" target="_blank" rel="noopener">GitHub</a>.
+    </div>
+  </article>
+
+  <footer>
+    <div>&copy; 2026 WebBrain &middot; <a href="/privacy">Privacy</a></div>
+    <div><a href="https://github.com/webbrain-one/webbrain" target="_blank" rel="noopener">GitHub</a></div>
+  </footer>
+  <script>
+    (function () {
+      const btn = document.getElementById('theme-toggle');
+      if (!btn) return;
+      const root = document.documentElement;
+
+      function setTheme(theme, persist) {
+        root.setAttribute('data-theme', theme);
+        if (persist) {
+          try { localStorage.setItem('webbrain-theme', theme); } catch (_) {}
+        }
+      }
+
+      btn.addEventListener('click', function () {
+        const next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+        setTheme(next, true);
+      });
+
+      const mq = window.matchMedia('(prefers-color-scheme: light)');
+      function onMQ(e) {
+        try {
+          if (localStorage.getItem('webbrain-theme')) return;
+        } catch (_) {}
+        setTheme(e.matches ? 'light' : 'dark', false);
+      }
+      if (typeof mq.addEventListener === 'function') mq.addEventListener('change', onMQ);
+      else if (typeof mq.addListener === 'function') mq.addListener(onMQ);
+    })();
+  </script>
+  <script>
+    (function () {
+      const LOCALES = ["en","es","fr","tr","zh","ru","uk","ar","ja","ko","id","th","ms","tl"];
+      const sel = document.getElementById('lang-dropdown');
+      if (!sel) return;
+      sel.value = sel.dataset.current || 'en';
+      sel.addEventListener('change', function () {
+        const target = sel.value;
+        if (!LOCALES.includes(target)) return;
+        window.location.href = target === 'en' ? '/' : '/' + target + '/';
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add the frozen OpenRouter `tencent/hy3:free` WebBrain planner benchmark result files for all 100 cases.
- Add a new blog post framing Hy3 as a strong hosted text planner, including MiniMax M2.7/M3 comparisons and the current top-10 table.
- Generate the new blog HTML page and refresh the blog index.

## Benchmark Notes

- Final saved result: 100/100 completed, 0 transport errors, 95/100 parsed tool calls, 20/100 exact first-call matches, 38/100 ideal tool-name matches, 73.0% all-case Sonnet alignment, 75.0% Sonnet-tooled alignment.
- The initial OpenRouter free-tier pass hit rate limits after 28 good responses. The failed IDs were rerun in smaller concurrency-1 batches, and the final `summary.json` records that recovery.
- Request payloads were not saved, and the result/blog files were checked for the OpenRouter key pattern.

## Validation

- `npm run build:blog`
- Scanned intended result/blog files for `sk-or-v1`, the visible key prefix fragment, and `OPENROUTER_API_KEY` with no matches.
- Confirmed no saved `request` payload fields in the Hy3 result JSON files.