### PR TITLE
Fix sidepanel composer height reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webbrain",
-  "version": "21.5.2",
+  "version": "21.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webbrain",
-      "version": "21.5.2",
+      "version": "21.5.3",
       "license": "MIT",
       "devDependencies": {
         "playwright": "^1.48.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webbrain",
-  "version": "21.5.2",
+  "version": "21.5.3",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "private": true,
   "type": "module",

--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Chrome/Edge Extension — Architecture
 
-> Version 21.5.2 · Manifest V3 · Service Worker background
+> Version 21.5.3 · Manifest V3 · Service Worker background
 
 ## High-Level Overview
 

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "21.5.2",
+  "version": "21.5.3",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -19,7 +19,7 @@ import {
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '21.5.2';
+const EXT_VERSION = '21.5.3';
 
 const providersContainer = document.getElementById('providers');
 const displaySettings = document.getElementById('display-settings');

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -4874,6 +4874,11 @@ function truncate(str, len) {
 
 function autoResizeInput() {
   inputEl.style.height = 'auto';
+  if (!inputEl.value) {
+    inputEl.style.height = '';
+    updateSlashCommandHighlight();
+    return;
+  }
   inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';
   updateSlashCommandHighlight();
 }

--- a/src/firefox/ARCHITECTURE.md
+++ b/src/firefox/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Firefox Extension — Architecture
 
-> Version 21.5.2 · Manifest V2 · Background Page
+> Version 21.5.3 · Manifest V2 · Background Page
 
 ## How Firefox Differs from Chrome
 

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "WebBrain",
-  "version": "21.5.2",
+  "version": "21.5.3",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "activeTab",

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -19,7 +19,7 @@ import {
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '21.5.2';
+const EXT_VERSION = '21.5.3';
 
 const providersContainer = document.getElementById('providers');
 const displaySettings = document.getElementById('display-settings');

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -4522,6 +4522,11 @@ function truncate(str, len) {
 
 function autoResizeInput() {
   inputEl.style.height = 'auto';
+  if (!inputEl.value) {
+    inputEl.style.height = '';
+    updateSlashCommandHighlight();
+    return;
+  }
   inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';
   updateSlashCommandHighlight();
 }

--- a/test/run.js
+++ b/test/run.js
@@ -7188,6 +7188,11 @@ test('sidepanel preserves stale residual slash-command prompts without hidden ru
     ['firefox', 'src/firefox/src/ui/sidepanel.js'],
   ]) {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    assert.match(
+      panel,
+      /function autoResizeInput\(\) \{\s*inputEl\.style\.height = 'auto';\s*if \(!inputEl\.value\) \{\s*inputEl\.style\.height = '';\s*updateSlashCommandHighlight\(\);\s*return;\s*\}\s*inputEl\.style\.height = Math\.min\(inputEl\.scrollHeight, 120\) \+ 'px';\s*updateSlashCommandHighlight\(\);\s*\}/,
+      `${label}: empty composer should reset to its rows=1 height instead of autosizing to placeholder scrollHeight`,
+    );
     assert.match(panel, /const tabInputDrafts = new Map\(\);/, `${label}: sidepanel should track per-tab composer drafts`);
     assert.match(panel, /function saveInputDraftForTab\(tabId, text\) \{[\s\S]*?tabInputDrafts\.set\(numericTabId, draft\);[\s\S]*?tabInputDrafts\.delete\(numericTabId\);[\s\S]*?\}/, `${label}: tab drafts should save non-empty text and clear empty text`);
     assert.match(panel, /function restoreInputDraftForTab\(tabId\) \{[\s\S]*?inputEl\.value = draft;[\s\S]*?autoResizeInput\(\);[\s\S]*?updateSlashCommandAutocomplete\(\);[\s\S]*?\}/, `${label}: tab drafts should restore into the composer when returning to a tab`);
@@ -7387,7 +7392,7 @@ test('sidepanel queued composer messages expose edit and delete controls', () =>
 
     assert.match(html, /id="queued-messages" class="queued-messages hidden" role="list"/, `${label}: queued message strip should exist above the composer`);
     assert.match(panel, /const queuedComposerMessagesByTab = new Map\(\);/, `${label}: queued composer messages should be tracked per tab`);
-    assert.match(panel, /function enqueueQueuedComposerMessage\(tabId, text\) \{[\s\S]*?queue\.push\(\{[\s\S]*?text: queuedText,[\s\S]*?inputEl\.value = '';[\s\S]*?syncSendButtonState\(\);[\s\S]*?return true;[\s\S]*?\}/, `${label}: busy drafts should be queued and clear the composer`);
+    assert.match(panel, /function enqueueQueuedComposerMessage\(tabId, text\) \{[\s\S]*?queue\.push\(\{[\s\S]*?text: queuedText,[\s\S]*?inputEl\.value = '';[\s\S]*?autoResizeInput\(\);[\s\S]*?syncSendButtonState\(\);[\s\S]*?return true;[\s\S]*?\}/, `${label}: busy drafts should be queued, clear the composer, and reset its height`);
     assert.match(panel, /function sameTabId\(a, b\) \{\s*return a != null && b != null && String\(a\) === String\(b\);\s*\}/, `${label}: queued-message tab checks should tolerate equivalent tab id types`);
     assert.match(panel, /function editQueuedComposerMessage\(tabId, queueId\) \{[\s\S]*?!sameTabId\(currentTabId, tabId\)[\s\S]*?removeQueuedComposerMessage\(tabId, queueId\);[\s\S]*?inputEl\.value = item\.text;[\s\S]*?inputEl\.setSelectionRange\(inputEl\.value\.length, inputEl\.value\.length\);[\s\S]*?\}/, `${label}: queued message edit should guard the tab and move text back into the composer`);
     assert.match(panel, /function editLastQueuedComposerMessageForCurrentTab\(\) \{[\s\S]*?const atStart = inputEl\.selectionStart === 0 && inputEl\.selectionEnd === 0;[\s\S]*?if \(inputEl\.value\.trim\(\) \|\| !atStart\) return false;[\s\S]*?const item = queue\[queue\.length - 1\];[\s\S]*?editQueuedComposerMessage\(currentTabId, item\.id\);[\s\S]*?return true;[\s\S]*?\}/, `${label}: ArrowUp edit should only pull the latest queued message into an empty composer at the start`);


### PR DESCRIPTION
## Summary

- Reset the sidepanel composer to its native one-row height when the textarea is empty.
- Keep autosizing for non-empty input up to the existing 120px cap.
- Mirror the fix across Chrome and Firefox sidepanel code and add regression coverage for the empty-composer reset and busy queue clear path.

## Root Cause

The autosize helper always measured `scrollHeight`, even after the composer was cleared. With an empty textarea, the placeholder or residual layout could inflate that measurement, leaving the composer visually tall until the next typed character triggered a fresh input resize.

## Validation

- `git diff --check`
- `node test/run.js` (`661 passed, 0 failed`)
- `npm test` (`661 passed, 0 failed` plus injection corpus `60/60`)