### PR TITLE
Add Hugging Face Inference provider, remove broken Claude OAuth provider

### DIFF
--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -363,7 +363,7 @@ export class ProviderManager {
         label: 'Hugging Face Inference',
         providerName: 'huggingface',
         baseUrl: 'https://router.huggingface.co/v1',
-        model: 'deepseek-ai/DeepSeek-V4',
+        model: 'zai-org/GLM-5.2',
         supportsStreamUsageOptions: true,
         apiKey: '',
         apiKeyUrl: 'https://huggingface.co/settings/tokens',

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -1,6 +1,7 @@
 import { LlamaCppProvider } from './llamacpp.js';
 import { OpenAICompatibleProvider } from './openai.js';
 import { AnthropicProvider, AnthropicOAuthProvider } from './anthropic.js';
+import { signOutClaude } from './oauth-claude.js';
 // Static, NOT dynamic: this module runs in the MV3 service worker, where
 // `await import()` throws "import() is disallowed on ServiceWorkerGlobalScope".
 // The provider modules above already import this statically, so it's in the SW
@@ -60,6 +61,11 @@ export class ProviderManager {
     delete configs.webbrain;
     delete configs.openai_subscription;
     delete configs.claude_subscription;
+    // The claude_subscription provider entry above is gone and its
+    // settings-UI sign-out control with it, so purge any leftover OAuth
+    // token bundle here — otherwise a previously-signed-in user's raw
+    // access/refresh tokens would sit in storage with no UI path to clear them.
+    await signOutClaude();
     if (configs[WEBBRAIN_CLOUD_PROVIDER_ID]) {
       configs[WEBBRAIN_CLOUD_PROVIDER_ID].deviceGuid = await this._getDeviceGuid(data[WEBBRAIN_DEVICE_GUID_KEY]);
     }

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -17,7 +17,7 @@ const OPENROUTER_DEFAULT_MODEL = 'openrouter/free';
 const OPENROUTER_LEGACY_DEFAULT_MODEL = 'stepfun/step-3.7-flash';
 const SUPPORTED_PROVIDER_TYPES = new Set(['llamacpp', 'openai', 'anthropic', 'anthropic_oauth']);
 const SAFE_PROVIDER_ID_RE = /^[A-Za-z0-9_-]+$/;
-const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq'];
+const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface'];
 
 /**
  * Manages LLM provider instances and persists configuration.
@@ -59,6 +59,7 @@ export class ProviderManager {
     }
     delete configs.webbrain;
     delete configs.openai_subscription;
+    delete configs.claude_subscription;
     if (configs[WEBBRAIN_CLOUD_PROVIDER_ID]) {
       configs[WEBBRAIN_CLOUD_PROVIDER_ID].deviceGuid = await this._getDeviceGuid(data[WEBBRAIN_DEVICE_GUID_KEY]);
     }
@@ -356,17 +357,16 @@ export class ProviderManager {
         apiKeyUrl: 'https://openrouter.ai/keys',
         enabled: false,
       },
-      // Subscription auth (OAuth) entry, kept distinct from the API-key
-      // entry above so a user can have both configured and switch
-      // between them. Tokens live in `chrome.storage.local` under
-      // `anthropicOauthTokens` (see oauth-claude.js), not in this
-      // config. Settings UI shows a "Sign in with Claude" button for
-      // this provider instead of the API-key field.
-      claude_subscription: {
-        type: 'anthropic_oauth',
-        category: 'cloud',
-        label: 'Claude (Pro/Max subscription)',
-        model: 'claude-sonnet-4-6',
+      huggingface: {
+        type: 'openai',
+        category: 'router',
+        label: 'Hugging Face Inference',
+        providerName: 'huggingface',
+        baseUrl: 'https://router.huggingface.co/v1',
+        model: 'deepseek-ai/DeepSeek-V4',
+        supportsStreamUsageOptions: true,
+        apiKey: '',
+        apiKeyUrl: 'https://huggingface.co/settings/tokens',
         enabled: false,
       },
     };

--- a/src/chrome/src/providers/openai.js
+++ b/src/chrome/src/providers/openai.js
@@ -33,8 +33,11 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     // OpenAI-compatible endpoint where the loaded model varies).
     if (this.config.supportsVision != null) return !!this.config.supportsVision;
     // Otherwise sniff the model name for known vision-capable identifiers.
+    // Qwen went natively multimodal starting at 3.5 (no separate -VL
+    // checkpoint needed), so qwen3\.[5-9] catches those alongside the
+    // older qwen*vl-suffixed lines.
     const m = (this.config.model || '').toLowerCase();
-    return /gpt-4o|gpt-4\.1|gpt-4-turbo|gpt-5|claude|gemini|llava|qwen.*vl|qwen2.*vl|qwen3.*vl|pixtral|llama.*vision|gemma.*vision|gemma-?[34]/.test(m);
+    return /gpt-4o|gpt-4\.1|gpt-4-turbo|gpt-5|claude|gemini|llava|qwen.*vl|qwen2.*vl|qwen3.*vl|qwen3\.[5-9]|pixtral|llama.*vision|gemma.*vision|gemma-?[34]/.test(m);
   }
 
   get useCompactPrompt() {

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1260,8 +1260,8 @@ function renderProviders() {
     huggingface: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'hf_...' },
-        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'deepseek-ai/DeepSeek-V4',
-          suggestions: ['deepseek-ai/DeepSeek-V4', 'meta-llama/Llama-4-Scout-17B-16E-Instruct', 'zai-org/GLM-5.2', 'Qwen/Qwen3.6-27B', 'moonshotai/Kimi-K2.5-Instruct'] },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'zai-org/GLM-5.2',
+          suggestions: ['zai-org/GLM-5.2', 'Qwen/Qwen3.6-27B', 'moonshotai/Kimi-K2.5-Instruct'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://router.huggingface.co/v1' },
         PROMPT_TIER_FIELD,
       ],

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1261,7 +1261,7 @@ function renderProviders() {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'hf_...' },
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'zai-org/GLM-5.2',
-          suggestions: ['zai-org/GLM-5.2', 'Qwen/Qwen3.6-27B', 'moonshotai/Kimi-K2.5-Instruct'] },
+          suggestions: ['zai-org/GLM-5.2', 'Qwen/Qwen3.6-27B'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://router.huggingface.co/v1' },
         PROMPT_TIER_FIELD,
       ],

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1263,6 +1263,11 @@ function renderProviders() {
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'zai-org/GLM-5.2',
           suggestions: ['zai-org/GLM-5.2', 'Qwen/Qwen3.6-27B'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://router.huggingface.co/v1' },
+        // Hugging Face's catalog is huge and open-ended — unlike curated
+        // routers, model-name sniffing (openai.js supportsVision) can't
+        // reliably tell VLMs from text-only models, so expose an explicit
+        // toggle like the local providers do.
+        { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
         PROMPT_TIER_FIELD,
       ],
     },

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1257,6 +1257,15 @@ function renderProviders() {
         PROMPT_TIER_FIELD,
       ],
     },
+    huggingface: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'hf_...' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'deepseek-ai/DeepSeek-V4',
+          suggestions: ['deepseek-ai/DeepSeek-V4', 'meta-llama/Llama-4-Scout-17B-16E-Instruct', 'zai-org/GLM-5.2', 'Qwen/Qwen3.6-27B', 'moonshotai/Kimi-K2.5-Instruct'] },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://router.huggingface.co/v1' },
+        PROMPT_TIER_FIELD,
+      ],
+    },
     anthropic: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-ant-...' },
@@ -1348,16 +1357,6 @@ function renderProviders() {
         ...COST_ESTIMATE_FIELDS,
       ],
     },
-    // OAuth-based Claude subscription provider. The card body is rendered
-    // by renderClaudeOAuthCard() — it shows a sign-in/out button, the
-    // current account state, and a disclaimer about Anthropic's terms.
-    // The model field is the only normal config field.
-    claude_subscription: {
-      customRender: 'claude_oauth',
-      fields: [
-        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'claude-sonnet-4-6' },
-      ],
-    },
   };
 
   // Filter bar — sits above the list. Pill row, click-to-switch.
@@ -1376,15 +1375,6 @@ function renderProviders() {
     const category = config.category || 'cloud';
     if (providerFilter !== 'all' && category !== providerFilter && !isActive) continue;
     visibleCount++;
-
-    // Custom render for the OAuth Claude provider — same collapsible
-    // wrapper, but the body comes from renderClaudeOAuthCard().
-    if (providerConfigs[id]?.customRender === 'claude_oauth') {
-      providersContainer.appendChild(
-        wrapCollapsibleCard(id, config, isActive, renderClaudeOAuthCardBody(id, config, fieldDefs))
-      );
-      continue;
-    }
 
     let fieldsHTML = '';
     for (const field of fieldDefs) {
@@ -1570,18 +1560,6 @@ function renderProviders() {
       closeLoadedModelDialog(dialog);
     });
   });
-  // OAuth-Claude-specific bindings. These only fire if the OAuth card is
-  // currently rendered (i.e., expanded — collapsed bodies aren't in DOM).
-  document.querySelectorAll('.btn-claude-signin').forEach(btn => {
-    btn.addEventListener('click', () => signInWithClaude(btn.dataset.provider));
-  });
-  document.querySelectorAll('.btn-claude-signout').forEach(btn => {
-    btn.addEventListener('click', () => signOutOfClaude(btn.dataset.provider));
-  });
-  document.querySelectorAll('.claude-oauth-status').forEach(el => {
-    const id = el.id.replace(/^claude-oauth-status-/, '');
-    if (id) queueMicrotask(() => refreshClaudeOAuthStatus(id));
-  });
 }
 
 /**
@@ -1671,116 +1649,6 @@ function wrapCollapsibleCard(id, config, isActive, bodyHtml) {
   card.appendChild(header);
   if (expanded) card.appendChild(body);
   return card;
-}
-
-/**
- * Render the BODY of the Claude (Pro/Max subscription) provider card.
- *
- * Returns the inner HTML — header + outer wrapper come from
- * wrapCollapsibleCard() in renderProviders(). Differs from a normal
- * provider card in three ways:
- *   - No API-key field. Auth is via OAuth — handled by the background
- *     script. We just dispatch claude_oauth_start/signout/status.
- *   - Loaded auth state shows the obtained-at timestamp and a "Sign
- *     out" button; unauthed state shows "Sign in with Claude".
- *   - A persistent disclaimer warns the user that Anthropic's terms
- *     restrict third-party clients from using Pro/Max subs and that
- *     this integration may stop working at any time.
- *
- * Event bindings (sign-in/out) + the async status refresh fire from
- * the per-card pass at the end of renderProviders() — see
- * bindClaudeOAuthCards().
- */
-function renderClaudeOAuthCardBody(id, config, fieldDefs) {
-  const isActive = id === activeProviderId;
-  let fieldsHTML = '';
-  for (const field of fieldDefs) {
-    const label = field.labelKey ? t(field.labelKey) : (field.label || field.key);
-    const placeholder = field.placeholder || '';
-    fieldsHTML += `
-      <div class="field">
-        <label>${escapeHtml(label)}</label>
-        <input type="${field.type}" data-provider="${id}" data-key="${field.key}"
-               value="${escapeHtml(config[field.key] || '')}" placeholder="${escapeHtml(placeholder)}">
-      </div>
-    `;
-  }
-
-  return `
-    <div class="claude-oauth-status" id="claude-oauth-status-${id}"
-         style="padding:10px 12px;border-radius:6px;background:var(--surface2,#f5f5f7);
-                margin-bottom:10px;font-size:13px;color:var(--text2);">
-      Loading sign-in status…
-    </div>
-
-    ${fieldsHTML}
-
-    <div class="btn-row">
-      <button class="btn-primary btn-claude-signin" data-provider="${id}" style="display:none;">
-        Sign in with Claude
-      </button>
-      <button class="btn-secondary btn-claude-signout" data-provider="${id}" style="display:none;">
-        Sign out
-      </button>
-      <button class="btn-primary btn-save" data-provider="${id}">${escapeHtml(t('st.providers.save'))}</button>
-      <button class="btn-secondary btn-test" data-provider="${id}">${escapeHtml(t('st.providers.test'))}</button>
-      ${!isActive ? `<button class="btn-secondary btn-activate" data-provider="${id}">${escapeHtml(t('st.providers.set_active'))}</button>` : ''}
-    </div>
-
-    <div class="test-result" id="test-${id}"></div>
-
-    <div style="margin-top:14px;padding:10px 12px;border-radius:6px;
-                background:rgba(204,153,0,0.08);border:1px solid rgba(204,153,0,0.25);
-                font-size:12px;color:var(--text2);line-height:1.5;">
-      <strong>Heads up:</strong> Uses your Claude.ai Pro/Max subscription's quota via the OAuth flow Anthropic ships for Claude Code. This is a third-party use of that flow — Anthropic's terms restrict using Pro/Max subscriptions with non-Anthropic tools, and the integration could stop working at any time if Anthropic rotates their CLI's OAuth client. Your access + refresh tokens are stored in <code>chrome.storage.local</code> in plaintext (same as API keys). Use at your own risk; for production / reliability, prefer the API-key Anthropic provider above.
-    </div>
-  `;
-}
-
-async function refreshClaudeOAuthStatus(id) {
-  const statusEl = document.getElementById(`claude-oauth-status-${id}`);
-  const signInBtn = document.querySelector(`.btn-claude-signin[data-provider="${id}"]`);
-  const signOutBtn = document.querySelector(`.btn-claude-signout[data-provider="${id}"]`);
-  if (!statusEl) return;
-
-  try {
-    const status = await sendToBackgroundWithTimeout('claude_oauth_status', {}, 5000);
-    if (status?.signedIn) {
-      const obtained = new Date(status.obtainedAt || Date.now()).toLocaleString();
-      const expires = new Date(status.expiresAt || Date.now()).toLocaleTimeString();
-      statusEl.innerHTML = `<strong style="color:var(--ok,#1a8a4a);">Signed in.</strong> Token issued ${escapeHtml(obtained)}, refreshes around ${escapeHtml(expires)}.`;
-      if (signInBtn) signInBtn.style.display = 'none';
-      if (signOutBtn) signOutBtn.style.display = '';
-    } else {
-      statusEl.innerHTML = `Not signed in. Click <strong>Sign in with Claude</strong> to authorize this extension against your Claude.ai account.`;
-      if (signInBtn) signInBtn.style.display = '';
-      if (signOutBtn) signOutBtn.style.display = 'none';
-    }
-  } catch (e) {
-    statusEl.innerHTML = `Status unavailable: ${escapeHtml(e.message)}`;
-    if (signInBtn) signInBtn.style.display = '';
-    if (signOutBtn) signOutBtn.style.display = 'none';
-  }
-}
-
-async function signInWithClaude(id) {
-  const statusEl = document.getElementById(`claude-oauth-status-${id}`);
-  if (statusEl) statusEl.innerHTML = `Opening Claude.ai sign-in tab… complete authorization in the new tab. The sign-in tab closes automatically once you approve.`;
-  try {
-    const res = await sendToBackground('claude_oauth_start');
-    if (res?.ok) {
-      await refreshClaudeOAuthStatus(id);
-    } else {
-      if (statusEl) statusEl.innerHTML = `Sign-in failed: ${escapeHtml(res?.error || 'Unknown error')}`;
-    }
-  } catch (e) {
-    if (statusEl) statusEl.innerHTML = `Sign-in failed: ${escapeHtml(e.message)}`;
-  }
-}
-
-async function signOutOfClaude(id) {
-  await sendToBackground('claude_oauth_signout');
-  await refreshClaudeOAuthStatus(id);
 }
 
 function setProviderLoadModelsStatus(id, message, color = 'var(--text2)') {
@@ -1984,15 +1852,6 @@ function sendToBackground(action, data = {}) {
       }
     );
   });
-}
-
-function sendToBackgroundWithTimeout(action, data = {}, timeoutMs = 5000) {
-  let timeoutId;
-  const timeout = new Promise((_, reject) => {
-    timeoutId = setTimeout(() => reject(new Error('Timed out waiting for background response. Reload the extension and reopen Settings.')), timeoutMs);
-  });
-  return Promise.race([sendToBackground(action, data), timeout])
-    .finally(() => clearTimeout(timeoutId));
 }
 
 init();

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -346,7 +346,7 @@ export class ProviderManager {
         label: 'Hugging Face Inference',
         providerName: 'huggingface',
         baseUrl: 'https://router.huggingface.co/v1',
-        model: 'deepseek-ai/DeepSeek-V4',
+        model: 'zai-org/GLM-5.2',
         supportsStreamUsageOptions: true,
         apiKey: '',
         apiKeyUrl: 'https://huggingface.co/settings/tokens',

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -1,6 +1,7 @@
 import { LlamaCppProvider } from './llamacpp.js';
 import { OpenAICompatibleProvider } from './openai.js';
 import { AnthropicProvider, AnthropicOAuthProvider } from './anthropic.js';
+import { signOutClaude } from './oauth-claude.js';
 
 const WEBBRAIN_CLOUD_PROVIDER_ID = 'webbrain_cloud';
 const WEBBRAIN_CLOUD_CONTEXT_WINDOW = 1000000;
@@ -47,6 +48,11 @@ export class ProviderManager {
     delete configs.webbrain;
     delete configs.openai_subscription;
     delete configs.claude_subscription;
+    // The claude_subscription provider entry above is gone and its
+    // settings-UI sign-out control with it, so purge any leftover OAuth
+    // token bundle here — otherwise a previously-signed-in user's raw
+    // access/refresh tokens would sit in storage with no UI path to clear them.
+    await signOutClaude();
     if (configs[WEBBRAIN_CLOUD_PROVIDER_ID]) {
       configs[WEBBRAIN_CLOUD_PROVIDER_ID].deviceGuid = await this._getDeviceGuid(data[WEBBRAIN_DEVICE_GUID_KEY]);
     }

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -10,7 +10,7 @@ const OPENROUTER_DEFAULT_MODEL = 'openrouter/free';
 const OPENROUTER_LEGACY_DEFAULT_MODEL = 'stepfun/step-3.7-flash';
 const SUPPORTED_PROVIDER_TYPES = new Set(['llamacpp', 'openai', 'anthropic', 'anthropic_oauth']);
 const SAFE_PROVIDER_ID_RE = /^[A-Za-z0-9_-]+$/;
-const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq'];
+const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface'];
 
 /**
  * Manages LLM provider instances and persists configuration.
@@ -46,6 +46,7 @@ export class ProviderManager {
     }
     delete configs.webbrain;
     delete configs.openai_subscription;
+    delete configs.claude_subscription;
     if (configs[WEBBRAIN_CLOUD_PROVIDER_ID]) {
       configs[WEBBRAIN_CLOUD_PROVIDER_ID].deviceGuid = await this._getDeviceGuid(data[WEBBRAIN_DEVICE_GUID_KEY]);
     }
@@ -339,15 +340,16 @@ export class ProviderManager {
         apiKeyUrl: 'https://openrouter.ai/keys',
         enabled: false,
       },
-      // Subscription auth (OAuth) entry, kept distinct from the API-key
-      // entry above so a user can have both configured. Tokens live in
-      // `browser.storage.local` under `anthropicOauthTokens` (see
-      // oauth-claude.js), not in this config.
-      claude_subscription: {
-        type: 'anthropic_oauth',
-        category: 'cloud',
-        label: 'Claude (Pro/Max subscription)',
-        model: 'claude-sonnet-4-6',
+      huggingface: {
+        type: 'openai',
+        category: 'router',
+        label: 'Hugging Face Inference',
+        providerName: 'huggingface',
+        baseUrl: 'https://router.huggingface.co/v1',
+        model: 'deepseek-ai/DeepSeek-V4',
+        supportsStreamUsageOptions: true,
+        apiKey: '',
+        apiKeyUrl: 'https://huggingface.co/settings/tokens',
         enabled: false,
       },
     };

--- a/src/firefox/src/providers/openai.js
+++ b/src/firefox/src/providers/openai.js
@@ -30,8 +30,11 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
 
   get supportsVision() {
     if (this.config.supportsVision != null) return !!this.config.supportsVision;
+    // Qwen went natively multimodal starting at 3.5 (no separate -VL
+    // checkpoint needed), so qwen3\.[5-9] catches those alongside the
+    // older qwen*vl-suffixed lines.
     const m = (this.config.model || '').toLowerCase();
-    return /gpt-4o|gpt-4\.1|gpt-4-turbo|gpt-5|claude|gemini|llava|qwen.*vl|qwen2.*vl|qwen3.*vl|pixtral|llama.*vision|gemma.*vision|gemma-?[34]/.test(m);
+    return /gpt-4o|gpt-4\.1|gpt-4-turbo|gpt-5|claude|gemini|llava|qwen.*vl|qwen2.*vl|qwen3.*vl|qwen3\.[5-9]|pixtral|llama.*vision|gemma.*vision|gemma-?[34]/.test(m);
   }
 
   get useCompactPrompt() {

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1229,7 +1229,7 @@ function renderProviders() {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'hf_...' },
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'zai-org/GLM-5.2',
-          suggestions: ['zai-org/GLM-5.2', 'Qwen/Qwen3.6-27B', 'moonshotai/Kimi-K2.5-Instruct'] },
+          suggestions: ['zai-org/GLM-5.2', 'Qwen/Qwen3.6-27B'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://router.huggingface.co/v1' },
         PROMPT_TIER_FIELD,
       ],

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1228,8 +1228,8 @@ function renderProviders() {
     huggingface: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'hf_...' },
-        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'deepseek-ai/DeepSeek-V4',
-          suggestions: ['deepseek-ai/DeepSeek-V4', 'meta-llama/Llama-4-Scout-17B-16E-Instruct', 'zai-org/GLM-5.2', 'Qwen/Qwen3.6-27B', 'moonshotai/Kimi-K2.5-Instruct'] },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'zai-org/GLM-5.2',
+          suggestions: ['zai-org/GLM-5.2', 'Qwen/Qwen3.6-27B', 'moonshotai/Kimi-K2.5-Instruct'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://router.huggingface.co/v1' },
         PROMPT_TIER_FIELD,
       ],

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1225,6 +1225,15 @@ function renderProviders() {
         PROMPT_TIER_FIELD,
       ],
     },
+    huggingface: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'hf_...' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'deepseek-ai/DeepSeek-V4',
+          suggestions: ['deepseek-ai/DeepSeek-V4', 'meta-llama/Llama-4-Scout-17B-16E-Instruct', 'zai-org/GLM-5.2', 'Qwen/Qwen3.6-27B', 'moonshotai/Kimi-K2.5-Instruct'] },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://router.huggingface.co/v1' },
+        PROMPT_TIER_FIELD,
+      ],
+    },
     anthropic: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-ant-...' },
@@ -1316,14 +1325,6 @@ function renderProviders() {
         ...COST_ESTIMATE_FIELDS,
       ],
     },
-    // OAuth-based Claude subscription provider. Card body rendered by
-    // renderClaudeOAuthCardBody() — sign-in button + auth status + disclaimer.
-    claude_subscription: {
-      customRender: 'claude_oauth',
-      fields: [
-        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'claude-sonnet-4-20250514' },
-      ],
-    },
   };
 
   // Filter pill row above the providers list.
@@ -1338,13 +1339,6 @@ function renderProviders() {
     const category = config.category || 'cloud';
     if (providerFilter !== 'all' && category !== providerFilter && !isActive) continue;
     visibleCount++;
-
-    if (providerConfigs[id]?.customRender === 'claude_oauth') {
-      providersContainer.appendChild(
-        wrapCollapsibleCard(id, config, isActive, renderClaudeOAuthCardBody(id, config, fieldDefs))
-      );
-      continue;
-    }
 
     let fieldsHTML = '';
     for (const field of fieldDefs) {
@@ -1527,16 +1521,6 @@ function renderProviders() {
       closeLoadedModelDialog(dialog);
     });
   });
-  document.querySelectorAll('.btn-claude-signin').forEach(btn => {
-    btn.addEventListener('click', () => signInWithClaude(btn.dataset.provider));
-  });
-  document.querySelectorAll('.btn-claude-signout').forEach(btn => {
-    btn.addEventListener('click', () => signOutOfClaude(btn.dataset.provider));
-  });
-  document.querySelectorAll('.claude-oauth-status').forEach(el => {
-    const id = el.id.replace(/^claude-oauth-status-/, '');
-    if (id) queueMicrotask(() => refreshClaudeOAuthStatus(id));
-  });
 }
 
 /**
@@ -1619,103 +1603,6 @@ function wrapCollapsibleCard(id, config, isActive, bodyHtml) {
   card.appendChild(header);
   if (expanded) card.appendChild(body);
   return card;
-}
-
-/**
- * Render the Claude (Pro/Max subscription) provider card. Differs from
- * the normal cards in that auth is via OAuth (Sign in with Claude button)
- * — see Chrome equivalent for full notes.
- */
-function renderClaudeOAuthCardBody(id, config, fieldDefs) {
-  const isActive = id === activeProviderId;
-  let fieldsHTML = '';
-  for (const field of fieldDefs) {
-    const label = field.labelKey ? t(field.labelKey) : (field.label || field.key);
-    const placeholder = field.placeholder || '';
-    fieldsHTML += `
-      <div class="field">
-        <label>${escapeHtml(label)}</label>
-        <input type="${field.type}" data-provider="${id}" data-key="${field.key}"
-               value="${escapeHtml(config[field.key] || '')}" placeholder="${escapeHtml(placeholder)}">
-      </div>
-    `;
-  }
-
-  return `
-    <div class="claude-oauth-status" id="claude-oauth-status-${id}"
-         style="padding:10px 12px;border-radius:6px;background:var(--surface2,#f5f5f7);
-                margin-bottom:10px;font-size:13px;color:var(--text2);">
-      Loading sign-in status…
-    </div>
-
-    ${fieldsHTML}
-
-    <div class="btn-row">
-      <button class="btn-primary btn-claude-signin" data-provider="${id}" style="display:none;">
-        Sign in with Claude
-      </button>
-      <button class="btn-secondary btn-claude-signout" data-provider="${id}" style="display:none;">
-        Sign out
-      </button>
-      <button class="btn-primary btn-save" data-provider="${id}">${escapeHtml(t('st.providers.save'))}</button>
-      <button class="btn-secondary btn-test" data-provider="${id}">${escapeHtml(t('st.providers.test'))}</button>
-      ${!isActive ? `<button class="btn-secondary btn-activate" data-provider="${id}">${escapeHtml(t('st.providers.set_active'))}</button>` : ''}
-    </div>
-
-    <div class="test-result" id="test-${id}"></div>
-
-    <div style="margin-top:14px;padding:10px 12px;border-radius:6px;
-                background:rgba(204,153,0,0.08);border:1px solid rgba(204,153,0,0.25);
-                font-size:12px;color:var(--text2);line-height:1.5;">
-      <strong>Heads up:</strong> Uses your Claude.ai Pro/Max subscription's quota via the OAuth flow Anthropic ships for Claude Code. This is a third-party use of that flow — Anthropic's terms restrict using Pro/Max subscriptions with non-Anthropic tools, and the integration could stop working at any time if Anthropic rotates their CLI's OAuth client. Your access + refresh tokens are stored in <code>browser.storage.local</code> in plaintext (same as API keys). Use at your own risk; for production / reliability, prefer the API-key Anthropic provider above.
-    </div>
-  `;
-}
-
-async function refreshClaudeOAuthStatus(id) {
-  const statusEl = document.getElementById(`claude-oauth-status-${id}`);
-  const signInBtn = document.querySelector(`.btn-claude-signin[data-provider="${id}"]`);
-  const signOutBtn = document.querySelector(`.btn-claude-signout[data-provider="${id}"]`);
-  if (!statusEl) return;
-
-  try {
-    const status = await sendToBackgroundWithTimeout('claude_oauth_status', {}, 5000);
-    if (status?.signedIn) {
-      const obtained = new Date(status.obtainedAt || Date.now()).toLocaleString();
-      const expires = new Date(status.expiresAt || Date.now()).toLocaleTimeString();
-      statusEl.innerHTML = `<strong style="color:var(--ok,#1a8a4a);">Signed in.</strong> Token issued ${escapeHtml(obtained)}, refreshes around ${escapeHtml(expires)}.`;
-      if (signInBtn) signInBtn.style.display = 'none';
-      if (signOutBtn) signOutBtn.style.display = '';
-    } else {
-      statusEl.innerHTML = `Not signed in. Click <strong>Sign in with Claude</strong> to authorize this extension against your Claude.ai account.`;
-      if (signInBtn) signInBtn.style.display = '';
-      if (signOutBtn) signOutBtn.style.display = 'none';
-    }
-  } catch (e) {
-    statusEl.innerHTML = `Status unavailable: ${escapeHtml(e.message)}`;
-    if (signInBtn) signInBtn.style.display = '';
-    if (signOutBtn) signOutBtn.style.display = 'none';
-  }
-}
-
-async function signInWithClaude(id) {
-  const statusEl = document.getElementById(`claude-oauth-status-${id}`);
-  if (statusEl) statusEl.innerHTML = `Opening Claude.ai sign-in tab… complete authorization in the new tab. The sign-in tab closes automatically once you approve.`;
-  try {
-    const res = await sendToBackground('claude_oauth_start');
-    if (res?.ok) {
-      await refreshClaudeOAuthStatus(id);
-    } else {
-      if (statusEl) statusEl.innerHTML = `Sign-in failed: ${escapeHtml(res?.error || 'Unknown error')}`;
-    }
-  } catch (e) {
-    if (statusEl) statusEl.innerHTML = `Sign-in failed: ${escapeHtml(e.message)}`;
-  }
-}
-
-async function signOutOfClaude(id) {
-  await sendToBackground('claude_oauth_signout');
-  await refreshClaudeOAuthStatus(id);
 }
 
 function setProviderLoadModelsStatus(id, message, color = 'var(--text2)') {
@@ -1904,15 +1791,6 @@ async function sendToBackground(action, data = {}) {
     throw new Error(response.error);
   }
   return response;
-}
-
-function sendToBackgroundWithTimeout(action, data = {}, timeoutMs = 5000) {
-  let timeoutId;
-  const timeout = new Promise((_, reject) => {
-    timeoutId = setTimeout(() => reject(new Error('Timed out waiting for background response. Reload the extension and reopen Settings.')), timeoutMs);
-  });
-  return Promise.race([sendToBackground(action, data), timeout])
-    .finally(() => clearTimeout(timeoutId));
 }
 
 init();

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1231,6 +1231,11 @@ function renderProviders() {
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'zai-org/GLM-5.2',
           suggestions: ['zai-org/GLM-5.2', 'Qwen/Qwen3.6-27B'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://router.huggingface.co/v1' },
+        // Hugging Face's catalog is huge and open-ended — unlike curated
+        // routers, model-name sniffing (openai.js supportsVision) can't
+        // reliably tell VLMs from text-only models, so expose an explicit
+        // toggle like the local providers do.
+        { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
         PROMPT_TIER_FIELD,
       ],
     },

--- a/test/run.js
+++ b/test/run.js
@@ -10455,6 +10455,9 @@ test('ProviderManager load ignores unsupported stored provider configs', async (
       async set(patch) {
         Object.assign(storageData, patch);
       },
+      async remove(keys) {
+        for (const key of Array.isArray(keys) ? keys : [keys]) delete storageData[key];
+      },
     };
     return {
       storage: { local },


### PR DESCRIPTION
Claude (Pro/Max subscription) is dropped from the settings/sidepanel provider list since Anthropic currently blocks third-party OAuth clients from using it. Hugging Face Inference is added as a new router-category provider (router.huggingface.co, OpenAI-compatible) with current open-weight model suggestions.