### PR TITLE
[codex] Speed up recommended media actions

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1432,6 +1432,16 @@ export class Agent {
   static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover', 'drag_drop']);
   static NAV_PRONE_TOOLS = new Set(['click', 'click_ax', 'navigate', 'go_back', 'go_forward', 'iframe_click']);
   static RECOMMENDED_ACTION_FAST_PATH_IDS = new Set(['download-media']);
+  static RECOMMENDED_ACTION_FIRST_TOOLS = Object.freeze({
+    'summarize-page': new Set(['read_page']),
+    'explain-page': new Set(['read_page', 'get_accessibility_tree']),
+    'summarize-youtube-video': new Set(['read_youtube_transcript']),
+    'summarize-thread': new Set(['get_accessibility_tree']),
+    'find-followups': new Set(['get_accessibility_tree']),
+    'rewrite-focused-draft': new Set(['get_accessibility_tree']),
+    'compare-price': new Set(['get_accessibility_tree']),
+  });
+  static RECOMMENDED_ACTION_READ_ONLY_FIRST_TOOLS = new Set(['read_page', 'get_accessibility_tree', 'read_youtube_transcript']);
 
   // System prompt for the dedicated "vision model" sub-call. Kept terse and
   // format-oriented so the description is actually useful to the planning
@@ -3985,6 +3995,67 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       ? action.steps.map(step => sanitizePlannerText(step, 300, { collapseWhitespace: true })).filter(Boolean).slice(0, 5)
       : [];
     return { id, tool, summary, steps };
+  }
+
+  _recommendedActionFirstToolArgs(tool, args = {}) {
+    const input = args && typeof args === 'object' && !Array.isArray(args) ? args : {};
+    if (tool === 'read_page') {
+      return { includeChrome: input.includeChrome === true };
+    }
+    if (tool === 'get_accessibility_tree') {
+      const out = {};
+      if (['all', 'visible', 'interactive'].includes(input.filter)) out.filter = input.filter;
+      if (Number.isFinite(input.maxDepth)) out.maxDepth = Math.max(1, Math.min(20, Math.trunc(input.maxDepth)));
+      if (Number.isFinite(input.maxChars)) out.maxChars = Math.max(1000, Math.min(60000, Math.trunc(input.maxChars)));
+      return out;
+    }
+    if (tool === 'read_youtube_transcript') {
+      const out = {};
+      if (typeof input.timestamps === 'boolean') out.timestamps = input.timestamps;
+      if (typeof input.include_segments === 'boolean') out.include_segments = input.include_segments;
+      if (Number.isFinite(input.text_limit)) out.text_limit = Math.max(1, Math.min(12000, Math.trunc(input.text_limit)));
+      if (Number.isFinite(input.text_offset)) out.text_offset = Math.max(0, Math.trunc(input.text_offset));
+      return out;
+    }
+    return {};
+  }
+
+  _recommendedActionFirstTool(runOptions = {}, allowedToolNames = null) {
+    const action = runOptions?.recommendedAction;
+    if (!action || action.autoExecute !== true) return null;
+    const id = sanitizePlannerText(action.id, 80, { collapseWhitespace: true });
+    const allowedToolsForAction = this.constructor.RECOMMENDED_ACTION_FIRST_TOOLS[id];
+    if (!allowedToolsForAction) return null;
+    const tool = sanitizePlannerText(action.tool, 80, { collapseWhitespace: true });
+    if (!allowedToolsForAction.has(tool)) return null;
+    if (!this.constructor.RECOMMENDED_ACTION_READ_ONLY_FIRST_TOOLS.has(tool)) return null;
+    if (this.constructor.STATE_CHANGE_TOOLS.has(tool)) return null;
+    if (allowedToolNames && !allowedToolNames.has(tool)) return null;
+    if (tool === 'read_youtube_transcript' && !this._skillToolForName(tool)) return null;
+    return {
+      id,
+      tool,
+      args: this._recommendedActionFirstToolArgs(tool, action.args),
+    };
+  }
+
+  async _maybeExecuteRecommendedActionFirstTool(tabId, runOptions, messages, onUpdate, provider, allowedToolNames) {
+    const firstTool = this._recommendedActionFirstTool(runOptions, allowedToolNames);
+    if (!firstTool) return null;
+    const callId = `recommended_${firstTool.id.replace(/[^a-z0-9_-]/gi, '_')}_first_tool`;
+    const toolCall = {
+      id: callId,
+      function: {
+        name: firstTool.tool,
+        arguments: JSON.stringify(firstTool.args || {}),
+      },
+    };
+    messages.push({
+      role: 'assistant',
+      content: null,
+      tool_calls: [toolCall],
+    });
+    return await this._executeToolBatch(tabId, [toolCall], messages, onUpdate, provider, null, allowedToolNames, 0);
   }
 
   _formatRecommendedActionFastPathScratchpad(plan) {
@@ -11359,6 +11430,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       runId = await this._startTraceRun(tabId, userMessage, mode, provider);
     }
 
+    const recommendedFirstTool = await this._maybeExecuteRecommendedActionFirstTool(
+      tabId, runOptions, messages, onUpdate, provider, allowedToolNames,
+    );
+    if (recommendedFirstTool?.action === 'return') {
+      finalResponse = recommendedFirstTool.value;
+      return finalResponse;
+    }
+    if (recommendedFirstTool?.action === 'abort') {
+      finalResponse = recommendedFirstTool.value;
+      _traceStatus = 'cancelled';
+      return finalResponse;
+    }
+
     while (steps < this.maxSteps) {
       // Check for abort before each step
       if (this._checkAbort(tabId)) {
@@ -11720,6 +11804,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // See processMessage — used to break the empty-response→nudge cycle.
     let emptyOutputRecoveryAttempted = false;
     let compressionPlaceholderRecoveryAttempted = false;
+
+    const recommendedFirstTool = await this._maybeExecuteRecommendedActionFirstTool(
+      tabId, runOptions, messages, onUpdate, provider, allowedToolNames,
+    );
+    if (recommendedFirstTool?.action === 'return') {
+      return finish(recommendedFirstTool.value);
+    }
+    if (recommendedFirstTool?.action === 'abort') {
+      return finish(recommendedFirstTool.value, 'cancelled');
+    }
 
     while (steps < this.maxSteps) {
       if (this._checkAbort(tabId)) {

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -3976,7 +3976,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const id = sanitizePlannerText(action.id, 80, { collapseWhitespace: true });
     if (!this.constructor.RECOMMENDED_ACTION_FAST_PATH_IDS.has(id)) return null;
     const tool = sanitizePlannerText(action.tool, 80, { collapseWhitespace: true });
-    if (id === 'download-media' && tool !== 'download_public_media') return null;
+    if (id === 'download-media') {
+      if (tool !== 'download_public_media') return null;
+      if (!this._skillToolForName(tool)) return null;
+    }
     const summary = sanitizePlannerText(action.summary || 'Run the selected recommended action.', 500, { collapseWhitespace: true });
     const steps = Array.isArray(action.steps)
       ? action.steps.map(step => sanitizePlannerText(step, 300, { collapseWhitespace: true })).filter(Boolean).slice(0, 5)

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1431,6 +1431,7 @@ export class Agent {
   static NAV_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward']);
   static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover', 'drag_drop']);
   static NAV_PRONE_TOOLS = new Set(['click', 'click_ax', 'navigate', 'go_back', 'go_forward', 'iframe_click']);
+  static RECOMMENDED_ACTION_FAST_PATH_IDS = new Set(['download-media']);
 
   // System prompt for the dedicated "vision model" sub-call. Kept terse and
   // format-oriented so the description is actually useful to the planning
@@ -3969,10 +3970,43 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return !this._plannerFollowUpHasExplicitUrl(text);
   }
 
+  _recommendedActionFastPathPlan(runOptions = {}) {
+    const action = runOptions?.recommendedAction;
+    if (!action || action.skipPlanner !== true) return null;
+    const id = sanitizePlannerText(action.id, 80, { collapseWhitespace: true });
+    if (!this.constructor.RECOMMENDED_ACTION_FAST_PATH_IDS.has(id)) return null;
+    const tool = sanitizePlannerText(action.tool, 80, { collapseWhitespace: true });
+    if (id === 'download-media' && tool !== 'download_public_media') return null;
+    const summary = sanitizePlannerText(action.summary || 'Run the selected recommended action.', 500, { collapseWhitespace: true });
+    const steps = Array.isArray(action.steps)
+      ? action.steps.map(step => sanitizePlannerText(step, 300, { collapseWhitespace: true })).filter(Boolean).slice(0, 5)
+      : [];
+    return { id, tool, summary, steps };
+  }
+
+  _formatRecommendedActionFastPathScratchpad(plan) {
+    const steps = plan.steps.length
+      ? plan.steps
+      : [`Call ${plan.tool || 'the intended tool'} for the selected recommended action.`];
+    const lines = [
+      '[Approved plan — pinned by recommended action]',
+      '',
+      '### Summary',
+      plan.summary,
+      '',
+      '### Steps',
+      ...steps.map((step, index) => `${index + 1}. ${step}`),
+    ];
+    if (plan.tool) {
+      lines.push('', '### Immediate tool', `- ${plan.tool}`);
+    }
+    return lines.join('\n').slice(0, 3000);
+  }
+
   /**
    * Plan-before-Act gate: push user message, pin approved plan after it, or stop early.
    */
-  async _maybeRunPlannerGate(tabId, messages, enriched, onUpdate, mode, costState, runId, tabInfo = null) {
+  async _maybeRunPlannerGate(tabId, messages, enriched, onUpdate, mode, costState, runId, tabInfo = null, runOptions = {}) {
     const plannerMode = this._isActionMode(mode) ? this._plannerMode() : 'off';
     const runPlanner = plannerMode !== 'off';
 
@@ -3985,6 +4019,25 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this._persist(tabId);
     if (!runPlanner) {
       this.plannerFollowUpSkipTabs.delete(tabId);
+      return { proceed: true };
+    }
+    const fastPathPlan = this._recommendedActionFastPathPlan(runOptions);
+    if (fastPathPlan) {
+      this.plannerFollowUpSkipTabs.delete(tabId);
+      const scratchResult = this._scratchpadWrite(tabId, {
+        text: this._formatRecommendedActionFastPathScratchpad(fastPathPlan),
+      });
+      if (!scratchResult?.success) {
+        onUpdate('warning', { message: scratchResult?.error || 'Could not pin recommended action plan to scratchpad.' });
+      } else {
+        const scratchIdx = this._findScratchpadIndex(messages);
+        if (scratchIdx >= 0 && scratchIdx < messages.length - 1) {
+          const scratchMsg = messages[scratchIdx];
+          messages.splice(scratchIdx, 1);
+          messages.push(scratchMsg);
+        }
+      }
+      this._persist(tabId);
       return { proceed: true };
     }
     if (this._shouldSkipPlannerForShortFollowUp(tabId, priorMessages, enriched, plannerMode)) {
@@ -11134,13 +11187,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return normalized === '[compressed]' || normalized === '[context compressed]';
   }
 
-  async processMessage(tabId, userMessage, onUpdate = () => {}, mode = 'ask', attachments = []) {
+  async processMessage(tabId, userMessage, onUpdate = () => {}, mode = 'ask', attachments = [], runOptions = {}) {
     if (this._runningTabs.has(tabId)) {
       throw new Error('An agent run is already in progress for this tab.');
     }
     this._runningTabs.add(tabId);
     try {
-      return await this._processMessageInner(tabId, userMessage, onUpdate, mode, attachments);
+      return await this._processMessageInner(tabId, userMessage, onUpdate, mode, attachments, runOptions);
     } finally {
       this.currentCostState.delete(tabId);
       this._runningTabs.delete(tabId);
@@ -11203,7 +11256,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return { ok: true };
   }
 
-  async _processMessageInner(tabId, userMessage, onUpdate, mode, attachments = []) {
+  async _processMessageInner(tabId, userMessage, onUpdate, mode, attachments = [], runOptions = {}) {
     await this._hydrate(tabId);
     const messages = this.getConversation(tabId, mode);
     // Scheduled resumes get the live ledger appended at fire time, so the
@@ -11277,7 +11330,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
 
     const gateOutcome = await this._maybeRunPlannerGate(
-      tabId, messages, enriched, onUpdate, mode, costState, runId, plannerTabInfo,
+      tabId, messages, enriched, onUpdate, mode, costState, runId, plannerTabInfo, runOptions,
     );
     if (!gateOutcome.proceed) {
       _traceStatus = gateOutcome.reason === 'cost_limit' ? 'cost_limit' : 'cancelled';
@@ -11582,20 +11635,20 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   /**
    * Process a message with streaming output.
    */
-  async processMessageStream(tabId, userMessage, onUpdate = () => {}, mode = 'ask') {
+  async processMessageStream(tabId, userMessage, onUpdate = () => {}, mode = 'ask', runOptions = {}) {
     if (this._runningTabs.has(tabId)) {
       throw new Error('An agent run is already in progress for this tab.');
     }
     this._runningTabs.add(tabId);
     try {
-      return await this._processMessageStreamInner(tabId, userMessage, onUpdate, mode);
+      return await this._processMessageStreamInner(tabId, userMessage, onUpdate, mode, runOptions);
     } finally {
       this.currentCostState.delete(tabId);
       this._runningTabs.delete(tabId);
     }
   }
 
-  async _processMessageStreamInner(tabId, userMessage, onUpdate, mode) {
+  async _processMessageStreamInner(tabId, userMessage, onUpdate, mode, runOptions = {}) {
     await this._hydrate(tabId);
     const messages = this.getConversation(tabId, mode);
     const costState = this._newCostRunState();
@@ -11646,7 +11699,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
 
     const gateOutcome = await this._maybeRunPlannerGate(
-      tabId, messages, enriched, onUpdate, mode, costState, runId, plannerTabInfo,
+      tabId, messages, enriched, onUpdate, mode, costState, runId, plannerTabInfo, runOptions,
     );
     if (!gateOutcome.proceed) {
       return finish(gateOutcome.message || 'Task cancelled.', gateOutcome.reason === 'cost_limit' ? 'cost_limit' : 'cancelled');

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -4045,6 +4045,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const callId = `recommended_${firstTool.id.replace(/[^a-z0-9_-]/gi, '_')}_first_tool`;
     const toolCall = {
       id: callId,
+      type: 'function',
       function: {
         name: firstTool.tool,
         arguments: JSON.stringify(firstTool.args || {}),

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -1505,6 +1505,7 @@ async function handleMessage(msg, sender) {
       const updates = [];
       let userMemoryTurnContextTaken = false;
       try {
+        const runOptions = msg.recommendedAction ? { recommendedAction: msg.recommendedAction } : {};
         const result = await agent.processMessage(tabId, msg.text, (type, data) => {
           updates.push({ type, data });
           chrome.runtime.sendMessage({
@@ -1514,7 +1515,7 @@ async function handleMessage(msg, sender) {
             type,
             data,
           }).catch(() => {});
-        }, mode, msg.attachments);
+        }, mode, msg.attachments, runOptions);
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
           userText: msg.text,
@@ -1543,6 +1544,7 @@ async function handleMessage(msg, sender) {
       let userMemoryTurnContextTaken = false;
       let userMemoryTurnHadError = false;
       try {
+        const runOptions = msg.recommendedAction ? { recommendedAction: msg.recommendedAction } : {};
         const result = await agent.processMessageStream(tabId, msg.text, (type, data) => {
           if (type === 'error') userMemoryTurnHadError = true;
           chrome.runtime.sendMessage({
@@ -1552,7 +1554,7 @@ async function handleMessage(msg, sender) {
             type,
             data,
           }).catch(() => {});
-        }, mode);
+        }, mode, runOptions);
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
           userText: msg.text,

--- a/src/chrome/src/ui/recommended-actions.js
+++ b/src/chrome/src/ui/recommended-actions.js
@@ -75,9 +75,9 @@ function isYouTubeVideoPage(host = '', path = '/', url = '') {
 function publicMediaKind(pageInfo = {}, path = '/') {
   const media = pageInfo.media || {};
   if ((media.videoCount || 0) > 0) return 'video';
-  if ((media.imageCount || 0) > 0) return 'image';
   if (/\b(video|reel|shorts|watch|live)\b/i.test(`${path} ${pageInfo.title || ''}`)) return 'video';
   if (/\b(photo|image|picture|pin)\b/i.test(`${path} ${pageInfo.title || ''}`)) return 'image';
+  if ((media.imageCount || 0) > 0) return 'auto';
   return 'auto';
 }
 
@@ -98,6 +98,21 @@ function publicMediaDownloadRunOptions(kind = 'auto') {
       'Report the saved downloadId/result. Use download_social_media only if download_public_media fails.',
     ],
   };
+}
+
+function firstToolRunOptions(id, tool, args = {}, summary = '', steps = []) {
+  return {
+    id,
+    autoExecute: true,
+    tool,
+    args,
+    summary: summary || 'Read the current page before answering.',
+    steps: steps.length ? steps : [`Call ${tool} first for this recommended action.`],
+  };
+}
+
+function visibleTreeArgs(maxDepth = 10) {
+  return { filter: 'visible', maxDepth };
 }
 
 function hasCartOrPriceSignal(pageInfo = {}) {
@@ -212,7 +227,14 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     addUnique(actions, {
       id: 'rewrite-focused-draft',
       label: 'Rewrite this draft',
-      prompt: 'Rewrite the text in the currently focused compose box in three versions: softer, shorter, and more formal. Do not type, send, or publish anything unless I ask.',
+      prompt: 'Use get_accessibility_tree with filter:"visible" first to read the currently focused compose box. Rewrite that draft in three versions: softer, shorter, and more formal. Do not type, send, or publish anything unless I ask.',
+      runOptions: firstToolRunOptions(
+        'rewrite-focused-draft',
+        'get_accessibility_tree',
+        visibleTreeArgs(8),
+        'Read the focused compose box before rewriting the draft.',
+        ['Call get_accessibility_tree with filter:"visible" and maxDepth:8.', 'Use the focused textbox/input text from the result to write variants only.'],
+      ),
     });
   }
 
@@ -225,12 +247,26 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     addUnique(actions, {
       id: 'summarize-thread',
       label: 'Summarize this thread',
-      prompt: 'Summarize the currently open email or message thread, including key points, decisions, and unanswered questions.',
+      prompt: 'Use get_accessibility_tree with filter:"visible" first to read the currently open email or message thread. Summarize key points, decisions, and unanswered questions.',
+      runOptions: firstToolRunOptions(
+        'summarize-thread',
+        'get_accessibility_tree',
+        visibleTreeArgs(12),
+        'Read the visible conversation thread before summarizing it.',
+        ['Call get_accessibility_tree with filter:"visible" and maxDepth:12.', 'Summarize the thread from the returned page data.'],
+      ),
     });
     addUnique(actions, {
       id: 'find-followups',
       label: 'Find follow-ups',
-      prompt: 'Extract action items, deadlines, people to follow up with, and open questions from this conversation.',
+      prompt: 'Use get_accessibility_tree with filter:"visible" first to read the current conversation. Extract action items, deadlines, people to follow up with, and open questions.',
+      runOptions: firstToolRunOptions(
+        'find-followups',
+        'get_accessibility_tree',
+        visibleTreeArgs(12),
+        'Read the visible conversation thread before extracting follow-ups.',
+        ['Call get_accessibility_tree with filter:"visible" and maxDepth:12.', 'Extract follow-ups from the returned page data.'],
+      ),
     });
   }
 
@@ -272,8 +308,15 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     addUnique(actions, {
       id: 'summarize-youtube-video',
       label: 'Summarize this video',
-      prompt: 'Use read_youtube_transcript for the current YouTube video first. Summarize the transcript in concise bullets with key points and timestamps when available. If the transcript tool is unavailable or returns no transcript, say that and use only the visible page context.',
+      prompt: 'Use read_youtube_transcript for the current YouTube video first, omitting url so it uses the active tab. Summarize the transcript in concise bullets with key points and timestamps when available. If the transcript tool is unavailable or returns no transcript, say that and use only the visible page context.',
       mode: 'ask',
+      runOptions: firstToolRunOptions(
+        'summarize-youtube-video',
+        'read_youtube_transcript',
+        { timestamps: true, text_limit: 6000, include_segments: false },
+        'Read the YouTube transcript before summarizing the video.',
+        ['Call read_youtube_transcript for the active tab with timestamps:true, text_limit:6000, and include_segments:false.', 'Summarize the transcript with key points and timestamps when available.'],
+      ),
     });
   }
 
@@ -302,7 +345,14 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     addUnique(actions, {
       id: 'summarize-page',
       label: 'Summarize this page',
-      prompt: 'Summarize this page in 5-8 concise bullet points and include any action items.',
+      prompt: 'Use read_page first for the current long-form page. Summarize it in 5-8 concise bullet points and include any action items.',
+      runOptions: firstToolRunOptions(
+        'summarize-page',
+        'read_page',
+        { includeChrome: false },
+        'Read the long-form page before summarizing it.',
+        ['Call read_page with includeChrome:false.', 'Summarize the returned article/page text in 5-8 concise bullets.'],
+      ),
     });
   }
 
@@ -310,15 +360,40 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     addUnique(actions, {
       id: 'compare-price',
       label: 'Compare this price with other stores',
-      prompt: 'Compare this product\'s price with other stores and summarize the best alternatives.',
+      prompt: 'Use get_accessibility_tree with filter:"visible" first to read the product title, price, and purchase context. Compare this product\'s price with other stores and summarize the best alternatives.',
+      runOptions: firstToolRunOptions(
+        'compare-price',
+        'get_accessibility_tree',
+        visibleTreeArgs(10),
+        'Read the visible product details before comparing prices.',
+        ['Call get_accessibility_tree with filter:"visible" and maxDepth:10.', 'Use the product title, price, and store context from the result before comparing alternatives.'],
+      ),
     });
   }
 
   if (!actions.length && pageInfo.title) {
+    const explainUsesArticleRead = isLongArticle(pageInfo);
     addUnique(actions, {
       id: 'explain-page',
       label: 'Explain this page',
-      prompt: 'Explain what this page is about and what I can do next.',
+      prompt: explainUsesArticleRead
+        ? 'Use read_page first for the current long-form page. Explain what this page is about and what I can do next.'
+        : 'Use get_accessibility_tree with filter:"visible" first for the current page. Explain what this page is about and what I can do next.',
+      runOptions: explainUsesArticleRead
+        ? firstToolRunOptions(
+          'explain-page',
+          'read_page',
+          { includeChrome: false },
+          'Read the long-form page before explaining it.',
+          ['Call read_page with includeChrome:false.', 'Explain the page from the returned page text.'],
+        )
+        : firstToolRunOptions(
+          'explain-page',
+          'get_accessibility_tree',
+          visibleTreeArgs(10),
+          'Read the visible page state before explaining it.',
+          ['Call get_accessibility_tree with filter:"visible" and maxDepth:10.', 'Explain the page from the returned page data.'],
+        ),
     });
   }
 

--- a/src/chrome/src/ui/recommended-actions.js
+++ b/src/chrome/src/ui/recommended-actions.js
@@ -63,7 +63,7 @@ function hasMedia(pageInfo = {}) {
 function isYouTubeVideoPage(host = '', path = '/', url = '') {
   if (host === 'youtu.be') return /^\/[^/?#]+/.test(path);
   if (host !== 'youtube.com' && !host.endsWith('.youtube.com')) return false;
-  if (/^\/(?:shorts|live|embed)\/[^/?#]+/i.test(path)) return true;
+  if (/^\/(?:shorts|live)\/[^/?#]+/i.test(path)) return true;
   try {
     const u = new URL(url);
     return path === '/watch' && !!u.searchParams.get('v');

--- a/src/chrome/src/ui/recommended-actions.js
+++ b/src/chrome/src/ui/recommended-actions.js
@@ -1,4 +1,5 @@
 const SOCIAL_HOST_RE = /(^|\.)(instagram\.com|tiktok\.com|x\.com|twitter\.com|facebook\.com|fb\.com|threads\.net|youtube\.com|youtu\.be|reddit\.com|pinterest\.com|snapchat\.com)$/i;
+const PUBLIC_MEDIA_HOST_RE = /(^|\.)(youtube\.com|youtu\.be|tiktok\.com|instagram\.com|x\.com|twitter\.com|reddit\.com|redd\.it|facebook\.com|fb\.com|fb\.watch|pinterest\.com|pin\.it|linkedin\.com|threads\.net)$/i;
 const MEETING_HOST_RE = /(^|\.)(zoom\.us|meet\.google\.com|teams\.microsoft\.com|whereby\.com|webex\.com|gotomeeting\.com)$/i;
 const DATING_HOST_RE = /(^|\.)(tinder\.com|bumble\.com|hinge\.co|okcupid\.com|match\.com|pof\.com|badoo\.com|happn\.com|coffeemeetsbagel\.com)$/i;
 const SHOPPING_HOST_RE = /(^|\.)(amazon\.[a-z.]+|ebay\.[a-z.]+|etsy\.com|walmart\.com|target\.com|bestbuy\.com|shopify\.com|aliexpress\.com|mercadolibre\.[a-z.]+|mercadolivre\.com\.br|hepsiburada\.com|trendyol\.com|n11\.com|shopee\.[a-z.]+|lazada\.[a-z.]+)$/i;
@@ -57,6 +58,46 @@ function hasMedia(pageInfo = {}) {
   if ((media.videoCount || 0) > 0 || (media.imageCount || 0) > 0) return true;
   const text = `${pageInfo.title || ''} ${pageInfo.description || ''} ${pageInfo.url || ''}`;
   return /\b(video|photo|image|reel|shorts|watch)\b/i.test(text);
+}
+
+function isYouTubeVideoPage(host = '', path = '/', url = '') {
+  if (host === 'youtu.be') return /^\/[^/?#]+/.test(path);
+  if (host !== 'youtube.com' && !host.endsWith('.youtube.com')) return false;
+  if (/^\/(?:shorts|live|embed)\/[^/?#]+/i.test(path)) return true;
+  try {
+    const u = new URL(url);
+    return path === '/watch' && !!u.searchParams.get('v');
+  } catch {
+    return false;
+  }
+}
+
+function publicMediaKind(pageInfo = {}, path = '/') {
+  const media = pageInfo.media || {};
+  if ((media.videoCount || 0) > 0) return 'video';
+  if ((media.imageCount || 0) > 0) return 'image';
+  if (/\b(video|reel|shorts|watch|live)\b/i.test(`${path} ${pageInfo.title || ''}`)) return 'video';
+  if (/\b(photo|image|picture|pin)\b/i.test(`${path} ${pageInfo.title || ''}`)) return 'image';
+  return 'auto';
+}
+
+function publicMediaDownloadPrompt(kind = 'auto') {
+  const args = kind === 'auto' ? '{ "kind": "auto" }' : `{ "kind": "${kind}" }`;
+  return `Download this public media from the current page. Call download_public_media first with ${args} and omit url so it uses the active tab. Do not make a separate plan or inspect the DOM first. Only call download_social_media if download_public_media fails, then report the saved downloadId/result.`;
+}
+
+function publicMediaDownloadRunOptions(kind = 'auto') {
+  const args = kind === 'auto' ? 'kind:"auto"' : `kind:"${kind}"`;
+  return {
+    id: 'download-media',
+    skipPlanner: true,
+    tool: 'download_public_media',
+    summary: 'Download the public media from the current page.',
+    steps: [
+      `Call download_public_media with ${args} and no url so it uses the active tab.`,
+      'Report the saved downloadId/result. Use download_social_media only if download_public_media fails.',
+    ],
+  };
 }
 
 function hasCartOrPriceSignal(pageInfo = {}) {
@@ -227,12 +268,24 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     });
   }
 
-  if ((SOCIAL_HOST_RE.test(host) || /\b(post|status|reel|shorts|watch|pin)\b/i.test(path)) && hasMedia(pageInfo)) {
+  if (isYouTubeVideoPage(host, path, pageInfo.url || '')) {
+    addUnique(actions, {
+      id: 'summarize-youtube-video',
+      label: 'Summarize this video',
+      prompt: 'Use read_youtube_transcript for the current YouTube video first. Summarize the transcript in concise bullets with key points and timestamps when available. If the transcript tool is unavailable or returns no transcript, say that and use only the visible page context.',
+      mode: 'ask',
+    });
+  }
+
+  const publicMediaHost = PUBLIC_MEDIA_HOST_RE.test(host);
+  if ((publicMediaHost || SOCIAL_HOST_RE.test(host) || /\b(post|status|reel|shorts|watch|pin)\b/i.test(path)) && hasMedia(pageInfo)) {
+    const kind = publicMediaKind(pageInfo, path);
     addUnique(actions, {
       id: 'download-media',
       label: 'Download this video/photo',
-      prompt: 'Download the video or photo from this post.',
+      prompt: publicMediaHost ? publicMediaDownloadPrompt(kind) : 'Download the video or photo from this post.',
       mode: 'act',
+      ...(publicMediaHost ? { runOptions: publicMediaDownloadRunOptions(kind) } : {}),
     });
   }
 

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -2504,15 +2504,17 @@ async function refreshRecommendedActions() {
   try {
     const pageInfo = await sendToBackground('get_page_info', { tabId });
     if (requestId !== recommendationsRequestId || currentTabId !== tabId || isProcessing) return;
+    const sourceUrl = typeof pageInfo?.url === 'string' ? pageInfo.url : '';
     const actions = buildRecommendedActions(pageInfo, { max: 4 });
     recommendedActionsListEl.replaceChildren();
     actions.forEach((action) => {
+      const actionForClick = sourceUrl ? { ...action, sourceUrl } : action;
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.className = 'recommended-action-chip';
       btn.textContent = action.label;
       btn.dataset.prompt = action.prompt;
-      btn.addEventListener('click', () => runRecommendedAction(action));
+      btn.addEventListener('click', () => runRecommendedAction(actionForClick));
       recommendedActionsListEl.appendChild(btn);
     });
     recommendedActionsEl.classList.toggle('hidden', actions.length === 0);
@@ -2521,13 +2523,32 @@ async function refreshRecommendedActions() {
   }
 }
 
+async function recommendedActionSourceStillCurrent(action, tabId) {
+  const sourceUrl = typeof action?.sourceUrl === 'string' ? action.sourceUrl : '';
+  if (!sourceUrl) return true;
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    return (tab?.url || '') === sourceUrl;
+  } catch {
+    return false;
+  }
+}
+
 async function runRecommendedAction(action) {
   const prompt = typeof action === 'string' ? action : action?.prompt;
   const tabId = currentTabId;
   if (!prompt || tabId == null || isProcessing) return;
+  if (!(await recommendedActionSourceStillCurrent(action, tabId)) || currentTabId !== tabId || isProcessing) {
+    hideRecommendedActions();
+    return;
+  }
   if (action?.mode === 'act') {
     const ok = await ensureActMode();
-    if (!ok || currentTabId !== tabId || isProcessing) return;
+    if (!ok) return;
+    if (!(await recommendedActionSourceStillCurrent(action, tabId)) || currentTabId !== tabId || isProcessing) {
+      hideRecommendedActions();
+      return;
+    }
   }
   inputEl.value = prompt;
   autoResizeInput();

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -2531,7 +2531,15 @@ async function runRecommendedAction(action) {
   }
   inputEl.value = prompt;
   autoResizeInput();
-  sendMessage(action?.runOptions ? { recommendedAction: action.runOptions } : {});
+  sendMessage(recommendedActionSendParams(action));
+}
+
+function recommendedActionSendParams(action) {
+  const params = action?.runOptions ? { recommendedAction: action.runOptions } : {};
+  if (['ask', 'act', 'dev'].includes(action?.mode)) {
+    params.__mode = action.mode;
+  }
+  return params;
 }
 
 // After restoring innerHTML the copy buttons need their click handlers re-bound,
@@ -3614,8 +3622,10 @@ function updateApiBadge() {
 
 async function sendMessage(extraChatParams = {}) {
   const retryOptions = extraChatParams?.__retry || null;
+  const modeOverride = ['ask', 'act', 'dev'].includes(extraChatParams?.__mode) ? extraChatParams.__mode : null;
   const chatExtraParams = { ...(extraChatParams || {}) };
   delete chatExtraParams.__retry;
+  delete chatExtraParams.__mode;
   stopListening();
   let text = inputEl.value.trim();
   if (!text) return;
@@ -3653,7 +3663,7 @@ async function sendMessage(extraChatParams = {}) {
     }
     return enqueueQueuedComposerMessage(tabId, text);
   }
-  const modeForSend = retryOptions?.mode || modeForMessageText(text);
+  const modeForSend = retryOptions?.mode || modeOverride || modeForMessageText(text);
   const apiMutationsAllowedForSend = retryOptions
     ? !!retryOptions.apiMutationsAllowed
     : isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -2531,7 +2531,7 @@ async function runRecommendedAction(action) {
   }
   inputEl.value = prompt;
   autoResizeInput();
-  sendMessage();
+  sendMessage(action?.runOptions ? { recommendedAction: action.runOptions } : {});
 }
 
 // After restoring innerHTML the copy buttons need their click handlers re-bound,

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1213,6 +1213,16 @@ export class Agent {
   static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover', 'drag_drop']);
   static NAV_PRONE_TOOLS = new Set(['click', 'click_ax', 'navigate', 'go_back', 'go_forward', 'execute_js', 'iframe_click']);
   static RECOMMENDED_ACTION_FAST_PATH_IDS = new Set(['download-media']);
+  static RECOMMENDED_ACTION_FIRST_TOOLS = Object.freeze({
+    'summarize-page': new Set(['read_page']),
+    'explain-page': new Set(['read_page', 'get_accessibility_tree']),
+    'summarize-youtube-video': new Set(['read_youtube_transcript']),
+    'summarize-thread': new Set(['get_accessibility_tree']),
+    'find-followups': new Set(['get_accessibility_tree']),
+    'rewrite-focused-draft': new Set(['get_accessibility_tree']),
+    'compare-price': new Set(['get_accessibility_tree']),
+  });
+  static RECOMMENDED_ACTION_READ_ONLY_FIRST_TOOLS = new Set(['read_page', 'get_accessibility_tree', 'read_youtube_transcript']);
 
   // System prompt for the dedicated "vision model" sub-call. Kept terse and
   // format-oriented so the description is actually useful to the planning
@@ -3263,6 +3273,67 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       ? action.steps.map(step => sanitizePlannerText(step, 300, { collapseWhitespace: true })).filter(Boolean).slice(0, 5)
       : [];
     return { id, tool, summary, steps };
+  }
+
+  _recommendedActionFirstToolArgs(tool, args = {}) {
+    const input = args && typeof args === 'object' && !Array.isArray(args) ? args : {};
+    if (tool === 'read_page') {
+      return { includeChrome: input.includeChrome === true };
+    }
+    if (tool === 'get_accessibility_tree') {
+      const out = {};
+      if (['all', 'visible', 'interactive'].includes(input.filter)) out.filter = input.filter;
+      if (Number.isFinite(input.maxDepth)) out.maxDepth = Math.max(1, Math.min(20, Math.trunc(input.maxDepth)));
+      if (Number.isFinite(input.maxChars)) out.maxChars = Math.max(1000, Math.min(60000, Math.trunc(input.maxChars)));
+      return out;
+    }
+    if (tool === 'read_youtube_transcript') {
+      const out = {};
+      if (typeof input.timestamps === 'boolean') out.timestamps = input.timestamps;
+      if (typeof input.include_segments === 'boolean') out.include_segments = input.include_segments;
+      if (Number.isFinite(input.text_limit)) out.text_limit = Math.max(1, Math.min(12000, Math.trunc(input.text_limit)));
+      if (Number.isFinite(input.text_offset)) out.text_offset = Math.max(0, Math.trunc(input.text_offset));
+      return out;
+    }
+    return {};
+  }
+
+  _recommendedActionFirstTool(runOptions = {}, allowedToolNames = null) {
+    const action = runOptions?.recommendedAction;
+    if (!action || action.autoExecute !== true) return null;
+    const id = sanitizePlannerText(action.id, 80, { collapseWhitespace: true });
+    const allowedToolsForAction = this.constructor.RECOMMENDED_ACTION_FIRST_TOOLS[id];
+    if (!allowedToolsForAction) return null;
+    const tool = sanitizePlannerText(action.tool, 80, { collapseWhitespace: true });
+    if (!allowedToolsForAction.has(tool)) return null;
+    if (!this.constructor.RECOMMENDED_ACTION_READ_ONLY_FIRST_TOOLS.has(tool)) return null;
+    if (this.constructor.STATE_CHANGE_TOOLS.has(tool)) return null;
+    if (allowedToolNames && !allowedToolNames.has(tool)) return null;
+    if (tool === 'read_youtube_transcript' && !this._skillToolForName(tool)) return null;
+    return {
+      id,
+      tool,
+      args: this._recommendedActionFirstToolArgs(tool, action.args),
+    };
+  }
+
+  async _maybeExecuteRecommendedActionFirstTool(tabId, runOptions, messages, onUpdate, provider, allowedToolNames) {
+    const firstTool = this._recommendedActionFirstTool(runOptions, allowedToolNames);
+    if (!firstTool) return null;
+    const callId = `recommended_${firstTool.id.replace(/[^a-z0-9_-]/gi, '_')}_first_tool`;
+    const toolCall = {
+      id: callId,
+      function: {
+        name: firstTool.tool,
+        arguments: JSON.stringify(firstTool.args || {}),
+      },
+    };
+    messages.push({
+      role: 'assistant',
+      content: null,
+      tool_calls: [toolCall],
+    });
+    return await this._executeToolBatch(tabId, [toolCall], messages, onUpdate, provider, null, allowedToolNames, 0);
   }
 
   _formatRecommendedActionFastPathScratchpad(plan) {
@@ -8248,6 +8319,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       runId = await this._startTraceRun(tabId, userMessage, mode, provider);
     }
 
+    const recommendedFirstTool = await this._maybeExecuteRecommendedActionFirstTool(
+      tabId, runOptions, messages, onUpdate, provider, allowedToolNames,
+    );
+    if (recommendedFirstTool?.action === 'return') {
+      finalResponse = recommendedFirstTool.value;
+      return finalResponse;
+    }
+    if (recommendedFirstTool?.action === 'abort') {
+      finalResponse = recommendedFirstTool.value;
+      _traceStatus = 'cancelled';
+      return finalResponse;
+    }
+
     while (steps < this.maxSteps) {
       if (this._checkAbort(tabId)) {
         finalResponse = finalResponse || '[Stopped by user]';
@@ -8593,6 +8677,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // See processMessage — used to break the empty-response→nudge cycle.
     let emptyOutputRecoveryAttempted = false;
     let compressionPlaceholderRecoveryAttempted = false;
+
+    const recommendedFirstTool = await this._maybeExecuteRecommendedActionFirstTool(
+      tabId, runOptions, messages, onUpdate, provider, allowedToolNames,
+    );
+    if (recommendedFirstTool?.action === 'return') {
+      return finish(recommendedFirstTool.value);
+    }
+    if (recommendedFirstTool?.action === 'abort') {
+      return finish(recommendedFirstTool.value, 'cancelled');
+    }
 
     while (steps < this.maxSteps) {
       if (this._checkAbort(tabId)) {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -3254,7 +3254,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const id = sanitizePlannerText(action.id, 80, { collapseWhitespace: true });
     if (!this.constructor.RECOMMENDED_ACTION_FAST_PATH_IDS.has(id)) return null;
     const tool = sanitizePlannerText(action.tool, 80, { collapseWhitespace: true });
-    if (id === 'download-media' && tool !== 'download_public_media') return null;
+    if (id === 'download-media') {
+      if (tool !== 'download_public_media') return null;
+      if (!this._skillToolForName(tool)) return null;
+    }
     const summary = sanitizePlannerText(action.summary || 'Run the selected recommended action.', 500, { collapseWhitespace: true });
     const steps = Array.isArray(action.steps)
       ? action.steps.map(step => sanitizePlannerText(step, 300, { collapseWhitespace: true })).filter(Boolean).slice(0, 5)

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1212,6 +1212,7 @@ export class Agent {
   static NAV_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward']);
   static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover', 'drag_drop']);
   static NAV_PRONE_TOOLS = new Set(['click', 'click_ax', 'navigate', 'go_back', 'go_forward', 'execute_js', 'iframe_click']);
+  static RECOMMENDED_ACTION_FAST_PATH_IDS = new Set(['download-media']);
 
   // System prompt for the dedicated "vision model" sub-call. Kept terse and
   // format-oriented so the description is actually useful to the planning
@@ -3247,7 +3248,40 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return !this._plannerFollowUpHasExplicitUrl(text);
   }
 
-  async _maybeRunPlannerGate(tabId, messages, enriched, onUpdate, mode, costState, runId, tabInfo = null) {
+  _recommendedActionFastPathPlan(runOptions = {}) {
+    const action = runOptions?.recommendedAction;
+    if (!action || action.skipPlanner !== true) return null;
+    const id = sanitizePlannerText(action.id, 80, { collapseWhitespace: true });
+    if (!this.constructor.RECOMMENDED_ACTION_FAST_PATH_IDS.has(id)) return null;
+    const tool = sanitizePlannerText(action.tool, 80, { collapseWhitespace: true });
+    if (id === 'download-media' && tool !== 'download_public_media') return null;
+    const summary = sanitizePlannerText(action.summary || 'Run the selected recommended action.', 500, { collapseWhitespace: true });
+    const steps = Array.isArray(action.steps)
+      ? action.steps.map(step => sanitizePlannerText(step, 300, { collapseWhitespace: true })).filter(Boolean).slice(0, 5)
+      : [];
+    return { id, tool, summary, steps };
+  }
+
+  _formatRecommendedActionFastPathScratchpad(plan) {
+    const steps = plan.steps.length
+      ? plan.steps
+      : [`Call ${plan.tool || 'the intended tool'} for the selected recommended action.`];
+    const lines = [
+      '[Approved plan — pinned by recommended action]',
+      '',
+      '### Summary',
+      plan.summary,
+      '',
+      '### Steps',
+      ...steps.map((step, index) => `${index + 1}. ${step}`),
+    ];
+    if (plan.tool) {
+      lines.push('', '### Immediate tool', `- ${plan.tool}`);
+    }
+    return lines.join('\n').slice(0, 3000);
+  }
+
+  async _maybeRunPlannerGate(tabId, messages, enriched, onUpdate, mode, costState, runId, tabInfo = null, runOptions = {}) {
     const plannerMode = this._isActionMode(mode) ? this._plannerMode() : 'off';
     const runPlanner = plannerMode !== 'off';
 
@@ -3260,6 +3294,25 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this._persist(tabId);
     if (!runPlanner) {
       this.plannerFollowUpSkipTabs.delete(tabId);
+      return { proceed: true };
+    }
+    const fastPathPlan = this._recommendedActionFastPathPlan(runOptions);
+    if (fastPathPlan) {
+      this.plannerFollowUpSkipTabs.delete(tabId);
+      const scratchResult = this._scratchpadWrite(tabId, {
+        text: this._formatRecommendedActionFastPathScratchpad(fastPathPlan),
+      });
+      if (!scratchResult?.success) {
+        onUpdate('warning', { message: scratchResult?.error || 'Could not pin recommended action plan to scratchpad.' });
+      } else {
+        const scratchIdx = this._findScratchpadIndex(messages);
+        if (scratchIdx >= 0 && scratchIdx < messages.length - 1) {
+          const scratchMsg = messages[scratchIdx];
+          messages.splice(scratchIdx, 1);
+          messages.push(scratchMsg);
+        }
+      }
+      this._persist(tabId);
       return { proceed: true };
     }
     if (this._shouldSkipPlannerForShortFollowUp(tabId, priorMessages, enriched, plannerMode)) {
@@ -8023,13 +8076,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * @param {function} onUpdate - callback(type, data) for streaming updates
    * @returns {Promise<string>} final text response
    */
-  async processMessage(tabId, userMessage, onUpdate = () => {}, mode = 'ask', attachments = []) {
+  async processMessage(tabId, userMessage, onUpdate = () => {}, mode = 'ask', attachments = [], runOptions = {}) {
     if (this._runningTabs.has(tabId)) {
       throw new Error('An agent run is already in progress for this tab.');
     }
     this._runningTabs.add(tabId);
     try {
-      return await this._processMessageInner(tabId, userMessage, onUpdate, mode, attachments);
+      return await this._processMessageInner(tabId, userMessage, onUpdate, mode, attachments, runOptions);
     } finally {
       this.currentCostState.delete(tabId);
       this._runningTabs.delete(tabId);
@@ -8092,7 +8145,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return { ok: true };
   }
 
-  async _processMessageInner(tabId, userMessage, onUpdate, mode, attachments = []) {
+  async _processMessageInner(tabId, userMessage, onUpdate, mode, attachments = [], runOptions = {}) {
     await this._hydrate(tabId);
     const messages = this.getConversation(tabId, mode);
     // Scheduled resumes get the live ledger appended at fire time, so the
@@ -8166,7 +8219,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
 
     const gateOutcome = await this._maybeRunPlannerGate(
-      tabId, messages, enriched, onUpdate, mode, costState, runId, plannerTabInfo,
+      tabId, messages, enriched, onUpdate, mode, costState, runId, plannerTabInfo, runOptions,
     );
     if (!gateOutcome.proceed) {
       _traceStatus = gateOutcome.reason === 'cost_limit' ? 'cost_limit' : 'cancelled';
@@ -8455,20 +8508,20 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   /**
    * Process a message with streaming output.
    */
-  async processMessageStream(tabId, userMessage, onUpdate = () => {}, mode = 'ask') {
+  async processMessageStream(tabId, userMessage, onUpdate = () => {}, mode = 'ask', runOptions = {}) {
     if (this._runningTabs.has(tabId)) {
       throw new Error('An agent run is already in progress for this tab.');
     }
     this._runningTabs.add(tabId);
     try {
-      return await this._processMessageStreamInner(tabId, userMessage, onUpdate, mode);
+      return await this._processMessageStreamInner(tabId, userMessage, onUpdate, mode, runOptions);
     } finally {
       this.currentCostState.delete(tabId);
       this._runningTabs.delete(tabId);
     }
   }
 
-  async _processMessageStreamInner(tabId, userMessage, onUpdate, mode) {
+  async _processMessageStreamInner(tabId, userMessage, onUpdate, mode, runOptions = {}) {
     await this._hydrate(tabId);
     const messages = this.getConversation(tabId, mode);
     const costState = this._newCostRunState();
@@ -8519,7 +8572,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
 
     const gateOutcome = await this._maybeRunPlannerGate(
-      tabId, messages, enriched, onUpdate, mode, costState, runId, plannerTabInfo,
+      tabId, messages, enriched, onUpdate, mode, costState, runId, plannerTabInfo, runOptions,
     );
     if (!gateOutcome.proceed) {
       return finish(gateOutcome.message || 'Task cancelled.', gateOutcome.reason === 'cost_limit' ? 'cost_limit' : 'cancelled');

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -3323,6 +3323,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const callId = `recommended_${firstTool.id.replace(/[^a-z0-9_-]/gi, '_')}_first_tool`;
     const toolCall = {
       id: callId,
+      type: 'function',
       function: {
         name: firstTool.tool,
         arguments: JSON.stringify(firstTool.args || {}),

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -1302,6 +1302,7 @@ async function handleMessage(msg, sender) {
       const updates = [];
       let userMemoryTurnContextTaken = false;
       try {
+        const runOptions = msg.recommendedAction ? { recommendedAction: msg.recommendedAction } : {};
         const result = await agent.processMessage(tabId, msg.text, (type, data) => {
           updates.push({ type, data });
           browser.runtime.sendMessage({
@@ -1311,7 +1312,7 @@ async function handleMessage(msg, sender) {
             type,
             data,
           }).catch(() => {});
-        }, mode, msg.attachments);
+        }, mode, msg.attachments, runOptions);
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
           userText: msg.text,
@@ -1340,6 +1341,7 @@ async function handleMessage(msg, sender) {
       let userMemoryTurnContextTaken = false;
       let userMemoryTurnHadError = false;
       try {
+        const runOptions = msg.recommendedAction ? { recommendedAction: msg.recommendedAction } : {};
         const result = await agent.processMessageStream(tabId, msg.text, (type, data) => {
           if (type === 'error') userMemoryTurnHadError = true;
           browser.runtime.sendMessage({
@@ -1349,7 +1351,7 @@ async function handleMessage(msg, sender) {
             type,
             data,
           }).catch(() => {});
-        }, mode);
+        }, mode, runOptions);
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
           userText: msg.text,

--- a/src/firefox/src/ui/recommended-actions.js
+++ b/src/firefox/src/ui/recommended-actions.js
@@ -62,7 +62,7 @@ function hasMedia(pageInfo = {}) {
 function isYouTubeVideoPage(host = '', path = '/', url = '') {
   if (host === 'youtu.be') return /^\/[^/?#]+/.test(path);
   if (host !== 'youtube.com' && !host.endsWith('.youtube.com')) return false;
-  if (/^\/(?:shorts|live|embed)\/[^/?#]+/i.test(path)) return true;
+  if (/^\/(?:shorts|live)\/[^/?#]+/i.test(path)) return true;
   try {
     const u = new URL(url);
     return path === '/watch' && !!u.searchParams.get('v');

--- a/src/firefox/src/ui/recommended-actions.js
+++ b/src/firefox/src/ui/recommended-actions.js
@@ -74,9 +74,9 @@ function isYouTubeVideoPage(host = '', path = '/', url = '') {
 function publicMediaKind(pageInfo = {}, path = '/') {
   const media = pageInfo.media || {};
   if ((media.videoCount || 0) > 0) return 'video';
-  if ((media.imageCount || 0) > 0) return 'image';
   if (/\b(video|reel|shorts|watch|live)\b/i.test(`${path} ${pageInfo.title || ''}`)) return 'video';
   if (/\b(photo|image|picture|pin)\b/i.test(`${path} ${pageInfo.title || ''}`)) return 'image';
+  if ((media.imageCount || 0) > 0) return 'auto';
   return 'auto';
 }
 
@@ -97,6 +97,21 @@ function publicMediaDownloadRunOptions(kind = 'auto') {
       'Report the saved downloadId/result. Use download_social_media only if download_public_media fails.',
     ],
   };
+}
+
+function firstToolRunOptions(id, tool, args = {}, summary = '', steps = []) {
+  return {
+    id,
+    autoExecute: true,
+    tool,
+    args,
+    summary: summary || 'Read the current page before answering.',
+    steps: steps.length ? steps : [`Call ${tool} first for this recommended action.`],
+  };
+}
+
+function visibleTreeArgs(maxDepth = 10) {
+  return { filter: 'visible', maxDepth };
 }
 
 function hasCartOrPriceSignal(pageInfo = {}) {
@@ -202,7 +217,14 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     addUnique(actions, {
       id: 'rewrite-focused-draft',
       label: 'Rewrite this draft',
-      prompt: 'Rewrite the text in the currently focused compose box in three versions: softer, shorter, and more formal. Do not type, send, or publish anything unless I ask.',
+      prompt: 'Use get_accessibility_tree with filter:"visible" first to read the currently focused compose box. Rewrite that draft in three versions: softer, shorter, and more formal. Do not type, send, or publish anything unless I ask.',
+      runOptions: firstToolRunOptions(
+        'rewrite-focused-draft',
+        'get_accessibility_tree',
+        visibleTreeArgs(8),
+        'Read the focused compose box before rewriting the draft.',
+        ['Call get_accessibility_tree with filter:"visible" and maxDepth:8.', 'Use the focused textbox/input text from the result to write variants only.'],
+      ),
     });
   }
 
@@ -215,12 +237,26 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     addUnique(actions, {
       id: 'summarize-thread',
       label: 'Summarize this thread',
-      prompt: 'Summarize the currently open email or message thread, including key points, decisions, and unanswered questions.',
+      prompt: 'Use get_accessibility_tree with filter:"visible" first to read the currently open email or message thread. Summarize key points, decisions, and unanswered questions.',
+      runOptions: firstToolRunOptions(
+        'summarize-thread',
+        'get_accessibility_tree',
+        visibleTreeArgs(12),
+        'Read the visible conversation thread before summarizing it.',
+        ['Call get_accessibility_tree with filter:"visible" and maxDepth:12.', 'Summarize the thread from the returned page data.'],
+      ),
     });
     addUnique(actions, {
       id: 'find-followups',
       label: 'Find follow-ups',
-      prompt: 'Extract action items, deadlines, people to follow up with, and open questions from this conversation.',
+      prompt: 'Use get_accessibility_tree with filter:"visible" first to read the current conversation. Extract action items, deadlines, people to follow up with, and open questions.',
+      runOptions: firstToolRunOptions(
+        'find-followups',
+        'get_accessibility_tree',
+        visibleTreeArgs(12),
+        'Read the visible conversation thread before extracting follow-ups.',
+        ['Call get_accessibility_tree with filter:"visible" and maxDepth:12.', 'Extract follow-ups from the returned page data.'],
+      ),
     });
   }
 
@@ -262,8 +298,15 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     addUnique(actions, {
       id: 'summarize-youtube-video',
       label: 'Summarize this video',
-      prompt: 'Use read_youtube_transcript for the current YouTube video first. Summarize the transcript in concise bullets with key points and timestamps when available. If the transcript tool is unavailable or returns no transcript, say that and use only the visible page context.',
+      prompt: 'Use read_youtube_transcript for the current YouTube video first, omitting url so it uses the active tab. Summarize the transcript in concise bullets with key points and timestamps when available. If the transcript tool is unavailable or returns no transcript, say that and use only the visible page context.',
       mode: 'ask',
+      runOptions: firstToolRunOptions(
+        'summarize-youtube-video',
+        'read_youtube_transcript',
+        { timestamps: true, text_limit: 6000, include_segments: false },
+        'Read the YouTube transcript before summarizing the video.',
+        ['Call read_youtube_transcript for the active tab with timestamps:true, text_limit:6000, and include_segments:false.', 'Summarize the transcript with key points and timestamps when available.'],
+      ),
     });
   }
 
@@ -292,7 +335,14 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     addUnique(actions, {
       id: 'summarize-page',
       label: 'Summarize this page',
-      prompt: 'Summarize this page in 5-8 concise bullet points and include any action items.',
+      prompt: 'Use read_page first for the current long-form page. Summarize it in 5-8 concise bullet points and include any action items.',
+      runOptions: firstToolRunOptions(
+        'summarize-page',
+        'read_page',
+        { includeChrome: false },
+        'Read the long-form page before summarizing it.',
+        ['Call read_page with includeChrome:false.', 'Summarize the returned article/page text in 5-8 concise bullets.'],
+      ),
     });
   }
 
@@ -300,15 +350,40 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     addUnique(actions, {
       id: 'compare-price',
       label: 'Compare this price with other stores',
-      prompt: 'Compare this product\'s price with other stores and summarize the best alternatives.',
+      prompt: 'Use get_accessibility_tree with filter:"visible" first to read the product title, price, and purchase context. Compare this product\'s price with other stores and summarize the best alternatives.',
+      runOptions: firstToolRunOptions(
+        'compare-price',
+        'get_accessibility_tree',
+        visibleTreeArgs(10),
+        'Read the visible product details before comparing prices.',
+        ['Call get_accessibility_tree with filter:"visible" and maxDepth:10.', 'Use the product title, price, and store context from the result before comparing alternatives.'],
+      ),
     });
   }
 
   if (!actions.length && pageInfo.title) {
+    const explainUsesArticleRead = isLongArticle(pageInfo);
     addUnique(actions, {
       id: 'explain-page',
       label: 'Explain this page',
-      prompt: 'Explain what this page is about and what I can do next.',
+      prompt: explainUsesArticleRead
+        ? 'Use read_page first for the current long-form page. Explain what this page is about and what I can do next.'
+        : 'Use get_accessibility_tree with filter:"visible" first for the current page. Explain what this page is about and what I can do next.',
+      runOptions: explainUsesArticleRead
+        ? firstToolRunOptions(
+          'explain-page',
+          'read_page',
+          { includeChrome: false },
+          'Read the long-form page before explaining it.',
+          ['Call read_page with includeChrome:false.', 'Explain the page from the returned page text.'],
+        )
+        : firstToolRunOptions(
+          'explain-page',
+          'get_accessibility_tree',
+          visibleTreeArgs(10),
+          'Read the visible page state before explaining it.',
+          ['Call get_accessibility_tree with filter:"visible" and maxDepth:10.', 'Explain the page from the returned page data.'],
+        ),
     });
   }
 

--- a/src/firefox/src/ui/recommended-actions.js
+++ b/src/firefox/src/ui/recommended-actions.js
@@ -1,4 +1,5 @@
 const SOCIAL_HOST_RE = /(^|\.)(instagram\.com|tiktok\.com|x\.com|twitter\.com|facebook\.com|fb\.com|threads\.net|youtube\.com|youtu\.be|reddit\.com|pinterest\.com|snapchat\.com)$/i;
+const PUBLIC_MEDIA_HOST_RE = /(^|\.)(youtube\.com|youtu\.be|tiktok\.com|instagram\.com|x\.com|twitter\.com|reddit\.com|redd\.it|facebook\.com|fb\.com|fb\.watch|pinterest\.com|pin\.it|linkedin\.com|threads\.net)$/i;
 const DATING_HOST_RE = /(^|\.)(tinder\.com|bumble\.com|hinge\.co|okcupid\.com|match\.com|pof\.com|badoo\.com|happn\.com|coffeemeetsbagel\.com)$/i;
 const SHOPPING_HOST_RE = /(^|\.)(amazon\.[a-z.]+|ebay\.[a-z.]+|etsy\.com|walmart\.com|target\.com|bestbuy\.com|shopify\.com|aliexpress\.com|mercadolibre\.[a-z.]+|mercadolivre\.com\.br|hepsiburada\.com|trendyol\.com|n11\.com|shopee\.[a-z.]+|lazada\.[a-z.]+)$/i;
 const PRODUCT_PATH_RE = /\/(dp|gp\/product|itm|p|product|products|prod|item|listing|ilan|urun)\b/i;
@@ -56,6 +57,46 @@ function hasMedia(pageInfo = {}) {
   if ((media.videoCount || 0) > 0 || (media.imageCount || 0) > 0) return true;
   const text = `${pageInfo.title || ''} ${pageInfo.description || ''} ${pageInfo.url || ''}`;
   return /\b(video|photo|image|reel|shorts|watch)\b/i.test(text);
+}
+
+function isYouTubeVideoPage(host = '', path = '/', url = '') {
+  if (host === 'youtu.be') return /^\/[^/?#]+/.test(path);
+  if (host !== 'youtube.com' && !host.endsWith('.youtube.com')) return false;
+  if (/^\/(?:shorts|live|embed)\/[^/?#]+/i.test(path)) return true;
+  try {
+    const u = new URL(url);
+    return path === '/watch' && !!u.searchParams.get('v');
+  } catch {
+    return false;
+  }
+}
+
+function publicMediaKind(pageInfo = {}, path = '/') {
+  const media = pageInfo.media || {};
+  if ((media.videoCount || 0) > 0) return 'video';
+  if ((media.imageCount || 0) > 0) return 'image';
+  if (/\b(video|reel|shorts|watch|live)\b/i.test(`${path} ${pageInfo.title || ''}`)) return 'video';
+  if (/\b(photo|image|picture|pin)\b/i.test(`${path} ${pageInfo.title || ''}`)) return 'image';
+  return 'auto';
+}
+
+function publicMediaDownloadPrompt(kind = 'auto') {
+  const args = kind === 'auto' ? '{ "kind": "auto" }' : `{ "kind": "${kind}" }`;
+  return `Download this public media from the current page. Call download_public_media first with ${args} and omit url so it uses the active tab. Do not make a separate plan or inspect the DOM first. Only call download_social_media if download_public_media fails, then report the saved downloadId/result.`;
+}
+
+function publicMediaDownloadRunOptions(kind = 'auto') {
+  const args = kind === 'auto' ? 'kind:"auto"' : `kind:"${kind}"`;
+  return {
+    id: 'download-media',
+    skipPlanner: true,
+    tool: 'download_public_media',
+    summary: 'Download the public media from the current page.',
+    steps: [
+      `Call download_public_media with ${args} and no url so it uses the active tab.`,
+      'Report the saved downloadId/result. Use download_social_media only if download_public_media fails.',
+    ],
+  };
 }
 
 function hasCartOrPriceSignal(pageInfo = {}) {
@@ -217,12 +258,24 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     });
   }
 
-  if ((SOCIAL_HOST_RE.test(host) || /\b(post|status|reel|shorts|watch|pin)\b/i.test(path)) && hasMedia(pageInfo)) {
+  if (isYouTubeVideoPage(host, path, pageInfo.url || '')) {
+    addUnique(actions, {
+      id: 'summarize-youtube-video',
+      label: 'Summarize this video',
+      prompt: 'Use read_youtube_transcript for the current YouTube video first. Summarize the transcript in concise bullets with key points and timestamps when available. If the transcript tool is unavailable or returns no transcript, say that and use only the visible page context.',
+      mode: 'ask',
+    });
+  }
+
+  const publicMediaHost = PUBLIC_MEDIA_HOST_RE.test(host);
+  if ((publicMediaHost || SOCIAL_HOST_RE.test(host) || /\b(post|status|reel|shorts|watch|pin)\b/i.test(path)) && hasMedia(pageInfo)) {
+    const kind = publicMediaKind(pageInfo, path);
     addUnique(actions, {
       id: 'download-media',
       label: 'Download this video/photo',
-      prompt: 'Download the video or photo from this post.',
+      prompt: publicMediaHost ? publicMediaDownloadPrompt(kind) : 'Download the video or photo from this post.',
       mode: 'act',
+      ...(publicMediaHost ? { runOptions: publicMediaDownloadRunOptions(kind) } : {}),
     });
   }
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -2468,15 +2468,17 @@ async function refreshRecommendedActions() {
   try {
     const pageInfo = await sendToBackground('get_page_info', { tabId });
     if (requestId !== recommendationsRequestId || currentTabId !== tabId || isProcessing) return;
+    const sourceUrl = typeof pageInfo?.url === 'string' ? pageInfo.url : '';
     const actions = buildRecommendedActions(pageInfo, { max: 4 });
     recommendedActionsListEl.replaceChildren();
     actions.forEach((action) => {
+      const actionForClick = sourceUrl ? { ...action, sourceUrl } : action;
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.className = 'recommended-action-chip';
       btn.textContent = action.label;
       btn.dataset.prompt = action.prompt;
-      btn.addEventListener('click', () => runRecommendedAction(action));
+      btn.addEventListener('click', () => runRecommendedAction(actionForClick));
       recommendedActionsListEl.appendChild(btn);
     });
     recommendedActionsEl.classList.toggle('hidden', actions.length === 0);
@@ -2485,13 +2487,32 @@ async function refreshRecommendedActions() {
   }
 }
 
+async function recommendedActionSourceStillCurrent(action, tabId) {
+  const sourceUrl = typeof action?.sourceUrl === 'string' ? action.sourceUrl : '';
+  if (!sourceUrl) return true;
+  try {
+    const tab = await browser.tabs.get(tabId);
+    return (tab?.url || '') === sourceUrl;
+  } catch {
+    return false;
+  }
+}
+
 async function runRecommendedAction(action) {
   const prompt = typeof action === 'string' ? action : action?.prompt;
   const tabId = currentTabId;
   if (!prompt || tabId == null || isProcessing) return;
+  if (!(await recommendedActionSourceStillCurrent(action, tabId)) || currentTabId !== tabId || isProcessing) {
+    hideRecommendedActions();
+    return;
+  }
   if (action?.mode === 'act') {
     const ok = await ensureActMode();
-    if (!ok || currentTabId !== tabId || isProcessing) return;
+    if (!ok) return;
+    if (!(await recommendedActionSourceStillCurrent(action, tabId)) || currentTabId !== tabId || isProcessing) {
+      hideRecommendedActions();
+      return;
+    }
   }
   inputEl.value = prompt;
   autoResizeInput();

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -2495,7 +2495,7 @@ async function runRecommendedAction(action) {
   }
   inputEl.value = prompt;
   autoResizeInput();
-  sendMessage();
+  sendMessage(action?.runOptions ? { recommendedAction: action.runOptions } : {});
 }
 
 // After restoring innerHTML the copy buttons need their click handlers re-bound,

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -2495,7 +2495,15 @@ async function runRecommendedAction(action) {
   }
   inputEl.value = prompt;
   autoResizeInput();
-  sendMessage(action?.runOptions ? { recommendedAction: action.runOptions } : {});
+  sendMessage(recommendedActionSendParams(action));
+}
+
+function recommendedActionSendParams(action) {
+  const params = action?.runOptions ? { recommendedAction: action.runOptions } : {};
+  if (['ask', 'act', 'dev'].includes(action?.mode)) {
+    params.__mode = action.mode;
+  }
+  return params;
 }
 
 // After restoring innerHTML the copy buttons need their click handlers re-bound,
@@ -3487,8 +3495,10 @@ function updateApiBadge() {
 
 async function sendMessage(extraChatParams = {}) {
   const retryOptions = extraChatParams?.__retry || null;
+  const modeOverride = ['ask', 'act', 'dev'].includes(extraChatParams?.__mode) ? extraChatParams.__mode : null;
   const chatExtraParams = { ...(extraChatParams || {}) };
   delete chatExtraParams.__retry;
+  delete chatExtraParams.__mode;
   stopListening();
   let text = inputEl.value.trim();
   if (!text) return;
@@ -3526,7 +3536,7 @@ async function sendMessage(extraChatParams = {}) {
     }
     return enqueueQueuedComposerMessage(tabId, text);
   }
-  const modeForSend = retryOptions?.mode || modeForMessageText(text);
+  const modeForSend = retryOptions?.mode || modeOverride || modeForMessageText(text);
   const apiMutationsAllowedForSend = retryOptions
     ? !!retryOptions.apiMutationsAllowed
     : isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);

--- a/test/run.js
+++ b/test/run.js
@@ -3073,7 +3073,10 @@ test('actionable recommendations opt into Act mode', () => {
 test('public media recommendations carry immediate download_public_media fast paths', () => {
   const pages = [
     { url: 'https://x.com/someone/status/123', title: 'Post with video / X', media: { videoCount: 1, imageCount: 0 }, expectedKind: 'video' },
+    { url: 'https://x.com/someone/status/456', title: 'Post / X', media: { videoCount: 0, imageCount: 1 }, expectedKind: 'auto' },
     { url: 'https://www.tiktok.com/@user/video/123', title: 'TikTok video', media: { videoCount: 1, imageCount: 0 }, expectedKind: 'video' },
+    { url: 'https://www.tiktok.com/@user/video/456', title: 'TikTok', media: { videoCount: 0, imageCount: 1 }, expectedKind: 'video' },
+    { url: 'https://www.youtube.com/watch?v=abc123', title: 'YouTube', media: { videoCount: 0, imageCount: 1 }, expectedKind: 'video' },
     { url: 'https://www.reddit.com/r/pics/comments/abc/photo/', title: 'A photo post', media: { imageCount: 1, videoCount: 0 }, expectedKind: 'image' },
     { url: 'https://www.linkedin.com/posts/example_123', title: 'LinkedIn public post video', media: { videoCount: 1, imageCount: 0 }, expectedKind: 'video' },
     { url: 'https://threads.net/@user/post/abc', title: 'Threads photo', media: { imageCount: 1, videoCount: 0 }, expectedKind: 'image' },
@@ -3118,6 +3121,8 @@ test('YouTube video recommendations start with transcript skill and keep media d
       assert.equal(transcript?.label, 'Summarize this video', `expected transcript summary for ${pageInfo.url}`);
       assert.equal(transcript?.mode, 'ask', `transcript summary should stay in Ask mode for ${pageInfo.url}`);
       assert.match(transcript?.prompt || '', /read_youtube_transcript/, `transcript summary should name the skill for ${pageInfo.url}`);
+      assert.equal(transcript?.runOptions?.autoExecute, true, `transcript summary should auto-execute first tool for ${pageInfo.url}`);
+      assert.equal(transcript?.runOptions?.tool, 'read_youtube_transcript', `transcript summary should pin transcript tool for ${pageInfo.url}`);
 
       const download = actions.find((a) => a.id === 'download-media');
       assert.equal(download?.runOptions?.tool, 'download_public_media', `YouTube download should use public media skill for ${pageInfo.url}`);
@@ -3142,6 +3147,60 @@ test('YouTube video recommendations start with transcript skill and keep media d
   }
 });
 
+test('read-only recommendations carry immediate first-tool run options', () => {
+  const cases = [
+    [
+      { url: 'https://news.example.com/article/story', title: 'Long article', text: 'word '.repeat(500) },
+      'summarize-page',
+      'read_page',
+      { includeChrome: false },
+    ],
+    [
+      { url: 'https://example.com/dashboard', title: 'Dashboard' },
+      'explain-page',
+      'get_accessibility_tree',
+      { filter: 'visible', maxDepth: 10 },
+    ],
+    [
+      { url: 'https://mail.google.com/mail/u/0/#inbox/FMfc123', title: 'Gmail - Thread', text: 'From Ada Subject Launch Reply' },
+      'summarize-thread',
+      'get_accessibility_tree',
+      { filter: 'visible', maxDepth: 12 },
+    ],
+    [
+      { url: 'https://x.com/messages/123-456', title: 'Messages / X', text: 'Direct message conversation' },
+      'find-followups',
+      'get_accessibility_tree',
+      { filter: 'visible', maxDepth: 12 },
+    ],
+    [
+      {
+        url: 'https://x.com/compose/post',
+        title: 'Post / X',
+        activeElement: { tag: 'div', role: 'textbox', editable: true, ariaLabel: 'Post text', textPreview: 'Please soften this draft.' },
+      },
+      'rewrite-focused-draft',
+      'get_accessibility_tree',
+      { filter: 'visible', maxDepth: 8 },
+    ],
+    [
+      { url: 'https://www.amazon.com/dp/B000000', title: 'Product', description: 'Price $19.99 Add to Cart' },
+      'compare-price',
+      'get_accessibility_tree',
+      { filter: 'visible', maxDepth: 10 },
+    ],
+  ];
+
+  for (const buildRecommendedActions of [buildRecommendedActionsCh, buildRecommendedActionsFx]) {
+    for (const [pageInfo, id, tool, args] of cases) {
+      const action = buildRecommendedActions(pageInfo).find((a) => a.id === id);
+      assert.equal(action?.runOptions?.autoExecute, true, `${id}: missing auto-execute metadata`);
+      assert.equal(action?.runOptions?.tool, tool, `${id}: wrong first tool`);
+      assert.deepEqual(action?.runOptions?.args, args, `${id}: wrong first-tool args`);
+    }
+  }
+});
+
 test('communication threads get reply, summary, and follow-up suggestions', () => {
   const pages = [
     { url: 'https://mail.google.com/mail/u/0/#inbox/FMfc123', title: 'Gmail - Thread', text: 'From Ada Subject Launch Reply' },
@@ -3155,6 +3214,8 @@ test('communication threads get reply, summary, and follow-up suggestions', () =
       assert.ok(labels.includes('Summarize this thread'), `expected thread summary for ${pageInfo.url}; got ${labels.join(', ')}`);
       assert.ok(labels.includes('Find follow-ups'), `expected follow-ups for ${pageInfo.url}; got ${labels.join(', ')}`);
       assert.equal(actions.find((a) => a.id === 'draft-reply')?.mode, undefined);
+      assert.equal(actions.find((a) => a.id === 'summarize-thread')?.runOptions?.tool, 'get_accessibility_tree');
+      assert.equal(actions.find((a) => a.id === 'find-followups')?.runOptions?.tool, 'get_accessibility_tree');
     }
     const inboxActions = buildRecommendedActions({
       url: 'https://mail.google.com/mail/u/0/#inbox',
@@ -3192,6 +3253,7 @@ test('focused compose boxes get rewrite suggestions', () => {
     const composeActions = buildRecommendedActions(composePage);
     assert.ok(composeActions.some((a) => a.id === 'rewrite-focused-draft'), 'expected rewrite action for focused compose box');
     assert.equal(composeActions.find((a) => a.id === 'rewrite-focused-draft')?.mode, undefined);
+    assert.equal(composeActions.find((a) => a.id === 'rewrite-focused-draft')?.runOptions?.tool, 'get_accessibility_tree');
     assert.equal(buildRecommendedActions(searchPage).some((a) => a.id === 'rewrite-focused-draft'), false);
   }
 });
@@ -19437,6 +19499,136 @@ test('planner gate: trusted recommended media action skips planner and pins read
       );
       assert.equal(noSkillOutcome.proceed, true, `${label} missing skill should still proceed through normal planner`);
       assert.equal(noSkillPlannerCalls, 1, `${label} missing skill should run planner`);
+    }
+  });
+});
+
+test('recommended action first tools are allowlisted and sanitized', () => {
+  for (const [label, AgentClass, prefix] of [['chrome', AgentCh, 'src/chrome'], ['firefox', AgentFx, 'src/firefox']]) {
+    const agent = new AgentClass({ getActive: () => ({}) });
+    const allowed = new Set(['read_page', 'get_accessibility_tree', 'read_youtube_transcript', 'click_ax']);
+
+    assert.deepEqual(
+      agent._recommendedActionFirstTool({
+        recommendedAction: {
+          id: 'summarize-page',
+          autoExecute: true,
+          tool: 'read_page',
+          args: { includeChrome: false, maxDepth: 999 },
+        },
+      }, allowed),
+      { id: 'summarize-page', tool: 'read_page', args: { includeChrome: false } },
+      `${label}: read_page args should be sanitized`,
+    );
+
+    assert.deepEqual(
+      agent._recommendedActionFirstTool({
+        recommendedAction: {
+          id: 'explain-page',
+          autoExecute: true,
+          tool: 'get_accessibility_tree',
+          args: { filter: 'visible', maxDepth: 99, maxChars: 999999, ref_id: 'ref_1' },
+        },
+      }, allowed),
+      { id: 'explain-page', tool: 'get_accessibility_tree', args: { filter: 'visible', maxDepth: 20, maxChars: 60000 } },
+      `${label}: accessibility tree args should be allowlisted and clamped`,
+    );
+
+    assert.equal(
+      agent._recommendedActionFirstTool({
+        recommendedAction: { id: 'summarize-page', autoExecute: true, tool: 'click_ax', args: { ref_id: 'ref_1' } },
+      }, allowed),
+      null,
+      `${label}: state-changing tools must not be accepted as recommended first tools`,
+    );
+
+    assert.equal(
+      agent._recommendedActionFirstTool({
+        recommendedAction: { id: 'summarize-youtube-video', autoExecute: true, tool: 'read_youtube_transcript', args: {} },
+      }, allowed),
+      null,
+      `${label}: transcript first tool should require the enabled skill`,
+    );
+
+    agent.setCustomSkills([packagedFreeSkillzRecord(prefix)]);
+    assert.deepEqual(
+      agent._recommendedActionFirstTool({
+        recommendedAction: {
+          id: 'summarize-youtube-video',
+          autoExecute: true,
+          tool: 'read_youtube_transcript',
+          args: { timestamps: true, include_segments: false, text_limit: 99999, url: 'https://youtu.be/abc' },
+        },
+      }, allowed),
+      {
+        id: 'summarize-youtube-video',
+        tool: 'read_youtube_transcript',
+        args: { timestamps: true, include_segments: false, text_limit: 12000 },
+      },
+      `${label}: transcript args should be sanitized and omit client URL`,
+    );
+  }
+});
+
+test('recommended action first tool executes before first model call', async () => {
+  await withPlannerBrowserGlobals(async () => {
+    for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+      const tabId = label === 'chrome' ? 9217 : 9218;
+      const executed = [];
+      let requestMessages = null;
+      const provider = {
+        supportsTools: true,
+        supportsVision: false,
+        promptTier: 'full',
+        contextWindow: 128000,
+        model: 'test-model',
+        name: 'test-provider',
+        chat: async (messages) => {
+          requestMessages = messages;
+          return { content: 'Summary from pre-read content.', toolCalls: [] };
+        },
+      };
+      const agent = new AgentClass({
+        getActive: () => provider,
+        getVisionProvider: async () => null,
+      });
+      agent.planBeforeAct = false;
+      agent.maxSteps = 1;
+      agent._skipPermissionGate = true;
+      agent._hydrate = async () => {};
+      agent._manageContext = async () => {};
+      agent._enrichUserMessageWithCurrentPage = async (_tabId, _messages, content) => ({ role: 'user', content });
+      agent._maybeReinjectAdapter = async () => {};
+      agent._persist = () => {};
+      agent._startTraceRun = async () => null;
+      agent._endTraceRun = () => {};
+      agent.executeTool = async (_tabId, name, args) => {
+        executed.push({ name, args });
+        return { success: true, text: 'Article body from read_page.' };
+      };
+
+      const final = await agent.processMessage(
+        tabId,
+        'Summarize this page in bullets.',
+        () => {},
+        'ask',
+        [],
+        {
+          recommendedAction: {
+            id: 'summarize-page',
+            autoExecute: true,
+            tool: 'read_page',
+            args: { includeChrome: false },
+          },
+        },
+      );
+
+      assert.equal(final, 'Summary from pre-read content.', `${label}: final response mismatch`);
+      assert.deepEqual(executed, [{ name: 'read_page', args: { includeChrome: false } }], `${label}: first tool was not executed before LLM call`);
+      const assistantToolIdx = requestMessages.findIndex((m) => m.role === 'assistant' && m.tool_calls?.[0]?.function?.name === 'read_page');
+      const toolResultIdx = requestMessages.findIndex((m) => m.role === 'tool' && m.tool_call_id === 'recommended_summarize-page_first_tool');
+      assert.ok(assistantToolIdx >= 0, `${label}: synthetic first-tool assistant call missing`);
+      assert.ok(toolResultIdx > assistantToolIdx, `${label}: first-tool result should precede first model answer`);
     }
   });
 });

--- a/test/run.js
+++ b/test/run.js
@@ -3123,6 +3123,22 @@ test('YouTube video recommendations start with transcript skill and keep media d
       assert.equal(download?.runOptions?.tool, 'download_public_media', `YouTube download should use public media skill for ${pageInfo.url}`);
       assert.equal(download?.runOptions?.skipPlanner, true, `YouTube download should skip planner for ${pageInfo.url}`);
     }
+
+    const embedActions = buildRecommendedActions({
+      url: 'https://www.youtube.com/embed/abc123',
+      title: 'Embedded YouTube player',
+      media: { videoCount: 1, imageCount: 0 },
+    });
+    assert.equal(
+      embedActions.find((a) => a.id === 'summarize-youtube-video'),
+      undefined,
+      'YouTube embed pages should not recommend the transcript-only shortcut',
+    );
+    assert.equal(
+      embedActions.find((a) => a.id === 'download-media')?.runOptions?.tool,
+      'download_public_media',
+      'YouTube embed pages should keep the public media download shortcut',
+    );
   }
 });
 
@@ -19311,9 +19327,10 @@ test('planner gate: approving plan appends without deleting scratchpad facts', a
 
 test('planner gate: trusted recommended media action skips planner and pins ready plan', async () => {
   await withPlannerBrowserGlobals(async () => {
-    for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+    for (const [label, AgentClass, prefix] of [['chrome', AgentCh, 'src/chrome'], ['firefox', AgentFx, 'src/firefox']]) {
       const tabId = label === 'chrome' ? 9207 : 9208;
       const agent = new AgentClass({ getActive: () => ({}) });
+      agent.setCustomSkills([packagedFreeSkillzRecord(prefix)]);
       agent.setPlanBeforeActMode('strict');
       agent.setPlanReviewSettings({ mode: 'always' });
       agent.conversations.set(tabId, [{ role: 'system', content: 'system' }]);
@@ -19389,6 +19406,37 @@ test('planner gate: trusted recommended media action skips planner and pins read
       );
       assert.equal(rejectedOutcome.proceed, true, `${label} rejected fast path should still proceed through normal planner`);
       assert.equal(fallbackPlannerCalls, 1, `${label} rejected fast path should run planner`);
+
+      const noSkillTabId = tabId + 40;
+      const noSkillAgent = new AgentClass({ getActive: () => ({}) });
+      noSkillAgent.setCustomSkills([]);
+      noSkillAgent.setPlanBeforeActMode('try');
+      noSkillAgent.conversations.set(noSkillTabId, [{ role: 'system', content: 'system' }]);
+      let noSkillPlannerCalls = 0;
+      noSkillAgent._runPlannerGate = async () => {
+        noSkillPlannerCalls += 1;
+        return { proceed: true };
+      };
+      const noSkillOutcome = await noSkillAgent._maybeRunPlannerGate(
+        noSkillTabId,
+        noSkillAgent.conversations.get(noSkillTabId),
+        { role: 'user', content: 'Download this public media from the current page.' },
+        () => {},
+        'act',
+        null,
+        null,
+        null,
+        {
+          recommendedAction: {
+            id: 'download-media',
+            skipPlanner: true,
+            tool: 'download_public_media',
+            summary: 'Download the public media from the current page.',
+          },
+        },
+      );
+      assert.equal(noSkillOutcome.proceed, true, `${label} missing skill should still proceed through normal planner`);
+      assert.equal(noSkillPlannerCalls, 1, `${label} missing skill should run planner`);
     }
   });
 });

--- a/test/run.js
+++ b/test/run.js
@@ -7338,12 +7338,16 @@ test('sidepanel drops stale recommended-action refreshes after tab changes or ru
     const sendIdx = body.indexOf("sendToBackground('get_page_info', { tabId })");
     const guard = 'requestId !== recommendationsRequestId || currentTabId !== tabId || isProcessing';
     const guardIdx = body.indexOf(guard);
+    const sourceUrlIdx = body.indexOf("const sourceUrl = typeof pageInfo?.url === 'string' ? pageInfo.url : '';");
+    const actionForClickIdx = body.indexOf('const actionForClick = sourceUrl ? { ...action, sourceUrl } : action;');
     const renderIdx = body.indexOf('recommendedActionsListEl.replaceChildren();');
     assert.notEqual(captureIdx, -1, `${label}: recommended-action refresh should capture the requested tab`);
     assert.notEqual(sendIdx, -1, `${label}: recommended-action refresh should request page info for the captured tab`);
     assert.notEqual(guardIdx, -1, `${label}: stale recommended-action refreshes should be dropped after tab switches or run start`);
+    assert.notEqual(sourceUrlIdx, -1, `${label}: rendered recommended actions should bind the source page URL`);
+    assert.notEqual(actionForClickIdx, -1, `${label}: click handlers should receive source-bound action metadata`);
     assert.notEqual(renderIdx, -1, `${label}: recommended-action refresh render point missing`);
-    assert.equal(captureIdx < sendIdx && sendIdx < guardIdx && guardIdx < renderIdx, true, `${label}: stale guard must run after the async page-info read and before rendering chips`);
+    assert.equal(captureIdx < sendIdx && sendIdx < guardIdx && guardIdx < sourceUrlIdx && sourceUrlIdx < renderIdx && renderIdx < actionForClickIdx, true, `${label}: stale guard must run before source binding and rendering chips`);
   }
 });
 
@@ -7359,24 +7363,34 @@ test('sidepanel drops stale recommended-action clicks after async act confirmati
     const captureIdx = body.indexOf('const tabId = currentTabId;');
     const initialGuard = '!prompt || tabId == null || isProcessing';
     const initialGuardIdx = body.indexOf(initialGuard);
+    const sourceGuard = 'recommendedActionSourceStillCurrent(action, tabId)';
+    const firstSourceGuardIdx = body.indexOf(sourceGuard);
     const ensureIdx = body.indexOf('await ensureActMode();');
-    const staleGuard = '!ok || currentTabId !== tabId || isProcessing';
+    const staleGuard = '!ok) return';
     const staleGuardIdx = body.indexOf(staleGuard);
+    const secondSourceGuardIdx = body.indexOf(sourceGuard, firstSourceGuardIdx + 1);
     const inputIdx = body.indexOf('inputEl.value = prompt;');
     const sendIdx = body.indexOf('sendMessage(recommendedActionSendParams(action));');
+    const sourceHelperMatch = panel.match(/async function recommendedActionSourceStillCurrent\(action, tabId\) \{([\s\S]*?)\n\}/);
     const helperMatch = panel.match(/function recommendedActionSendParams\(action\) \{([\s\S]*?)\n\}/);
+    assert.ok(sourceHelperMatch, `${label}: recommendedActionSourceStillCurrent missing`);
     assert.ok(helperMatch, `${label}: recommendedActionSendParams missing`);
+    const sourceHelperBody = sourceHelperMatch[1];
     const helperBody = helperMatch[1];
     assert.notEqual(captureIdx, -1, `${label}: recommended-action click should capture the initiating tab`);
     assert.notEqual(initialGuardIdx, -1, `${label}: recommended-action click should reject missing tabs before sending`);
+    assert.notEqual(firstSourceGuardIdx, -1, `${label}: recommended-action click should re-check the source URL before sending`);
     assert.notEqual(ensureIdx, -1, `${label}: act recommended-action click should await act confirmation`);
     assert.notEqual(staleGuardIdx, -1, `${label}: stale recommended-action clicks should be dropped after act confirmation`);
+    assert.notEqual(secondSourceGuardIdx, -1, `${label}: act recommended-action click should re-check the source URL after confirmation`);
     assert.notEqual(inputIdx, -1, `${label}: recommended-action click composer write missing`);
     assert.notEqual(sendIdx, -1, `${label}: recommended-action click should pass trusted run options to chat`);
+    assert.match(sourceHelperBody, /const sourceUrl = typeof action\?\.sourceUrl === 'string' \? action\.sourceUrl : '';/, `${label}: source URL helper should read bound action source`);
+    assert.match(sourceHelperBody, /const tab = await (chrome|browser)\.tabs\.get\(tabId\);[\s\S]*?return \(tab\?\.url \|\| ''\) === sourceUrl;/, `${label}: source URL helper should compare against the live tab URL`);
     assert.ok(helperBody.includes('const params = action?.runOptions ? { recommendedAction: action.runOptions } : {};'), `${label}: recommended-action send params should preserve trusted run options`);
     assert.ok(helperBody.includes("if (['ask', 'act', 'dev'].includes(action?.mode)) {"), `${label}: recommended-action send params should only allow known modes`);
     assert.ok(helperBody.includes('params.__mode = action.mode;'), `${label}: recommended-action send params should pass the declared action mode`);
-    assert.equal(captureIdx < initialGuardIdx && initialGuardIdx < ensureIdx && ensureIdx < staleGuardIdx && staleGuardIdx < inputIdx && inputIdx < sendIdx, true, `${label}: stale click guard must run after async act confirmation and before mutating the composer`);
+    assert.equal(captureIdx < initialGuardIdx && initialGuardIdx < firstSourceGuardIdx && firstSourceGuardIdx < ensureIdx && ensureIdx < staleGuardIdx && staleGuardIdx < secondSourceGuardIdx && secondSourceGuardIdx < inputIdx && inputIdx < sendIdx, true, `${label}: stale click guards must run before mutating the composer`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -7363,13 +7363,19 @@ test('sidepanel drops stale recommended-action clicks after async act confirmati
     const staleGuard = '!ok || currentTabId !== tabId || isProcessing';
     const staleGuardIdx = body.indexOf(staleGuard);
     const inputIdx = body.indexOf('inputEl.value = prompt;');
-    const sendIdx = body.indexOf('sendMessage(action?.runOptions ? { recommendedAction: action.runOptions } : {});');
+    const sendIdx = body.indexOf('sendMessage(recommendedActionSendParams(action));');
+    const helperMatch = panel.match(/function recommendedActionSendParams\(action\) \{([\s\S]*?)\n\}/);
+    assert.ok(helperMatch, `${label}: recommendedActionSendParams missing`);
+    const helperBody = helperMatch[1];
     assert.notEqual(captureIdx, -1, `${label}: recommended-action click should capture the initiating tab`);
     assert.notEqual(initialGuardIdx, -1, `${label}: recommended-action click should reject missing tabs before sending`);
     assert.notEqual(ensureIdx, -1, `${label}: act recommended-action click should await act confirmation`);
     assert.notEqual(staleGuardIdx, -1, `${label}: stale recommended-action clicks should be dropped after act confirmation`);
     assert.notEqual(inputIdx, -1, `${label}: recommended-action click composer write missing`);
     assert.notEqual(sendIdx, -1, `${label}: recommended-action click should pass trusted run options to chat`);
+    assert.ok(helperBody.includes('const params = action?.runOptions ? { recommendedAction: action.runOptions } : {};'), `${label}: recommended-action send params should preserve trusted run options`);
+    assert.ok(helperBody.includes("if (['ask', 'act', 'dev'].includes(action?.mode)) {"), `${label}: recommended-action send params should only allow known modes`);
+    assert.ok(helperBody.includes('params.__mode = action.mode;'), `${label}: recommended-action send params should pass the declared action mode`);
     assert.equal(captureIdx < initialGuardIdx && initialGuardIdx < ensureIdx && ensureIdx < staleGuardIdx && staleGuardIdx < inputIdx && inputIdx < sendIdx, true, `${label}: stale click guard must run after async act confirmation and before mutating the composer`);
   }
 });
@@ -8077,13 +8083,19 @@ test('sidepanel preserves stale residual slash-command prompts without hidden ru
     ]) {
       assert.ok(modeHelper.includes(snippet), `${label}: modeForMessageText should handle ${commandLabel}`);
     }
-    const modeCapture = "const modeForSend = retryOptions?.mode || modeForMessageText(text);";
+    const modeOverride = "const modeOverride = ['ask', 'act', 'dev'].includes(extraChatParams?.__mode) ? extraChatParams.__mode : null;";
+    const modeCapture = "const modeForSend = retryOptions?.mode || modeOverride || modeForMessageText(text);";
     const apiCapture = 'const apiMutationsAllowedForSend = retryOptions';
+    const modeOverrideIdx = sendBody.indexOf(modeOverride);
+    const deleteModeIdx = sendBody.indexOf('delete chatExtraParams.__mode;');
     const modeCaptureIdx = sendBody.indexOf(modeCapture);
     const apiCaptureIdx = sendBody.indexOf(apiCapture);
     const parseIdx = sendBody.indexOf('text = await parseSlashCommands(text, tabId);');
+    assert.notEqual(modeOverrideIdx, -1, `${label}: recommended-action mode override should be captured before send mode selection`);
+    assert.notEqual(deleteModeIdx, -1, `${label}: internal recommended-action mode override should not leak into chat payload`);
     assert.notEqual(modeCaptureIdx, -1, `${label}: send mode should be captured from the initiating command before async slash parsing`);
     assert.notEqual(apiCaptureIdx, -1, `${label}: API override should be captured from the initiating tab before async slash parsing`);
+    assert.equal(modeOverrideIdx < modeCaptureIdx && deleteModeIdx < modeCaptureIdx, true, `${label}: recommended-action mode override should be captured and stripped before selecting send mode`);
     assert.equal(modeCaptureIdx < parseIdx && apiCaptureIdx < parseIdx, true, `${label}: stale-tab residual sends should not read visible-tab options after slash parsing`);
     assert.match(
       sendBody,

--- a/test/run.js
+++ b/test/run.js
@@ -3070,6 +3070,62 @@ test('actionable recommendations opt into Act mode', () => {
   assert.equal(buildRecommendedActionsCh(readOnlyPage).find((a) => a.id === 'summarize-page')?.mode, undefined);
 });
 
+test('public media recommendations carry immediate download_public_media fast paths', () => {
+  const pages = [
+    { url: 'https://x.com/someone/status/123', title: 'Post with video / X', media: { videoCount: 1, imageCount: 0 }, expectedKind: 'video' },
+    { url: 'https://www.tiktok.com/@user/video/123', title: 'TikTok video', media: { videoCount: 1, imageCount: 0 }, expectedKind: 'video' },
+    { url: 'https://www.reddit.com/r/pics/comments/abc/photo/', title: 'A photo post', media: { imageCount: 1, videoCount: 0 }, expectedKind: 'image' },
+    { url: 'https://www.linkedin.com/posts/example_123', title: 'LinkedIn public post video', media: { videoCount: 1, imageCount: 0 }, expectedKind: 'video' },
+    { url: 'https://threads.net/@user/post/abc', title: 'Threads photo', media: { imageCount: 1, videoCount: 0 }, expectedKind: 'image' },
+  ];
+
+  for (const buildRecommendedActions of [buildRecommendedActionsCh, buildRecommendedActionsFx]) {
+    for (const pageInfo of pages) {
+      const action = buildRecommendedActions(pageInfo).find((a) => a.id === 'download-media');
+      assert.equal(action?.mode, 'act', `download action should use Act mode for ${pageInfo.url}`);
+      assert.match(action?.prompt || '', /download_public_media first/, `download prompt should name the skill first for ${pageInfo.url}`);
+      assert.match(action?.prompt || '', /Do not make a separate plan/, `download prompt should avoid planner work for ${pageInfo.url}`);
+      assert.equal(action?.runOptions?.skipPlanner, true, `download action should skip planner for ${pageInfo.url}`);
+      assert.equal(action?.runOptions?.tool, 'download_public_media', `download action should pin the intended tool for ${pageInfo.url}`);
+      assert.ok(
+        action?.runOptions?.steps?.some((step) => step.includes(`kind:"${pageInfo.expectedKind}"`)),
+        `download action should carry ${pageInfo.expectedKind} args for ${pageInfo.url}`,
+      );
+    }
+
+    const unsupported = buildRecommendedActions({
+      url: 'https://www.snapchat.com/spotlight/abc',
+      title: 'Spotlight video',
+      media: { videoCount: 1, imageCount: 0 },
+    }).find((a) => a.id === 'download-media');
+    assert.equal(unsupported?.mode, 'act', 'unsupported social media still gets a generic download action');
+    assert.equal(unsupported?.runOptions, undefined, 'unsupported public-media host should not get the skill fast path');
+    assert.doesNotMatch(unsupported?.prompt || '', /download_public_media/, 'unsupported public-media host should not force the skill tool');
+  }
+});
+
+test('YouTube video recommendations start with transcript skill and keep media download fast path', () => {
+  const pages = [
+    { url: 'https://www.youtube.com/watch?v=abc123', title: 'Launch update video', media: { videoCount: 1, imageCount: 0 } },
+    { url: 'https://youtu.be/abc123', title: 'Launch update video', media: { videoCount: 1, imageCount: 0 } },
+    { url: 'https://m.youtube.com/shorts/abc123', title: 'Shorts video', media: { videoCount: 1, imageCount: 0 } },
+  ];
+
+  for (const buildRecommendedActions of [buildRecommendedActionsCh, buildRecommendedActionsFx]) {
+    for (const pageInfo of pages) {
+      const actions = buildRecommendedActions(pageInfo);
+      const transcript = actions.find((a) => a.id === 'summarize-youtube-video');
+      assert.equal(transcript?.label, 'Summarize this video', `expected transcript summary for ${pageInfo.url}`);
+      assert.equal(transcript?.mode, 'ask', `transcript summary should stay in Ask mode for ${pageInfo.url}`);
+      assert.match(transcript?.prompt || '', /read_youtube_transcript/, `transcript summary should name the skill for ${pageInfo.url}`);
+
+      const download = actions.find((a) => a.id === 'download-media');
+      assert.equal(download?.runOptions?.tool, 'download_public_media', `YouTube download should use public media skill for ${pageInfo.url}`);
+      assert.equal(download?.runOptions?.skipPlanner, true, `YouTube download should skip planner for ${pageInfo.url}`);
+    }
+  }
+});
+
 test('communication threads get reply, summary, and follow-up suggestions', () => {
   const pages = [
     { url: 'https://mail.google.com/mail/u/0/#inbox/FMfc123', title: 'Gmail - Thread', text: 'From Ada Subject Launch Reply' },
@@ -7229,12 +7285,14 @@ test('sidepanel drops stale recommended-action clicks after async act confirmati
     const staleGuard = '!ok || currentTabId !== tabId || isProcessing';
     const staleGuardIdx = body.indexOf(staleGuard);
     const inputIdx = body.indexOf('inputEl.value = prompt;');
+    const sendIdx = body.indexOf('sendMessage(action?.runOptions ? { recommendedAction: action.runOptions } : {});');
     assert.notEqual(captureIdx, -1, `${label}: recommended-action click should capture the initiating tab`);
     assert.notEqual(initialGuardIdx, -1, `${label}: recommended-action click should reject missing tabs before sending`);
     assert.notEqual(ensureIdx, -1, `${label}: act recommended-action click should await act confirmation`);
     assert.notEqual(staleGuardIdx, -1, `${label}: stale recommended-action clicks should be dropped after act confirmation`);
     assert.notEqual(inputIdx, -1, `${label}: recommended-action click composer write missing`);
-    assert.equal(captureIdx < initialGuardIdx && initialGuardIdx < ensureIdx && ensureIdx < staleGuardIdx && staleGuardIdx < inputIdx, true, `${label}: stale click guard must run after async act confirmation and before mutating the composer`);
+    assert.notEqual(sendIdx, -1, `${label}: recommended-action click should pass trusted run options to chat`);
+    assert.equal(captureIdx < initialGuardIdx && initialGuardIdx < ensureIdx && ensureIdx < staleGuardIdx && staleGuardIdx < inputIdx && inputIdx < sendIdx, true, `${label}: stale click guard must run after async act confirmation and before mutating the composer`);
   }
 });
 
@@ -8339,6 +8397,25 @@ test('background awaits context-menu prompt clear before agent chat starts', () 
     assert.notEqual(processIdx, -1, `${label}: chat handler should start an agent run`);
     assert.equal(clearIdx < processIdx, true, `${label}: context-menu prompt clear must finish before the agent run starts`);
     assert.doesNotMatch(chatBody, /contextMenuStorage\.clear\(msg\.contextMenuClear\.tabId,\s*msg\.contextMenuClear\.promptId\)\.catch\(\(\) => \{\}\)/, `${label}: context-menu clear should not be fire-and-forget`);
+  }
+});
+
+test('background forwards recommended-action run options to agent chat handlers', () => {
+  for (const [label, bgRel] of [
+    ['chrome', 'src/chrome/src/background.js'],
+    ['firefox', 'src/firefox/src/background.js'],
+  ]) {
+    const bg = fs.readFileSync(path.join(ROOT, bgRel), 'utf8');
+    const chatMatch = bg.match(/case 'chat': \{([\s\S]*?)\n\s+case 'chat_stream':/);
+    const streamMatch = bg.match(/case 'chat_stream': \{([\s\S]*?)\n\s+case 'continue':/);
+    assert.ok(chatMatch, `${label}: chat handler missing`);
+    assert.ok(streamMatch, `${label}: chat_stream handler missing`);
+    const chatBody = chatMatch[1];
+    const streamBody = streamMatch[1];
+    assert.ok(chatBody.includes('const runOptions = msg.recommendedAction ? { recommendedAction: msg.recommendedAction } : {};'), `${label}: chat handler should build recommended-action run options`);
+    assert.match(chatBody, /agent\.processMessage\([\s\S]*?, mode, msg\.attachments, runOptions\)/, `${label}: chat handler should pass run options to processMessage`);
+    assert.ok(streamBody.includes('const runOptions = msg.recommendedAction ? { recommendedAction: msg.recommendedAction } : {};'), `${label}: chat_stream handler should build recommended-action run options`);
+    assert.match(streamBody, /agent\.processMessageStream\([\s\S]*?, mode, runOptions\)/, `${label}: chat_stream handler should pass run options to processMessageStream`);
   }
 });
 
@@ -19228,6 +19305,90 @@ test('planner gate: approving plan appends without deleting scratchpad facts', a
       assert.ok(userIdx >= 0, `${label} user message present`);
       assert.ok(idx > userIdx, `${label} scratchpad should follow user task`);
       assert.equal(idx, agent.conversations.get(tabId).length - 1, `${label} scratchpad should be last`);
+    }
+  });
+});
+
+test('planner gate: trusted recommended media action skips planner and pins ready plan', async () => {
+  await withPlannerBrowserGlobals(async () => {
+    for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+      const tabId = label === 'chrome' ? 9207 : 9208;
+      const agent = new AgentClass({ getActive: () => ({}) });
+      agent.setPlanBeforeActMode('strict');
+      agent.setPlanReviewSettings({ mode: 'always' });
+      agent.conversations.set(tabId, [{ role: 'system', content: 'system' }]);
+      let plannerCalls = 0;
+      agent._runPlannerGate = async () => {
+        plannerCalls += 1;
+        throw new Error('recommended action fast path should not call planner');
+      };
+
+      const outcome = await agent._maybeRunPlannerGate(
+        tabId,
+        agent.conversations.get(tabId),
+        { role: 'user', content: 'Download this public media from the current page.' },
+        () => {},
+        'act',
+        null,
+        null,
+        null,
+        {
+          recommendedAction: {
+            id: 'download-media',
+            skipPlanner: true,
+            tool: 'download_public_media',
+            summary: 'Download the public media from the current page.',
+            steps: [
+              'Call download_public_media with kind:"video" and no url so it uses the active tab.',
+              'Report the saved downloadId/result.',
+            ],
+          },
+        },
+      );
+
+      assert.equal(outcome.proceed, true, `${label} should proceed`);
+      assert.equal(plannerCalls, 0, `${label} should skip the planner call`);
+      assert.equal(agent.plannerFollowUpSkipTabs.has(tabId), false, `${label} should not arm the ordinary planner follow-up skip`);
+
+      const messages = agent.conversations.get(tabId);
+      const idx = agent._findScratchpadIndex(messages);
+      assert.ok(idx >= 0, `${label} should pin a recommended-action scratchpad plan`);
+      const body = agent._extractScratchpadBody(messages[idx].content);
+      assert.match(body, /\[Approved plan — pinned by recommended action\]/, `${label} should mark first-party recommended plan`);
+      assert.match(body, /download_public_media/, `${label} should pin the intended immediate tool`);
+      assert.doesNotMatch(body, /pinned by planner/, `${label} should not pretend a planner generated this`);
+      const userIdx = messages.findIndex((m) => m.role === 'user' && /Download this public media/.test(m.content));
+      assert.ok(idx > userIdx, `${label} scratchpad should follow the user task`);
+
+      const rejectedTabId = tabId + 20;
+      const rejected = new AgentClass({ getActive: () => ({}) });
+      rejected.setPlanBeforeActMode('try');
+      rejected.conversations.set(rejectedTabId, [{ role: 'system', content: 'system' }]);
+      let fallbackPlannerCalls = 0;
+      rejected._runPlannerGate = async () => {
+        fallbackPlannerCalls += 1;
+        return { proceed: true };
+      };
+      const rejectedOutcome = await rejected._maybeRunPlannerGate(
+        rejectedTabId,
+        rejected.conversations.get(rejectedTabId),
+        { role: 'user', content: 'Do something else.' },
+        () => {},
+        'act',
+        null,
+        null,
+        null,
+        {
+          recommendedAction: {
+            id: 'download-media',
+            skipPlanner: true,
+            tool: 'download_social_media',
+            summary: 'Invalid fast path.',
+          },
+        },
+      );
+      assert.equal(rejectedOutcome.proceed, true, `${label} rejected fast path should still proceed through normal planner`);
+      assert.equal(fallbackPlannerCalls, 1, `${label} rejected fast path should run planner`);
     }
   });
 });

--- a/test/run.js
+++ b/test/run.js
@@ -19640,6 +19640,7 @@ test('recommended action first tool executes before first model call', async () 
       const assistantToolIdx = requestMessages.findIndex((m) => m.role === 'assistant' && m.tool_calls?.[0]?.function?.name === 'read_page');
       const toolResultIdx = requestMessages.findIndex((m) => m.role === 'tool' && m.tool_call_id === 'recommended_summarize-page_first_tool');
       assert.ok(assistantToolIdx >= 0, `${label}: synthetic first-tool assistant call missing`);
+      assert.equal(requestMessages[assistantToolIdx].tool_calls[0].type, 'function', `${label}: synthetic first-tool call should use OpenAI function tool-call shape`);
       assert.ok(toolResultIdx > assistantToolIdx, `${label}: first-tool result should precede first model answer`);
     }
   });


### PR DESCRIPTION
## Summary

- Adds ready-to-run recommended-action prompts for supported public media hosts so the agent starts with `download_public_media` instead of planning or DOM inspection.
- Plumbs trusted recommended-action metadata from the sidepanel through background chat handlers into the agent planner gate.
- Skips Plan-before-Act only for the allowlisted media-download recommended action and pins a first-party recommended-action scratchpad plan.
- Adds a YouTube video summary chip that starts with `read_youtube_transcript`, plus regression coverage for supported and unsupported media hosts.

## Validation

- `npm test`
- `git diff --check`