### PR TITLE
Move homepage security section after features

### DIFF
--- a/web/ar/index.html
+++ b/web/ar/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">الأمان</div>
-  <h2 class="section-title">كيف يبقيك WebBrain متحكمًا</h2>
-  <p class="section-subtitle">المتصفح هو المكان الذي يحدث فيه العمل الحقيقي — وهو أيضًا سطح معادٍ. يبدأ WebBrain في وضع السؤال للقراءة فقط، ويطلب الإذن قبل أن يتصرف، ويدافع ضد حقن التعليمات المخفية، ويتعامل مع الحقول الحساسة بقواعد أكثر صرامة.</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">المزايا</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>موفّر للرموز</h3>
       <p>تُغيَّر أبعاد لقطات الشاشة وتُضغط بصيغة JPEG تكراريًا قبل أن تغادر جهازك، ما يُبقي رموز الصور صغيرة. التقصّ الذكي للسياق وحدود مخرجات الأدوات تجعل فواتير السحابة قابلة للتنبؤ — بلا مفاجآت في الجلسات الطويلة.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">الأمان</div>
+  <h2 class="section-title">كيف يبقيك WebBrain متحكمًا</h2>
+  <p class="section-subtitle">المتصفح هو المكان الذي يحدث فيه العمل الحقيقي — وهو أيضًا سطح معادٍ. يبدأ WebBrain في وضع السؤال للقراءة فقط، ويطلب الإذن قبل أن يتصرف، ويدافع ضد حقن التعليمات المخفية، ويتعامل مع الحقول الحساسة بقواعد أكثر صرامة.</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/build/template.html
+++ b/web/build/template.html
@@ -2113,18 +2113,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">{{t:security.label}}</div>
-  <h2 class="section-title">{{t:security.title}}</h2>
-  <p class="section-subtitle">{{t:security.subtitle}}</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">{{t:features.label}}</div>
@@ -2192,6 +2180,18 @@
       <div class="feature-icon">💰</div>
       <h3>{{t:features.token_conscious.title}}</h3>
       <p>{{t:features.token_conscious.desc}}</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">{{t:security.label}}</div>
+  <h2 class="section-title">{{t:security.title}}</h2>
+  <p class="section-subtitle">{{t:security.subtitle}}</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/es/index.html
+++ b/web/es/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">Seguridad</div>
-  <h2 class="section-title">Cómo WebBrain te mantiene en control</h2>
-  <p class="section-subtitle">El navegador es donde ocurre el trabajo real — y también una superficie adversarial. WebBrain empieza en modo Preguntar de solo lectura, pide permiso antes de actuar, se defiende contra inyecciones de prompt ocultas y trata los campos sensibles con reglas más estrictas.</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">Funciones</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>Consumo optimizado de tokens</h3>
       <p>Las capturas se redimensionan y comprimen iterativamente en JPEG antes de salir de tu máquina, manteniendo bajos los tokens de imagen. El recorte inteligente de contexto y los límites en la salida de herramientas mantienen predecibles las facturas en la nube — sin sorpresas en sesiones largas.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">Seguridad</div>
+  <h2 class="section-title">Cómo WebBrain te mantiene en control</h2>
+  <p class="section-subtitle">El navegador es donde ocurre el trabajo real — y también una superficie adversarial. WebBrain empieza en modo Preguntar de solo lectura, pide permiso antes de actuar, se defiende contra inyecciones de prompt ocultas y trata los campos sensibles con reglas más estrictas.</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/fr/index.html
+++ b/web/fr/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">Sécurité</div>
-  <h2 class="section-title">Comment WebBrain vous garde aux commandes</h2>
-  <p class="section-subtitle">Le navigateur est l&#39;endroit où le vrai travail se fait — et aussi une surface d&#39;attaque. WebBrain démarre en mode Demander, en lecture seule, demande avant d&#39;agir, se défend contre les injections de prompt cachées et applique des règles plus strictes aux champs sensibles.</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">Fonctionnalités</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>Économe en tokens</h3>
       <p>Les captures sont redimensionnées et compressées itérativement en JPEG avant de quitter votre machine, pour garder les tokens d&#39;image faibles. Le rognage intelligent du contexte et les plafonds de sortie d&#39;outils rendent les factures cloud prévisibles — pas de surprise sur les sessions longues.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">Sécurité</div>
+  <h2 class="section-title">Comment WebBrain vous garde aux commandes</h2>
+  <p class="section-subtitle">Le navigateur est l&#39;endroit où le vrai travail se fait — et aussi une surface d&#39;attaque. WebBrain démarre en mode Demander, en lecture seule, demande avant d&#39;agir, se défend contre les injections de prompt cachées et applique des règles plus strictes aux champs sensibles.</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/id/index.html
+++ b/web/id/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">Keamanan</div>
-  <h2 class="section-title">Bagaimana WebBrain menjaga Anda tetap memegang kendali</h2>
-  <p class="section-subtitle">Browser adalah tempat pekerjaan nyata terjadi — sekaligus permukaan yang bisa dimanfaatkan pihak adversarial. WebBrain dimulai dalam Ask Mode hanya-baca, meminta izin sebelum bertindak, bertahan dari injeksi prompt tersembunyi, dan menangani kolom sensitif dengan aturan yang lebih ketat.</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">Fitur</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>Hemat Token</h3>
       <p>Tangkapan layar diubah ukurannya dan dikompresi JPEG secara iteratif sebelum meninggalkan mesin Anda, sehingga token gambar tetap kecil. Pemangkasan konteks cerdas dan batas keluaran alat menjaga tagihan cloud tetap terprediksi — tanpa pengeluaran kejutan pada sesi panjang.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">Keamanan</div>
+  <h2 class="section-title">Bagaimana WebBrain menjaga Anda tetap memegang kendali</h2>
+  <p class="section-subtitle">Browser adalah tempat pekerjaan nyata terjadi — sekaligus permukaan yang bisa dimanfaatkan pihak adversarial. WebBrain dimulai dalam Ask Mode hanya-baca, meminta izin sebelum bertindak, bertahan dari injeksi prompt tersembunyi, dan menangani kolom sensitif dengan aturan yang lebih ketat.</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/index.html
+++ b/web/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">Security</div>
-  <h2 class="section-title">How WebBrain keeps you in control</h2>
-  <p class="section-subtitle">The browser is where real work happens — and an adversarial surface. WebBrain starts in read-only Ask Mode, asks before it acts, defends against hidden prompt injections, and handles sensitive fields with stricter rules.</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">Features</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>Token-Conscious</h3>
       <p>Screenshots are resized and iteratively JPEG-compressed before they leave your machine, keeping image tokens small. Smart context trimming and tool-output caps keep cloud bills predictable — no surprise spend on long sessions.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">Security</div>
+  <h2 class="section-title">How WebBrain keeps you in control</h2>
+  <p class="section-subtitle">The browser is where real work happens — and an adversarial surface. WebBrain starts in read-only Ask Mode, asks before it acts, defends against hidden prompt injections, and handles sensitive fields with stricter rules.</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/ja/index.html
+++ b/web/ja/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">セキュリティ</div>
-  <h2 class="section-title">WebBrain が主導権を保つ仕組み</h2>
-  <p class="section-subtitle">ブラウザーは実際の作業が行われる場所であり、同時に攻撃的な入力が入り込む面でもあります。WebBrain は読み取り専用の Ask Mode から始め、操作前に確認し、隠れたプロンプト注入を防ぎ、機密フィールドにはより厳しいルールを適用します。</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">機能</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>トークンに配慮</h3>
       <p>スクリーンショットは、あなたのマシンから出ていく前にリサイズされ、JPEG で反復的に圧縮されるので、画像トークンは小さく抑えられます。スマートなコンテキスト圧縮とツール出力の上限が、クラウド料金を予測可能に — 長いセッションでの想定外の支出はなし。</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">セキュリティ</div>
+  <h2 class="section-title">WebBrain が主導権を保つ仕組み</h2>
+  <p class="section-subtitle">ブラウザーは実際の作業が行われる場所であり、同時に攻撃的な入力が入り込む面でもあります。WebBrain は読み取り専用の Ask Mode から始め、操作前に確認し、隠れたプロンプト注入を防ぎ、機密フィールドにはより厳しいルールを適用します。</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/ko/index.html
+++ b/web/ko/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">보안</div>
-  <h2 class="section-title">WebBrain이 제어권을 지켜 주는 방식</h2>
-  <p class="section-subtitle">브라우저는 실제 작업이 이루어지는 곳이자 공격적인 입력이 들어올 수 있는 표면입니다. WebBrain은 읽기 전용 Ask Mode에서 시작하고, 행동하기 전에 허락을 구하며, 숨겨진 프롬프트 주입을 방어하고, 민감한 입력란에는 더 엄격한 규칙을 적용합니다.</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">기능</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>토큰을 아끼는</h3>
       <p>스크린샷은 당신의 머신을 떠나기 전에 크기가 조정되고 반복적으로 JPEG 압축되어 이미지 토큰이 작게 유지됩니다. 스마트 컨텍스트 트리밍과 도구 출력 상한이 클라우드 비용을 예측 가능하게 유지해 — 긴 세션에서도 깜짝 지출이 없습니다.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">보안</div>
+  <h2 class="section-title">WebBrain이 제어권을 지켜 주는 방식</h2>
+  <p class="section-subtitle">브라우저는 실제 작업이 이루어지는 곳이자 공격적인 입력이 들어올 수 있는 표면입니다. WebBrain은 읽기 전용 Ask Mode에서 시작하고, 행동하기 전에 허락을 구하며, 숨겨진 프롬프트 주입을 방어하고, 민감한 입력란에는 더 엄격한 규칙을 적용합니다.</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/ms/index.html
+++ b/web/ms/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">Keselamatan</div>
-  <h2 class="section-title">Cara WebBrain memastikan anda kekal mengawal</h2>
-  <p class="section-subtitle">Pelayar ialah tempat kerja sebenar berlaku — dan juga permukaan yang boleh dimanipulasi pihak lawan. WebBrain bermula dalam Mod Tanya yang baca sahaja, meminta izin sebelum bertindak, mempertahankan diri daripada suntikan prompt tersembunyi, dan mengendalikan medan sensitif dengan peraturan yang lebih ketat.</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">Ciri</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>Jimat Token</h3>
       <p>Tangkapan skrin diubah saiz dan dimampatkan JPEG secara berulang sebelum meninggalkan mesin anda, menjadikan token imej kekal kecil. Pemangkasan konteks pintar dan had output alat memastikan bil awan boleh diramal — tiada perbelanjaan mengejut pada sesi panjang.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">Keselamatan</div>
+  <h2 class="section-title">Cara WebBrain memastikan anda kekal mengawal</h2>
+  <p class="section-subtitle">Pelayar ialah tempat kerja sebenar berlaku — dan juga permukaan yang boleh dimanipulasi pihak lawan. WebBrain bermula dalam Mod Tanya yang baca sahaja, meminta izin sebelum bertindak, mempertahankan diri daripada suntikan prompt tersembunyi, dan mengendalikan medan sensitif dengan peraturan yang lebih ketat.</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/ru/index.html
+++ b/web/ru/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">Безопасность</div>
-  <h2 class="section-title">Как WebBrain оставляет контроль за вами</h2>
-  <p class="section-subtitle">Браузер — место, где происходит реальная работа, и одновременно поверхность для атак. WebBrain начинает в режиме Ask только для чтения, спрашивает перед действиями, защищается от скрытых prompt-инъекций и применяет более строгие правила к чувствительным полям.</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">Возможности</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>Бережём токены</h3>
       <p>Скриншоты уменьшаются по размеру и итеративно сжимаются в JPEG, прежде чем покинуть вашу машину, — image-токены остаются маленькими. Умное подрезание контекста и ограничения на вывод инструментов делают облачные расходы предсказуемыми, без сюрпризов на длинных сессиях.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">Безопасность</div>
+  <h2 class="section-title">Как WebBrain оставляет контроль за вами</h2>
+  <p class="section-subtitle">Браузер — место, где происходит реальная работа, и одновременно поверхность для атак. WebBrain начинает в режиме Ask только для чтения, спрашивает перед действиями, защищается от скрытых prompt-инъекций и применяет более строгие правила к чувствительным полям.</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/th/index.html
+++ b/web/th/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">ความปลอดภัย</div>
-  <h2 class="section-title">WebBrain ช่วยให้คุณคุมทุกอย่างได้อย่างไร</h2>
-  <p class="section-subtitle">เบราว์เซอร์คือที่ที่งานจริงเกิดขึ้น และเป็นพื้นผิวที่อาจถูกโจมตีได้ด้วย WebBrain เริ่มในโหมด Ask แบบอ่านอย่างเดียว ขออนุญาตก่อนลงมือทำ ป้องกันการแทรกพรอมป์ที่ซ่อนอยู่ และจัดการช่องข้อมูลอ่อนไหวด้วยกฎที่เข้มงวดกว่าเดิม</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">คุณสมบัติ</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>ประหยัดโทเค็น</h3>
       <p>ภาพหน้าจอจะถูกปรับขนาดและบีบอัด JPEG ซ้ำ ๆ ก่อนออกจากเครื่องของคุณ ทำให้โทเค็นรูปภาพเล็ก การตัด context อัจฉริยะและขีดจำกัดเอาต์พุตของเครื่องมือทำให้บิลคลาวด์คาดเดาได้ — ไม่มีค่าใช้จ่ายเซอร์ไพรส์ในเซสชันยาว ๆ</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">ความปลอดภัย</div>
+  <h2 class="section-title">WebBrain ช่วยให้คุณคุมทุกอย่างได้อย่างไร</h2>
+  <p class="section-subtitle">เบราว์เซอร์คือที่ที่งานจริงเกิดขึ้น และเป็นพื้นผิวที่อาจถูกโจมตีได้ด้วย WebBrain เริ่มในโหมด Ask แบบอ่านอย่างเดียว ขออนุญาตก่อนลงมือทำ ป้องกันการแทรกพรอมป์ที่ซ่อนอยู่ และจัดการช่องข้อมูลอ่อนไหวด้วยกฎที่เข้มงวดกว่าเดิม</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/tl/index.html
+++ b/web/tl/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">Seguridad</div>
-  <h2 class="section-title">Paano pinapanatili ng WebBrain ang kontrol sa iyo</h2>
-  <p class="section-subtitle">Sa browser nangyayari ang tunay na trabaho — at isa rin itong surface na puwedeng atakihin. Nagsisimula ang WebBrain sa read-only na Ask Mode, humihingi muna ng pahintulot bago kumilos, dumedepensa laban sa nakatagong prompt injection, at mas mahigpit ang mga panuntunan para sa sensitibong fields.</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">Mga Tampok</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>Pinatipid sa Tokens</h3>
       <p>Ang mga screenshot ay binabago ang sukat at iteratively na nila-JPEG-compress bago umalis sa iyong makina, kaya nananatiling maliit ang image tokens. Ang smart context trimming at tool-output caps ay nagpapanatili ng predictable na cloud bills — walang kagulat-gulat na gastos sa mahabang sesyon.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">Seguridad</div>
+  <h2 class="section-title">Paano pinapanatili ng WebBrain ang kontrol sa iyo</h2>
+  <p class="section-subtitle">Sa browser nangyayari ang tunay na trabaho — at isa rin itong surface na puwedeng atakihin. Nagsisimula ang WebBrain sa read-only na Ask Mode, humihingi muna ng pahintulot bago kumilos, dumedepensa laban sa nakatagong prompt injection, at mas mahigpit ang mga panuntunan para sa sensitibong fields.</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/tr/index.html
+++ b/web/tr/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">Güvenlik</div>
-  <h2 class="section-title">WebBrain kontrolü sende nasıl tutar</h2>
-  <p class="section-subtitle">Gerçek iş tarayıcıda olur — ve burası aynı zamanda saldırgan bir yüzeydir. WebBrain salt okunur Sor kipinde başlar, hareket etmeden önce izin ister, gizli prompt enjeksiyonlarına karşı savunma yapar ve hassas alanları daha sıkı kurallarla ele alır.</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">Özellikler</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>Token bilincine sahip</h3>
       <p>Ekran görüntüleri, makineden çıkmadan önce yeniden boyutlandırılır ve yinelemeli olarak JPEG sıkıştırılır; böylece görüntü tokenleri küçük kalır. Akıllı bağlam kırpma ve araç çıktısı sınırları, bulut faturalarını öngörülebilir tutar — uzun oturumlarda sürpriz harcama yok.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">Güvenlik</div>
+  <h2 class="section-title">WebBrain kontrolü sende nasıl tutar</h2>
+  <p class="section-subtitle">Gerçek iş tarayıcıda olur — ve burası aynı zamanda saldırgan bir yüzeydir. WebBrain salt okunur Sor kipinde başlar, hareket etmeden önce izin ister, gizli prompt enjeksiyonlarına karşı savunma yapar ve hassas alanları daha sıkı kurallarla ele alır.</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/uk/index.html
+++ b/web/uk/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">Безпека</div>
-  <h2 class="section-title">Як WebBrain залишає контроль за вами</h2>
-  <p class="section-subtitle">Браузер — це місце, де відбувається реальна робота, і водночас поверхня для атак. WebBrain починає в режимі Ask лише для читання, запитує перед діями, захищається від прихованих prompt-інʼєкцій і застосовує суворіші правила до чутливих полів.</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">Можливості</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>Бережемо токени</h3>
       <p>Скриншоти зменшуються за розміром та ітеративно стискаються в JPEG, перш ніж покинути вашу машину, — image-токени лишаються маленькими. Розумне підрізання контексту та обмеження виводу інструментів роблять хмарні рахунки передбачуваними — жодних сюрпризів у довгих сесіях.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">Безпека</div>
+  <h2 class="section-title">Як WebBrain залишає контроль за вами</h2>
+  <p class="section-subtitle">Браузер — це місце, де відбувається реальна робота, і водночас поверхня для атак. WebBrain починає в режимі Ask лише для читання, запитує перед діями, захищається від прихованих prompt-інʼєкцій і застосовує суворіші правила до чутливих полів.</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -2342,18 +2342,6 @@
   </div>
 </section>
 
-<!-- SECURITY VIDEO -->
-<section class="section" id="security" style="padding-top: 30px;">
-  <div class="section-label">安全</div>
-  <h2 class="section-title">WebBrain 如何让你保持掌控</h2>
-  <p class="section-subtitle">浏览器是真正工作发生的地方，也是一块对抗性表面。WebBrain 从只读的询问模式开始，行动前先请求确认，防御隐藏的提示注入，并用更严格的规则处理敏感字段。</p>
-  <div class="video-showcase">
-    <div class="video-frame">
-      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
-    </div>
-  </div>
-</section>
-
 <!-- FEATURES -->
 <section class="section" id="features">
   <div class="section-label">功能</div>
@@ -2421,6 +2409,18 @@
       <div class="feature-icon">💰</div>
       <h3>节省 token</h3>
       <p>截图在离开你的机器之前会先按比例缩放并迭代 JPEG 压缩,让图像 token 保持很小。智能上下文裁剪和工具输出上限让云端费用可预测 —— 长会话不会出现意外支出。</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY VIDEO -->
+<section class="section" id="security" style="padding-top: 30px;">
+  <div class="section-label">安全</div>
+  <h2 class="section-title">WebBrain 如何让你保持掌控</h2>
+  <p class="section-subtitle">浏览器是真正工作发生的地方，也是一块对抗性表面。WebBrain 从只读的询问模式开始，行动前先请求确认，防御隐藏的提示注入，并用更严格的规则处理敏感字段。</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <video id="security-video" data-desktop-src="/assets/security-desktop.mp4" data-mobile-src="/assets/security-mobile.mp4" poster="/assets/security-poster.jpg" controls preload="none" playsinline></video>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary

- move the homepage Security section immediately after Features
- regenerate the English homepage and all 13 localized homepage outputs
- keep the existing Watch WebBrain in Action video unchanged, with no placeholder or premature comparison-video move

## Why

The security deep dive appeared before visitors reached the product capabilities. This change lets the homepage explain WebBrain’s value first, then present the trust and control story before providers and installation.

## User impact

The homepage sequence is now: current demo → Features → Security → Providers → Install → Comparison → FAQ. Existing anchors, video assets, and responsive behavior are preserved.

## Validation

- `npm run build:web`
- `git diff --check`
- local desktop preview verified the generated section order and existing responsive media sources
