### PR TITLE
Polish homepage hero demo scenes

### DIFF
--- a/web/ar/index.html
+++ b/web/ar/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>اكتمل التنزيل</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">اسأل أي شيء عن هذه الصفحة...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/products</div>

--- a/web/build/locales/ar.json
+++ b/web/build/locales/ar.json
@@ -251,6 +251,7 @@
   "hero.mockup.v3.step_fetch": "جلب MP4",
   "hero.mockup.v3.result_html": "تم الحفظ في <strong>Downloads/nomad-bodrum.mp4</strong>",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "اكتمل التنزيل",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "مستقبل الذكاء الاصطناعي المحلي",
   "hero.mockup.v4.byline": "بقلم Jane Smith · قراءة 8 دقائق",

--- a/web/build/locales/en.json
+++ b/web/build/locales/en.json
@@ -57,6 +57,7 @@
   "hero.mockup.v3.step_fetch": "Fetching MP4",
   "hero.mockup.v3.result_html": "Saved to <strong>Downloads/nomad-bodrum.mp4</strong>",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "Download complete",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "The Future of Local AI",
   "hero.mockup.v4.byline": "By Jane Smith · 8 min read",

--- a/web/build/locales/es.json
+++ b/web/build/locales/es.json
@@ -251,6 +251,7 @@
   "hero.mockup.v3.step_fetch": "Obteniendo el MP4",
   "hero.mockup.v3.result_html": "Se guardó en <strong>Descargas/nomad-bodrum.mp4</strong>",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "Descarga completada",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "El futuro de la IA local",
   "hero.mockup.v4.byline": "Por Jane Smith · 8 min de lectura",

--- a/web/build/locales/fr.json
+++ b/web/build/locales/fr.json
@@ -251,6 +251,7 @@
   "hero.mockup.v3.step_fetch": "Récupération du MP4",
   "hero.mockup.v3.result_html": "Enregistré dans <strong>Downloads/nomad-bodrum.mp4</strong>",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "Téléchargement terminé",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "L'avenir de l'IA locale",
   "hero.mockup.v4.byline": "Par Jane Smith · 8 min de lecture",

--- a/web/build/locales/id.json
+++ b/web/build/locales/id.json
@@ -251,6 +251,7 @@
   "hero.mockup.v3.step_fetch": "Mengambil MP4",
   "hero.mockup.v3.result_html": "Disimpan ke <strong>Downloads/nomad-bodrum.mp4</strong>",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "Unduhan selesai",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "Masa Depan AI Lokal",
   "hero.mockup.v4.byline": "Oleh Jane Smith · 8 mnt baca",

--- a/web/build/locales/ja.json
+++ b/web/build/locales/ja.json
@@ -251,6 +251,7 @@
   "hero.mockup.v3.step_fetch": "MP4 を取得中",
   "hero.mockup.v3.result_html": "<strong>Downloads/nomad-bodrum.mp4</strong> に保存しました",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "ダウンロード完了",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "ローカル AI の未来",
   "hero.mockup.v4.byline": "By Jane Smith · 8 分で読了",

--- a/web/build/locales/ko.json
+++ b/web/build/locales/ko.json
@@ -251,6 +251,7 @@
   "hero.mockup.v3.step_fetch": "MP4 가져오는 중",
   "hero.mockup.v3.result_html": "<strong>Downloads/nomad-bodrum.mp4</strong>에 저장했습니다",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "다운로드 완료",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "로컬 AI의 미래",
   "hero.mockup.v4.byline": "Jane Smith · 8분 읽기",

--- a/web/build/locales/ms.json
+++ b/web/build/locales/ms.json
@@ -251,6 +251,7 @@
   "hero.mockup.v3.step_fetch": "Mengambil MP4",
   "hero.mockup.v3.result_html": "Disimpan ke <strong>Downloads/nomad-bodrum.mp4</strong>",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "Muat turun selesai",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "Masa Depan AI Tempatan",
   "hero.mockup.v4.byline": "Oleh Jane Smith · bacaan 8 min",

--- a/web/build/locales/ru.json
+++ b/web/build/locales/ru.json
@@ -251,6 +251,7 @@
   "hero.mockup.v3.step_fetch": "Загрузка MP4",
   "hero.mockup.v3.result_html": "Сохранено в <strong>Downloads/nomad-bodrum.mp4</strong>",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "Загрузка завершена",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "Будущее локального AI",
   "hero.mockup.v4.byline": "Автор Jane Smith · 8 мин чтения",

--- a/web/build/locales/th.json
+++ b/web/build/locales/th.json
@@ -251,6 +251,7 @@
   "hero.mockup.v3.step_fetch": "กำลังดึง MP4",
   "hero.mockup.v3.result_html": "บันทึกไปยัง <strong>Downloads/nomad-bodrum.mp4</strong> แล้ว",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "ดาวน์โหลดเสร็จแล้ว",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "อนาคตของ AI ในเครื่อง",
   "hero.mockup.v4.byline": "โดย Jane Smith · อ่าน 8 นาที",

--- a/web/build/locales/tl.json
+++ b/web/build/locales/tl.json
@@ -251,6 +251,7 @@
   "hero.mockup.v3.step_fetch": "Kinukuha ang MP4",
   "hero.mockup.v3.result_html": "Na-save sa <strong>Downloads/nomad-bodrum.mp4</strong>",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "Tapos na ang pag-download",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "Ang Kinabukasan ng Local AI",
   "hero.mockup.v4.byline": "Ni Jane Smith · 8 min na pagbabasa",

--- a/web/build/locales/tr.json
+++ b/web/build/locales/tr.json
@@ -251,6 +251,7 @@
   "hero.mockup.v3.step_fetch": "MP4 alınıyor",
   "hero.mockup.v3.result_html": "<strong>Downloads/nomad-bodrum.mp4</strong> konumuna kaydedildi",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "İndirme tamamlandı",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "Yerel AI'nın Geleceği",
   "hero.mockup.v4.byline": "Jane Smith · 8 dk okuma",

--- a/web/build/locales/uk.json
+++ b/web/build/locales/uk.json
@@ -251,6 +251,7 @@
   "hero.mockup.v3.step_fetch": "Отримуємо MP4",
   "hero.mockup.v3.result_html": "Збережено в <strong>Downloads/nomad-bodrum.mp4</strong>",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "Завантаження завершено",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "Майбутнє локального AI",
   "hero.mockup.v4.byline": "Автор: Jane Smith · 8 хв читання",

--- a/web/build/locales/zh.json
+++ b/web/build/locales/zh.json
@@ -251,6 +251,7 @@
   "hero.mockup.v3.step_fetch": "正在获取 MP4",
   "hero.mockup.v3.result_html": "已保存到 <strong>Downloads/nomad-bodrum.mp4</strong>",
   "hero.mockup.v3.result_meta": "1080p · 24s · 4.2 MB",
+  "hero.mockup.v3.download_complete": "下载完成",
   "hero.mockup.v4.url": "https://magazine.dev/local-ai-2026",
   "hero.mockup.v4.page_title": "本地 AI 的未来",
   "hero.mockup.v4.byline": "作者 Jane Smith · 8 分钟阅读",

--- a/web/build/template.html
+++ b/web/build/template.html
@@ -439,6 +439,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -856,6 +859,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1033,6 +1133,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2017,7 +2123,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2032,6 +2138,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">{{t:hero.mockup.v3.result_meta}}</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>{{t:hero.mockup.v3.download_complete}}</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">{{t:hero.mockup.input_placeholder}}</div>
             </div>
@@ -2040,7 +2159,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">{{t:hero.mockup.url}}</div>

--- a/web/es/index.html
+++ b/web/es/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>Descarga completada</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">Pregunta lo que quieras sobre esta página...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/productos</div>

--- a/web/fr/index.html
+++ b/web/fr/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>Téléchargement terminé</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">Posez une question sur cette page...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/produits</div>

--- a/web/id/index.html
+++ b/web/id/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>Unduhan selesai</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">Tanyakan apa saja tentang halaman ini...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/products</div>

--- a/web/index.html
+++ b/web/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>Download complete</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">Ask anything about this page...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/products</div>

--- a/web/ja/index.html
+++ b/web/ja/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>ダウンロード完了</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">このページについて何でも聞いてください...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/products</div>

--- a/web/ko/index.html
+++ b/web/ko/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>다운로드 완료</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">이 페이지에 대해 무엇이든 물어보세요...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/products</div>

--- a/web/ms/index.html
+++ b/web/ms/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>Muat turun selesai</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">Tanya apa-apa sahaja tentang halaman ini...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/products</div>

--- a/web/ru/index.html
+++ b/web/ru/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>Загрузка завершена</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">Спросите что угодно об этой странице...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/products</div>

--- a/web/th/index.html
+++ b/web/th/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>ดาวน์โหลดเสร็จแล้ว</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">ถามอะไรก็ได้เกี่ยวกับหน้านี้...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/products</div>

--- a/web/tl/index.html
+++ b/web/tl/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>Tapos na ang pag-download</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">Magtanong kahit ano tungkol sa pahinang ito...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/products</div>

--- a/web/tr/index.html
+++ b/web/tr/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>İndirme tamamlandı</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">Bu sayfayla ilgili istediğini sor...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/urunler</div>

--- a/web/uk/index.html
+++ b/web/uk/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>Завантаження завершено</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">Запитайте будь-що про цю сторінку...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/products</div>

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -668,6 +668,9 @@
       flex-direction: column;
       flex-shrink: 0;
     }
+    /* Scene 5 has list-like extraction output, so keep the response aligned
+       like real chat content instead of inheriting the centered hero text. */
+    .scene-response-left .sp-msg.assistant { text-align: start; }
     .sp-header {
       padding: 10px 14px;
       border-bottom: 1px solid var(--border);
@@ -1085,6 +1088,103 @@
       font-size: 13px;
     }
 
+    /* Scene 4 — a compact browser-style completion bubble lands with the
+       assistant's response. The ring draw and check pop make the
+       successful file handoff readable without turning it into confetti. */
+    .download-complete-toast {
+      position: absolute;
+      inset-inline-end: 14px;
+      bottom: 58px;
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      width: min(218px, calc(100% - 28px));
+      padding: 9px 11px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 11px;
+      background: rgba(15,18,31,0.94);
+      color: #f2f4ff;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.38);
+      backdrop-filter: blur(10px);
+      opacity: 0;
+      transform: translateY(14px) scale(0.96);
+    }
+    .scene-download-panel { position: relative; }
+    .download-complete-icon {
+      position: relative;
+      width: 32px;
+      height: 32px;
+      flex: 0 0 32px;
+    }
+    .download-complete-icon svg {
+      position: absolute;
+      inset: 0;
+      width: 32px;
+      height: 32px;
+      overflow: visible;
+    }
+    .download-complete-track,
+    .download-complete-ring {
+      fill: none;
+      stroke-width: 2.5;
+    }
+    .download-complete-track { stroke: rgba(52,211,153,0.20); }
+    .download-complete-ring {
+      stroke: var(--success);
+      stroke-linecap: round;
+      stroke-dasharray: 69.2;
+      stroke-dashoffset: 69.2;
+      transform: rotate(-90deg);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-check {
+      fill: none;
+      stroke: var(--success);
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: 0;
+      transform: scale(0.55);
+      transform-origin: 16px 16px;
+    }
+    .download-complete-copy { min-width: 0; line-height: 1.3; text-align: start; }
+    .download-complete-copy strong {
+      display: block;
+      font-size: 11px;
+      letter-spacing: 0.1px;
+    }
+    .download-complete-copy span {
+      display: block;
+      margin-top: 2px;
+      color: rgba(226,231,247,0.70);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    @keyframes downloadToastIn {
+      from { opacity: 0; transform: translateY(14px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes downloadRingComplete {
+      from { stroke-dashoffset: 69.2; }
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes downloadCheckPop {
+      from { opacity: 0; transform: scale(0.55); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .browser-mockup.is-active .download-complete-toast {
+      animation: downloadToastIn 0.42s cubic-bezier(0.2, 0.85, 0.25, 1.15) 0.45s both;
+    }
+    .browser-mockup.is-active .download-complete-ring {
+      animation: downloadRingComplete 0.62s ease-out 0.55s both;
+    }
+    .browser-mockup.is-active .download-complete-check {
+      animation: downloadCheckPop 0.28s cubic-bezier(0.2, 0.9, 0.3, 1.4) 1.08s both;
+    }
+
     /* ----- v5 (scene 5) — product catalog grid ----- */
     .pp-sub {
       font-size: 10px;
@@ -1262,6 +1362,12 @@
       .tf-check, .browser-mockup.is-active .tf-check { animation: none; opacity: 1; }
       .tf-mem, .browser-mockup.is-active .tf-mem { animation: none; opacity: 1; }
       .browser-mockup.is-active .pl-grid { animation: none; gap: 26px; margin-top: 14px; }
+      .download-complete-toast,
+      .browser-mockup.is-active .download-complete-toast { animation: none; opacity: 1; transform: none; }
+      .download-complete-ring,
+      .browser-mockup.is-active .download-complete-ring { animation: none; stroke-dashoffset: 0; }
+      .download-complete-check,
+      .browser-mockup.is-active .download-complete-check { animation: none; opacity: 1; transform: none; }
     }
 
     /* ================================================================
@@ -2246,7 +2352,7 @@
               </div>
             </div>
           </div>
-          <div class="side-panel">
+          <div class="side-panel scene-download-panel">
             <div class="sp-header">
               <span class="sp-brand"><img class="sp-brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="sp-domain">.one</span></span>
               <span class="sp-modes" aria-hidden="true"><span class="sp-mode">Ask</span><span class="sp-mode is-on">Act</span><span class="sp-mode">Dev</span></span>
@@ -2261,6 +2367,19 @@
                 <div style="margin-top:4px; font-size:11px; color: var(--text-dim);">1080p · 24s · 4.2 MB</div>
               </div>
             </div>
+            <div class="download-complete-toast" aria-hidden="true">
+              <span class="download-complete-icon">
+                <svg viewBox="0 0 32 32" aria-hidden="true">
+                  <circle class="download-complete-track" cx="16" cy="16" r="11"></circle>
+                  <circle class="download-complete-ring" cx="16" cy="16" r="11"></circle>
+                  <path class="download-complete-check" d="M10.5 16.3l3.6 3.5 7.5-8"></path>
+                </svg>
+              </span>
+              <span class="download-complete-copy">
+                <strong>下载完成</strong>
+                <span>nomad-bodrum.mp4 · 4.2 MB</span>
+              </span>
+            </div>
             <div class="sp-input">
               <div class="sp-input-box">针对此页面随便问点什么...</div>
             </div>
@@ -2269,7 +2388,7 @@
       </div>
 
       <!-- Scene 5: Product extraction (Act mode) -->
-      <div class="browser-mockup" data-scene="4" aria-hidden="true" inert>
+      <div class="browser-mockup scene-response-left" data-scene="4" aria-hidden="true" inert>
         <div class="browser-bar">
           <div class="browser-dots"><span></span><span></span><span></span></div>
           <div class="browser-url">https://example.com/products</div>


### PR DESCRIPTION
## Summary

- left-align the fifth hero scene's extraction response while keeping the WebBrain panel on the right
- add a synchronized download-complete effect inside the fourth scene's WebBrain panel
- localize the completion copy and regenerate all 14 homepage locales

## Why

The hero carousel should resemble the real extension UI more closely. Structured extraction output reads more naturally from the content edge, and the download scenario now provides a visible completion signal in the panel where the action is reported.

## Impact

Visitors see clearer, more realistic hero demonstrations across every localized homepage. The download effect respects reduced-motion preferences.

## Validation

- `npm run build:web`
- parsed and checked all 14 generated homepage HTML files
- `git diff --check`