### PR TITLE
Fix accessibility-tree loops and isolate per-tab run UI

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15637,7 +15637,8 @@ const ADAPTERS = [
 - The body is a contenteditable div (rich text), not a textarea. Click into it before typing.
 - Sending: the "Send" button is bottom-left of the compose window; "Send + Schedule" arrow is next to it for scheduled send.
 - Search uses operators: from:, to:, subject:, has:attachment, before:YYYY/MM/DD.
-- Threads collapse old messages — click "Show trimmed content" or the message header to expand.`,
+- Threads collapse old messages — click "Show trimmed content" or the message header to expand.
+- Gmail's accessibility tree is large and noisy. Prefer visible/interactive reads, use compose fields as soon as they appear, and never inspect generic or sibling ref_ids one-by-one; continue with the returned nextPage when truncated.`,
   },
   {
     name: 'google-docs',

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -748,7 +748,10 @@ export class Agent {
     state.seenPages.add(page);
     this.axReadStates.set(tabId, state);
 
-    if (state.suspicious >= 6 || state.total >= 12) {
+    // A root read followed by the exact returned nextPage can legitimately span
+    // large applications. Keep the consecutive-read cap for every other AX
+    // pattern, but do not stop a valid sequential pagination step.
+    if (state.suspicious >= 6 || (state.total >= 12 && (state.suspicious > 0 || !sequentialPage))) {
       this.axReadStates.delete(tabId);
       return {
         kind: 'stop',

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -176,6 +176,9 @@ export class Agent {
     this.recentCalls = new Map(); // tabId -> [{ key, name, ts }]
     this.loopNudges = new Map();  // tabId -> consecutive-nudge counter
     this.healthyCallsSinceLoop = new Map(); // tabId -> count of clean calls since last nudge
+    // A model can walk ref_1, ref_2, … forever while every call looks unique
+    // to the exact-argument loop detector. Track that semantic read pattern.
+    this.axReadStates = new Map(); // tabId -> { total, suspicious, nextPage, seenPages, warned }
     this.lastAutoScreenshotTs = new Map(); // tabId -> ms — defensive debounce
     this.lastSeenAdapter = new Map(); // tabId -> adapter name from last enrichment
     // Separate buffer for coordinate-based click attempts. The general loop
@@ -698,6 +701,7 @@ export class Agent {
     this.recentCalls.delete(tabId);
     this.loopNudges.delete(tabId);
     this.healthyCallsSinceLoop.delete(tabId);
+    this.axReadStates.delete(tabId);
     this.recentCoordClicks.delete(tabId);
     this.bulkApiMutationClicks.delete(tabId);
     this.bulkApiMutationHints.delete(tabId);
@@ -707,6 +711,58 @@ export class Agent {
         this.failedBulkApiReplayShapes.delete(key);
       }
     }
+  }
+
+  _checkAccessibilityReadLoop(tabId, name, args, result) {
+    if (name !== 'get_accessibility_tree') {
+      this.axReadStates.delete(tabId);
+      return { kind: 'none' };
+    }
+
+    const previous = this.axReadStates.get(tabId) || {
+      total: 0,
+      suspicious: 0,
+      nextPage: null,
+      seenPages: new Set(),
+      warned: false,
+    };
+    const page = Number(args?.page || 1);
+    const hasRef = typeof args?.ref_id === 'string' && args.ref_id.trim() !== '';
+    const sequentialPage = !hasRef
+      && previous.total > 0
+      && Number.isFinite(previous.nextPage)
+      && page === previous.nextPage
+      && !previous.seenPages.has(page);
+    const repeatedRootOrPage = !hasRef && previous.total > 0 && !sequentialPage;
+    const content = String(result?.pageContent || '').trim();
+    const meaningfulLines = content ? content.split(/\r?\n/).filter(line => line.trim()).length : 0;
+    const suspicious = hasRef || repeatedRootOrPage || (hasRef && meaningfulLines <= 1);
+
+    const state = {
+      total: previous.total + 1,
+      suspicious: previous.suspicious + (suspicious ? 1 : 0),
+      nextPage: Number.isFinite(Number(result?.nextPage)) ? Number(result.nextPage) : null,
+      seenPages: new Set(previous.seenPages),
+      warned: previous.warned,
+    };
+    state.seenPages.add(page);
+    this.axReadStates.set(tabId, state);
+
+    if (state.suspicious >= 6 || state.total >= 12) {
+      this.axReadStates.delete(tabId);
+      return {
+        kind: 'stop',
+        message: 'Stopped: I kept reading accessibility-tree nodes without taking an action or changing approach. The tree is not meant to be enumerated ref-by-ref. Use an element already found, request the returned nextPage, switch to read_page/extract_data, or ask for help.',
+      };
+    }
+    if (!state.warned && state.suspicious >= 3) {
+      state.warned = true;
+      return {
+        kind: 'nudge',
+        warning: '[ACCESSIBILITY READ LOOP: Stop enumerating sibling or generic ref_ids. If the result has hasMore/nextPage, request exactly that page. If the needed textbox/button is already visible, use set_field, type_ax, or click_ax now. Otherwise switch once to read_page/extract_data or finish with what you have. Do not call another arbitrary ref_id subtree.]',
+      };
+    }
+    return { kind: 'none' };
   }
 
   /**
@@ -2219,7 +2275,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         return { action: 'return', value: finalResponse };
       }
 
-      // Loop detection — two parallel checks, strongest action wins.
+      // Loop detection — exact calls, semantic AX reads, and coordinates run
+      // in parallel; the strongest action wins.
       let loopCheck = { kind: 'none' };
       const loopKey = this._loopCallKey(fnName, fnArgs, toolResult);
       const failedApiMutation = this._isFailedApiMutationForLoop(fnName, fnArgs, toolResult);
@@ -2231,12 +2288,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (fnName === 'click' && fnArgs?.x != null && fnArgs?.y != null) {
         coordCheck = this._checkCoordClickLoop(tabId, fnArgs.x, fnArgs.y);
       }
+      const axReadCheck = this._checkAccessibilityReadLoop(tabId, fnName, fnArgs, toolResult);
 
       // Combine: stop > nudge > none.
       let effectiveKind = 'none';
       let nudgeWarning = '';
       let stopMessage = '';
-      if (loopCheck.kind === 'stop' || coordCheck.kind === 'stop') {
+      if (loopCheck.kind === 'stop' || coordCheck.kind === 'stop' || axReadCheck.kind === 'stop') {
         effectiveKind = 'stop';
         if (coordCheck.kind === 'stop') {
           // Show the model's actual args, not _checkCoordClickLoop's 5px
@@ -2244,13 +2302,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           // rounds to (0, 0) and the message reads as if we'd clicked the
           // top-left corner, hiding what really happened.
           stopMessage = `Stopped: I clicked at (or near) coordinates (${fnArgs.x}, ${fnArgs.y}) multiple times and the page never responded. That position is hitting empty space, an overlay, or the wrong element. Please give a different instruction or check the page yourself.`;
+        } else if (axReadCheck.kind === 'stop') {
+          stopMessage = axReadCheck.message;
         } else {
           stopMessage = loopCheck.message;
         }
-      } else if (loopCheck.kind === 'nudge' || coordCheck.kind === 'nudge') {
+      } else if (loopCheck.kind === 'nudge' || coordCheck.kind === 'nudge' || axReadCheck.kind === 'nudge') {
         effectiveKind = 'nudge';
         if (coordCheck.kind === 'nudge') {
           nudgeWarning = this._coordinateClickRecoveryWarning(fnArgs, allowedToolNames);
+        } else if (axReadCheck.kind === 'nudge') {
+          nudgeWarning = axReadCheck.warning;
         } else {
           nudgeWarning = loopCheck.warning;
         }
@@ -3928,7 +3990,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       } catch {}
     }
     try {
-      return await Promise.race([responsePromise, timeoutPromise]);
+      const response = await Promise.race([responsePromise, timeoutPromise]);
+      if (response?.cancelled && typeof onUpdate === 'function') {
+        try {
+          onUpdate('plan_resolved', {
+            planId,
+            decision: response.reason === 'plan review timed out' ? 'timeout' : 'cancelled',
+          });
+        } catch {}
+      }
+      return response;
     } finally {
       // Cancel the 10-minute timer once the race settles so a fast approval
       // doesn't leave an armed timer (and its captured resolve/plan closure)
@@ -11421,12 +11492,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (this._runningTabs.has(tabId)) {
       throw new Error('An agent run is already in progress for this tab.');
     }
+    this._clearLoopState(tabId);
     this._runningTabs.add(tabId);
     try {
       return await this._processMessageInner(tabId, userMessage, onUpdate, mode, attachments, runOptions);
     } finally {
       this.currentCostState.delete(tabId);
       this._runningTabs.delete(tabId);
+      this._clearLoopState(tabId);
     }
   }
 
@@ -11882,12 +11955,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (this._runningTabs.has(tabId)) {
       throw new Error('An agent run is already in progress for this tab.');
     }
+    this._clearLoopState(tabId);
     this._runningTabs.add(tabId);
     try {
       return await this._processMessageStreamInner(tabId, userMessage, onUpdate, mode, runOptions);
     } finally {
       this.currentCostState.delete(tabId);
       this._runningTabs.delete(tabId);
+      this._clearLoopState(tabId);
     }
   }
 

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -17,7 +17,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'get_accessibility_tree',
-      description: 'PREFERRED page-reading tool. Returns the page as a flat, indented text representation of its accessibility tree. Each kept node is one line of the form `role "accessible name" [ref_id] href="..." type="..." placeholder="..."`. Indentation shows hierarchy. ref_ids are STABLE across calls — re-use them in click_ax / type_ax. If the result is truncated (`truncated:true`, `hasMore:true`), call again with `page:` set to `nextPage` to read the next slice before scrolling. When you pass an explicit `maxChars` and the tree is larger, the tool now AUTO-SLICES to fit and sets `autoDegraded:true` + a `notice` field explaining how to continue — so a single oversized call no longer wastes a round-trip with empty pageContent. Use this first; read_page is a prose fallback for long-form articles only.',
+      description: 'PREFERRED page-reading tool. Returns the page as a flat, indented text representation of its accessibility tree. Each kept node is one line of the form `role "accessible name" [ref_id] href="..." type="..." placeholder="..."`. Indentation shows hierarchy. ref_ids are STABLE across calls — re-use them in click_ax / type_ax. NEVER enumerate sibling or generic ref_ids one-by-one: ref_id is only for one targeted subtree you already know matters. If the result is truncated (`truncated:true`, `hasMore:true`), call again with `page:` set exactly to `nextPage` before trying arbitrary subtrees or scrolling. Once the needed field/button is visible, act on it instead of reading more. When you pass an explicit `maxChars` and the tree is larger, the tool now AUTO-SLICES to fit and sets `autoDegraded:true` + a `notice` field explaining how to continue — so a single oversized call no longer wastes a round-trip with empty pageContent. Use this first; read_page is a prose fallback for long-form articles only.',
       parameters: {
         type: 'object',
         properties: {
@@ -1053,6 +1053,7 @@ ACCESSIBILITY TREE — read this carefully:
     ref_id: anchor the read at a specific element — returns its subtree only
 - \`ref_id\`s are STABLE across calls. A ref_id you saw in a previous turn still points to the same element, unless the element was removed from the DOM or the page navigated.
 - Default read pattern: \`get_accessibility_tree({filter: "visible"})\` → locate what you need → answer.
+- Never enumerate sibling/generic ref_ids. Use ref_id only for one subtree already known to matter; if hasMore is returned, request exactly nextPage, and once the target is visible stop reading and act or answer.
 - Use \`read_page\` only when the user's question is about prose (summarize this article, what does this README say).
 - SHADOW DOM FALLBACK: If the tree is missing expected elements (common on Stripe, Salesforce, Shopify, and other Web Component-heavy pages), the page likely uses shadow DOM. Try \`get_interactive_elements\` which pierces open shadow roots. If that still misses the content, explain that Dev mode has deeper DOM inspection.
 
@@ -1157,6 +1158,7 @@ ACCESSIBILITY TREE — read this carefully:
 - DEFAULT ACT LOOP:
     1. \`get_accessibility_tree({filter: "visible"})\` — see what's on screen.
     2. If the tree is truncated and you cannot find a visible target, call \`get_accessibility_tree({filter: "visible", page: nextPage})\` before scrolling.
+    3. Never enumerate sibling/generic ref_ids. Use one targeted subtree at most; once the target field/button is visible, act on it instead of reading more.
     3. Identify the ref_ids you need for the next step.
     4. \`click_ax({ref_id: "ref_N"})\` or \`type_ax({ref_id: "ref_N", text: "..."})\`.
     5. Re-read the tree or inspect any injected auto-screenshot/visual context to verify the page changed.

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -30,6 +30,7 @@ import {
   setProviderManager as setRecorderProviderManager,
 } from './recorder/host.js';
 import { normalizeOllamaLaunchHandoff } from './ollama-handoff.js';
+import { RunUiJournal } from './run-ui-journal.js';
 import {
   USER_MEMORY_AUTO_CAPTURE_KEY,
   USER_MEMORY_ENABLED_KEY,
@@ -1014,14 +1015,91 @@ chrome.tabs.onRemoved.addListener((tabId) => {
   activeIndicatorTabs.delete(tabId);
 });
 
-function sendAgentRunComplete(tabId) {
-  if (tabId == null) return;
+const RUN_UI_PREFIX = 'runUi:';
+const runUiJournal = new RunUiJournal({
+  onChange(tabId, snapshot) {
+    try {
+      chrome.storage.session?.set({ [RUN_UI_PREFIX + tabId]: snapshot }).catch(() => {});
+    } catch {}
+  },
+});
+
+function beginRunUiSnapshot(tabId, requestId) {
+  return runUiJournal.begin(tabId, requestId);
+}
+
+function recordRunUiEvent(tabId, requestId, type, data) {
+  return runUiJournal.record(tabId, requestId, type, data, agent.currentRunId.get(tabId));
+}
+
+function terminalRunUiStatus(content, updates = [], error = null) {
+  if (error) return 'failed';
+  const text = String(content || '');
+  if (/stopped by user|aborted by user/i.test(text)) return 'stopped';
+  if (/before executing requested tool calls/i.test(text)) return 'cancelled';
+  if (updates.some(update => update?.type === 'error')) return 'failed';
+  return 'completed';
+}
+
+function finishRunUiSnapshot(tabId, requestId, status, finalContent = '') {
+  return runUiJournal.finish(tabId, requestId, status, finalContent, agent.currentRunId.get(tabId));
+}
+
+async function getRunUiSnapshot(tabId) {
+  const live = runUiJournal.get(tabId);
+  if (live) return live;
+  try {
+    const key = RUN_UI_PREFIX + tabId;
+    const stored = await chrome.storage.session?.get(key);
+    const snapshot = stored?.[key];
+    if (snapshot && typeof snapshot === 'object') {
+      return runUiJournal.restore(tabId, snapshot);
+    }
+  } catch {}
+  return null;
+}
+
+function clearRunUiSnapshot(tabId) {
+  runUiJournal.clear(tabId);
+  try { chrome.storage.session?.remove(RUN_UI_PREFIX + tabId).catch(() => {}); } catch {}
+}
+
+function sendAgentUpdate(tabId, requestId, type, data) {
+  const event = recordRunUiEvent(tabId, requestId, type, data);
+  if (!event) return;
   chrome.runtime.sendMessage({
     target: 'sidepanel',
     action: 'agent_update',
     tabId,
+    requestId,
+    runId: event?.runId || agent.currentRunId.get(tabId) || null,
+    seq: event?.seq || null,
+    type,
+    data: event?.data ?? data,
+  }).catch(() => {});
+}
+
+function assertNoActiveTabRun(tabId) {
+  if (agent.activeRunState(tabId)?.running) {
+    throw new Error('A run is already active for this tab.');
+  }
+}
+
+function sendAgentRunComplete(tabId, snapshot = null) {
+  if (tabId == null || !snapshot) return;
+  chrome.runtime.sendMessage({
+    target: 'sidepanel',
+    action: 'agent_update',
+    tabId,
+    requestId: snapshot.requestId,
+    runId: snapshot.runId || null,
+    seq: snapshot.seq,
     type: 'run_complete',
-    data: {},
+    data: {
+      status: snapshot.status || 'completed',
+      finalContent: snapshot.finalContent || '',
+      endedAt: snapshot.endedAt || Date.now(),
+    },
   }).catch(() => {});
 }
 
@@ -1093,6 +1171,7 @@ chrome.windows?.onRemoved?.addListener?.((windowId) => {
 
 chrome.tabs.onRemoved.addListener((tabId) => {
   panelTabs.delete(tabId);
+  clearRunUiSnapshot(tabId);
   clearTimeout(pendingContextMenuNotifications.get(tabId));
   pendingContextMenuNotifications.delete(tabId);
   contextMenuStorage.cleanup(tabId);
@@ -1495,7 +1574,9 @@ async function handleMessage(msg, sender) {
     case 'chat': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) throw new Error('No tab ID');
+      assertNoActiveTabRun(tabId);
       const mode = msg.mode || 'ask';
+      const runUi = beginRunUiSnapshot(tabId, msg.requestId);
 
       // /allow-api flag is per-conversation. The sidebar tracks it locally
       // but sends it on every chat call so the agent stays in sync after a
@@ -1517,17 +1598,13 @@ async function handleMessage(msg, sender) {
 
       const updates = [];
       let userMemoryTurnContextTaken = false;
+      let result = '';
+      let runError = null;
       try {
         const runOptions = msg.recommendedAction ? { recommendedAction: msg.recommendedAction } : {};
-        const result = await agent.processMessage(tabId, msg.text, (type, data) => {
+        result = await agent.processMessage(tabId, msg.text, (type, data) => {
           updates.push({ type, data });
-          chrome.runtime.sendMessage({
-            target: 'sidepanel',
-            action: 'agent_update',
-            tabId,          // see sidepanel onMessage — filters out cross-tab leak
-            type,
-            data,
-          }).catch(() => {});
+          sendAgentUpdate(tabId, runUi.requestId, type, data);
         }, mode, msg.attachments, runOptions);
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
@@ -1538,10 +1615,19 @@ async function handleMessage(msg, sender) {
         });
         userMemoryTurnContextTaken = true;
         enqueueUserMemoryExtractionAfterTurn(userMemoryPayload);
-        return { content: result, updates, conversationId: await agent.getConversationId(tabId) };
+        return { content: result, updates, requestId: runUi.requestId, conversationId: await agent.getConversationId(tabId) };
+      } catch (error) {
+        runError = error;
+        throw error;
       } finally {
         if (!userMemoryTurnContextTaken) clearUserMemoryTurnContext(tabId);
-        sendAgentRunComplete(tabId);
+        const snapshot = finishRunUiSnapshot(
+          tabId,
+          runUi.requestId,
+          terminalRunUiStatus(result, updates, runError),
+          result || (runError ? `Error: ${runError.message}` : ''),
+        );
+        sendAgentRunComplete(tabId, snapshot);
         sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
       }
     }
@@ -1549,24 +1635,22 @@ async function handleMessage(msg, sender) {
     case 'chat_stream': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) throw new Error('No tab ID');
+      assertNoActiveTabRun(tabId);
       const mode = msg.mode || 'ask';
+      const runUi = beginRunUiSnapshot(tabId, msg.requestId);
 
       if (msg.apiMutationsAllowed) agent.setApiMutationsAllowed(tabId, true);
 
       sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
       let userMemoryTurnContextTaken = false;
       let userMemoryTurnHadError = false;
+      let result = '';
+      let runError = null;
       try {
         const runOptions = msg.recommendedAction ? { recommendedAction: msg.recommendedAction } : {};
-        const result = await agent.processMessageStream(tabId, msg.text, (type, data) => {
+        result = await agent.processMessageStream(tabId, msg.text, (type, data) => {
           if (type === 'error') userMemoryTurnHadError = true;
-          chrome.runtime.sendMessage({
-            target: 'sidepanel',
-            action: 'agent_update',
-            tabId,          // see sidepanel onMessage — filters out cross-tab leak
-            type,
-            data,
-          }).catch(() => {});
+          sendAgentUpdate(tabId, runUi.requestId, type, data);
         }, mode, runOptions);
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
@@ -1577,10 +1661,19 @@ async function handleMessage(msg, sender) {
         });
         userMemoryTurnContextTaken = true;
         enqueueUserMemoryExtractionAfterTurn(userMemoryPayload);
-        return { content: result, conversationId: await agent.getConversationId(tabId) };
+        return { content: result, requestId: runUi.requestId, conversationId: await agent.getConversationId(tabId) };
+      } catch (error) {
+        runError = error;
+        throw error;
       } finally {
         if (!userMemoryTurnContextTaken) clearUserMemoryTurnContext(tabId);
-        sendAgentRunComplete(tabId);
+        const snapshot = finishRunUiSnapshot(
+          tabId,
+          runUi.requestId,
+          terminalRunUiStatus(result, userMemoryTurnHadError ? [{ type: 'error' }] : [], runError),
+          result || (runError ? `Error: ${runError.message}` : ''),
+        );
+        sendAgentRunComplete(tabId, snapshot);
         sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
       }
     }
@@ -1588,21 +1681,19 @@ async function handleMessage(msg, sender) {
     case 'continue': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) throw new Error('No tab ID');
+      assertNoActiveTabRun(tabId);
       const mode = msg.mode || 'ask';
+      const runUi = beginRunUiSnapshot(tabId, msg.requestId);
 
       sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
       let userMemoryTurnContextTaken = false;
       let userMemoryTurnHadError = false;
+      let result = '';
+      let runError = null;
       try {
-        const result = await agent.continueProcessing(tabId, (type, data) => {
+        result = await agent.continueProcessing(tabId, (type, data) => {
           if (type === 'error') userMemoryTurnHadError = true;
-          chrome.runtime.sendMessage({
-            target: 'sidepanel',
-            action: 'agent_update',
-            tabId,          // see sidepanel onMessage — filters out cross-tab leak
-            type,
-            data,
-          }).catch(() => {});
+          sendAgentUpdate(tabId, runUi.requestId, type, data);
         }, mode);
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
@@ -1613,10 +1704,19 @@ async function handleMessage(msg, sender) {
         });
         userMemoryTurnContextTaken = true;
         enqueueUserMemoryExtractionAfterTurn(userMemoryPayload);
-        return { content: result, conversationId: await agent.getConversationId(tabId) };
+        return { content: result, requestId: runUi.requestId, conversationId: await agent.getConversationId(tabId) };
+      } catch (error) {
+        runError = error;
+        throw error;
       } finally {
         if (!userMemoryTurnContextTaken) clearUserMemoryTurnContext(tabId);
-        sendAgentRunComplete(tabId);
+        const snapshot = finishRunUiSnapshot(
+          tabId,
+          runUi.requestId,
+          terminalRunUiStatus(result, userMemoryTurnHadError ? [{ type: 'error' }] : [], runError),
+          result || (runError ? `Error: ${runError.message}` : ''),
+        );
+        sendAgentRunComplete(tabId, snapshot);
         sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
       }
     }
@@ -1627,6 +1727,7 @@ async function handleMessage(msg, sender) {
         const conversationId = await agent.getConversationId(tabId);
         await scheduler.cancelForConversation(tabId, conversationId);
         agent.clearConversation(tabId);
+        clearRunUiSnapshot(tabId);
       }
       return { ok: true };
     }
@@ -1646,7 +1747,13 @@ async function handleMessage(msg, sender) {
     case 'agent_run_state': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) return { ok: false, error: 'No tab ID' };
-      return { ok: true, ...agent.activeRunState(tabId) };
+      return { ok: true, ...agent.activeRunState(tabId), runUi: await getRunUiSnapshot(tabId) };
+    }
+
+    case 'agent_run_ack': {
+      const tabId = msg.tabId || sender.tab?.id;
+      if (!tabId) return { ok: false, error: 'No tab ID' };
+      return { ok: !!runUiJournal.acknowledge(tabId, String(msg.requestId || ''), msg.seq) };
     }
 
     case 'get_scratchpad': {
@@ -1750,6 +1857,10 @@ async function handleMessage(msg, sender) {
       const markdownMode = msg.markdownMode === 'verbose' ? 'verbose' : 'compact';
       if (!planId) return { ok: false, error: 'planId required' };
       const matched = agent.submitPlanResponse(tabId, planId, decision, editedText, markdownMode);
+      const snapshot = await getRunUiSnapshot(tabId);
+      if (matched && snapshot?.requestId) {
+        sendAgentUpdate(tabId, snapshot.requestId, 'plan_resolved', { planId, decision });
+      }
       return { ok: matched, matched };
     }
 

--- a/src/chrome/src/run-ui-journal.js
+++ b/src/chrome/src/run-ui-journal.js
@@ -1,0 +1,132 @@
+export const RUN_UI_EVENT_LIMIT = 256;
+
+export function createRunRequestId(tabId, supplied = '') {
+  const clean = String(supplied || '').trim();
+  return clean || `req_${tabId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function compactRunUiData(type, data) {
+  if (!data || typeof data !== 'object') return data;
+  if (type === 'tool_result') {
+    const result = data.result || {};
+    return {
+      name: data.name,
+      result: {
+        success: result.success,
+        ok: result.ok,
+        error: result.error ? String(result.error).slice(0, 1000) : undefined,
+        warning: result.warning ? String(result.warning).slice(0, 1000) : undefined,
+        summary: result.summary ? String(result.summary).slice(0, 2000) : undefined,
+      },
+    };
+  }
+  if (type === 'text' || type === 'text_delta') {
+    return { ...data, content: String(data.content || '').slice(0, 30000) };
+  }
+  return data;
+}
+
+export class RunUiJournal {
+  constructor({ eventLimit = RUN_UI_EVENT_LIMIT, onChange = null } = {}) {
+    this.eventLimit = eventLimit;
+    this.onChange = onChange;
+    this.snapshots = new Map();
+  }
+
+  _changed(tabId, snapshot) {
+    if (typeof this.onChange === 'function') this.onChange(tabId, snapshot);
+    return snapshot;
+  }
+
+  begin(tabId, requestId = '') {
+    const snapshot = {
+      tabId,
+      requestId: createRunRequestId(tabId, requestId),
+      runId: null,
+      status: 'running',
+      seq: 0,
+      ackedSeq: 0,
+      truncatedBeforeSeq: 0,
+      events: [],
+      pendingPlanId: null,
+      finalContent: '',
+      startedAt: Date.now(),
+      endedAt: null,
+    };
+    this.snapshots.set(tabId, snapshot);
+    return this._changed(tabId, snapshot);
+  }
+
+  record(tabId, requestId, type, data, runId = null) {
+    const snapshot = this.snapshots.get(tabId);
+    if (!snapshot || snapshot.requestId !== requestId) return null;
+    snapshot.runId = runId || snapshot.runId || null;
+    const event = {
+      seq: ++snapshot.seq,
+      type,
+      data: compactRunUiData(type, data),
+      ts: Date.now(),
+    };
+    snapshot.events.push(event);
+    while (snapshot.events.length > this.eventLimit) {
+      const removed = snapshot.events.shift();
+      snapshot.truncatedBeforeSeq = removed?.seq || snapshot.truncatedBeforeSeq;
+    }
+    if (type === 'plan_review') {
+      snapshot.status = 'awaiting_plan';
+      snapshot.pendingPlanId = String(data?.planId || '') || null;
+    }
+    if (type === 'plan_resolved') {
+      snapshot.status = 'running';
+      if (!data?.planId || String(data.planId) === String(snapshot.pendingPlanId)) snapshot.pendingPlanId = null;
+    }
+    this._changed(tabId, snapshot);
+    return { ...event, requestId: snapshot.requestId, runId: snapshot.runId };
+  }
+
+  finish(tabId, requestId, status, finalContent = '', runId = null) {
+    const snapshot = this.snapshots.get(tabId);
+    if (!snapshot || snapshot.requestId !== requestId) return null;
+    snapshot.runId = runId || snapshot.runId || null;
+    snapshot.status = status;
+    snapshot.pendingPlanId = null;
+    snapshot.finalContent = String(finalContent || '').slice(0, 30000);
+    snapshot.endedAt = Date.now();
+    const event = {
+      seq: ++snapshot.seq,
+      type: 'run_complete',
+      data: { status: snapshot.status, finalContent: snapshot.finalContent, endedAt: snapshot.endedAt },
+      ts: snapshot.endedAt,
+    };
+    snapshot.events.push(event);
+    while (snapshot.events.length > this.eventLimit) {
+      const removed = snapshot.events.shift();
+      snapshot.truncatedBeforeSeq = removed?.seq || snapshot.truncatedBeforeSeq;
+    }
+    return this._changed(tabId, snapshot);
+  }
+
+  restore(tabId, snapshot) {
+    if (!snapshot || typeof snapshot !== 'object') return null;
+    this.snapshots.set(tabId, snapshot);
+    return snapshot;
+  }
+
+  acknowledge(tabId, requestId, seq) {
+    const snapshot = this.snapshots.get(tabId);
+    const numericSeq = Number(seq);
+    if (!snapshot || snapshot.requestId !== requestId || !Number.isFinite(numericSeq)) return null;
+    snapshot.ackedSeq = Math.max(Number(snapshot.ackedSeq || 0), numericSeq);
+    snapshot.events = snapshot.events.filter(event => Number(event?.seq || 0) > snapshot.ackedSeq);
+    snapshot.truncatedBeforeSeq = Math.max(Number(snapshot.truncatedBeforeSeq || 0), snapshot.ackedSeq);
+    return this._changed(tabId, snapshot);
+  }
+
+  get(tabId) {
+    return this.snapshots.get(tabId) || null;
+  }
+
+  clear(tabId) {
+    this.snapshots.delete(tabId);
+  }
+}

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -442,6 +442,7 @@ let currentTabId = null;
 let renderedTabId = null;
 let pendingTabSwitch = null; // tab the user switched to while isProcessing was true
 let tabSwitchTransitionId = null;
+let tabSwitchGeneration = 0;
 let queuedTabSwitchMessages = [];
 const pendingAttachmentsByTab = new Map(); // tabId -> [{ kind: 'image'|'document'|'text', name, dataUrl?, textContent? }]
 const attachmentReadCountsByTab = new Map();
@@ -451,8 +452,10 @@ let currentAssistantEl = null;
 let verboseMode = false;
 let agentMode = 'ask'; // 'ask' | 'act' | 'dev'
 let abortRequested = false;
-let activeRunRestoredFromBackground = false;
 const awaitingPlanReviewTabs = new Set();
+const processingTabs = new Set();
+const abortRequestedTabs = new Set();
+const localRunRequestIds = new Map();
 let recommendationsRequestId = 0;
 let providerSelectionRequestId = 0;
 let providerTestRequestId = 0;
@@ -466,6 +469,42 @@ let retryPayloadSeq = 0;
 const activeChatPayloadsByTab = new Map();
 const retryAttachmentPayloads = new Map();
 const retryAttachmentIdsByTab = new Map();
+
+function setTabProcessing(tabId, processing) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return;
+  if (processing) processingTabs.add(numericTabId);
+  else processingTabs.delete(numericTabId);
+  if (sameTabId(currentTabId, numericTabId)) isProcessing = !!processing;
+}
+
+function isTabProcessing(tabId) {
+  const numericTabId = Number(tabId);
+  return Number.isFinite(numericTabId) && processingTabs.has(numericTabId);
+}
+
+function setTabAbortRequested(tabId, requested) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return;
+  if (requested) abortRequestedTabs.add(numericTabId);
+  else abortRequestedTabs.delete(numericTabId);
+  if (sameTabId(currentTabId, numericTabId)) abortRequested = !!requested;
+}
+
+function isTabAbortRequested(tabId) {
+  const numericTabId = Number(tabId);
+  return Number.isFinite(numericTabId) && abortRequestedTabs.has(numericTabId);
+}
+
+function syncCurrentTabRunFlags() {
+  const numericTabId = Number(currentTabId);
+  isProcessing = Number.isFinite(numericTabId) && processingTabs.has(numericTabId);
+  abortRequested = Number.isFinite(numericTabId) && abortRequestedTabs.has(numericTabId);
+}
+
+function createRunRequestId(tabId) {
+  return `req_${tabId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
 const {
   acceptContextMenuPrompt,
   drainQueuedContextMenuPrompts,
@@ -881,8 +920,8 @@ function setPlanReviewAwaiting(tabId, awaiting, assistantEl = null) {
   if (sameTabId(currentTabId, numericTabId)) {
     if (awaiting) {
       if (assistantEl) currentAssistantEl = assistantEl;
-      isProcessing = true;
-      abortRequested = false;
+      setTabProcessing(numericTabId, true);
+      setTabAbortRequested(numericTabId, false);
       hideRecommendedActions();
     }
     syncSendButtonState();
@@ -1642,8 +1681,11 @@ async function drainQueuedContextMenuPromptsAfterPendingTabSwitch() {
 
 function queueAgentUpdateDuringTabSwitch(msg) {
   const tabId = msg?.tabId;
-  if (tabSwitchTransitionId == null || tabId == null || tabId !== tabSwitchTransitionId) return false;
-  queuedTabSwitchMessages.push(msg);
+  if (tabSwitchTransitionId == null || tabId == null) return false;
+  // Never render into a DOM whose tab is changing. Target-tab events are
+  // queued so updates newer than the fetched journal snapshot are not lost;
+  // sequence de-duplication drops events the snapshot already replayed.
+  if (tabId === tabSwitchTransitionId) queuedTabSwitchMessages.push(msg);
   return true;
 }
 
@@ -1659,7 +1701,8 @@ function drainQueuedAgentUpdatesForTab(tabId) {
   replay.forEach((msg) => handleAgentUpdateMessage(msg));
 }
 
-async function settleScheduledRun(event, job) {
+async function settleScheduledRun(event, job, tabId = currentTabId) {
+  const runTabId = normalizePlanReviewTabId(tabId);
   if (job?.id) crossPanelScheduledJobIds.delete(String(job.id));
   const assistantEl = job?.id ? findScheduledAssistantMessageForJob(job.id) : currentAssistantEl;
   if (assistantEl) {
@@ -1671,12 +1714,14 @@ async function settleScheduledRun(event, job) {
     }
   }
   const ownsActiveRun = !currentAssistantEl || currentAssistantEl === assistantEl;
-  if (ownsActiveRun) {
-    isProcessing = false;
+  if (runTabId != null) {
+    setTabProcessing(runTabId, false);
+    setTabAbortRequested(runTabId, false);
+  }
+  if (ownsActiveRun && sameTabId(currentTabId, runTabId)) {
     syncSendButtonState();
     hideActivity();
     if (currentAssistantEl === assistantEl) currentAssistantEl = null;
-    abortRequested = false;
     if (renderedTabId != null) await flushRenderedTabChat();
     await drainQueuedContextMenuPromptsAfterPendingTabSwitch();
   }
@@ -1690,6 +1735,7 @@ async function handleScheduledJobEvent(data, tabId) {
   if (!event || !job) return;
 
   const sameTab = tabId == null || tabId === currentTabId;
+  const runTabId = normalizePlanReviewTabId(tabId ?? currentTabId);
   const jobId = job?.id ? String(job.id) : '';
   const terminalScheduledEvent = ['completed', 'failed'].includes(event);
   const crossPanelScheduledEvent = isUrlTargetScheduledJob(job) && (
@@ -1702,9 +1748,9 @@ async function handleScheduledJobEvent(data, tabId) {
   if (event === 'created') {
     addMessage('system', systemHtml(tSystemHtml('sp.scheduled.created', { title, time: formatScheduledTime(job.nextRunAt || job.scheduledAt) })));
   } else if (event === 'running') {
-    clearActiveChatPayloadForTab(tabId ?? currentTabId);
-    isProcessing = true;
-    abortRequested = false;
+    clearActiveChatPayloadForTab(runTabId);
+    setTabProcessing(runTabId, true);
+    setTabAbortRequested(runTabId, false);
     syncSendButtonState();
     hideRecommendedActions();
     currentAssistantEl = addMessage('assistant', '');
@@ -1712,21 +1758,21 @@ async function handleScheduledJobEvent(data, tabId) {
     showActivity(t('sp.scheduled.running', { title }));
   } else if (event === 'completed') {
     ensureScheduledTerminalMessage(job);
-    await settleScheduledRun(event, job);
+    await settleScheduledRun(event, job, runTabId);
   } else if (event === 'failed') {
     addMessage('error', t('sp.scheduled.failed', { title, msg: job.lastError || t('sp.scheduled.unknown_error') }));
-    await settleScheduledRun(event, job);
+    await settleScheduledRun(event, job, runTabId);
   } else if (event === 'needs_user_input') {
     ensureScheduledClarifyCards([job]);
     hideActivity();
-    abortRequested = false;
+    setTabAbortRequested(runTabId, false);
     if (currentAssistantEl) {
-      clearActiveChatPayloadForTab(tabId ?? currentTabId);
-      isProcessing = true;
+      clearActiveChatPayloadForTab(runTabId);
+      setTabProcessing(runTabId, true);
       syncSendButtonState();
       hideRecommendedActions();
     } else {
-      isProcessing = false;
+      setTabProcessing(runTabId, false);
       syncSendButtonState();
       addMessage('system', systemHtml(tSystemHtml('sp.scheduled.needs_user_input', { title })));
       drainQueuedContextMenuPromptsAfterPendingTabSwitch();
@@ -2355,12 +2401,10 @@ if (verboseBtn) {
 
 async function switchToTab(newTabId) {
   if (newTabId === currentTabId && renderedTabId === newTabId) { pendingTabSwitch = null; return; }
-  if (isProcessing) {
-    pendingTabSwitch = newTabId; // apply after the run ends
-    return;
-  }
+  const switchGeneration = ++tabSwitchGeneration;
   pendingTabSwitch = null;
   tabSwitchTransitionId = newTabId;
+  queuedTabSwitchMessages = [];
 
   try {
     // Save the tab currently represented by the DOM. During an async restore,
@@ -2368,27 +2412,23 @@ async function switchToTab(newTabId) {
     if (renderedTabId != null) {
       const outgoingTabId = renderedTabId;
       await flushRenderedTabChat();
-      if (isProcessing) {
-        pendingTabSwitch = newTabId;
-        return;
-      }
+      if (switchGeneration !== tabSwitchGeneration) return;
       await flushChatHistorySnapshot(outgoingTabId);
-      if (isProcessing) {
-        pendingTabSwitch = newTabId;
-        return;
-      }
+      if (switchGeneration !== tabSwitchGeneration) return;
       captureInputDraftForTab(outgoingTabId);
     }
 
     currentTabId = newTabId;
+    currentAssistantEl = null;
+    syncCurrentTabRunFlags();
     syncApiMutationsAllowedForCurrentTab();
 
     // Restore new tab's chat from memory or storage.
     const html = await loadTabChat(newTabId);
-    if (currentTabId !== newTabId) return;
+    if (switchGeneration !== tabSwitchGeneration || currentTabId !== newTabId) return;
     if (html) {
       await hydrateRestoredChatHistory(newTabId, html);
-      if (currentTabId !== newTabId) return;
+      if (switchGeneration !== tabSwitchGeneration || currentTabId !== newTabId) return;
     }
     renderedTabId = newTabId;
     if (html) {
@@ -2404,10 +2444,11 @@ async function switchToTab(newTabId) {
     renderQueuedComposerMessages(newTabId);
     scrollToBottom();
     await restoreActiveRunState(newTabId);
+    if (switchGeneration !== tabSwitchGeneration || currentTabId !== newTabId) return;
     refreshScheduledJobs({ tabId: newTabId });
     refreshRecommendedActions();
   } finally {
-    if (tabSwitchTransitionId === newTabId) tabSwitchTransitionId = null;
+    if (switchGeneration === tabSwitchGeneration && tabSwitchTransitionId === newTabId) tabSwitchTransitionId = null;
   }
   drainQueuedAgentUpdatesForTab(newTabId);
   consumePendingContextMenuPrompt().then(() => drainQueuedContextMenuPrompts()).catch(() => {});
@@ -2423,20 +2464,81 @@ async function restoreActiveRunState(tabId = currentTabId) {
     return;
   }
   if (!sameTabId(currentTabId, numericTabId) || !sameTabId(renderedTabId, numericTabId)) return;
-  if (state?.pendingPlan?.planId) {
-    activeRunRestoredFromBackground = true;
-    renderPlanReviewCard({ ...state.pendingPlan, tabId: numericTabId });
+  const runUi = state?.runUi && typeof state.runUi === 'object' ? state.runUi : null;
+  if (runUi?.requestId) {
+    const runAssistantEl = messagesEl.querySelector(`.message.assistant[data-run-request-id="${CSS.escape(String(runUi.requestId))}"]`)
+      || messagesEl.querySelector('.message.assistant:last-of-type')
+      || addMessage('assistant', '');
+    currentAssistantEl = runAssistantEl;
+    runAssistantEl.dataset.runRequestId = String(runUi.requestId);
+    if (runUi.runId) runAssistantEl.dataset.runId = String(runUi.runId);
+    const lastRenderedSeq = Number(runAssistantEl.dataset.lastRenderedSeq || 0);
+    if (runUi.truncatedBeforeSeq > lastRenderedSeq) {
+      addContextCompactedNote({ message: 'Some hidden-tab progress was compacted.' });
+    }
+    for (const event of Array.isArray(runUi.events) ? runUi.events : []) {
+      if (Number(event?.seq || 0) <= lastRenderedSeq) continue;
+      handleAgentUpdateMessage({
+        target: 'sidepanel',
+        action: 'agent_update',
+        tabId: numericTabId,
+        requestId: runUi.requestId,
+        runId: runUi.runId,
+        seq: event.seq,
+        type: event.type,
+        data: event.data,
+      });
+      runAssistantEl.dataset.lastRenderedSeq = String(event.seq);
+    }
+    const renderedSeq = Number(runAssistantEl.dataset.lastRenderedSeq || 0);
+    if (renderedSeq > Number(runUi.ackedSeq || 0)) {
+      await sendToBackground('agent_run_ack', {
+        tabId: numericTabId,
+        requestId: runUi.requestId,
+        seq: renderedSeq,
+      }).catch(() => {});
+    }
+  }
+  const pendingPlan = state?.pendingPlan;
+  const lastPlanLifecycleEvent = [...(Array.isArray(runUi?.events) ? runUi.events : [])]
+    .reverse()
+    .find(event => event?.type === 'plan_review' || event?.type === 'plan_resolved');
+  const pendingPlanMatchesRun = !!pendingPlan?.planId
+    && runUi?.status === 'awaiting_plan'
+    && (String(runUi.pendingPlanId || '') === String(pendingPlan.planId)
+      || (lastPlanLifecycleEvent?.type === 'plan_review'
+        && String(lastPlanLifecycleEvent.data?.planId || '') === String(pendingPlan.planId)));
+  if (pendingPlanMatchesRun) {
+    renderPlanReviewCard({
+      ...pendingPlan,
+      tabId: numericTabId,
+      requestId: runUi?.requestId || null,
+      runId: runUi?.runId || null,
+    });
     return;
   }
+  invalidatePlanReviewCards({ tabId: numericTabId });
   if (state?.running) {
-    activeRunRestoredFromBackground = true;
-    isProcessing = true;
-    abortRequested = false;
+    setTabProcessing(numericTabId, true);
+    setTabAbortRequested(numericTabId, false);
     hideRecommendedActions();
     showActivity(t('sp.activity.thinking'));
     syncSendButtonState();
   } else {
     setPlanReviewAwaiting(numericTabId, false);
+    setTabProcessing(numericTabId, false);
+    setTabAbortRequested(numericTabId, false);
+    if (runUi && ['completed', 'stopped', 'failed', 'cancelled'].includes(runUi.status)
+        && Number(currentAssistantEl?.dataset.lastRenderedSeq || 0) < Number(runUi.seq || 0)) {
+      handleAgentUpdateMessage({
+        tabId: numericTabId,
+        requestId: runUi.requestId,
+        runId: runUi.runId,
+        seq: runUi.seq,
+        type: 'run_complete',
+        data: { status: runUi.status, finalContent: runUi.finalContent },
+      });
+    }
   }
 }
 
@@ -2704,21 +2806,25 @@ function bindPlanReviewCard(card) {
 function reattachPlanReviewActiveRun(card) {
   const assistantEl = card?.closest?.('.message.assistant');
   if (!assistantEl) return null;
-  clearActiveChatPayloadForTab(currentTabId);
+  const tabId = Number(card?.dataset?.tabId || currentTabId);
+  clearActiveChatPayloadForTab(tabId);
   currentAssistantEl = assistantEl;
-  isProcessing = true;
-  abortRequested = false;
+  setTabProcessing(tabId, true);
+  setTabAbortRequested(tabId, false);
   sendBtn.disabled = true;
   hideRecommendedActions();
   showActivity(t('sp.activity.thinking'));
   return assistantEl;
 }
 
-function clearPlanReviewActiveRun(assistantEl) {
+function clearPlanReviewActiveRun(assistantEl, tabId = currentTabId) {
   if (currentAssistantEl === assistantEl) currentAssistantEl = null;
-  isProcessing = false;
-  sendBtn.disabled = false;
-  hideActivity();
+  setTabProcessing(tabId, false);
+  setTabAbortRequested(tabId, false);
+  if (sameTabId(currentTabId, tabId)) {
+    sendBtn.disabled = false;
+    hideActivity();
+  }
   drainQueuedContextMenuPromptsAfterPendingTabSwitch();
   refreshRecommendedActions();
 }
@@ -3690,6 +3796,7 @@ async function sendMessage(extraChatParams = {}) {
   let text = inputEl.value.trim();
   if (!text) return;
   const tabId = currentTabId;
+  const requestId = createRunRequestId(tabId);
   text = normalizeScreenshotCommandText(text);
   if (isAwaitingPlanReviewForTab(tabId)) {
     showComposerToast(t('sp.plan.awaiting_review'), { duration: 5000 });
@@ -3753,24 +3860,24 @@ async function sendMessage(extraChatParams = {}) {
     syncSendButtonState();
     return;
   }
-  isProcessing = true;
-  abortRequested = false;
+  setTabProcessing(tabId, true);
+  setTabAbortRequested(tabId, false);
   inputEl.value = '';
   autoResizeInput();
   syncSendButtonState();
 
   await prepareChatHistoryForTurn(tabId, modeForSend);
-  if (abortRequested) {
-    isProcessing = false;
-    abortRequested = false;
+  if (isTabAbortRequested(tabId)) {
+    setTabProcessing(tabId, false);
+    setTabAbortRequested(tabId, false);
     syncSendButtonState();
     return false;
   }
   renderToCurrentTab = sameTabId(currentTabId, tabId) && sameTabId(renderedTabId, tabId);
   if (!renderToCurrentTab) {
     if (text) saveInputDraftForTab(tabId, text);
-    isProcessing = false;
-    abortRequested = false;
+    setTabProcessing(tabId, false);
+    setTabAbortRequested(tabId, false);
     syncSendButtonState();
     return false;
   }
@@ -3786,8 +3893,8 @@ async function sendMessage(extraChatParams = {}) {
     attachments: attachmentsForSend,
   };
   if (renderToCurrentTab) {
-    isProcessing = true;
-    abortRequested = false;
+    setTabProcessing(tabId, true);
+    setTabAbortRequested(tabId, false);
     syncSendButtonState();
     hideRecommendedActions();
     if (!retryOptions) {
@@ -3797,10 +3904,13 @@ async function sendMessage(extraChatParams = {}) {
     addMessage('user', text);
     showActivity(t('sp.activity.thinking'));
     assistantEl = addMessage('assistant', '');
+    assistantEl.dataset.runRequestId = requestId;
+    assistantEl.dataset.lastRenderedSeq = '0';
     currentAssistantEl = assistantEl;
   }
   const activePayloadState = createActiveChatPayloadState(retryPayload);
   activeChatPayloadsByTab.set(tabId, activePayloadState);
+  localRunRequestIds.set(tabId, requestId);
 
   let accepted = false;
   let completedSuccessfully = false;
@@ -3808,6 +3918,7 @@ async function sendMessage(extraChatParams = {}) {
   try {
     const res = await sendToBackground('chat', {
       tabId,
+      requestId,
       text,
       mode: modeForSend,
       apiMutationsAllowed: apiMutationsAllowedForSend,
@@ -3824,7 +3935,7 @@ async function sendMessage(extraChatParams = {}) {
     const returnedErrorUpdate = Array.isArray(res?.updates)
       ? res.updates.find(u => u?.type === 'error')
       : null;
-    if (returnedErrorUpdate && renderToCurrentTab && currentTabId === tabId && !abortRequested) {
+    if (returnedErrorUpdate && renderToCurrentTab && currentTabId === tabId && !isTabAbortRequested(tabId)) {
       renderAgentErrorUpdate(returnedErrorUpdate.data, tabId);
     }
 
@@ -3850,7 +3961,7 @@ async function sendMessage(extraChatParams = {}) {
       syncSendButtonState();
     }
 
-    if (renderToCurrentTab && currentTabId === tabId && abortRequested) {
+    if (renderToCurrentTab && currentTabId === tabId && isTabAbortRequested(tabId)) {
       // Agent was stopped — show what we got so far
       const textEl = assistantEl?.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
@@ -3869,11 +3980,12 @@ async function sendMessage(extraChatParams = {}) {
       }
     }
   } catch (e) {
-    if (renderToCurrentTab && currentTabId === tabId && !abortRequested) {
+    if (renderToCurrentTab && currentTabId === tabId && !isTabAbortRequested(tabId)) {
       takeActiveRetryPayloadForError(tabId, e.message);
       addMessage('error', t('sp.error_prefix', { msg: e.message }), { retryPayload });
     }
   } finally {
+    if (localRunRequestIds.get(tabId) === requestId) localRunRequestIds.delete(tabId);
     if (activeChatPayloadsByTab.get(tabId) === activePayloadState) {
       scheduleActiveChatPayloadCleanup(tabId, activePayloadState);
     }
@@ -3883,10 +3995,10 @@ async function sendMessage(extraChatParams = {}) {
     // error completion — anything that wasn't an explicit user abort. The
     // sound is what takes them from "glance back at the tab" to "know it's
     // done" without having to sit and watch the sidebar.
-    const wasAborted = abortRequested;
-    if (renderToCurrentTab) {
-      isProcessing = false;
-      abortRequested = false;
+    const wasAborted = isTabAbortRequested(tabId);
+    setTabProcessing(tabId, false);
+    setTabAbortRequested(tabId, false);
+    if (renderToCurrentTab && currentTabId === tabId) {
       syncSendButtonState();
       hideActivity();
     }
@@ -4111,6 +4223,36 @@ function summarizeLastTranscript() {
   if (sendBtn) sendBtn.click();
 }
 
+function ensureCurrentRunAssistant(msg) {
+  if (!msg?.requestId) return currentAssistantEl;
+  const requestId = String(msg.requestId);
+  let assistantEl = messagesEl.querySelector(`.message.assistant[data-run-request-id="${CSS.escape(requestId)}"]`);
+  if (!assistantEl && currentAssistantEl
+      && (!currentAssistantEl.dataset.runRequestId || currentAssistantEl.dataset.runRequestId === requestId)) {
+    assistantEl = currentAssistantEl;
+  }
+  if (!assistantEl) assistantEl = addMessage('assistant', '');
+  assistantEl.dataset.runRequestId = requestId;
+  if (msg.runId) assistantEl.dataset.runId = String(msg.runId);
+  currentAssistantEl = assistantEl;
+  return assistantEl;
+}
+
+function invalidatePlanReviewCards({ tabId = currentTabId, planId = '', requestId = '', runId = '', remove = true } = {}) {
+  for (const card of messagesEl.querySelectorAll('.plan-review-card')) {
+    if (tabId != null && String(card.dataset.tabId || '') !== String(tabId)) continue;
+    if (planId && String(card.dataset.planId || '') !== String(planId)) continue;
+    if (requestId && card.dataset.runRequestId && card.dataset.runRequestId !== String(requestId)) continue;
+    if (runId && card.dataset.runId && card.dataset.runId !== String(runId)) continue;
+    setPlanReviewAwaiting(tabId, false);
+    if (remove) card.remove();
+    else {
+      card.classList.add('plan-reviewed');
+      card.querySelectorAll('button, textarea').forEach(el => { el.disabled = true; });
+    }
+  }
+}
+
 function handleAgentUpdateMessage(msg) {
   if (msg.type === 'scheduled_job') {
     handleScheduledJobEvent(msg.data, msg.tabId).catch((err) => {
@@ -4128,6 +4270,20 @@ function handleAgentUpdateMessage(msg) {
   // panel finished mounting. `msg.tabId == null` keeps backward compat
   // for any in-flight events from a pre-tabId background build.
   if (msg.tabId != null && msg.tabId !== currentTabId) return;
+
+  const eventTabId = msg.tabId ?? currentTabId;
+  const localRequestId = localRunRequestIds.get(Number(eventTabId));
+  if (localRequestId && msg.requestId && localRequestId !== String(msg.requestId)) return;
+  const locallyOwnedEvent = !!localRequestId
+    && (!msg.requestId || localRequestId === String(msg.requestId));
+  const sequencedRequestAssistantEl = msg.requestId && Number.isFinite(Number(msg.seq))
+    ? messagesEl.querySelector(`.message.assistant[data-run-request-id="${CSS.escape(String(msg.requestId))}"]`)
+    : null;
+  if (sequencedRequestAssistantEl
+      && Number(sequencedRequestAssistantEl.dataset.lastRenderedSeq || 0) >= Number(msg.seq)) return;
+  const eventAssistantEl = ensureCurrentRunAssistant(msg);
+  if (eventAssistantEl && Number.isFinite(Number(msg.seq))
+      && Number(eventAssistantEl.dataset.lastRenderedSeq || 0) >= Number(msg.seq)) return;
 
   const { type, data } = msg;
 
@@ -4222,17 +4378,24 @@ function handleAgentUpdateMessage(msg) {
 
     case 'run_complete':
       if (currentAssistantEl) finalizeSteps(currentAssistantEl);
-      // When a local send is still in flight (isProcessing), its own finally
-      // resets run state and refreshes recommended actions *after* the final
-      // text renders — so only finalize the steps visually here and let that
-      // owner tear down, avoiding a premature double refresh/drain. When nothing
-      // is processing locally (e.g. the panel remounted on a tab switch away and
-      // back mid-run), run_complete is the sole finalizer and must tear down. (#4)
-      if (!isProcessing || activeRunRestoredFromBackground) {
-        setPlanReviewAwaiting(msg.tabId ?? currentTabId, false);
-        clearPlanReviewActiveRun(currentAssistantEl);
-        activeRunRestoredFromBackground = false;
+      invalidatePlanReviewCards({
+        tabId: msg.tabId ?? currentTabId,
+        requestId: msg.requestId,
+        runId: msg.runId,
+      });
+      if (currentAssistantEl && data?.finalContent) {
+        const textEl = currentAssistantEl.querySelector('.message-text');
+        if (textEl && !textEl.textContent.trim()) {
+          if (data.status === 'stopped' || data.status === 'cancelled') textEl.innerHTML = t('sp.stopped_by_user_html');
+          else textEl.innerHTML = formatMarkdown(data.finalContent);
+          addMessageCopyButton(currentAssistantEl);
+        }
       }
+      setPlanReviewAwaiting(msg.tabId ?? currentTabId, false);
+      if (!locallyOwnedEvent) {
+        clearPlanReviewActiveRun(currentAssistantEl, eventTabId);
+      }
+      schedulePersist();
       scrollToBottom();
       break;
 
@@ -4251,12 +4414,25 @@ function handleAgentUpdateMessage(msg) {
       break;
 
     case 'plan_review':
-      renderPlanReviewCard(data);
+      renderPlanReviewCard({ ...data, tabId: msg.tabId ?? currentTabId, requestId: msg.requestId, runId: msg.runId });
+      break;
+
+    case 'plan_resolved':
+      invalidatePlanReviewCards({
+        tabId: msg.tabId ?? currentTabId,
+        planId: data?.planId,
+        requestId: msg.requestId,
+        runId: msg.runId,
+      });
+      schedulePersist();
       break;
 
     case 'plan_auto_approved':
       addPlanAutoApprovedNote(data);
       break;
+  }
+  if (eventAssistantEl && Number.isFinite(Number(msg.seq))) {
+    eventAssistantEl.dataset.lastRenderedSeq = String(msg.seq);
   }
 }
 
@@ -4475,6 +4651,8 @@ function renderPlanReviewCard(data) {
   const existing = [...messagesEl.querySelectorAll('.plan-review-card')]
     .find(card => String(card.dataset.planId || '') === planId
       && String(card.dataset.tabId || '') === String(tabId)
+      && (!data.requestId || card.dataset.runRequestId === String(data.requestId))
+      && (!data.runId || card.dataset.runId === String(data.runId))
       && !card.classList.contains('plan-reviewed'));
   if (existing) {
     bindPlanReviewCard(existing);
@@ -4490,6 +4668,8 @@ function renderPlanReviewCard(data) {
   card.className = 'plan-review-card';
   card.dataset.planId = planId;
   card.dataset.tabId = String(tabId);
+  if (data.requestId) card.dataset.runRequestId = String(data.requestId);
+  if (data.runId) card.dataset.runId = String(data.runId);
   card.dataset.editing = 'false';
 
   const header = document.createElement('div');
@@ -4593,7 +4773,7 @@ function submitPlanReview(card, tabId, planId, action, editedText) {
         note.textContent = expiredText();
         card.appendChild(note);
         setPlanReviewAwaiting(tabId, false);
-        if (activeAssistantEl) clearPlanReviewActiveRun(activeAssistantEl);
+        if (activeAssistantEl) clearPlanReviewActiveRun(activeAssistantEl, tabId);
       }
       scrollToBottom();
     })
@@ -4602,7 +4782,7 @@ function submitPlanReview(card, tabId, planId, action, editedText) {
         note.textContent = failureText(error);
         card.appendChild(note);
         setPlanReviewAwaiting(tabId, false);
-        if (activeAssistantEl) clearPlanReviewActiveRun(activeAssistantEl);
+        if (activeAssistantEl) clearPlanReviewActiveRun(activeAssistantEl, tabId);
         scrollToBottom();
       }
     });
@@ -4648,7 +4828,8 @@ function submitClarify(card, tabId, clarifyId, answer, source) {
     if (msgEl && (!currentAssistantEl || currentAssistantEl.dataset?.scheduledJobId === scheduledJobId)) {
       currentAssistantEl = msgEl;
     }
-    isProcessing = true;
+    setTabProcessing(tabId, true);
+    setTabAbortRequested(tabId, false);
     syncSendButtonState();
     hideRecommendedActions();
     showActivity(t('sp.activity.thinking'));
@@ -4659,9 +4840,12 @@ function submitClarify(card, tabId, clarifyId, answer, source) {
   sendToBackground('clarify_response', clarifyPayload)
     .catch(() => {
       if (isScheduledClarify) {
-        isProcessing = false;
-        syncSendButtonState();
-        hideActivity();
+        setTabProcessing(tabId, false);
+        setTabAbortRequested(tabId, false);
+        if (sameTabId(currentTabId, tabId)) {
+          syncSendButtonState();
+          hideActivity();
+        }
         drainQueuedContextMenuPromptsAfterPendingTabSwitch();
       }
       /* background may be torn down — clarify state already lives there */
@@ -5102,29 +5286,34 @@ function showContinueButton() {
 
 async function continueAgent() {
   const tabId = currentTabId;
+  const requestId = createRunRequestId(tabId);
   const modeForSend = agentMode;
   clearActiveChatPayloadForTab(tabId);
 
-  isProcessing = true;
-  abortRequested = false;
+  setTabProcessing(tabId, true);
+  setTabAbortRequested(tabId, false);
   syncSendButtonState();
 
   let assistantEl = null;
 
   try {
     await prepareChatHistoryForTurn(tabId, modeForSend);
-    if (abortRequested) return false;
+    if (isTabAbortRequested(tabId)) return false;
     if (!sameTabId(currentTabId, tabId) || !sameTabId(renderedTabId, tabId)) return false;
 
     // Remove the continue bar only after the durable history id is hydrated.
     document.querySelectorAll('.continue-bar').forEach(el => el.remove());
 
     assistantEl = addMessage('assistant', '');
+    assistantEl.dataset.runRequestId = requestId;
+    assistantEl.dataset.lastRenderedSeq = '0';
     currentAssistantEl = assistantEl;
     showActivity(t('sp.activity.continuing'));
+    localRunRequestIds.set(tabId, requestId);
 
     const res = await sendToBackground('continue', {
       tabId,
+      requestId,
       mode: modeForSend,
     });
     if (res?.conversationId) {
@@ -5144,16 +5333,19 @@ async function continueAgent() {
       }
     }
   } catch (e) {
-    if (currentTabId === tabId && assistantEl && !abortRequested) {
+    if (currentTabId === tabId && assistantEl && !isTabAbortRequested(tabId)) {
       addMessage('error', t('sp.error_prefix', { msg: e.message }));
     }
   } finally {
+    if (localRunRequestIds.get(tabId) === requestId) localRunRequestIds.delete(tabId);
     if (currentTabId === tabId && assistantEl) finalizeSteps(assistantEl);
     clearAssistantTextStreamState(assistantEl);
-    isProcessing = false;
-    abortRequested = false;
-    syncSendButtonState();
-    hideActivity();
+    setTabProcessing(tabId, false);
+    setTabAbortRequested(tabId, false);
+    if (currentTabId === tabId) {
+      syncSendButtonState();
+      hideActivity();
+    }
     if (currentAssistantEl === assistantEl) currentAssistantEl = null;
     if (currentTabId === tabId) scrollToBottom();
     if (currentTabId === tabId && renderedTabId === tabId) await flushRenderedTabChat();
@@ -5631,19 +5823,21 @@ modeDevBtn?.addEventListener('click', async () => {
 // --- Stop / Abort ---
 
 async function abortRun() {
-  if (!isProcessing) return;
-  abortRequested = true;
+  const tabId = currentTabId;
+  if (!isTabProcessing(tabId)) return;
+  setTabAbortRequested(tabId, true);
   showActivity(t('sp.activity.stopping'));
 
   try {
-    await sendToBackground('abort', { tabId: currentTabId });
+    await sendToBackground('abort', { tabId });
   } catch {
     // Best effort
   }
 
   // Force UI to settle even if background doesn't respond cleanly
   setTimeout(async () => {
-    if (abortRequested) {
+    if (isTabAbortRequested(tabId)) {
+      if (!sameTabId(currentTabId, tabId) || !sameTabId(renderedTabId, tabId)) return;
       finalizeSteps();
       if (currentAssistantEl) {
         const textEl = currentAssistantEl.querySelector('.message-text');
@@ -5651,11 +5845,11 @@ async function abortRun() {
           textEl.innerHTML = t('sp.stopped_by_user_html');
         }
       }
-      isProcessing = false;
+      setTabProcessing(tabId, false);
       syncSendButtonState();
       hideActivity();
       currentAssistantEl = null;
-      abortRequested = false;
+      setTabAbortRequested(tabId, false);
       await flushRenderedTabChat();
       await drainQueuedContextMenuPromptsAfterPendingTabSwitch();
     }

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15637,7 +15637,8 @@ const ADAPTERS = [
 - The body is a contenteditable div (rich text), not a textarea. Click into it before typing.
 - Sending: the "Send" button is bottom-left of the compose window; "Send + Schedule" arrow is next to it for scheduled send.
 - Search uses operators: from:, to:, subject:, has:attachment, before:YYYY/MM/DD.
-- Threads collapse old messages — click "Show trimmed content" or the message header to expand.`,
+- Threads collapse old messages — click "Show trimmed content" or the message header to expand.
+- Gmail's accessibility tree is large and noisy. Prefer visible/interactive reads, use compose fields as soon as they appear, and never inspect generic or sibling ref_ids one-by-one; continue with the returned nextPage when truncated.`,
   },
   {
     name: 'google-docs',

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -713,7 +713,10 @@ export class Agent {
     state.seenPages.add(page);
     this.axReadStates.set(tabId, state);
 
-    if (state.suspicious >= 6 || state.total >= 12) {
+    // A root read followed by the exact returned nextPage can legitimately span
+    // large applications. Keep the consecutive-read cap for every other AX
+    // pattern, but do not stop a valid sequential pagination step.
+    if (state.suspicious >= 6 || (state.total >= 12 && (state.suspicious > 0 || !sequentialPage))) {
       this.axReadStates.delete(tabId);
       return {
         kind: 'stop',

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -138,6 +138,9 @@ export class Agent {
     this.recentCalls = new Map();
     this.loopNudges = new Map();
     this.healthyCallsSinceLoop = new Map();
+    // A model can walk ref_1, ref_2, … forever while every call looks unique
+    // to the exact-argument loop detector. Track that semantic read pattern.
+    this.axReadStates = new Map();
     // Local screenshot redaction (issue #312). When true, screenshots sent
     // to a Vision endpoint are pixelated over DOM-detected PII regions
     // (form fields + email/phone text) BEFORE leaving the extension. Off by
@@ -663,6 +666,7 @@ export class Agent {
     this.recentCalls.delete(tabId);
     this.loopNudges.delete(tabId);
     this.healthyCallsSinceLoop.delete(tabId);
+    this.axReadStates.delete(tabId);
     this.recentCoordClicks.delete(tabId);
     this.bulkApiMutationClicks.delete(tabId);
     this.bulkApiMutationHints.delete(tabId);
@@ -672,6 +676,58 @@ export class Agent {
         this.failedBulkApiReplayShapes.delete(key);
       }
     }
+  }
+
+  _checkAccessibilityReadLoop(tabId, name, args, result) {
+    if (name !== 'get_accessibility_tree') {
+      this.axReadStates.delete(tabId);
+      return { kind: 'none' };
+    }
+
+    const previous = this.axReadStates.get(tabId) || {
+      total: 0,
+      suspicious: 0,
+      nextPage: null,
+      seenPages: new Set(),
+      warned: false,
+    };
+    const page = Number(args?.page || 1);
+    const hasRef = typeof args?.ref_id === 'string' && args.ref_id.trim() !== '';
+    const sequentialPage = !hasRef
+      && previous.total > 0
+      && Number.isFinite(previous.nextPage)
+      && page === previous.nextPage
+      && !previous.seenPages.has(page);
+    const repeatedRootOrPage = !hasRef && previous.total > 0 && !sequentialPage;
+    const content = String(result?.pageContent || '').trim();
+    const meaningfulLines = content ? content.split(/\r?\n/).filter(line => line.trim()).length : 0;
+    const suspicious = hasRef || repeatedRootOrPage || (hasRef && meaningfulLines <= 1);
+
+    const state = {
+      total: previous.total + 1,
+      suspicious: previous.suspicious + (suspicious ? 1 : 0),
+      nextPage: Number.isFinite(Number(result?.nextPage)) ? Number(result.nextPage) : null,
+      seenPages: new Set(previous.seenPages),
+      warned: previous.warned,
+    };
+    state.seenPages.add(page);
+    this.axReadStates.set(tabId, state);
+
+    if (state.suspicious >= 6 || state.total >= 12) {
+      this.axReadStates.delete(tabId);
+      return {
+        kind: 'stop',
+        message: 'Stopped: I kept reading accessibility-tree nodes without taking an action or changing approach. The tree is not meant to be enumerated ref-by-ref. Use an element already found, request the returned nextPage, switch to read_page/extract_data, or ask for help.',
+      };
+    }
+    if (!state.warned && state.suspicious >= 3) {
+      state.warned = true;
+      return {
+        kind: 'nudge',
+        warning: '[ACCESSIBILITY READ LOOP: Stop enumerating sibling or generic ref_ids. If the result has hasMore/nextPage, request exactly that page. If the needed textbox/button is already visible, use set_field, type_ax, or click_ax now. Otherwise switch once to read_page/extract_data or finish with what you have. Do not call another arbitrary ref_id subtree.]',
+      };
+    }
+    return { kind: 'none' };
   }
 
   /**
@@ -1841,7 +1897,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         return { action: 'return', value: finalResponse };
       }
 
-      // Loop detection — general + coordinate-specific. Strongest wins.
+      // Loop detection — exact calls, semantic AX reads, and coordinates run
+      // in parallel; the strongest action wins.
       let loopCheck = { kind: 'none' };
       const loopKey = this._loopCallKey(fnName, fnArgs, toolResult);
       const failedApiMutation = this._isFailedApiMutationForLoop(fnName, fnArgs, toolResult);
@@ -1853,11 +1910,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (fnName === 'click' && fnArgs?.x != null && fnArgs?.y != null) {
         coordCheck = this._checkCoordClickLoop(tabId, fnArgs.x, fnArgs.y);
       }
+      const axReadCheck = this._checkAccessibilityReadLoop(tabId, fnName, fnArgs, toolResult);
 
       let effectiveKind = 'none';
       let nudgeWarning = '';
       let stopMessage = '';
-      if (loopCheck.kind === 'stop' || coordCheck.kind === 'stop') {
+      if (loopCheck.kind === 'stop' || coordCheck.kind === 'stop' || axReadCheck.kind === 'stop') {
         effectiveKind = 'stop';
         // Show the model's actual args, not _checkCoordClickLoop's 5px
         // bucket — for fractional inputs like (0.911, 0.331) the bucket
@@ -1865,12 +1923,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         // top-left corner, hiding what really happened.
         stopMessage = coordCheck.kind === 'stop'
           ? `Stopped: I clicked at (or near) coordinates (${fnArgs.x}, ${fnArgs.y}) multiple times and the page never responded. That position is hitting empty space, an overlay, or the wrong element. Please give a different instruction or check the page yourself.`
-          : loopCheck.message;
-      } else if (loopCheck.kind === 'nudge' || coordCheck.kind === 'nudge') {
+          : axReadCheck.kind === 'stop'
+            ? axReadCheck.message
+            : loopCheck.message;
+      } else if (loopCheck.kind === 'nudge' || coordCheck.kind === 'nudge' || axReadCheck.kind === 'nudge') {
         effectiveKind = 'nudge';
         nudgeWarning = coordCheck.kind === 'nudge'
           ? this._coordinateClickRecoveryWarning(fnArgs, allowedToolNames)
-          : loopCheck.warning;
+          : axReadCheck.kind === 'nudge'
+            ? axReadCheck.warning
+            : loopCheck.warning;
       }
 
       // Strip `_attachImage` BEFORE stringifying the tool result — otherwise
@@ -3181,7 +3243,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       } catch {}
     }
     try {
-      return await Promise.race([responsePromise, timeoutPromise]);
+      const response = await Promise.race([responsePromise, timeoutPromise]);
+      if (response?.cancelled && typeof onUpdate === 'function') {
+        try {
+          onUpdate('plan_resolved', {
+            planId,
+            decision: response.reason === 'plan review timed out' ? 'timeout' : 'cancelled',
+          });
+        } catch {}
+      }
+      return response;
     } finally {
       // Cancel the 10-minute timer once the race settles so a fast approval
       // doesn't leave an armed timer (and its captured resolve/plan closure)
@@ -8273,12 +8344,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (this._runningTabs.has(tabId)) {
       throw new Error('An agent run is already in progress for this tab.');
     }
+    this._clearLoopState(tabId);
     this._runningTabs.add(tabId);
     try {
       return await this._processMessageInner(tabId, userMessage, onUpdate, mode, attachments, runOptions);
     } finally {
       this.currentCostState.delete(tabId);
       this._runningTabs.delete(tabId);
+      this._clearLoopState(tabId);
     }
   }
 
@@ -8718,12 +8791,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (this._runningTabs.has(tabId)) {
       throw new Error('An agent run is already in progress for this tab.');
     }
+    this._clearLoopState(tabId);
     this._runningTabs.add(tabId);
     try {
       return await this._processMessageStreamInner(tabId, userMessage, onUpdate, mode, runOptions);
     } finally {
       this.currentCostState.delete(tabId);
       this._runningTabs.delete(tabId);
+      this._clearLoopState(tabId);
     }
   }
 

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -17,7 +17,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'get_accessibility_tree',
-      description: 'PREFERRED page-reading tool. Returns the page as a flat, indented text representation of its accessibility tree. Each kept node is one line of the form `role "accessible name" [ref_id] href="..." type="..." placeholder="..."`. Indentation shows hierarchy. ref_ids are STABLE across calls — re-use them in click_ax / type_ax / set_field. If the result is truncated (`truncated:true`, `hasMore:true`), call again with `page:` set to `nextPage` to read the next slice before scrolling. When you pass an explicit `maxChars` and the tree is larger, the tool now AUTO-SLICES to fit and sets `autoDegraded:true` + a `notice` field explaining how to continue — so a single oversized call no longer wastes a round-trip with empty pageContent.',
+      description: 'PREFERRED page-reading tool. Returns the page as a flat, indented text representation of its accessibility tree. Each kept node is one line of the form `role "accessible name" [ref_id] href="..." type="..." placeholder="..."`. Indentation shows hierarchy. ref_ids are STABLE across calls — re-use them in click_ax / type_ax / set_field. NEVER enumerate sibling or generic ref_ids one-by-one: ref_id is only for one targeted subtree you already know matters. If the result is truncated (`truncated:true`, `hasMore:true`), call again with `page:` set exactly to `nextPage` before trying arbitrary subtrees or scrolling. Once the needed field/button is visible, act on it instead of reading more. When you pass an explicit `maxChars` and the tree is larger, the tool now AUTO-SLICES to fit and sets `autoDegraded:true` + a `notice` field explaining how to continue — so a single oversized call no longer wastes a round-trip with empty pageContent.',
       parameters: {
         type: 'object',
         properties: {
@@ -1031,7 +1031,9 @@ PATTERN:
 1. get_accessibility_tree({filter:"visible"}) -> find ref_ids
 2. click_ax or set_field with the ref_id
 3. Verify by re-reading the tree or inspecting injected visual context
-4. Repeat until done`;
+4. Repeat until done
+
+Never enumerate sibling or generic ref_ids one-by-one. Use ref_id only for one targeted subtree already known to matter. If hasMore is returned, request exactly nextPage; once the required field or button is visible, act instead of reading more.`;
 
 export const SYSTEM_PROMPT_ASK = `You are WebBrain, a helpful AI browser assistant running in Ask mode.
 
@@ -1073,6 +1075,7 @@ IMPORTANT — Current Page Priority:
 
 READING THE CURRENT TAB vs. FETCHING URLS — read this:
 - If the answer lives on the active tab, READ THE TAB. Use \`get_accessibility_tree\` (default) or \`read_page\` (long-form prose). Use \`extract_data\` for tables, headings, images, or link lists, and \`get_selection\` for highlighted text.
+- Never walk accessibility references one-by-one. A ref_id read is only for one already-identified subtree; follow hasMore with exactly nextPage, and stop inspecting as soon as the actionable element or answer is visible.
 - Exception for YouTube video-content questions: if an enabled skill exposes a transcript tool such as \`read_youtube_transcript\`, call it first. Purpose-built skill tools are not generic \`fetch_url\`. Do not ask for \`/allow-api\` before calling a skill tool; \`/allow-api\` only applies to mutating \`fetch_url\`/\`research_url\` API calls. Read-only skill tools can run in Ask mode; download-job skill tools require Act mode plus download permission.
 - DO NOT call \`fetch_url\` or \`research_url\` against the URL of the active tab, the API equivalent of the active tab, or a "renderable" / "raw" / "amp" / "mobile" variant of the active tab's URL. Re-fetching content the user is already looking at is the most common wasted step. Symptom of this antipattern: you fetch a Wikipedia/MediaWiki API URL for the same page the user is on, get a truncated result, then fetch a slightly different variant hoping for more content. Stop and call \`read_page\` instead.
 - \`fetch_url\` and \`research_url\` are for content on OTHER URLs — a referenced article, an API the page links to, a sibling page, a different site entirely.

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -20,6 +20,7 @@ import {
 import { getBalance as capsolverGetBalance } from './agent/captcha-solver.js';
 import { buildContextMenuPrompt, createContextMenuStorage } from './context-menu-storage.js';
 import { normalizeOllamaLaunchHandoff } from './ollama-handoff.js';
+import { RunUiJournal } from './run-ui-journal.js';
 import {
   USER_MEMORY_AUTO_CAPTURE_KEY,
   USER_MEMORY_ENABLED_KEY,
@@ -1153,16 +1154,87 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo) => {
 
 browser.tabs.onRemoved.addListener((tabId) => {
   activeIndicatorTabs.delete(tabId);
+  clearRunUiSnapshot(tabId);
 });
 
-function sendAgentRunComplete(tabId) {
-  if (tabId == null) return;
+const RUN_UI_PREFIX = 'runUi:';
+const runUiJournal = new RunUiJournal({
+  onChange(tabId, snapshot) {
+    try { browser.storage.session?.set({ [RUN_UI_PREFIX + tabId]: snapshot }).catch(() => {}); } catch {}
+  },
+});
+
+function beginRunUiSnapshot(tabId, requestId) {
+  return runUiJournal.begin(tabId, requestId);
+}
+
+function recordRunUiEvent(tabId, requestId, type, data) {
+  return runUiJournal.record(tabId, requestId, type, data, agent.currentRunId.get(tabId));
+}
+
+function terminalRunUiStatus(content, updates = [], error = null) {
+  if (error) return 'failed';
+  const text = String(content || '');
+  if (/stopped by user|aborted by user/i.test(text)) return 'stopped';
+  if (/before executing requested tool calls/i.test(text)) return 'cancelled';
+  if (updates.some(update => update?.type === 'error')) return 'failed';
+  return 'completed';
+}
+
+function finishRunUiSnapshot(tabId, requestId, status, finalContent = '') {
+  return runUiJournal.finish(tabId, requestId, status, finalContent, agent.currentRunId.get(tabId));
+}
+
+async function getRunUiSnapshot(tabId) {
+  const live = runUiJournal.get(tabId);
+  if (live) return live;
+  try {
+    const key = RUN_UI_PREFIX + tabId;
+    const stored = await browser.storage.session?.get(key);
+    const snapshot = stored?.[key];
+    if (snapshot && typeof snapshot === 'object') {
+      return runUiJournal.restore(tabId, snapshot);
+    }
+  } catch {}
+  return null;
+}
+
+function clearRunUiSnapshot(tabId) {
+  runUiJournal.clear(tabId);
+  try { browser.storage.session?.remove(RUN_UI_PREFIX + tabId).catch(() => {}); } catch {}
+}
+
+function sendAgentUpdate(tabId, requestId, type, data) {
+  const event = recordRunUiEvent(tabId, requestId, type, data);
+  if (!event) return;
+  browser.runtime.sendMessage({
+    target: 'sidepanel', action: 'agent_update', tabId, requestId,
+    runId: event?.runId || agent.currentRunId.get(tabId) || null,
+    seq: event?.seq || null, type, data: event?.data ?? data,
+  }).catch(() => {});
+}
+
+function assertNoActiveTabRun(tabId) {
+  if (agent.activeRunState(tabId)?.running) {
+    throw new Error('A run is already active for this tab.');
+  }
+}
+
+function sendAgentRunComplete(tabId, snapshot = null) {
+  if (tabId == null || !snapshot) return;
   browser.runtime.sendMessage({
     target: 'sidepanel',
     action: 'agent_update',
     tabId,
+    requestId: snapshot.requestId,
+    runId: snapshot.runId || null,
+    seq: snapshot.seq,
     type: 'run_complete',
-    data: {},
+    data: {
+      status: snapshot.status || 'completed',
+      finalContent: snapshot.finalContent || '',
+      endedAt: snapshot.endedAt || Date.now(),
+    },
   }).catch(() => {});
 }
 
@@ -1298,7 +1370,9 @@ async function handleMessage(msg, sender) {
     case 'chat': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) throw new Error('No tab ID');
+      assertNoActiveTabRun(tabId);
       const mode = msg.mode || 'ask';
+      const runUi = beginRunUiSnapshot(tabId, msg.requestId);
 
       if (msg.apiMutationsAllowed) agent.setApiMutationsAllowed(tabId, true);
 
@@ -1314,17 +1388,13 @@ async function handleMessage(msg, sender) {
 
       const updates = [];
       let userMemoryTurnContextTaken = false;
+      let result = '';
+      let runError = null;
       try {
         const runOptions = msg.recommendedAction ? { recommendedAction: msg.recommendedAction } : {};
-        const result = await agent.processMessage(tabId, msg.text, (type, data) => {
+        result = await agent.processMessage(tabId, msg.text, (type, data) => {
           updates.push({ type, data });
-          browser.runtime.sendMessage({
-            target: 'sidepanel',
-            action: 'agent_update',
-            tabId,          // see sidepanel onMessage — filters out cross-tab leak
-            type,
-            data,
-          }).catch(() => {});
+          sendAgentUpdate(tabId, runUi.requestId, type, data);
         }, mode, msg.attachments, runOptions);
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
@@ -1335,10 +1405,14 @@ async function handleMessage(msg, sender) {
         });
         userMemoryTurnContextTaken = true;
         enqueueUserMemoryExtractionAfterTurn(userMemoryPayload);
-        return { content: result, updates, conversationId: await agent.getConversationId(tabId) };
+        return { content: result, updates, requestId: runUi.requestId, conversationId: await agent.getConversationId(tabId) };
+      } catch (error) {
+        runError = error;
+        throw error;
       } finally {
         if (!userMemoryTurnContextTaken) clearUserMemoryTurnContext(tabId);
-        sendAgentRunComplete(tabId);
+        const snapshot = finishRunUiSnapshot(tabId, runUi.requestId, terminalRunUiStatus(result, updates, runError), result || (runError ? `Error: ${runError.message}` : ''));
+        sendAgentRunComplete(tabId, snapshot);
         sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
       }
     }
@@ -1346,24 +1420,22 @@ async function handleMessage(msg, sender) {
     case 'chat_stream': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) throw new Error('No tab ID');
+      assertNoActiveTabRun(tabId);
       const mode = msg.mode || 'ask';
+      const runUi = beginRunUiSnapshot(tabId, msg.requestId);
 
       if (msg.apiMutationsAllowed) agent.setApiMutationsAllowed(tabId, true);
 
       sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
       let userMemoryTurnContextTaken = false;
       let userMemoryTurnHadError = false;
+      let result = '';
+      let runError = null;
       try {
         const runOptions = msg.recommendedAction ? { recommendedAction: msg.recommendedAction } : {};
-        const result = await agent.processMessageStream(tabId, msg.text, (type, data) => {
+        result = await agent.processMessageStream(tabId, msg.text, (type, data) => {
           if (type === 'error') userMemoryTurnHadError = true;
-          browser.runtime.sendMessage({
-            target: 'sidepanel',
-            action: 'agent_update',
-            tabId,          // see sidepanel onMessage — filters out cross-tab leak
-            type,
-            data,
-          }).catch(() => {});
+          sendAgentUpdate(tabId, runUi.requestId, type, data);
         }, mode, runOptions);
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
@@ -1374,10 +1446,14 @@ async function handleMessage(msg, sender) {
         });
         userMemoryTurnContextTaken = true;
         enqueueUserMemoryExtractionAfterTurn(userMemoryPayload);
-        return { content: result, conversationId: await agent.getConversationId(tabId) };
+        return { content: result, requestId: runUi.requestId, conversationId: await agent.getConversationId(tabId) };
+      } catch (error) {
+        runError = error;
+        throw error;
       } finally {
         if (!userMemoryTurnContextTaken) clearUserMemoryTurnContext(tabId);
-        sendAgentRunComplete(tabId);
+        const snapshot = finishRunUiSnapshot(tabId, runUi.requestId, terminalRunUiStatus(result, userMemoryTurnHadError ? [{ type: 'error' }] : [], runError), result || (runError ? `Error: ${runError.message}` : ''));
+        sendAgentRunComplete(tabId, snapshot);
         sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
       }
     }
@@ -1385,21 +1461,19 @@ async function handleMessage(msg, sender) {
     case 'continue': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) throw new Error('No tab ID');
+      assertNoActiveTabRun(tabId);
       const mode = msg.mode || 'ask';
+      const runUi = beginRunUiSnapshot(tabId, msg.requestId);
 
       sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
       let userMemoryTurnContextTaken = false;
       let userMemoryTurnHadError = false;
+      let result = '';
+      let runError = null;
       try {
-        const result = await agent.continueProcessing(tabId, (type, data) => {
+        result = await agent.continueProcessing(tabId, (type, data) => {
           if (type === 'error') userMemoryTurnHadError = true;
-          browser.runtime.sendMessage({
-            target: 'sidepanel',
-            action: 'agent_update',
-            tabId,          // see sidepanel onMessage — filters out cross-tab leak
-            type,
-            data,
-          }).catch(() => {});
+          sendAgentUpdate(tabId, runUi.requestId, type, data);
         }, mode);
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
@@ -1410,10 +1484,14 @@ async function handleMessage(msg, sender) {
         });
         userMemoryTurnContextTaken = true;
         enqueueUserMemoryExtractionAfterTurn(userMemoryPayload);
-        return { content: result, conversationId: await agent.getConversationId(tabId) };
+        return { content: result, requestId: runUi.requestId, conversationId: await agent.getConversationId(tabId) };
+      } catch (error) {
+        runError = error;
+        throw error;
       } finally {
         if (!userMemoryTurnContextTaken) clearUserMemoryTurnContext(tabId);
-        sendAgentRunComplete(tabId);
+        const snapshot = finishRunUiSnapshot(tabId, runUi.requestId, terminalRunUiStatus(result, userMemoryTurnHadError ? [{ type: 'error' }] : [], runError), result || (runError ? `Error: ${runError.message}` : ''));
+        sendAgentRunComplete(tabId, snapshot);
         sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
       }
     }
@@ -1424,6 +1502,7 @@ async function handleMessage(msg, sender) {
         const conversationId = await agent.getConversationId(tabId);
         await scheduler.cancelForConversation(tabId, conversationId);
         agent.clearConversation(tabId);
+        clearRunUiSnapshot(tabId);
       }
       return { ok: true };
     }
@@ -1443,7 +1522,13 @@ async function handleMessage(msg, sender) {
     case 'agent_run_state': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) return { ok: false, error: 'No tab ID' };
-      return { ok: true, ...agent.activeRunState(tabId) };
+      return { ok: true, ...agent.activeRunState(tabId), runUi: await getRunUiSnapshot(tabId) };
+    }
+
+    case 'agent_run_ack': {
+      const tabId = msg.tabId || sender.tab?.id;
+      if (!tabId) return { ok: false, error: 'No tab ID' };
+      return { ok: !!runUiJournal.acknowledge(tabId, String(msg.requestId || ''), msg.seq) };
     }
 
     case 'get_scratchpad': {
@@ -1547,6 +1632,10 @@ async function handleMessage(msg, sender) {
       const markdownMode = msg.markdownMode === 'verbose' ? 'verbose' : 'compact';
       if (!planId) return { ok: false, error: 'planId required' };
       const matched = agent.submitPlanResponse(tabId, planId, decision, editedText, markdownMode);
+      const snapshot = await getRunUiSnapshot(tabId);
+      if (matched && snapshot?.requestId) {
+        sendAgentUpdate(tabId, snapshot.requestId, 'plan_resolved', { planId, decision });
+      }
       return { ok: matched, matched };
     }
 

--- a/src/firefox/src/run-ui-journal.js
+++ b/src/firefox/src/run-ui-journal.js
@@ -1,0 +1,132 @@
+export const RUN_UI_EVENT_LIMIT = 256;
+
+export function createRunRequestId(tabId, supplied = '') {
+  const clean = String(supplied || '').trim();
+  return clean || `req_${tabId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function compactRunUiData(type, data) {
+  if (!data || typeof data !== 'object') return data;
+  if (type === 'tool_result') {
+    const result = data.result || {};
+    return {
+      name: data.name,
+      result: {
+        success: result.success,
+        ok: result.ok,
+        error: result.error ? String(result.error).slice(0, 1000) : undefined,
+        warning: result.warning ? String(result.warning).slice(0, 1000) : undefined,
+        summary: result.summary ? String(result.summary).slice(0, 2000) : undefined,
+      },
+    };
+  }
+  if (type === 'text' || type === 'text_delta') {
+    return { ...data, content: String(data.content || '').slice(0, 30000) };
+  }
+  return data;
+}
+
+export class RunUiJournal {
+  constructor({ eventLimit = RUN_UI_EVENT_LIMIT, onChange = null } = {}) {
+    this.eventLimit = eventLimit;
+    this.onChange = onChange;
+    this.snapshots = new Map();
+  }
+
+  _changed(tabId, snapshot) {
+    if (typeof this.onChange === 'function') this.onChange(tabId, snapshot);
+    return snapshot;
+  }
+
+  begin(tabId, requestId = '') {
+    const snapshot = {
+      tabId,
+      requestId: createRunRequestId(tabId, requestId),
+      runId: null,
+      status: 'running',
+      seq: 0,
+      ackedSeq: 0,
+      truncatedBeforeSeq: 0,
+      events: [],
+      pendingPlanId: null,
+      finalContent: '',
+      startedAt: Date.now(),
+      endedAt: null,
+    };
+    this.snapshots.set(tabId, snapshot);
+    return this._changed(tabId, snapshot);
+  }
+
+  record(tabId, requestId, type, data, runId = null) {
+    const snapshot = this.snapshots.get(tabId);
+    if (!snapshot || snapshot.requestId !== requestId) return null;
+    snapshot.runId = runId || snapshot.runId || null;
+    const event = {
+      seq: ++snapshot.seq,
+      type,
+      data: compactRunUiData(type, data),
+      ts: Date.now(),
+    };
+    snapshot.events.push(event);
+    while (snapshot.events.length > this.eventLimit) {
+      const removed = snapshot.events.shift();
+      snapshot.truncatedBeforeSeq = removed?.seq || snapshot.truncatedBeforeSeq;
+    }
+    if (type === 'plan_review') {
+      snapshot.status = 'awaiting_plan';
+      snapshot.pendingPlanId = String(data?.planId || '') || null;
+    }
+    if (type === 'plan_resolved') {
+      snapshot.status = 'running';
+      if (!data?.planId || String(data.planId) === String(snapshot.pendingPlanId)) snapshot.pendingPlanId = null;
+    }
+    this._changed(tabId, snapshot);
+    return { ...event, requestId: snapshot.requestId, runId: snapshot.runId };
+  }
+
+  finish(tabId, requestId, status, finalContent = '', runId = null) {
+    const snapshot = this.snapshots.get(tabId);
+    if (!snapshot || snapshot.requestId !== requestId) return null;
+    snapshot.runId = runId || snapshot.runId || null;
+    snapshot.status = status;
+    snapshot.pendingPlanId = null;
+    snapshot.finalContent = String(finalContent || '').slice(0, 30000);
+    snapshot.endedAt = Date.now();
+    const event = {
+      seq: ++snapshot.seq,
+      type: 'run_complete',
+      data: { status: snapshot.status, finalContent: snapshot.finalContent, endedAt: snapshot.endedAt },
+      ts: snapshot.endedAt,
+    };
+    snapshot.events.push(event);
+    while (snapshot.events.length > this.eventLimit) {
+      const removed = snapshot.events.shift();
+      snapshot.truncatedBeforeSeq = removed?.seq || snapshot.truncatedBeforeSeq;
+    }
+    return this._changed(tabId, snapshot);
+  }
+
+  restore(tabId, snapshot) {
+    if (!snapshot || typeof snapshot !== 'object') return null;
+    this.snapshots.set(tabId, snapshot);
+    return snapshot;
+  }
+
+  acknowledge(tabId, requestId, seq) {
+    const snapshot = this.snapshots.get(tabId);
+    const numericSeq = Number(seq);
+    if (!snapshot || snapshot.requestId !== requestId || !Number.isFinite(numericSeq)) return null;
+    snapshot.ackedSeq = Math.max(Number(snapshot.ackedSeq || 0), numericSeq);
+    snapshot.events = snapshot.events.filter(event => Number(event?.seq || 0) > snapshot.ackedSeq);
+    snapshot.truncatedBeforeSeq = Math.max(Number(snapshot.truncatedBeforeSeq || 0), snapshot.ackedSeq);
+    return this._changed(tabId, snapshot);
+  }
+
+  get(tabId) {
+    return this.snapshots.get(tabId) || null;
+  }
+
+  clear(tabId) {
+    this.snapshots.delete(tabId);
+  }
+}

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -413,14 +413,17 @@ const pendingAttachmentsByTab = new Map(); // tabId -> [{ kind: 'image'|'documen
 const attachmentReadCountsByTab = new Map();
 const attachmentGenerationByTab = new Map();
 let tabSwitchTransitionId = null;
+let tabSwitchGeneration = 0;
 let queuedTabSwitchMessages = [];
 let isProcessing = false;
 let currentAssistantEl = null;
 let verboseMode = false;
 let agentMode = 'ask'; // 'ask' | 'act' | 'dev'
 let abortRequested = false;
-let activeRunRestoredFromBackground = false;
 const awaitingPlanReviewTabs = new Set();
+const processingTabs = new Set();
+const abortRequestedTabs = new Set();
+const localRunRequestIds = new Map();
 let recommendationsRequestId = 0;
 let providerSelectionRequestId = 0;
 let providerTestRequestId = 0;
@@ -434,6 +437,42 @@ let retryPayloadSeq = 0;
 const activeChatPayloadsByTab = new Map();
 const retryAttachmentPayloads = new Map();
 const retryAttachmentIdsByTab = new Map();
+
+function setTabProcessing(tabId, processing) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return;
+  if (processing) processingTabs.add(numericTabId);
+  else processingTabs.delete(numericTabId);
+  if (sameTabId(currentTabId, numericTabId)) isProcessing = !!processing;
+}
+
+function isTabProcessing(tabId) {
+  const numericTabId = Number(tabId);
+  return Number.isFinite(numericTabId) && processingTabs.has(numericTabId);
+}
+
+function setTabAbortRequested(tabId, requested) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return;
+  if (requested) abortRequestedTabs.add(numericTabId);
+  else abortRequestedTabs.delete(numericTabId);
+  if (sameTabId(currentTabId, numericTabId)) abortRequested = !!requested;
+}
+
+function isTabAbortRequested(tabId) {
+  const numericTabId = Number(tabId);
+  return Number.isFinite(numericTabId) && abortRequestedTabs.has(numericTabId);
+}
+
+function syncCurrentTabRunFlags() {
+  const numericTabId = Number(currentTabId);
+  isProcessing = Number.isFinite(numericTabId) && processingTabs.has(numericTabId);
+  abortRequested = Number.isFinite(numericTabId) && abortRequestedTabs.has(numericTabId);
+}
+
+function createRunRequestId(tabId) {
+  return `req_${tabId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
 const {
   acceptContextMenuPrompt,
   drainQueuedContextMenuPrompts,
@@ -1081,8 +1120,8 @@ function setPlanReviewAwaiting(tabId, awaiting, assistantEl = null) {
   if (sameTabId(currentTabId, numericTabId)) {
     if (awaiting) {
       if (assistantEl) currentAssistantEl = assistantEl;
-      isProcessing = true;
-      abortRequested = false;
+      setTabProcessing(numericTabId, true);
+      setTabAbortRequested(numericTabId, false);
       hideRecommendedActions();
     }
     syncSendButtonState();
@@ -1618,8 +1657,11 @@ async function drainQueuedContextMenuPromptsAfterPendingTabSwitch() {
 
 function queueAgentUpdateDuringTabSwitch(msg) {
   const tabId = msg?.tabId;
-  if (tabSwitchTransitionId == null || tabId == null || tabId !== tabSwitchTransitionId) return false;
-  queuedTabSwitchMessages.push(msg);
+  if (tabSwitchTransitionId == null || tabId == null) return false;
+  // Never render into a DOM whose tab is changing. Target-tab events are
+  // queued so updates newer than the fetched journal snapshot are not lost;
+  // sequence de-duplication drops events the snapshot already replayed.
+  if (tabId === tabSwitchTransitionId) queuedTabSwitchMessages.push(msg);
   return true;
 }
 
@@ -1635,7 +1677,8 @@ function drainQueuedAgentUpdatesForTab(tabId) {
   replay.forEach((msg) => handleAgentUpdateMessage(msg));
 }
 
-async function settleScheduledRun(event, job) {
+async function settleScheduledRun(event, job, tabId = currentTabId) {
+  const runTabId = normalizePlanReviewTabId(tabId);
   if (job?.id) crossPanelScheduledJobIds.delete(String(job.id));
   const assistantEl = job?.id ? findScheduledAssistantMessageForJob(job.id) : currentAssistantEl;
   if (assistantEl) {
@@ -1647,12 +1690,14 @@ async function settleScheduledRun(event, job) {
     }
   }
   const ownsActiveRun = !currentAssistantEl || currentAssistantEl === assistantEl;
-  if (ownsActiveRun) {
-    isProcessing = false;
+  if (runTabId != null) {
+    setTabProcessing(runTabId, false);
+    setTabAbortRequested(runTabId, false);
+  }
+  if (ownsActiveRun && sameTabId(currentTabId, runTabId)) {
     syncSendButtonState();
     hideActivity();
     if (currentAssistantEl === assistantEl) currentAssistantEl = null;
-    abortRequested = false;
     if (renderedTabId != null) await flushRenderedTabChat();
     await drainQueuedContextMenuPromptsAfterPendingTabSwitch();
   }
@@ -1666,6 +1711,7 @@ function handleScheduledJobEvent(data, tabId) {
   if (!event || !job) return;
 
   const sameTab = tabId == null || tabId === currentTabId;
+  const runTabId = normalizePlanReviewTabId(tabId ?? currentTabId);
   const jobId = job?.id ? String(job.id) : '';
   const terminalScheduledEvent = ['completed', 'failed'].includes(event);
   const crossPanelScheduledEvent = isUrlTargetScheduledJob(job) && (
@@ -1678,9 +1724,9 @@ function handleScheduledJobEvent(data, tabId) {
   if (event === 'created') {
     addMessage('system', systemHtml(tSystemHtml('sp.scheduled.created', { title, time: formatScheduledTime(job.nextRunAt || job.scheduledAt) })));
   } else if (event === 'running') {
-    clearActiveChatPayloadForTab(tabId ?? currentTabId);
-    isProcessing = true;
-    abortRequested = false;
+    clearActiveChatPayloadForTab(runTabId);
+    setTabProcessing(runTabId, true);
+    setTabAbortRequested(runTabId, false);
     syncSendButtonState();
     hideRecommendedActions();
     currentAssistantEl = addMessage('assistant', '');
@@ -1688,21 +1734,21 @@ function handleScheduledJobEvent(data, tabId) {
     showActivity(t('sp.scheduled.running', { title }));
   } else if (event === 'completed') {
     ensureScheduledTerminalMessage(job);
-    settleScheduledRun(event, job);
+    settleScheduledRun(event, job, runTabId);
   } else if (event === 'failed') {
-    settleScheduledRun(event, job);
+    settleScheduledRun(event, job, runTabId);
     addMessage('error', t('sp.scheduled.failed', { title, msg: job.lastError || t('sp.scheduled.unknown_error') }));
   } else if (event === 'needs_user_input') {
     ensureScheduledClarifyCards([job]);
     hideActivity();
-    abortRequested = false;
+    setTabAbortRequested(runTabId, false);
     if (currentAssistantEl) {
-      clearActiveChatPayloadForTab(tabId ?? currentTabId);
-      isProcessing = true;
+      clearActiveChatPayloadForTab(runTabId);
+      setTabProcessing(runTabId, true);
       syncSendButtonState();
       hideRecommendedActions();
     } else {
-      isProcessing = false;
+      setTabProcessing(runTabId, false);
       syncSendButtonState();
       addMessage('system', systemHtml(tSystemHtml('sp.scheduled.needs_user_input', { title })));
       drainQueuedContextMenuPromptsAfterPendingTabSwitch();
@@ -2319,12 +2365,10 @@ if (verboseBtn) {
 
 async function switchToTab(newTabId) {
   if (newTabId === currentTabId && renderedTabId === newTabId) { pendingTabSwitch = null; return; }
-  if (isProcessing) {
-    pendingTabSwitch = newTabId; // apply after the run ends
-    return;
-  }
+  const switchGeneration = ++tabSwitchGeneration;
   pendingTabSwitch = null;
   tabSwitchTransitionId = newTabId;
+  queuedTabSwitchMessages = [];
 
   try {
     // Save the tab currently represented by the DOM. During an async restore,
@@ -2332,27 +2376,23 @@ async function switchToTab(newTabId) {
     if (renderedTabId != null) {
       const outgoingTabId = renderedTabId;
       await flushRenderedTabChat();
-      if (isProcessing) {
-        pendingTabSwitch = newTabId;
-        return;
-      }
+      if (switchGeneration !== tabSwitchGeneration) return;
       await flushChatHistorySnapshot(outgoingTabId);
-      if (isProcessing) {
-        pendingTabSwitch = newTabId;
-        return;
-      }
+      if (switchGeneration !== tabSwitchGeneration) return;
       captureInputDraftForTab(outgoingTabId);
     }
 
     currentTabId = newTabId;
+    currentAssistantEl = null;
+    syncCurrentTabRunFlags();
     syncApiMutationsAllowedForCurrentTab();
 
     // Restore new tab's chat from memory or storage.
     const html = await loadTabChat(newTabId);
-    if (currentTabId !== newTabId) return;
+    if (switchGeneration !== tabSwitchGeneration || currentTabId !== newTabId) return;
     if (html) {
       await hydrateRestoredChatHistory(newTabId, html);
-      if (currentTabId !== newTabId) return;
+      if (switchGeneration !== tabSwitchGeneration || currentTabId !== newTabId) return;
     }
     renderedTabId = newTabId;
     if (html) {
@@ -2368,10 +2408,11 @@ async function switchToTab(newTabId) {
     renderQueuedComposerMessages(newTabId);
     scrollToBottom();
     await restoreActiveRunState(newTabId);
+    if (switchGeneration !== tabSwitchGeneration || currentTabId !== newTabId) return;
     refreshScheduledJobs({ tabId: newTabId });
     refreshRecommendedActions();
   } finally {
-    if (tabSwitchTransitionId === newTabId) tabSwitchTransitionId = null;
+    if (switchGeneration === tabSwitchGeneration && tabSwitchTransitionId === newTabId) tabSwitchTransitionId = null;
   }
   drainQueuedAgentUpdatesForTab(newTabId);
   consumePendingContextMenuPrompt().then(() => drainQueuedContextMenuPrompts()).catch(() => {});
@@ -2387,20 +2428,68 @@ async function restoreActiveRunState(tabId = currentTabId) {
     return;
   }
   if (!sameTabId(currentTabId, numericTabId) || !sameTabId(renderedTabId, numericTabId)) return;
-  if (state?.pendingPlan?.planId) {
-    activeRunRestoredFromBackground = true;
-    renderPlanReviewCard({ ...state.pendingPlan, tabId: numericTabId });
+  const runUi = state?.runUi && typeof state.runUi === 'object' ? state.runUi : null;
+  if (runUi?.requestId) {
+    const runAssistantEl = messagesEl.querySelector(`.message.assistant[data-run-request-id="${CSS.escape(String(runUi.requestId))}"]`)
+      || messagesEl.querySelector('.message.assistant:last-of-type')
+      || addMessage('assistant', '');
+    currentAssistantEl = runAssistantEl;
+    runAssistantEl.dataset.runRequestId = String(runUi.requestId);
+    if (runUi.runId) runAssistantEl.dataset.runId = String(runUi.runId);
+    const lastRenderedSeq = Number(runAssistantEl.dataset.lastRenderedSeq || 0);
+    if (runUi.truncatedBeforeSeq > lastRenderedSeq) {
+      addContextCompactedNote({ message: 'Some hidden-tab progress was compacted.' });
+    }
+    for (const event of Array.isArray(runUi.events) ? runUi.events : []) {
+      if (Number(event?.seq || 0) <= lastRenderedSeq) continue;
+      handleAgentUpdateMessage({
+        target: 'sidepanel', action: 'agent_update', tabId: numericTabId,
+        requestId: runUi.requestId, runId: runUi.runId, seq: event.seq,
+        type: event.type, data: event.data,
+      });
+      runAssistantEl.dataset.lastRenderedSeq = String(event.seq);
+    }
+    const renderedSeq = Number(runAssistantEl.dataset.lastRenderedSeq || 0);
+    if (renderedSeq > Number(runUi.ackedSeq || 0)) {
+      await sendToBackground('agent_run_ack', {
+        tabId: numericTabId,
+        requestId: runUi.requestId,
+        seq: renderedSeq,
+      }).catch(() => {});
+    }
+  }
+  const pendingPlan = state?.pendingPlan;
+  const lastPlanLifecycleEvent = [...(Array.isArray(runUi?.events) ? runUi.events : [])]
+    .reverse()
+    .find(event => event?.type === 'plan_review' || event?.type === 'plan_resolved');
+  const pendingPlanMatchesRun = !!pendingPlan?.planId
+    && runUi?.status === 'awaiting_plan'
+    && (String(runUi.pendingPlanId || '') === String(pendingPlan.planId)
+      || (lastPlanLifecycleEvent?.type === 'plan_review'
+        && String(lastPlanLifecycleEvent.data?.planId || '') === String(pendingPlan.planId)));
+  if (pendingPlanMatchesRun) {
+    renderPlanReviewCard({ ...pendingPlan, tabId: numericTabId, requestId: runUi?.requestId || null, runId: runUi?.runId || null });
     return;
   }
+  invalidatePlanReviewCards({ tabId: numericTabId });
   if (state?.running) {
-    activeRunRestoredFromBackground = true;
-    isProcessing = true;
-    abortRequested = false;
+    setTabProcessing(numericTabId, true);
+    setTabAbortRequested(numericTabId, false);
     hideRecommendedActions();
     showActivity(t('sp.activity.thinking'));
     syncSendButtonState();
   } else {
     setPlanReviewAwaiting(numericTabId, false);
+    setTabProcessing(numericTabId, false);
+    setTabAbortRequested(numericTabId, false);
+    if (runUi && ['completed', 'stopped', 'failed', 'cancelled'].includes(runUi.status)
+        && Number(currentAssistantEl?.dataset.lastRenderedSeq || 0) < Number(runUi.seq || 0)) {
+      handleAgentUpdateMessage({
+        tabId: numericTabId, requestId: runUi.requestId, runId: runUi.runId,
+        seq: runUi.seq, type: 'run_complete',
+        data: { status: runUi.status, finalContent: runUi.finalContent },
+      });
+    }
   }
 }
 
@@ -2668,21 +2757,25 @@ function bindPlanReviewCard(card) {
 function reattachPlanReviewActiveRun(card) {
   const assistantEl = card?.closest?.('.message.assistant');
   if (!assistantEl) return null;
-  clearActiveChatPayloadForTab(currentTabId);
+  const tabId = Number(card?.dataset?.tabId || currentTabId);
+  clearActiveChatPayloadForTab(tabId);
   currentAssistantEl = assistantEl;
-  isProcessing = true;
-  abortRequested = false;
+  setTabProcessing(tabId, true);
+  setTabAbortRequested(tabId, false);
   sendBtn.disabled = true;
   hideRecommendedActions();
   showActivity(t('sp.activity.thinking'));
   return assistantEl;
 }
 
-function clearPlanReviewActiveRun(assistantEl) {
+function clearPlanReviewActiveRun(assistantEl, tabId = currentTabId) {
   if (currentAssistantEl === assistantEl) currentAssistantEl = null;
-  isProcessing = false;
-  sendBtn.disabled = false;
-  hideActivity();
+  setTabProcessing(tabId, false);
+  setTabAbortRequested(tabId, false);
+  if (sameTabId(currentTabId, tabId)) {
+    sendBtn.disabled = false;
+    hideActivity();
+  }
   drainQueuedContextMenuPromptsAfterPendingTabSwitch();
   refreshRecommendedActions();
 }
@@ -3563,6 +3656,7 @@ async function sendMessage(extraChatParams = {}) {
   let text = inputEl.value.trim();
   if (!text) return;
   const tabId = currentTabId;
+  const requestId = createRunRequestId(tabId);
   text = normalizeScreenshotCommandText(text);
   if (isAwaitingPlanReviewForTab(tabId)) {
     showComposerToast(t('sp.plan.awaiting_review'), { duration: 5000 });
@@ -3621,24 +3715,24 @@ async function sendMessage(extraChatParams = {}) {
     syncSendButtonState();
     return;
   }
-  isProcessing = true;
-  abortRequested = false;
+  setTabProcessing(tabId, true);
+  setTabAbortRequested(tabId, false);
   inputEl.value = '';
   autoResizeInput();
   syncSendButtonState();
 
   await prepareChatHistoryForTurn(tabId, modeForSend);
-  if (abortRequested) {
-    isProcessing = false;
-    abortRequested = false;
+  if (isTabAbortRequested(tabId)) {
+    setTabProcessing(tabId, false);
+    setTabAbortRequested(tabId, false);
     syncSendButtonState();
     return false;
   }
   renderToCurrentTab = sameTabId(currentTabId, tabId) && sameTabId(renderedTabId, tabId);
   if (!renderToCurrentTab) {
     if (text) saveInputDraftForTab(tabId, text);
-    isProcessing = false;
-    abortRequested = false;
+    setTabProcessing(tabId, false);
+    setTabAbortRequested(tabId, false);
     syncSendButtonState();
     return false;
   }
@@ -3654,8 +3748,8 @@ async function sendMessage(extraChatParams = {}) {
     attachments: attachmentsForSend,
   };
   if (renderToCurrentTab) {
-    isProcessing = true;
-    abortRequested = false;
+    setTabProcessing(tabId, true);
+    setTabAbortRequested(tabId, false);
     syncSendButtonState();
     hideRecommendedActions();
     if (!retryOptions) {
@@ -3665,10 +3759,13 @@ async function sendMessage(extraChatParams = {}) {
     addMessage('user', text);
     showActivity(t('sp.activity.thinking'));
     assistantEl = addMessage('assistant', '');
+    assistantEl.dataset.runRequestId = requestId;
+    assistantEl.dataset.lastRenderedSeq = '0';
     currentAssistantEl = assistantEl;
   }
   const activePayloadState = createActiveChatPayloadState(retryPayload);
   activeChatPayloadsByTab.set(tabId, activePayloadState);
+  localRunRequestIds.set(tabId, requestId);
 
   let accepted = false;
   let completedSuccessfully = false;
@@ -3676,6 +3773,7 @@ async function sendMessage(extraChatParams = {}) {
   try {
     const res = await sendToBackground('chat', {
       tabId,
+      requestId,
       text,
       mode: modeForSend,
       apiMutationsAllowed: apiMutationsAllowedForSend,
@@ -3692,7 +3790,7 @@ async function sendMessage(extraChatParams = {}) {
     const returnedErrorUpdate = Array.isArray(res?.updates)
       ? res.updates.find(u => u?.type === 'error')
       : null;
-    if (returnedErrorUpdate && renderToCurrentTab && currentTabId === tabId && !abortRequested) {
+    if (returnedErrorUpdate && renderToCurrentTab && currentTabId === tabId && !isTabAbortRequested(tabId)) {
       renderAgentErrorUpdate(returnedErrorUpdate.data, tabId);
     }
 
@@ -3718,7 +3816,7 @@ async function sendMessage(extraChatParams = {}) {
       syncSendButtonState();
     }
 
-    if (renderToCurrentTab && currentTabId === tabId && abortRequested) {
+    if (renderToCurrentTab && currentTabId === tabId && isTabAbortRequested(tabId)) {
       // Agent was stopped — show what we got so far
       const textEl = assistantEl?.querySelector('.message-text');
       if (textEl && !textEl.textContent.trim()) {
@@ -3737,20 +3835,21 @@ async function sendMessage(extraChatParams = {}) {
       }
     }
   } catch (e) {
-    if (renderToCurrentTab && currentTabId === tabId && !abortRequested) {
+    if (renderToCurrentTab && currentTabId === tabId && !isTabAbortRequested(tabId)) {
       takeActiveRetryPayloadForError(tabId, e.message);
       addMessage('error', t('sp.error_prefix', { msg: e.message }), { retryPayload });
     }
   } finally {
+    if (localRunRequestIds.get(tabId) === requestId) localRunRequestIds.delete(tabId);
     if (activeChatPayloadsByTab.get(tabId) === activePayloadState) {
       scheduleActiveChatPayloadCleanup(tabId, activePayloadState);
     }
     if (renderToCurrentTab && currentTabId === tabId) finalizeSteps(assistantEl);
     clearAssistantTextStreamState(assistantEl);
-    const wasAborted = abortRequested;
-    if (renderToCurrentTab) {
-      isProcessing = false;
-      abortRequested = false;
+    const wasAborted = isTabAbortRequested(tabId);
+    setTabProcessing(tabId, false);
+    setTabAbortRequested(tabId, false);
+    if (renderToCurrentTab && currentTabId === tabId) {
       syncSendButtonState();
       hideActivity();
     }
@@ -3784,6 +3883,36 @@ browser.runtime.onMessage.addListener((msg) => {
   clearQueuedForTab(msg.tabId);
 });
 
+function ensureCurrentRunAssistant(msg) {
+  if (!msg?.requestId) return currentAssistantEl;
+  const requestId = String(msg.requestId);
+  let assistantEl = messagesEl.querySelector(`.message.assistant[data-run-request-id="${CSS.escape(requestId)}"]`);
+  if (!assistantEl && currentAssistantEl
+      && (!currentAssistantEl.dataset.runRequestId || currentAssistantEl.dataset.runRequestId === requestId)) {
+    assistantEl = currentAssistantEl;
+  }
+  if (!assistantEl) assistantEl = addMessage('assistant', '');
+  assistantEl.dataset.runRequestId = requestId;
+  if (msg.runId) assistantEl.dataset.runId = String(msg.runId);
+  currentAssistantEl = assistantEl;
+  return assistantEl;
+}
+
+function invalidatePlanReviewCards({ tabId = currentTabId, planId = '', requestId = '', runId = '', remove = true } = {}) {
+  for (const card of messagesEl.querySelectorAll('.plan-review-card')) {
+    if (tabId != null && String(card.dataset.tabId || '') !== String(tabId)) continue;
+    if (planId && String(card.dataset.planId || '') !== String(planId)) continue;
+    if (requestId && card.dataset.runRequestId && card.dataset.runRequestId !== String(requestId)) continue;
+    if (runId && card.dataset.runId && card.dataset.runId !== String(runId)) continue;
+    setPlanReviewAwaiting(tabId, false);
+    if (remove) card.remove();
+    else {
+      card.classList.add('plan-reviewed');
+      card.querySelectorAll('button, textarea').forEach(el => { el.disabled = true; });
+    }
+  }
+}
+
 function handleAgentUpdateMessage(msg) {
   if (msg.type === 'scheduled_job') {
     handleScheduledJobEvent(msg.data, msg.tabId);
@@ -3798,6 +3927,20 @@ function handleAgentUpdateMessage(msg) {
   // brand-new Ctrl+T tab B the moment B becomes active. `msg.tabId == null`
   // keeps backward compat for any in-flight events from a pre-tabId build.
   if (msg.tabId != null && msg.tabId !== currentTabId) return;
+
+  const eventTabId = msg.tabId ?? currentTabId;
+  const localRequestId = localRunRequestIds.get(Number(eventTabId));
+  if (localRequestId && msg.requestId && localRequestId !== String(msg.requestId)) return;
+  const locallyOwnedEvent = !!localRequestId
+    && (!msg.requestId || localRequestId === String(msg.requestId));
+  const sequencedRequestAssistantEl = msg.requestId && Number.isFinite(Number(msg.seq))
+    ? messagesEl.querySelector(`.message.assistant[data-run-request-id="${CSS.escape(String(msg.requestId))}"]`)
+    : null;
+  if (sequencedRequestAssistantEl
+      && Number(sequencedRequestAssistantEl.dataset.lastRenderedSeq || 0) >= Number(msg.seq)) return;
+  const eventAssistantEl = ensureCurrentRunAssistant(msg);
+  if (eventAssistantEl && Number.isFinite(Number(msg.seq))
+      && Number(eventAssistantEl.dataset.lastRenderedSeq || 0) >= Number(msg.seq)) return;
 
   const { type, data } = msg;
 
@@ -3889,17 +4032,20 @@ function handleAgentUpdateMessage(msg) {
 
     case 'run_complete':
       if (currentAssistantEl) finalizeSteps(currentAssistantEl);
-      // When a local send is still in flight (isProcessing), its own finally
-      // resets run state and refreshes recommended actions *after* the final
-      // text renders — so only finalize the steps visually here and let that
-      // owner tear down, avoiding a premature double refresh/drain. When nothing
-      // is processing locally (e.g. the panel remounted on a tab switch away and
-      // back mid-run), run_complete is the sole finalizer and must tear down. (#4)
-      if (!isProcessing || activeRunRestoredFromBackground) {
-        setPlanReviewAwaiting(msg.tabId ?? currentTabId, false);
-        clearPlanReviewActiveRun(currentAssistantEl);
-        activeRunRestoredFromBackground = false;
+      invalidatePlanReviewCards({ tabId: msg.tabId ?? currentTabId, requestId: msg.requestId, runId: msg.runId });
+      if (currentAssistantEl && data?.finalContent) {
+        const textEl = currentAssistantEl.querySelector('.message-text');
+        if (textEl && !textEl.textContent.trim()) {
+          if (data.status === 'stopped' || data.status === 'cancelled') textEl.innerHTML = t('sp.stopped_by_user_html');
+          else textEl.innerHTML = formatMarkdown(data.finalContent);
+          addMessageCopyButton(currentAssistantEl);
+        }
       }
+      setPlanReviewAwaiting(msg.tabId ?? currentTabId, false);
+      if (!locallyOwnedEvent) {
+        clearPlanReviewActiveRun(currentAssistantEl, eventTabId);
+      }
+      schedulePersist();
       scrollToBottom();
       break;
 
@@ -3919,12 +4065,20 @@ function handleAgentUpdateMessage(msg) {
       break;
 
     case 'plan_review':
-      renderPlanReviewCard(data);
+      renderPlanReviewCard({ ...data, tabId: msg.tabId ?? currentTabId, requestId: msg.requestId, runId: msg.runId });
+      break;
+
+    case 'plan_resolved':
+      invalidatePlanReviewCards({ tabId: msg.tabId ?? currentTabId, planId: data?.planId, requestId: msg.requestId, runId: msg.runId });
+      schedulePersist();
       break;
 
     case 'plan_auto_approved':
       addPlanAutoApprovedNote(data);
       break;
+  }
+  if (eventAssistantEl && Number.isFinite(Number(msg.seq))) {
+    eventAssistantEl.dataset.lastRenderedSeq = String(msg.seq);
   }
 }
 
@@ -4140,6 +4294,8 @@ function renderPlanReviewCard(data) {
   const existing = [...messagesEl.querySelectorAll('.plan-review-card')]
     .find(card => String(card.dataset.planId || '') === planId
       && String(card.dataset.tabId || '') === String(tabId)
+      && (!data.requestId || card.dataset.runRequestId === String(data.requestId))
+      && (!data.runId || card.dataset.runId === String(data.runId))
       && !card.classList.contains('plan-reviewed'));
   if (existing) {
     bindPlanReviewCard(existing);
@@ -4155,6 +4311,8 @@ function renderPlanReviewCard(data) {
   card.className = 'plan-review-card';
   card.dataset.planId = planId;
   card.dataset.tabId = String(tabId);
+  if (data.requestId) card.dataset.runRequestId = String(data.requestId);
+  if (data.runId) card.dataset.runId = String(data.runId);
   card.dataset.editing = 'false';
 
   const header = document.createElement('div');
@@ -4258,7 +4416,7 @@ function submitPlanReview(card, tabId, planId, action, editedText) {
         note.textContent = expiredText();
         card.appendChild(note);
         setPlanReviewAwaiting(tabId, false);
-        if (activeAssistantEl) clearPlanReviewActiveRun(activeAssistantEl);
+        if (activeAssistantEl) clearPlanReviewActiveRun(activeAssistantEl, tabId);
       }
       scrollToBottom();
     })
@@ -4267,7 +4425,7 @@ function submitPlanReview(card, tabId, planId, action, editedText) {
         note.textContent = failureText(error);
         card.appendChild(note);
         setPlanReviewAwaiting(tabId, false);
-        if (activeAssistantEl) clearPlanReviewActiveRun(activeAssistantEl);
+        if (activeAssistantEl) clearPlanReviewActiveRun(activeAssistantEl, tabId);
         scrollToBottom();
       }
     });
@@ -4310,7 +4468,8 @@ function submitClarify(card, tabId, clarifyId, answer, source) {
     if (msgEl && (!currentAssistantEl || currentAssistantEl.dataset?.scheduledJobId === scheduledJobId)) {
       currentAssistantEl = msgEl;
     }
-    isProcessing = true;
+    setTabProcessing(tabId, true);
+    setTabAbortRequested(tabId, false);
     syncSendButtonState();
     hideRecommendedActions();
     showActivity(t('sp.activity.thinking'));
@@ -4321,9 +4480,12 @@ function submitClarify(card, tabId, clarifyId, answer, source) {
   sendToBackground('clarify_response', clarifyPayload)
     .catch(() => {
       if (isScheduledClarify) {
-        isProcessing = false;
-        syncSendButtonState();
-        hideActivity();
+        setTabProcessing(tabId, false);
+        setTabAbortRequested(tabId, false);
+        if (sameTabId(currentTabId, tabId)) {
+          syncSendButtonState();
+          hideActivity();
+        }
         drainQueuedContextMenuPromptsAfterPendingTabSwitch();
       }
       /* background may be torn down — clarify state already lives there */
@@ -4764,28 +4926,33 @@ function showContinueButton() {
 
 async function continueAgent() {
   const tabId = currentTabId;
+  const requestId = createRunRequestId(tabId);
   const modeForSend = agentMode;
   clearActiveChatPayloadForTab(tabId);
 
-  isProcessing = true;
-  abortRequested = false;
+  setTabProcessing(tabId, true);
+  setTabAbortRequested(tabId, false);
   syncSendButtonState();
 
   let assistantEl = null;
 
   try {
     await prepareChatHistoryForTurn(tabId, modeForSend);
-    if (abortRequested) return false;
+    if (isTabAbortRequested(tabId)) return false;
     if (!sameTabId(currentTabId, tabId) || !sameTabId(renderedTabId, tabId)) return false;
 
     document.querySelectorAll('.continue-bar').forEach(el => el.remove());
 
     assistantEl = addMessage('assistant', '');
+    assistantEl.dataset.runRequestId = requestId;
+    assistantEl.dataset.lastRenderedSeq = '0';
     currentAssistantEl = assistantEl;
     showActivity(t('sp.activity.continuing'));
+    localRunRequestIds.set(tabId, requestId);
 
     const res = await sendToBackground('continue', {
       tabId,
+      requestId,
       mode: modeForSend,
     });
     if (res?.conversationId) {
@@ -4805,16 +4972,19 @@ async function continueAgent() {
       }
     }
   } catch (e) {
-    if (currentTabId === tabId && assistantEl && !abortRequested) {
+    if (currentTabId === tabId && assistantEl && !isTabAbortRequested(tabId)) {
       addMessage('error', t('sp.error_prefix', { msg: e.message }));
     }
   } finally {
+    if (localRunRequestIds.get(tabId) === requestId) localRunRequestIds.delete(tabId);
     if (currentTabId === tabId && assistantEl) finalizeSteps(assistantEl);
     clearAssistantTextStreamState(assistantEl);
-    isProcessing = false;
-    abortRequested = false;
-    syncSendButtonState();
-    hideActivity();
+    setTabProcessing(tabId, false);
+    setTabAbortRequested(tabId, false);
+    if (currentTabId === tabId) {
+      syncSendButtonState();
+      hideActivity();
+    }
     if (currentAssistantEl === assistantEl) currentAssistantEl = null;
     if (currentTabId === tabId) scrollToBottom();
     if (currentTabId === tabId && renderedTabId === tabId) await flushRenderedTabChat();
@@ -5185,19 +5355,21 @@ modeDevBtn?.addEventListener('click', async () => {
 // --- Stop / Abort ---
 
 stopBtn.addEventListener('click', async () => {
-  if (!isProcessing) return;
-  abortRequested = true;
+  const tabId = currentTabId;
+  if (!isTabProcessing(tabId)) return;
+  setTabAbortRequested(tabId, true);
   showActivity(t('sp.activity.stopping'));
 
   try {
-    await sendToBackground('abort', { tabId: currentTabId });
+    await sendToBackground('abort', { tabId });
   } catch {
     // Best effort
   }
 
   // Force UI to settle even if background doesn't respond cleanly
   setTimeout(async () => {
-    if (abortRequested) {
+    if (isTabAbortRequested(tabId)) {
+      if (!sameTabId(currentTabId, tabId) || !sameTabId(renderedTabId, tabId)) return;
       finalizeSteps();
       if (currentAssistantEl) {
         const textEl = currentAssistantEl.querySelector('.message-text');
@@ -5205,11 +5377,11 @@ stopBtn.addEventListener('click', async () => {
           textEl.innerHTML = t('sp.stopped_by_user_html');
         }
       }
-      isProcessing = false;
+      setTabProcessing(tabId, false);
       syncSendButtonState();
       hideActivity();
       currentAssistantEl = null;
-      abortRequested = false;
+      setTabAbortRequested(tabId, false);
       await flushRenderedTabChat();
       await drainQueuedContextMenuPromptsAfterPendingTabSwitch();
     }

--- a/test/run.js
+++ b/test/run.js
@@ -603,7 +603,7 @@ class LoopDetectorShim {
     };
     state.seenPages.add(page);
     this.axReadStates.set(tabId, state);
-    if (state.suspicious >= 6 || state.total >= 12) {
+    if (state.suspicious >= 6 || (state.total >= 12 && (state.suspicious > 0 || !sequentialPage))) {
       this.axReadStates.delete(tabId);
       return { kind: 'stop' };
     }
@@ -1675,10 +1675,10 @@ test('accessibility-tree ref enumeration nudges at three and stops at six', () =
   assert.equal(d._checkAccessibilityReadLoop(tab, 'get_accessibility_tree', { ref_id: 'ref_6' }, { pageContent: 'generic [ref_6]' }).kind, 'stop');
 });
 
-test('accessibility-tree nextPage pagination is not suspicious and other tools reset it', () => {
+test('accessibility-tree nextPage pagination past the read cap is not suspicious and other tools reset it', () => {
   const d = new LoopDetectorShim();
   const tab = 22;
-  for (let page = 1; page <= 5; page++) {
+  for (let page = 1; page <= 15; page++) {
     const result = d._checkAccessibilityReadLoop(
       tab,
       'get_accessibility_tree',
@@ -1687,9 +1687,32 @@ test('accessibility-tree nextPage pagination is not suspicious and other tools r
     );
     assert.equal(result.kind, 'none');
   }
-  d._checkAccessibilityReadLoop(tab, 'click_ax', { ref_id: 'ref_5' }, { success: true });
+  d._checkAccessibilityReadLoop(tab, 'click_ax', { ref_id: 'ref_15' }, { success: true });
   assert.equal(d.axReadStates.has(tab), false);
   assert.equal(d._checkAccessibilityReadLoop(tab, 'get_accessibility_tree', { ref_id: 'ref_9' }, { pageContent: 'generic [ref_9]' }).kind, 'none');
+});
+
+test('accessibility-tree read cap still stops a non-sequential read after long pagination', () => {
+  const d = new LoopDetectorShim();
+  const tab = 23;
+  for (let page = 1; page <= 11; page++) {
+    const result = d._checkAccessibilityReadLoop(
+      tab,
+      'get_accessibility_tree',
+      { filter: 'visible', ...(page > 1 ? { page } : {}) },
+      { pageContent: `button "Page ${page}" [ref_${page}]`, nextPage: page + 1 },
+    );
+    assert.equal(result.kind, 'none');
+  }
+  assert.equal(
+    d._checkAccessibilityReadLoop(
+      tab,
+      'get_accessibility_tree',
+      { filter: 'visible', page: 11 },
+      { pageContent: 'button "Page 11" [ref_11]', nextPage: 12 },
+    ).kind,
+    'stop',
+  );
 });
 
 // ────────────────────────────────────────────────────────────────────────

--- a/test/run.js
+++ b/test/run.js
@@ -92,6 +92,13 @@ const { sanitizeLink, sanitizeMarkdownLinks } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/ui/markdown-link.js').replace(/\\/g, '/')
 );
 
+const { RunUiJournal: RunUiJournalCh } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/run-ui-journal.js').replace(/\\/g, '/')
+);
+const { RunUiJournal: RunUiJournalFx } = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/run-ui-journal.js').replace(/\\/g, '/')
+);
+
 // anthropic.js imports cleanly under Node (its chrome.* touches are lazy); we
 // only exercise the pure _convertMessages transform here.
 const { AnthropicProvider: AnthropicProviderCh } = await import(
@@ -489,6 +496,7 @@ class LoopDetectorShim {
     this.loopNudges = new Map();
     this.healthyCallsSinceLoop = new Map();
     this.recentCoordClicks = new Map();
+    this.axReadStates = new Map();
   }
   _checkCoordClickLoop(tabId, x, y) {
     const bx = Math.round(x / 5) * 5;
@@ -566,6 +574,44 @@ class LoopDetectorShim {
       return { kind: 'stop' };
     }
     return { kind: 'nudge' };
+  }
+  _checkAccessibilityReadLoop(tabId, name, args, result) {
+    if (name !== 'get_accessibility_tree') {
+      this.axReadStates.delete(tabId);
+      return { kind: 'none' };
+    }
+    const previous = this.axReadStates.get(tabId) || {
+      total: 0, suspicious: 0, nextPage: null, seenPages: new Set(), warned: false,
+    };
+    const page = Number(args?.page || 1);
+    const hasRef = typeof args?.ref_id === 'string' && args.ref_id.trim() !== '';
+    const sequentialPage = !hasRef
+      && previous.total > 0
+      && Number.isFinite(previous.nextPage)
+      && page === previous.nextPage
+      && !previous.seenPages.has(page);
+    const repeatedRootOrPage = !hasRef && previous.total > 0 && !sequentialPage;
+    const content = String(result?.pageContent || '').trim();
+    const meaningfulLines = content ? content.split(/\r?\n/).filter(line => line.trim()).length : 0;
+    const suspicious = hasRef || repeatedRootOrPage || (hasRef && meaningfulLines <= 1);
+    const state = {
+      total: previous.total + 1,
+      suspicious: previous.suspicious + (suspicious ? 1 : 0),
+      nextPage: Number.isFinite(Number(result?.nextPage)) ? Number(result.nextPage) : null,
+      seenPages: new Set(previous.seenPages),
+      warned: previous.warned,
+    };
+    state.seenPages.add(page);
+    this.axReadStates.set(tabId, state);
+    if (state.suspicious >= 6 || state.total >= 12) {
+      this.axReadStates.delete(tabId);
+      return { kind: 'stop' };
+    }
+    if (!state.warned && state.suspicious >= 3) {
+      state.warned = true;
+      return { kind: 'nudge' };
+    }
+    return { kind: 'none' };
   }
   _detectApiShortcut(tabId, loop, buf) {
     if (loop.type !== 'repeat') return null;
@@ -1610,6 +1656,40 @@ test('tabs are isolated from each other', () => {
   d._checkLoop(10, 'click', { selector: '#x' }, { success: true });
   const result = d._checkLoop(20, 'click', { selector: '#x' }, { success: true });
   assert.equal(result.kind, 'none');
+});
+
+test('accessibility-tree ref enumeration nudges at three and stops at six', () => {
+  const d = new LoopDetectorShim();
+  const tab = 21;
+  const root = d._checkAccessibilityReadLoop(tab, 'get_accessibility_tree', { filter: 'visible' }, {
+    pageContent: 'form [ref_1]\n textbox "Subject" [ref_2]',
+    hasMore: true,
+    nextPage: 2,
+  });
+  assert.equal(root.kind, 'none');
+  assert.equal(d._checkAccessibilityReadLoop(tab, 'get_accessibility_tree', { ref_id: 'ref_1' }, { pageContent: 'form [ref_1]\n textbox "Subject" [ref_2]' }).kind, 'none');
+  assert.equal(d._checkAccessibilityReadLoop(tab, 'get_accessibility_tree', { ref_id: 'ref_2' }, { pageContent: 'textbox "Subject" [ref_2]' }).kind, 'none');
+  assert.equal(d._checkAccessibilityReadLoop(tab, 'get_accessibility_tree', { ref_id: 'ref_3' }, { pageContent: 'generic [ref_3]' }).kind, 'nudge');
+  assert.equal(d._checkAccessibilityReadLoop(tab, 'get_accessibility_tree', { ref_id: 'ref_4' }, { pageContent: 'generic [ref_4]' }).kind, 'none');
+  assert.equal(d._checkAccessibilityReadLoop(tab, 'get_accessibility_tree', { ref_id: 'ref_5' }, { pageContent: 'generic [ref_5]' }).kind, 'none');
+  assert.equal(d._checkAccessibilityReadLoop(tab, 'get_accessibility_tree', { ref_id: 'ref_6' }, { pageContent: 'generic [ref_6]' }).kind, 'stop');
+});
+
+test('accessibility-tree nextPage pagination is not suspicious and other tools reset it', () => {
+  const d = new LoopDetectorShim();
+  const tab = 22;
+  for (let page = 1; page <= 5; page++) {
+    const result = d._checkAccessibilityReadLoop(
+      tab,
+      'get_accessibility_tree',
+      { filter: 'visible', ...(page > 1 ? { page } : {}) },
+      { pageContent: `button "Page ${page}" [ref_${page}]`, nextPage: page + 1 },
+    );
+    assert.equal(result.kind, 'none');
+  }
+  d._checkAccessibilityReadLoop(tab, 'click_ax', { ref_id: 'ref_5' }, { success: true });
+  assert.equal(d.axReadStates.has(tab), false);
+  assert.equal(d._checkAccessibilityReadLoop(tab, 'get_accessibility_tree', { ref_id: 'ref_9' }, { pageContent: 'generic [ref_9]' }).kind, 'none');
 });
 
 // ────────────────────────────────────────────────────────────────────────
@@ -3567,7 +3647,7 @@ test('scheduled runs hide suggested actions immediately', () => {
   ]) {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
     const runningIdx = panel.indexOf("} else if (event === 'running') {");
-    const isProcessingIdx = panel.indexOf('isProcessing = true;', runningIdx);
+    const isProcessingIdx = panel.indexOf('setTabProcessing(runTabId, true);', runningIdx);
     const hideIdx = panel.indexOf('hideRecommendedActions();', runningIdx);
     const addAssistantIdx = panel.indexOf("currentAssistantEl = addMessage('assistant', '');", runningIdx);
     assert.notEqual(runningIdx, -1, `${label}: scheduled running branch missing`);
@@ -3586,7 +3666,7 @@ test('scheduled clarify resumes hide suggested actions immediately', () => {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
     const submitIdx = panel.indexOf('function submitClarify(');
     const scheduledIdx = panel.indexOf('if (isScheduledClarify) {', submitIdx);
-    const isProcessingIdx = panel.indexOf('isProcessing = true;', scheduledIdx);
+    const isProcessingIdx = panel.indexOf('setTabProcessing(tabId, true);', scheduledIdx);
     const hideIdx = panel.indexOf('hideRecommendedActions();', scheduledIdx);
     const activityIdx = panel.indexOf("showActivity(t('sp.activity.thinking'));", scheduledIdx);
     assert.notEqual(submitIdx, -1, `${label}: submitClarify missing`);
@@ -7156,15 +7236,13 @@ test('chrome sidepanel drops stale async tab-chat restores', () => {
   const body = match[1];
   const setIdx = body.indexOf('currentTabId = newTabId;');
   const loadIdx = body.indexOf('const html = await loadTabChat(newTabId);');
-  const guardIdx = body.indexOf('if (currentTabId !== newTabId) return;');
+  const guardIdx = body.indexOf('if (switchGeneration !== tabSwitchGeneration || currentTabId !== newTabId) return;');
   const renderedSetIdx = body.indexOf('renderedTabId = newTabId;');
   const restoreIdx = body.indexOf('messagesEl.innerHTML =');
   const consumeIdx = body.indexOf('consumePendingContextMenuPrompt()');
   const flushIdx = body.indexOf('await flushRenderedTabChat();');
   const historyFlushIdx = body.indexOf('await flushChatHistorySnapshot(outgoingTabId);');
-  const postFlushProcessingIdx = body.indexOf('if (isProcessing) {', flushIdx);
-  const postFlushPendingIdx = body.indexOf('pendingTabSwitch = newTabId;', postFlushProcessingIdx);
-  const postFlushReturnIdx = body.indexOf('return;', postFlushPendingIdx);
+  const syncRunFlagsIdx = body.indexOf('syncCurrentTabRunFlags();');
   assert.notEqual(setIdx, -1, 'chrome: switchToTab should set the visible tab before restoring chat');
   assert.notEqual(loadIdx, -1, 'chrome: switchToTab should load persisted tab chat asynchronously');
   assert.notEqual(guardIdx, -1, 'chrome: stale async tab-chat restores should be dropped');
@@ -7173,25 +7251,25 @@ test('chrome sidepanel drops stale async tab-chat restores', () => {
   assert.notEqual(consumeIdx, -1, 'chrome: switchToTab context-menu consume point missing');
   assert.notEqual(flushIdx, -1, 'chrome: switchToTab should flush rendered chat before changing tabs');
   assert.notEqual(historyFlushIdx, -1, 'chrome: switchToTab should flush rendered history before changing tabs');
-  assert.notEqual(postFlushProcessingIdx, -1, 'chrome: switchToTab should recheck processing after the async flush yields');
-  assert.notEqual(postFlushPendingIdx, -1, 'chrome: switchToTab should defer the requested tab switch if a run starts during the flush');
-  assert.notEqual(postFlushReturnIdx, -1, 'chrome: switchToTab should stop before changing currentTabId when a run starts during the flush');
-  assert.equal(flushIdx < postFlushProcessingIdx && postFlushProcessingIdx < postFlushPendingIdx && postFlushPendingIdx < postFlushReturnIdx && postFlushReturnIdx < setIdx, true, 'chrome: post-flush processing recheck must happen before currentTabId changes');
+  assert.notEqual(syncRunFlagsIdx, -1, 'chrome: switchToTab should restore the destination tab run flags');
+  assert.doesNotMatch(body, /if \(isProcessing\)[\s\S]*?pendingTabSwitch = newTabId/, 'chrome: active runs must not defer visible tab switches');
   assert.equal(flushIdx < historyFlushIdx && historyFlushIdx < setIdx, true, 'chrome: pending history snapshots should flush before currentTabId changes');
+  assert.equal(setIdx < syncRunFlagsIdx, true, 'chrome: destination run flags should load after currentTabId changes');
   assert.equal(setIdx < loadIdx && loadIdx < guardIdx && guardIdx < renderedSetIdx && renderedSetIdx < restoreIdx && guardIdx < consumeIdx, true, 'chrome: stale guard must run after async chat load and before rendered-tab/DOM/context-menu work');
   assert.match(body, /if \(renderedTabId != null\) \{[\s\S]*?const outgoingTabId = renderedTabId;[\s\S]*?await flushRenderedTabChat\(\);[\s\S]*?await flushChatHistorySnapshot\(outgoingTabId\);[\s\S]*?captureInputDraftForTab\(outgoingTabId\);[\s\S]*?\}/, 'chrome: overlapping tab switches should flush chat/history and save drafts for the tab represented by the DOM');
   assert.doesNotMatch(body, /persistTabChat\(currentTabId,\s*messagesEl\.innerHTML\)|captureInputDraftForTab\(currentTabId\)/, 'chrome: overlapping tab switches must not save DOM or drafts under a pending target tab');
 });
 
-test('sidepanel queues target-tab updates during async tab switches', () => {
+test('sidepanel queues target-tab updates and suppresses non-target updates during tab switches', () => {
   for (const [label, panelRel] of [
     ['chrome', 'src/chrome/src/ui/sidepanel.js'],
     ['firefox', 'src/firefox/src/ui/sidepanel.js'],
   ]) {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
     assert.match(panel, /let tabSwitchTransitionId = null;/, `${label}: tab switches should track the tab currently being restored`);
+    assert.match(panel, /let tabSwitchGeneration = 0;/, `${label}: overlapping tab switches should invalidate stale async work`);
     assert.match(panel, /let queuedTabSwitchMessages = \[\];/, `${label}: tab switches should keep target-tab messages that arrive mid-restore`);
-    assert.match(panel, /function queueAgentUpdateDuringTabSwitch\(msg\) \{[\s\S]*?const tabId = msg\?\.tabId;[\s\S]*?tabSwitchTransitionId == null[\s\S]*?tabId !== tabSwitchTransitionId[\s\S]*?return false;[\s\S]*?queuedTabSwitchMessages\.push\(msg\);[\s\S]*?return true;[\s\S]*?\}/, `${label}: target-tab messages should be queued while that tab is being restored`);
+    assert.match(panel, /function queueAgentUpdateDuringTabSwitch\(msg\) \{[\s\S]*?tabSwitchTransitionId == null \|\| tabId == null[\s\S]*?if \(tabId === tabSwitchTransitionId\) queuedTabSwitchMessages\.push\(msg\);[\s\S]*?return true;[\s\S]*?\}/, `${label}: target events should queue while non-target events are consumed during a transition`);
     assert.match(panel, /function drainQueuedAgentUpdatesForTab\(tabId\) \{[\s\S]*?queuedTabSwitchMessages = remaining;[\s\S]*?replay\.forEach\(\(msg\) => handleAgentUpdateMessage\(msg\)\);[\s\S]*?\}/, `${label}: queued target-tab messages should replay through the normal agent update handler`);
 
     const switchMatch = panel.match(/async function switchToTab\(newTabId\) \{([\s\S]*?)\n\}/);
@@ -7201,13 +7279,15 @@ test('sidepanel queues target-tab updates during async tab switches', () => {
     const flushIdx = body.indexOf('await flushRenderedTabChat();');
     const historyFlushIdx = body.indexOf('await flushChatHistorySnapshot(outgoingTabId);');
     const loadIdx = body.indexOf('const html = await loadTabChat(newTabId);');
-    const clearTransitionIdx = body.indexOf('if (tabSwitchTransitionId === newTabId) tabSwitchTransitionId = null;');
+    const clearTransitionIdx = body.indexOf('if (switchGeneration === tabSwitchGeneration && tabSwitchTransitionId === newTabId) tabSwitchTransitionId = null;');
     const replayIdx = body.indexOf('drainQueuedAgentUpdatesForTab(newTabId);');
     const consumeIdx = body.indexOf('consumePendingContextMenuPrompt()');
     assert.notEqual(markIdx, -1, `${label}: switchToTab should mark the target tab before any async flush can yield`);
     assert.notEqual(flushIdx, -1, `${label}: switchToTab flush point missing`);
     assert.notEqual(historyFlushIdx, -1, `${label}: switchToTab history flush point missing`);
     assert.notEqual(loadIdx, -1, `${label}: switchToTab restore load point missing`);
+    assert.notEqual(body.indexOf('const switchGeneration = ++tabSwitchGeneration;'), -1, `${label}: switchToTab should invalidate older overlapping transitions`);
+    assert.notEqual(body.indexOf('if (switchGeneration !== tabSwitchGeneration) return;'), -1, `${label}: stale transitions should stop after async flushes`);
     assert.notEqual(clearTransitionIdx, -1, `${label}: switchToTab should clear the transition marker after restore settles`);
     assert.notEqual(replayIdx, -1, `${label}: switchToTab should replay queued target-tab messages after restore`);
     assert.notEqual(consumeIdx, -1, `${label}: switchToTab context-menu consume point missing`);
@@ -7247,7 +7327,7 @@ test('sidepanel hydrates restored history ids before fallback records', () => {
     const loadIdx = switchBody.indexOf('const html = await loadTabChat(newTabId);');
     const restoredHasUserIdx = switchBody.indexOf('if (html) {');
     const hydrateRestoredIdx = switchBody.indexOf('await hydrateRestoredChatHistory(newTabId, html);');
-    const postHydrateGuardIdx = switchBody.indexOf('if (currentTabId !== newTabId) return;', hydrateRestoredIdx);
+    const postHydrateGuardIdx = switchBody.indexOf('if (switchGeneration !== tabSwitchGeneration || currentTabId !== newTabId) return;', hydrateRestoredIdx);
     const restoreDomIdx = switchBody.indexOf('messagesEl.innerHTML = html;');
     assert.notEqual(loadIdx, -1, `${label}: switchToTab should load persisted tab chat`);
     assert.notEqual(restoredHasUserIdx, -1, `${label}: switchToTab should detect restored user chats before DOM insertion`);
@@ -7378,7 +7458,7 @@ test('chrome sidepanel persists tab chat to the tab captured before debounce', (
   assert.doesNotMatch(body, /persistTabChat\(currentTabId,\s*messagesEl\.innerHTML\)/, 'chrome: debounced persistence should not save live DOM under the later currentTabId');
 });
 
-test('sidepanel flushes completed run chat before deferred tab switches', () => {
+test('sidepanel flushes run chat before queue settlement after immediate tab switches', () => {
   for (const [label, panelRel] of [
     ['chrome', 'src/chrome/src/ui/sidepanel.js'],
     ['firefox', 'src/firefox/src/ui/sidepanel.js'],
@@ -7411,7 +7491,7 @@ test('sidepanel flushes completed run chat before deferred tab switches', () => 
     assert.notEqual(continueDrainIdx, -1, `${label}: Continue completion should drain pending tab switches`);
     assert.equal(continueFlushIdx < continueDrainIdx, true, `${label}: Continue completion must flush before deferred tab switching`);
 
-    const scheduledStart = panel.search(/(?:async\s+)?function settleScheduledRun\(event, job\)/);
+    const scheduledStart = panel.search(/(?:async\s+)?function settleScheduledRun\(event, job, tabId = currentTabId\)/);
     const scheduledEnd = panel.search(/(?:async\s+)?function handleScheduledJobEvent\(data, tabId\)/);
     assert.notEqual(scheduledStart, -1, `${label}: scheduled settlement helper missing`);
     assert.notEqual(scheduledEnd, -1, `${label}: scheduled event handler boundary missing`);
@@ -7424,7 +7504,7 @@ test('sidepanel flushes completed run chat before deferred tab switches', () => 
     assert.notEqual(scheduledDrainIdx, -1, `${label}: scheduled completion should drain pending tab switches`);
     assert.equal(scheduledFlushIdx < scheduledDrainIdx, true, `${label}: scheduled completion must flush before deferred tab switching`);
 
-    const abortMatch = panel.match(/setTimeout\(async \(\) => \{[\s\S]*?if \(abortRequested\) \{([\s\S]*?)\n    \}\n  \}, 3000\);/);
+    const abortMatch = panel.match(/setTimeout\(async \(\) => \{[\s\S]*?if \(isTabAbortRequested\(tabId\)\) \{([\s\S]*?)\n    \}\n  \}, 3000\);/);
     assert.ok(abortMatch, `${label}: abort safety timeout body missing`);
     const abortBody = abortMatch[1];
     const abortFlushIdx = abortBody.indexOf('flushRenderedTabChat()');
@@ -8365,12 +8445,12 @@ test('sidepanel preserves stale residual slash-command prompts without hidden ru
     );
     assert.match(
       sendBody,
-      /if \(!text\) \{[\s\S]*?return;[\s\S]*?\}\s*isProcessing = true;\s*abortRequested = false;\s*inputEl\.value = '';\s*autoResizeInput\(\);\s*syncSendButtonState\(\);\s*await prepareChatHistoryForTurn\(tabId, modeForSend\);/,
+      /if \(!text\) \{[\s\S]*?return;[\s\S]*?\}\s*setTabProcessing\(tabId, true\);\s*setTabAbortRequested\(tabId, false\);\s*inputEl\.value = '';\s*autoResizeInput\(\);\s*syncSendButtonState\(\);\s*await prepareChatHistoryForTurn\(tabId, modeForSend\);/,
       `${label}: send should enter a busy state and clear the composer before async history hydration`,
     );
     assert.match(
       sendBody,
-      /await prepareChatHistoryForTurn\(tabId, modeForSend\);\s*if \(abortRequested\) \{[\s\S]*?isProcessing = false;[\s\S]*?abortRequested = false;[\s\S]*?syncSendButtonState\(\);[\s\S]*?return false;[\s\S]*?\}[\s\S]*?renderToCurrentTab = sameTabId\(currentTabId, tabId\) && sameTabId\(renderedTabId, tabId\);/,
+      /await prepareChatHistoryForTurn\(tabId, modeForSend\);\s*if \(isTabAbortRequested\(tabId\)\) \{[\s\S]*?setTabProcessing\(tabId, false\);[\s\S]*?setTabAbortRequested\(tabId, false\);[\s\S]*?syncSendButtonState\(\);[\s\S]*?return false;[\s\S]*?\}[\s\S]*?renderToCurrentTab = sameTabId\(currentTabId, tabId\) && sameTabId\(renderedTabId, tabId\);/,
       `${label}: aborted sends during history hydration should stop before chat dispatch`,
     );
     const staleReturnIdx = sendBody.indexOf('if (!renderToCurrentTab) {');
@@ -8380,7 +8460,7 @@ test('sidepanel preserves stale residual slash-command prompts without hidden ru
     assert.equal(staleReturnIdx < sendIdx, true, `${label}: stale-tab residual guard must run before chat dispatch`);
     assert.match(
       sendBody,
-      /if \(renderToCurrentTab\) \{\s*isProcessing = true;\s*abortRequested = false;\s*syncSendButtonState\(\);[\s\S]*?addMessage\('user', text\);[\s\S]*?currentAssistantEl = assistantEl;[\s\S]*?\}/,
+      /if \(renderToCurrentTab\) \{\s*setTabProcessing\(tabId, true\);\s*setTabAbortRequested\(tabId, false\);\s*syncSendButtonState\(\);[\s\S]*?addMessage\('user', text\);[\s\S]*?currentAssistantEl = assistantEl;[\s\S]*?\}/,
       `${label}: stale-tab residual sends should not mutate or render chat UI in the currently visible tab`,
     );
     assert.doesNotMatch(
@@ -8454,22 +8534,22 @@ test('sidepanel keeps retry metadata long enough for returned error updates', ()
     );
     assert.match(
       source,
-      /else if \(event === 'running'\) \{[\s\S]*?clearActiveChatPayloadForTab\(tabId \?\? currentTabId\);[\s\S]*?isProcessing = true;/,
+      /else if \(event === 'running'\) \{[\s\S]*?clearActiveChatPayloadForTab\(runTabId\);[\s\S]*?setTabProcessing\(runTabId, true\);/,
       `${label}: scheduled runs should clear stale chat retry metadata before starting`,
     );
     assert.match(
       source,
-      /function reattachPlanReviewActiveRun\(card\) \{[\s\S]*?clearActiveChatPayloadForTab\(currentTabId\);[\s\S]*?isProcessing = true;/,
+      /function reattachPlanReviewActiveRun\(card\) \{[\s\S]*?clearActiveChatPayloadForTab\(tabId\);[\s\S]*?setTabProcessing\(tabId, true\);/,
       `${label}: plan review resumes should clear stale chat retry metadata before starting`,
     );
     assert.match(
       source,
-      /const isScheduledClarify = !!card\.dataset\.scheduledJobId;[\s\S]*?if \(isScheduledClarify\) \{[\s\S]*?clearActiveChatPayloadForTab\(tabId\);[\s\S]*?isProcessing = true;/,
+      /const isScheduledClarify = !!card\.dataset\.scheduledJobId;[\s\S]*?if \(isScheduledClarify\) \{[\s\S]*?clearActiveChatPayloadForTab\(tabId\);[\s\S]*?setTabProcessing\(tabId, true\);/,
       `${label}: scheduled clarify resumes should clear stale chat retry metadata before starting`,
     );
     assert.match(
       source,
-      /async function continueAgent\(\) \{[\s\S]*?const tabId = currentTabId;[\s\S]*?clearActiveChatPayloadForTab\(tabId\);[\s\S]*?isProcessing = true;/,
+      /async function continueAgent\(\) \{[\s\S]*?const tabId = currentTabId;[\s\S]*?clearActiveChatPayloadForTab\(tabId\);[\s\S]*?setTabProcessing\(tabId, true\);/,
       `${label}: Continue runs should clear stale chat retry metadata before starting`,
     );
   }
@@ -8618,7 +8698,7 @@ test('sidepanel continue runs use the initiating tab state', () => {
     assert.match(body, /const tabId = currentTabId;[\s\S]*?const modeForSend = agentMode;[\s\S]*?sendToBackground\('continue', \{[\s\S]*?tabId,[\s\S]*?mode: modeForSend,/, `${label}: Continue should send with the tab and mode captured before awaiting`);
     assert.doesNotMatch(body, /sendToBackground\('continue', \{[\s\S]*?tabId: currentTabId/, `${label}: Continue should not read currentTabId inside the async send payload`);
     assert.doesNotMatch(body, /sendToBackground\('continue', \{[\s\S]*?mode: agentMode/, `${label}: Continue should not read agentMode inside the async send payload`);
-    assert.match(body, /await prepareChatHistoryForTurn\(tabId, modeForSend\);[\s\S]*?if \(abortRequested\) return false;[\s\S]*?if \(!sameTabId\(currentTabId, tabId\) \|\| !sameTabId\(renderedTabId, tabId\)\) return false;[\s\S]*?assistantEl = addMessage\('assistant', ''\);/, `${label}: Continue should hydrate history, honor aborts, and re-check the initiating tab before rendering`);
+    assert.match(body, /await prepareChatHistoryForTurn\(tabId, modeForSend\);[\s\S]*?if \(isTabAbortRequested\(tabId\)\) return false;[\s\S]*?if \(!sameTabId\(currentTabId, tabId\) \|\| !sameTabId\(renderedTabId, tabId\)\) return false;[\s\S]*?assistantEl = addMessage\('assistant', ''\);/, `${label}: Continue should hydrate history, honor aborts, and re-check the initiating tab before rendering`);
     assert.match(body, /let assistantEl = null;[\s\S]*?assistantEl = addMessage\('assistant', ''\);[\s\S]*?currentAssistantEl = assistantEl;[\s\S]*?if \(currentTabId === tabId && res\?\.content && assistantEl\) \{[\s\S]*?addMessageCopyButton\(assistantEl\);/, `${label}: Continue should render only into its captured assistant bubble for the initiating tab`);
     assert.match(body, /if \(currentTabId === tabId && assistantEl\) finalizeSteps\(assistantEl\);[\s\S]*?if \(currentAssistantEl === assistantEl\) currentAssistantEl = null;/, `${label}: Continue should finalize and clear only its captured assistant bubble`);
   }
@@ -8638,7 +8718,7 @@ test('sidepanel drains queued context-menu prompts after pending tab switches on
       const match = panel.match(pattern);
       assert.ok(match, `${label}: ${fnName} finally block missing`);
       const finallyBody = match[1];
-      const idleIdx = finallyBody.indexOf('isProcessing = false;');
+      const idleIdx = finallyBody.indexOf('setTabProcessing(tabId, false);');
       const helperIdx = finallyBody.indexOf('await drainQueuedContextMenuPromptsAfterPendingTabSwitch();');
       assert.notEqual(idleIdx, -1, `${label}: ${fnName} should clear processing state`);
       assert.notEqual(helperIdx, -1, `${label}: ${fnName} completion should apply pending tab switches before draining queued prompts`);
@@ -8655,10 +8735,10 @@ test('sidepanel abort safety timeout drains queued prompts after pending tab swi
     ['firefox', 'src/firefox/src/ui/sidepanel.js'],
   ]) {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
-    const match = panel.match(/setTimeout\(async \(\) => \{[\s\S]*?if \(abortRequested\) \{([\s\S]*?)\n    \}\n  \}, 3000\);/);
+    const match = panel.match(/setTimeout\(async \(\) => \{[\s\S]*?if \(isTabAbortRequested\(tabId\)\) \{([\s\S]*?)\n    \}\n  \}, 3000\);/);
     assert.ok(match, `${label}: abort safety timeout body missing`);
     const body = match[1];
-    const idleIdx = body.indexOf('isProcessing = false;');
+    const idleIdx = body.indexOf('setTabProcessing(tabId, false);');
     const helperIdx = body.indexOf('await drainQueuedContextMenuPromptsAfterPendingTabSwitch();');
     assert.notEqual(idleIdx, -1, `${label}: abort timeout should clear processing state`);
     assert.notEqual(helperIdx, -1, `${label}: abort timeout should apply pending tab switches before draining queued prompts`);
@@ -8676,7 +8756,7 @@ test('sidepanel drains scheduled-run context-menu prompts after pending tab swit
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
     assert.match(panel, /async function drainQueuedContextMenuPromptsAfterPendingTabSwitch\(\) \{[\s\S]*?if \(pendingTabSwitch == null\) \{[\s\S]*?drainQueuedContextMenuPrompts\(\);[\s\S]*?const pending = pendingTabSwitch;[\s\S]*?pendingTabSwitch = null;[\s\S]*?try \{[\s\S]*?await switchToTab\(pending\);[\s\S]*?\} catch \{[\s\S]*?\}[\s\S]*?drainQueuedContextMenuPrompts\(\);/, `${label}: scheduled completions need a non-throwing pending-tab switch before draining context-menu prompts`);
 
-    const scheduledStart = panel.search(/(?:async\s+)?function settleScheduledRun\(event, job\)/);
+    const scheduledStart = panel.search(/(?:async\s+)?function settleScheduledRun\(event, job, tabId = currentTabId\)/);
     const scheduledEnd = panel.indexOf('if (scheduledJobsEl)', scheduledStart);
     assert.notEqual(scheduledStart, -1, `${label}: scheduled run settlement helper missing`);
     assert.notEqual(scheduledEnd, -1, `${label}: scheduled job event block missing`);
@@ -8695,7 +8775,7 @@ test('sidepanel drains scheduled-clarify rejection prompts after pending tab swi
     const match = panel.match(/sendToBackground\('clarify_response', clarifyPayload\)\s*\.catch\(\(\) => \{\s*if \(isScheduledClarify\) \{([\s\S]*?)\n      \}\s*\/\* background may be torn down/);
     assert.ok(match, `${label}: scheduled clarify rejection handler missing`);
     const body = match[1];
-    const idleIdx = body.indexOf('isProcessing = false;');
+    const idleIdx = body.indexOf('setTabProcessing(tabId, false);');
     const drainIdx = body.indexOf('drainQueuedContextMenuPromptsAfterPendingTabSwitch();');
     assert.notEqual(idleIdx, -1, `${label}: scheduled clarify rejection should clear processing state`);
     assert.notEqual(drainIdx, -1, `${label}: scheduled clarify rejection should apply pending tab switches before draining`);
@@ -20532,6 +20612,136 @@ test('planner gate: background exposes pending plan state for restored sidepanel
     assert.match(agentSource, /pendingPlan:[\s\S]*?null/, `${label}: active run state should include pendingPlan`);
     assert.match(agentSource, /tabPending\.set\(planId, \{ resolve, ts: Date\.now\(\), plan, markdown, verboseMarkdown \}\)/, `${label}: pending plans should keep renderable metadata`);
     assert.match(bgSource, /case 'agent_run_state':[\s\S]*?agent\.activeRunState\(tabId\)/, `${label}: background should expose active run state to the sidepanel`);
+  }
+});
+
+test('run UI journal: mocked tab switching keeps plans and progress scoped to their origin tab', () => {
+  for (const [label, Journal] of [['chrome', RunUiJournalCh], ['firefox', RunUiJournalFx]]) {
+    const journal = new Journal();
+    const gmailTab = 41;
+    const githubTab = 42;
+    const gmailRequest = 'gmail-request';
+    const githubRequest = 'github-request';
+    const mounted = [];
+    let currentTabId = githubTab;
+
+    const deliver = (tabId, requestId, type, data, runId) => {
+      const event = journal.record(tabId, requestId, type, data, runId);
+      const message = { tabId, requestId, runId, type, data, seq: event?.seq };
+      // This is the side-panel runtime routing contract: live events from a
+      // hidden tab are journaled but never mounted in the visible tab.
+      if (message.tabId === currentTabId) mounted.push(message);
+    };
+
+    journal.begin(gmailTab, gmailRequest);
+    deliver(gmailTab, gmailRequest, 'plan_review', { planId: 'gmail-plan', markdown: 'Gmail plan' }, 'gmail-run');
+    journal.begin(githubTab, githubRequest);
+    deliver(githubTab, githubRequest, 'thinking', { content: 'Reading GitHub' }, 'github-run');
+
+    assert.deepEqual(mounted.map(event => event.data?.content), ['Reading GitHub'], `${label}: GitHub must not mount Gmail's plan`);
+    assert.equal(journal.get(gmailTab).status, 'awaiting_plan', `${label}: hidden Gmail plan should remain pending`);
+    assert.equal(journal.get(githubTab).status, 'running', `${label}: GitHub should keep its own run state`);
+
+    currentTabId = gmailTab;
+    const lastRenderedSeq = 0;
+    const replay = journal.get(gmailTab).events.filter(event => event.seq > lastRenderedSeq);
+    assert.deepEqual(replay.map(event => event.data.planId), ['gmail-plan'], `${label}: returning to Gmail should replay its plan exactly once`);
+
+    deliver(gmailTab, gmailRequest, 'plan_resolved', { planId: 'gmail-plan', decision: 'approve' }, 'gmail-run');
+    assert.equal(journal.get(gmailTab).status, 'running', `${label}: resolving the plan should make restored copies non-pending`);
+    assert.equal(journal.get(gmailTab).events.at(-1).type, 'plan_resolved', `${label}: plan resolution should be journaled for every mounted copy`);
+  }
+});
+
+test('run UI journal: concurrent tabs, bounded replay, terminal snapshots, and stale requests are isolated', () => {
+  for (const [label, Journal] of [['chrome', RunUiJournalCh], ['firefox', RunUiJournalFx]]) {
+    const persisted = new Map();
+    const journal = new Journal({ eventLimit: 3, onChange: (tabId, snapshot) => persisted.set(tabId, structuredClone(snapshot)) });
+    journal.begin(1, 'request-a');
+    journal.begin(2, 'request-b');
+    journal.record(1, 'request-a', 'thinking', { content: 'a1' }, 'run-a');
+    journal.record(2, 'request-b', 'thinking', { content: 'b1' }, 'run-b');
+    journal.record(1, 'request-a', 'thinking', { content: 'a2' }, 'run-a');
+    journal.record(1, 'request-a', 'thinking', { content: 'a3' }, 'run-a');
+    journal.record(1, 'request-a', 'thinking', { content: 'a4' }, 'run-a');
+
+    assert.equal(journal.get(1).events.length, 3, `${label}: replay journal should remain bounded`);
+    assert.equal(journal.get(1).truncatedBeforeSeq, 1, `${label}: compaction should expose the missing sequence boundary`);
+    assert.deepEqual(journal.get(2).events.map(event => event.data.content), ['b1'], `${label}: tab B events must remain independent`);
+    assert.equal(journal.record(1, 'stale-request', 'plan_review', { planId: 'stale' }, 'run-stale'), null, `${label}: stale request events must be rejected`);
+
+    journal.finish(1, 'request-a', 'completed', 'A finished', 'run-a');
+    assert.equal(journal.get(1).status, 'completed', `${label}: hidden completion should persist a terminal state`);
+    assert.equal(journal.get(1).finalContent, 'A finished', `${label}: hidden completion should persist final content`);
+    assert.equal(journal.get(1).events.at(-1).type, 'run_complete', `${label}: terminal completion should receive the next ordered sequence`);
+    assert.equal(journal.get(2).status, 'running', `${label}: completing tab A must not stop tab B`);
+
+    const terminalSeq = journal.get(1).seq;
+    assert.ok(journal.acknowledge(1, 'request-a', terminalSeq), `${label}: the rendered tab should acknowledge replay`);
+    assert.equal(journal.get(1).events.length, 0, `${label}: acknowledged replay events should be released`);
+    assert.equal(journal.get(1).finalContent, 'A finished', `${label}: acknowledgement must retain the terminal snapshot`);
+
+    const remounted = new Journal();
+    remounted.restore(1, persisted.get(1));
+    assert.equal(remounted.get(1).finalContent, 'A finished', `${label}: service-worker/panel remount should restore the terminal snapshot`);
+  }
+});
+
+test('plan review: cancellation emits plan_resolved and timeout has an explicit terminal decision', async () => {
+  await withPlannerBrowserGlobals(async () => {
+    for (const [label, AgentClass, sourceRel] of [
+      ['chrome', AgentCh, 'src/chrome/src/agent/agent.js'],
+      ['firefox', AgentFx, 'src/firefox/src/agent/agent.js'],
+    ]) {
+      const tabId = label === 'chrome' ? 9301 : 9302;
+      const agent = new AgentClass({ getActive: () => ({}) });
+      const updates = [];
+      const waiting = agent._waitForPlanReview(
+        tabId,
+        'plan-1',
+        { steps: [] },
+        'Plan',
+        (type, data) => updates.push({ type, data }),
+      );
+      agent._cancelPendingPlans(tabId, 'Stopped by user');
+      const result = await waiting;
+      assert.equal(result.cancelled, true, `${label}: abort should cancel the pending plan`);
+      assert.deepEqual(updates.map(update => update.type), ['plan_review', 'plan_resolved'], `${label}: abort should invalidate all plan copies`);
+      assert.equal(updates.at(-1).data.decision, 'cancelled', `${label}: abort should have an explicit resolution`);
+
+      const source = fs.readFileSync(path.join(ROOT, sourceRel), 'utf8');
+      assert.match(source, /response\.reason === 'plan review timed out' \? 'timeout' : 'cancelled'/, `${label}: timeout should emit an explicit plan resolution`);
+    }
+  });
+});
+
+test('per-tab run UI protocol is wired into both backgrounds and side panels', () => {
+  for (const [label, bgRel, panelRel] of [
+    ['chrome', 'src/chrome/src/background.js', 'src/chrome/src/ui/sidepanel.js'],
+    ['firefox', 'src/firefox/src/background.js', 'src/firefox/src/ui/sidepanel.js'],
+  ]) {
+    const background = fs.readFileSync(path.join(ROOT, bgRel), 'utf8');
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    assert.match(background, /new RunUiJournal\(/, `${label}: background should own the bounded run journal`);
+    assert.match(background, /function assertNoActiveTabRun\(tabId\)/, `${label}: background should prevent duplicate runs within one tab`);
+    assert.match(background, /tabId,[\s\S]*?requestId,[\s\S]*?runId:[\s\S]*?seq:/, `${label}: agent updates should carry tab, request, run, and sequence IDs`);
+    assert.match(background, /case 'agent_run_state':[\s\S]*?runUi: await getRunUiSnapshot\(tabId\)/, `${label}: remount state should include the UI journal snapshot`);
+    assert.match(background, /case 'agent_run_ack':[\s\S]*?runUiJournal\.acknowledge/, `${label}: background should accept ordered replay acknowledgements`);
+    assert.match(background, /status: snapshot\.status \|\| 'completed'/, `${label}: run_complete should carry explicit terminal status`);
+    assert.match(panel, /const processingTabs = new Set\(\);/, `${label}: processing state should be tab scoped`);
+    assert.match(panel, /const localRunRequestIds = new Map\(\);/, `${label}: local request ownership should be tab scoped`);
+    assert.match(panel, /function ensureCurrentRunAssistant\(msg\)/, `${label}: rendering should bind updates to their request bubble`);
+    assert.match(panel, /const runAssistantEl = messagesEl\.querySelector[\s\S]*?runAssistantEl\.dataset\.lastRenderedSeq = String\(event\.seq\);[\s\S]*?const renderedSeq = Number\(runAssistantEl\.dataset\.lastRenderedSeq/, `${label}: terminal replay should retain its assistant reference through acknowledgement`);
+    assert.match(panel, /const locallyOwnedEvent = [\s\S]*?if \(!locallyOwnedEvent\) \{[\s\S]*?clearPlanReviewActiveRun/, `${label}: live terminal broadcasts should not tear down their locally owned request`);
+    assert.match(panel, /const sequencedRequestAssistantEl = [\s\S]*?if \(sequencedRequestAssistantEl[\s\S]*?return;[\s\S]*?const eventAssistantEl = ensureCurrentRunAssistant\(msg\);/, `${label}: duplicate queued events should be rejected before rebinding the completed assistant as current`);
+    assert.match(panel, /Number\(event\?\.seq \|\| 0\) <= lastRenderedSeq\) continue;/, `${label}: remount should replay only unseen events`);
+    assert.match(panel, /Number\(eventAssistantEl\.dataset\.lastRenderedSeq \|\| 0\) >= Number\(msg\.seq\)\) return;/, `${label}: queued and journaled events should be sequence-deduplicated`);
+    assert.match(panel, /sendToBackground\('agent_run_ack'/, `${label}: the correct mounted tab should acknowledge replay`);
+    assert.match(panel, /function invalidatePlanReviewCards\(/, `${label}: plan copies should be invalidated by tab and run identity`);
+    assert.match(panel, /const pendingPlanMatchesRun =/, `${label}: restored plan cards should require an exact live journal match`);
+    assert.match(panel, /card\.dataset\.runRequestId/, `${label}: plan cards should store their request identity`);
+    assert.match(panel, /else if \(event === 'running'\) \{[\s\S]*?setTabProcessing\(runTabId, true\);[\s\S]*?setTabAbortRequested\(runTabId, false\);/, `${label}: scheduled runs should participate in tab-scoped stop state`);
+    assert.match(panel, /const switchGeneration = \+\+tabSwitchGeneration;[\s\S]*?if \(switchGeneration !== tabSwitchGeneration\) return;/, `${label}: overlapping tab switches should cancel stale async transitions`);
   }
 });
 


### PR DESCRIPTION
## Summary

- add a generic accessibility-tree inspection guard that warns on suspicious ref/page walking and hard-stops runaway reads
- tighten generic AX tool guidance and add supplemental Gmail large-tree guidance
- replace panel-wide interactive run state with per-tab request/run state in Chrome and Firefox
- journal bounded, ordered UI events in background session storage and replay/acknowledge them on the correct tab
- scope plan cards to tab/request/run/plan identities and invalidate them on resolution, timeout, abort, or completion
- support immediate tab switching and concurrent runs across different tabs without redirecting updates
- make rapid switches generation-safe and preserve local/scheduled run ownership during completion and Stop handling

## Root cause

The model could enumerate changing accessibility refs without triggering the existing exact-call loop detector. Separately, side-panel processing state and the active assistant bubble were shared across tabs, so switching tabs during a run could render an origin tab's pending plan or progress into the destination tab.

## Impact

Large applications such as Gmail, Slack, Notion, and GitHub now receive generic cost containment for AX inspection loops. Each browser tab owns its chat, active run, approval state, replay cursor, and Stop target, while hidden runs continue safely in the background.

Chrome and Firefox implementations are kept in parity.

## Validation

- `npm test`: 733/733 tests passed
- injection corpus: 60/60 checks passed
- syntax checks passed for both browser builds
- `git diff --check` passed
