### PR TITLE
Fix Gmail compose recipient detection

### DIFF
--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -317,7 +317,7 @@ Injected before `content.js` via `content_scripts`. Exposes three globals on `wi
 ### What makes the tree useful for small models
 
 - **Overlay hoisting.** Open dialogs / listboxes / menus / `[aria-expanded=true]` comboboxes are emitted first under an `[open overlays]` banner so portal-rendered popups (React / Radix / Stripe) survive the 3000-char soft cap.
-- **Accessible-name resolution** (`getAccessibleName`): priority is `<select>` selected option → `aria-label` → `aria-labelledby` (concatenates all referenced ids) → `placeholder` → `title` → `alt` → `<label for>` → input `value` (submit/button/reset only, never for text inputs — those emit `value="..."` separately) → direct text → `innerText` fallback for buttons/links/summary → `innerText` fallback for option/menuitem/tab/listitem/row/gridcell/cell → preceding-sibling text for unlabeled form fields ("Every 1 month(s)" pattern) → direct-text fallback.
+- **Accessible-name resolution** (`getAccessibleName`): priority is `<select>` selected option → `aria-label` → `aria-labelledby` (concatenates all referenced ids) → `placeholder` → `title` → `alt` → `<label for>` → input `value` (submit/button/reset only, never for text inputs — those emit `value="..."` separately) → direct text → `innerText` fallback for buttons/links/summary → `innerText` fallback for option/menuitem/tab/listitem/row/gridcell/cell → short visible descendant text for focusable, leaf-like generic token/chip wrappers → preceding-sibling text for unlabeled form fields ("Every 1 month(s)" pattern) → direct-text fallback.
 - **`ref_id` stability.** WeakRef-backed registry with a monotonic counter means a ref you saw three turns ago still works if the element survived.
 
 ### AX tools (content-script handlers)

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15634,6 +15634,7 @@ const ADAPTERS = [
     match: (url) => /^https?:\/\/mail\.google\.com\//.test(url),
     notes: `
 - Composing: the "Compose" button opens a floating window. The "To" field is a contact picker — type the name and pick from the dropdown, don't just type the raw email.
+- In an already-open compose, Gmail may hide the "To recipients" combobox after turning the selected contact into a named focusable generic/chip immediately above Subject. If that chip matches the requested contact, treat the recipient as confirmed and proceed directly to Subject and Message Body. Never enumerate the compose form's generic sibling ref_ids to find the hidden To field. If neither a named chip nor a visible To field exists, focus the recipient row once and re-read the visible/interactive tree.
 - The body is a contenteditable div (rich text), not a textarea. Click into it before typing.
 - Sending: the "Send" button is bottom-left of the compose window; "Send + Schedule" arrow is next to it for scheduled send.
 - Search uses operators: from:, to:, subject:, has:attachment, before:YYYY/MM/DD.

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -91,6 +91,55 @@
     return TAG_ROLES[tag] || 'generic';
   }
 
+  const NESTED_ACTION_SELECTOR = [
+    'a', 'button', 'input', 'select', 'textarea', 'details', 'summary',
+    '[onclick]', '[tabindex]', '[contenteditable="true"]',
+    '[role="button"]', '[role="link"]', '[role="textbox"]',
+    '[role="searchbox"]', '[role="combobox"]', '[role="option"]',
+    '[role="menuitem"]', '[role="tab"]', '[role="checkbox"]', '[role="radio"]',
+  ].join(',');
+
+  function rectsOverlap(a, b) {
+    return a.right > b.left && a.left < b.right && a.bottom > b.top && a.top < b.bottom;
+  }
+
+  function getVisibleDescendantText(root) {
+    const rootRect = root.getBoundingClientRect();
+    const parts = [];
+    const visit = (parent) => {
+      for (const child of parent.childNodes) {
+        if (child.nodeType === Node.TEXT_NODE) {
+          const text = String(child.textContent || '').replace(/\s+/g, ' ').trim();
+          if (text) parts.push(text);
+          continue;
+        }
+        if (child.nodeType !== Node.ELEMENT_NODE) continue;
+        if (child.getAttribute('aria-hidden') === 'true') continue;
+        if (!isVisible(child) || !isInViewport(child)) continue;
+        if (!rectsOverlap(rootRect, child.getBoundingClientRect())) continue;
+        visit(child);
+      }
+    };
+    visit(root);
+    return parts.join(' ').replace(/\s+/g, ' ').trim();
+  }
+
+  function getFocusableGenericDescendantName(el) {
+    if (getRole(el) !== 'generic' || !el.hasAttribute('tabindex')) return '';
+    if (el.getAttribute('contenteditable') === 'true') return '';
+    try {
+      if (!isVisible(el) || el.querySelector(NESTED_ACTION_SELECTOR)) return '';
+      // Inspect each descendant instead of using innerText: browsers include
+      // opacity:0 and offscreen content in innerText, which would leak hidden
+      // picker state (or hidden prompt text) into a visible token/chip label.
+      const text = getVisibleDescendantText(el);
+      if (!text || text.length > MAX_NAME_LEN) return '';
+      return text;
+    } catch {
+      return '';
+    }
+  }
+
   // ── Accessible name (matches Claude's priority order) ───────────────────
   function getAccessibleName(el) {
     const tag = el.tagName.toLowerCase();
@@ -195,6 +244,15 @@
       const s = (el.innerText || el.textContent || '').trim();
       if (s) return s.length > MAX_NAME_LEN ? s.substring(0, MAX_NAME_LEN) + '...' : s;
     }
+
+    // Tokenized inputs often replace their real textbox/combobox with a
+    // focusable generic wrapper once a value is selected. Gmail recipient
+    // chips are one example: the visible contact label lives in a nested
+    // span while the actual "To recipients" input becomes 0x0. Preserve the
+    // short visible label only for leaf-like wrappers so large composite
+    // containers do not absorb all of their descendants' text.
+    const focusableGenericName = getFocusableGenericDescendantName(el);
+    if (focusableGenericName) return focusableGenericName;
 
     // Form fields without an explicit label (aria-label, aria-labelledby,
     // placeholder, title, <label for>) often sit next to a small text node or

--- a/src/chrome/src/ui/run-error-dedupe.js
+++ b/src/chrome/src/ui/run-error-dedupe.js
@@ -1,0 +1,34 @@
+export function normalizeRunErrorMessage(message) {
+  return String(message || '').replace(/\s+/g, ' ').trim() || 'unknown error';
+}
+
+export function runErrorIdentity(tabId, requestId, messageKey) {
+  return JSON.stringify([
+    String(tabId ?? ''),
+    String(requestId || ''),
+    String(messageKey || ''),
+  ]);
+}
+
+export function claimRunError({
+  seenErrors = null,
+  renderedErrors = [],
+  tabId,
+  requestId,
+  message,
+} = {}) {
+  const scopedTabId = String(tabId ?? '');
+  const scopedRequestId = String(requestId || '');
+  const key = normalizeRunErrorMessage(message);
+  const identity = runErrorIdentity(scopedTabId, scopedRequestId, key);
+  const duplicate = !!scopedRequestId && (
+    seenErrors?.has(identity)
+    || renderedErrors.some(rendered => (
+      String(rendered?.tabId ?? '') === scopedTabId
+      && String(rendered?.requestId || '') === scopedRequestId
+      && String(rendered?.key || '') === key
+    ))
+  );
+  if (!duplicate && scopedRequestId) seenErrors?.add(identity);
+  return { duplicate, identity, key, tabId: scopedTabId, requestId: scopedRequestId };
+}

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -9,6 +9,7 @@ import { applyMode, loadMode, watch } from './theme.js';
 import { buildRecommendedActions, shouldShowRecommendedActions } from './recommended-actions.js';
 import { createContextMenuPromptHandler } from './context-menu-prompts.js';
 import { deleteChatHistoryRecord, saveChatHistoryRecord } from './chat-history-store.js';
+import { claimRunError } from './run-error-dedupe.js';
 import {
   STORAGE_KEY as STORE_REVIEW_STORAGE_KEY,
   recordSuccessfulTask,
@@ -2971,27 +2972,35 @@ function rebindRetryButtons() {
   document.querySelectorAll('.error-retry-btn').forEach(bindErrorRetryButton);
 }
 
-function createActiveChatPayloadState(retryPayload) {
-  return { retryPayload, renderedErrorMessages: new Set() };
+function createActiveChatPayloadState(retryPayload, requestId = '') {
+  return {
+    retryPayload,
+    requestId: String(requestId || ''),
+    renderedErrorMessages: new Set(),
+  };
 }
 
 function clearActiveChatPayloadForTab(tabId) {
   if (tabId != null) activeChatPayloadsByTab.delete(tabId);
 }
 
-function errorMessageKey(message) {
-  return String(message || '').trim() || 'unknown error';
-}
-
-function takeActiveRetryPayloadForError(tabId, message) {
+function takeActiveRetryPayloadForError(tabId, requestId, message) {
   const state = activeChatPayloadsByTab.get(tabId);
-  if (!state?.retryPayload) return { retryPayload: null, duplicate: false };
-  const key = errorMessageKey(message);
-  if (state.renderedErrorMessages?.has(key)) {
-    return { retryPayload: state.retryPayload, duplicate: true };
-  }
-  state.renderedErrorMessages?.add(key);
-  return { retryPayload: state.retryPayload, duplicate: false };
+  const scopedRequestId = String(requestId || state?.requestId || '');
+  const stateMatchesRequest = !!state && (!scopedRequestId || state.requestId === scopedRequestId);
+  const renderedErrors = Array.from(messagesEl.querySelectorAll('.message.error')).map(el => ({
+    tabId: el.dataset.tabId,
+    requestId: el.dataset.runRequestId,
+    key: el.dataset.errorMessageKey,
+  }));
+  const claim = claimRunError({
+    seenErrors: stateMatchesRequest ? state.renderedErrorMessages : null,
+    renderedErrors,
+    tabId,
+    requestId: scopedRequestId,
+    message,
+  });
+  return { ...claim, retryPayload: stateMatchesRequest ? state.retryPayload : null };
 }
 
 function scheduleActiveChatPayloadCleanup(tabId, state) {
@@ -3002,11 +3011,18 @@ function scheduleActiveChatPayloadCleanup(tabId, state) {
   }, 30000);
 }
 
-function renderAgentErrorUpdate(data, tabId = currentTabId) {
+function renderAgentErrorUpdate(data, tabId = currentTabId, requestId = '') {
   const message = data?.message || data?.error || 'unknown error';
-  const active = abortRequested ? { retryPayload: null, duplicate: false } : takeActiveRetryPayloadForError(tabId, message);
+  const active = takeActiveRetryPayloadForError(tabId, requestId, message);
   if (active.duplicate) return;
-  addMessage('error', t('sp.error_prefix', { msg: message }), { retryPayload: active.retryPayload });
+  const msgEl = addMessage('error', t('sp.error_prefix', { msg: message }), {
+    retryPayload: isTabAbortRequested(tabId) ? null : active.retryPayload,
+  });
+  if (active.requestId) {
+    msgEl.dataset.tabId = active.tabId;
+    msgEl.dataset.runRequestId = active.requestId;
+    msgEl.dataset.errorMessageKey = active.key;
+  }
 }
 
 function rebindRestoredMessageControls() {
@@ -3908,7 +3924,7 @@ async function sendMessage(extraChatParams = {}) {
     assistantEl.dataset.lastRenderedSeq = '0';
     currentAssistantEl = assistantEl;
   }
-  const activePayloadState = createActiveChatPayloadState(retryPayload);
+  const activePayloadState = createActiveChatPayloadState(retryPayload, requestId);
   activeChatPayloadsByTab.set(tabId, activePayloadState);
   localRunRequestIds.set(tabId, requestId);
 
@@ -3936,7 +3952,7 @@ async function sendMessage(extraChatParams = {}) {
       ? res.updates.find(u => u?.type === 'error')
       : null;
     if (returnedErrorUpdate && renderToCurrentTab && currentTabId === tabId && !isTabAbortRequested(tabId)) {
-      renderAgentErrorUpdate(returnedErrorUpdate.data, tabId);
+      renderAgentErrorUpdate(returnedErrorUpdate.data, tabId, requestId);
     }
 
     // An unsupported-attachment rejection never records the turn in history;
@@ -3981,8 +3997,7 @@ async function sendMessage(extraChatParams = {}) {
     }
   } catch (e) {
     if (renderToCurrentTab && currentTabId === tabId && !isTabAbortRequested(tabId)) {
-      takeActiveRetryPayloadForError(tabId, e.message);
-      addMessage('error', t('sp.error_prefix', { msg: e.message }), { retryPayload });
+      renderAgentErrorUpdate({ message: e.message }, tabId, requestId);
     }
   } finally {
     if (localRunRequestIds.get(tabId) === requestId) localRunRequestIds.delete(tabId);
@@ -4359,7 +4374,7 @@ function handleAgentUpdateMessage(msg) {
     case 'error':
       hideActivity();
       if (currentAssistantEl) markLastStepFailed();
-      renderAgentErrorUpdate(data, currentTabId);
+      renderAgentErrorUpdate(data, currentTabId, msg.requestId);
       break;
 
     case 'max_steps_reached':

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15634,6 +15634,7 @@ const ADAPTERS = [
     match: (url) => /^https?:\/\/mail\.google\.com\//.test(url),
     notes: `
 - Composing: the "Compose" button opens a floating window. The "To" field is a contact picker — type the name and pick from the dropdown, don't just type the raw email.
+- In an already-open compose, Gmail may hide the "To recipients" combobox after turning the selected contact into a named focusable generic/chip immediately above Subject. If that chip matches the requested contact, treat the recipient as confirmed and proceed directly to Subject and Message Body. Never enumerate the compose form's generic sibling ref_ids to find the hidden To field. If neither a named chip nor a visible To field exists, focus the recipient row once and re-read the visible/interactive tree.
 - The body is a contenteditable div (rich text), not a textarea. Click into it before typing.
 - Sending: the "Send" button is bottom-left of the compose window; "Send + Schedule" arrow is next to it for scheduled send.
 - Search uses operators: from:, to:, subject:, has:attachment, before:YYYY/MM/DD.

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -91,6 +91,55 @@
     return TAG_ROLES[tag] || 'generic';
   }
 
+  const NESTED_ACTION_SELECTOR = [
+    'a', 'button', 'input', 'select', 'textarea', 'details', 'summary',
+    '[onclick]', '[tabindex]', '[contenteditable="true"]',
+    '[role="button"]', '[role="link"]', '[role="textbox"]',
+    '[role="searchbox"]', '[role="combobox"]', '[role="option"]',
+    '[role="menuitem"]', '[role="tab"]', '[role="checkbox"]', '[role="radio"]',
+  ].join(',');
+
+  function rectsOverlap(a, b) {
+    return a.right > b.left && a.left < b.right && a.bottom > b.top && a.top < b.bottom;
+  }
+
+  function getVisibleDescendantText(root) {
+    const rootRect = root.getBoundingClientRect();
+    const parts = [];
+    const visit = (parent) => {
+      for (const child of parent.childNodes) {
+        if (child.nodeType === Node.TEXT_NODE) {
+          const text = String(child.textContent || '').replace(/\s+/g, ' ').trim();
+          if (text) parts.push(text);
+          continue;
+        }
+        if (child.nodeType !== Node.ELEMENT_NODE) continue;
+        if (child.getAttribute('aria-hidden') === 'true') continue;
+        if (!isVisible(child) || !isInViewport(child)) continue;
+        if (!rectsOverlap(rootRect, child.getBoundingClientRect())) continue;
+        visit(child);
+      }
+    };
+    visit(root);
+    return parts.join(' ').replace(/\s+/g, ' ').trim();
+  }
+
+  function getFocusableGenericDescendantName(el) {
+    if (getRole(el) !== 'generic' || !el.hasAttribute('tabindex')) return '';
+    if (el.getAttribute('contenteditable') === 'true') return '';
+    try {
+      if (!isVisible(el) || el.querySelector(NESTED_ACTION_SELECTOR)) return '';
+      // Inspect each descendant instead of using innerText: browsers include
+      // opacity:0 and offscreen content in innerText, which would leak hidden
+      // picker state (or hidden prompt text) into a visible token/chip label.
+      const text = getVisibleDescendantText(el);
+      if (!text || text.length > MAX_NAME_LEN) return '';
+      return text;
+    } catch {
+      return '';
+    }
+  }
+
   // ── Accessible name (matches Claude's priority order) ───────────────────
   function getAccessibleName(el) {
     const tag = el.tagName.toLowerCase();
@@ -195,6 +244,15 @@
       const s = (el.innerText || el.textContent || '').trim();
       if (s) return s.length > MAX_NAME_LEN ? s.substring(0, MAX_NAME_LEN) + '...' : s;
     }
+
+    // Tokenized inputs often replace their real textbox/combobox with a
+    // focusable generic wrapper once a value is selected. Gmail recipient
+    // chips are one example: the visible contact label lives in a nested
+    // span while the actual "To recipients" input becomes 0x0. Preserve the
+    // short visible label only for leaf-like wrappers so large composite
+    // containers do not absorb all of their descendants' text.
+    const focusableGenericName = getFocusableGenericDescendantName(el);
+    if (focusableGenericName) return focusableGenericName;
 
     // Form fields without an explicit label (aria-label, aria-labelledby,
     // placeholder, title, <label for>) often sit next to a small text node or

--- a/src/firefox/src/ui/run-error-dedupe.js
+++ b/src/firefox/src/ui/run-error-dedupe.js
@@ -1,0 +1,34 @@
+export function normalizeRunErrorMessage(message) {
+  return String(message || '').replace(/\s+/g, ' ').trim() || 'unknown error';
+}
+
+export function runErrorIdentity(tabId, requestId, messageKey) {
+  return JSON.stringify([
+    String(tabId ?? ''),
+    String(requestId || ''),
+    String(messageKey || ''),
+  ]);
+}
+
+export function claimRunError({
+  seenErrors = null,
+  renderedErrors = [],
+  tabId,
+  requestId,
+  message,
+} = {}) {
+  const scopedTabId = String(tabId ?? '');
+  const scopedRequestId = String(requestId || '');
+  const key = normalizeRunErrorMessage(message);
+  const identity = runErrorIdentity(scopedTabId, scopedRequestId, key);
+  const duplicate = !!scopedRequestId && (
+    seenErrors?.has(identity)
+    || renderedErrors.some(rendered => (
+      String(rendered?.tabId ?? '') === scopedTabId
+      && String(rendered?.requestId || '') === scopedRequestId
+      && String(rendered?.key || '') === key
+    ))
+  );
+  if (!duplicate && scopedRequestId) seenErrors?.add(identity);
+  return { duplicate, identity, key, tabId: scopedTabId, requestId: scopedRequestId };
+}

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -9,6 +9,7 @@ import { applyMode, loadMode, watch } from './theme.js';
 import { buildRecommendedActions, shouldShowRecommendedActions } from './recommended-actions.js';
 import { createContextMenuPromptHandler } from './context-menu-prompts.js';
 import { deleteChatHistoryRecord, saveChatHistoryRecord } from './chat-history-store.js';
+import { claimRunError } from './run-error-dedupe.js';
 import {
   STORAGE_KEY as STORE_REVIEW_STORAGE_KEY,
   recordSuccessfulTask,
@@ -2922,27 +2923,35 @@ function rebindRetryButtons() {
   document.querySelectorAll('.error-retry-btn').forEach(bindErrorRetryButton);
 }
 
-function createActiveChatPayloadState(retryPayload) {
-  return { retryPayload, renderedErrorMessages: new Set() };
+function createActiveChatPayloadState(retryPayload, requestId = '') {
+  return {
+    retryPayload,
+    requestId: String(requestId || ''),
+    renderedErrorMessages: new Set(),
+  };
 }
 
 function clearActiveChatPayloadForTab(tabId) {
   if (tabId != null) activeChatPayloadsByTab.delete(tabId);
 }
 
-function errorMessageKey(message) {
-  return String(message || '').trim() || 'unknown error';
-}
-
-function takeActiveRetryPayloadForError(tabId, message) {
+function takeActiveRetryPayloadForError(tabId, requestId, message) {
   const state = activeChatPayloadsByTab.get(tabId);
-  if (!state?.retryPayload) return { retryPayload: null, duplicate: false };
-  const key = errorMessageKey(message);
-  if (state.renderedErrorMessages?.has(key)) {
-    return { retryPayload: state.retryPayload, duplicate: true };
-  }
-  state.renderedErrorMessages?.add(key);
-  return { retryPayload: state.retryPayload, duplicate: false };
+  const scopedRequestId = String(requestId || state?.requestId || '');
+  const stateMatchesRequest = !!state && (!scopedRequestId || state.requestId === scopedRequestId);
+  const renderedErrors = Array.from(messagesEl.querySelectorAll('.message.error')).map(el => ({
+    tabId: el.dataset.tabId,
+    requestId: el.dataset.runRequestId,
+    key: el.dataset.errorMessageKey,
+  }));
+  const claim = claimRunError({
+    seenErrors: stateMatchesRequest ? state.renderedErrorMessages : null,
+    renderedErrors,
+    tabId,
+    requestId: scopedRequestId,
+    message,
+  });
+  return { ...claim, retryPayload: stateMatchesRequest ? state.retryPayload : null };
 }
 
 function scheduleActiveChatPayloadCleanup(tabId, state) {
@@ -2953,11 +2962,18 @@ function scheduleActiveChatPayloadCleanup(tabId, state) {
   }, 30000);
 }
 
-function renderAgentErrorUpdate(data, tabId = currentTabId) {
+function renderAgentErrorUpdate(data, tabId = currentTabId, requestId = '') {
   const message = data?.message || data?.error || 'unknown error';
-  const active = abortRequested ? { retryPayload: null, duplicate: false } : takeActiveRetryPayloadForError(tabId, message);
+  const active = takeActiveRetryPayloadForError(tabId, requestId, message);
   if (active.duplicate) return;
-  addMessage('error', t('sp.error_prefix', { msg: message }), { retryPayload: active.retryPayload });
+  const msgEl = addMessage('error', t('sp.error_prefix', { msg: message }), {
+    retryPayload: isTabAbortRequested(tabId) ? null : active.retryPayload,
+  });
+  if (active.requestId) {
+    msgEl.dataset.tabId = active.tabId;
+    msgEl.dataset.runRequestId = active.requestId;
+    msgEl.dataset.errorMessageKey = active.key;
+  }
 }
 
 function rebindRestoredMessageControls() {
@@ -3763,7 +3779,7 @@ async function sendMessage(extraChatParams = {}) {
     assistantEl.dataset.lastRenderedSeq = '0';
     currentAssistantEl = assistantEl;
   }
-  const activePayloadState = createActiveChatPayloadState(retryPayload);
+  const activePayloadState = createActiveChatPayloadState(retryPayload, requestId);
   activeChatPayloadsByTab.set(tabId, activePayloadState);
   localRunRequestIds.set(tabId, requestId);
 
@@ -3791,7 +3807,7 @@ async function sendMessage(extraChatParams = {}) {
       ? res.updates.find(u => u?.type === 'error')
       : null;
     if (returnedErrorUpdate && renderToCurrentTab && currentTabId === tabId && !isTabAbortRequested(tabId)) {
-      renderAgentErrorUpdate(returnedErrorUpdate.data, tabId);
+      renderAgentErrorUpdate(returnedErrorUpdate.data, tabId, requestId);
     }
 
     // An unsupported-attachment rejection never records the turn in history;
@@ -3836,8 +3852,7 @@ async function sendMessage(extraChatParams = {}) {
     }
   } catch (e) {
     if (renderToCurrentTab && currentTabId === tabId && !isTabAbortRequested(tabId)) {
-      takeActiveRetryPayloadForError(tabId, e.message);
-      addMessage('error', t('sp.error_prefix', { msg: e.message }), { retryPayload });
+      renderAgentErrorUpdate({ message: e.message }, tabId, requestId);
     }
   } finally {
     if (localRunRequestIds.get(tabId) === requestId) localRunRequestIds.delete(tabId);
@@ -4016,7 +4031,7 @@ function handleAgentUpdateMessage(msg) {
     case 'error':
       hideActivity();
       if (currentAssistantEl) markLastStepFailed();
-      renderAgentErrorUpdate(data, currentTabId);
+      renderAgentErrorUpdate(data, currentTabId, msg.requestId);
       break;
 
     case 'max_steps_reached':

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -20,6 +20,7 @@ import path from 'node:path';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..', '..');
 const accessibilityTreeJsPath = path.join(root, 'src', 'chrome', 'src', 'content', 'accessibility-tree.js');
+const firefoxAccessibilityTreeJsPath = path.join(root, 'src', 'firefox', 'src', 'content', 'accessibility-tree.js');
 const contentJsPath = path.join(root, 'src', 'chrome', 'src', 'content', 'content.js');
 const firefoxContentJsPath = path.join(root, 'src', 'firefox', 'src', 'content', 'content.js');
 const smdJsPath = path.join(root, 'src', 'chrome', 'src', 'agent', 'social-media-downloader.js');
@@ -66,6 +67,13 @@ async function setupFirefoxHtml(page, html) {
   await page.waitForFunction(() => typeof window.__wb_handler === 'function');
 }
 
+async function setupAccessibilityTreeHtml(page, html, sourcePath) {
+  await page.setContent(html, { waitUntil: 'domcontentloaded' });
+  const src = await readFile(sourcePath, 'utf-8');
+  await page.addScriptTag({ content: src });
+  await page.waitForFunction(() => typeof window.__generateAccessibilityTree === 'function');
+}
+
 async function call(page, action, params) {
   return page.evaluate(({ action, params }) => new Promise((resolve) => {
     const ret = window.__wb_handler(
@@ -104,6 +112,67 @@ async function collectSmd(page, mode = 'auto') {
 
 const tests = [];
 function test(name, fn) { tests.push({ name, fn }); }
+
+const gmailComposeRecipientFixture = `<!doctype html>
+  <style>
+    body { margin: 0; font: 16px sans-serif; }
+    [role="dialog"] { width: 620px; min-height: 360px; padding: 16px; }
+    .recipient { width: 500px; height: 40px; }
+    .field { display: block; width: 500px; height: 32px; margin-top: 8px; }
+    .body { width: 500px; height: 160px; margin-top: 8px; }
+    .hidden-to { position: absolute; width: 0; height: 0; opacity: 0; }
+    .hidden-wrapper { display: none; }
+  </style>
+  <div role="dialog" aria-label="Compose: New Message">
+    <div role="region" aria-label="New Message">
+      <input class="hidden-to" role="combobox" aria-label="To recipients">
+      <div class="recipient" tabindex="1">
+        <span>Alex Russell (gmail.com)</span>
+        <span style="display:none">Hidden stale recipient</span>
+        <span style="opacity:0">Opacity hidden override</span>
+        <span style="position:absolute;left:-10000px;width:200px">Offscreen hidden override</span>
+        <span aria-hidden="true">ARIA hidden override</span>
+      </div>
+      <input class="field" aria-label="Subject" placeholder="Subject">
+      <div class="body" role="textbox" contenteditable="true" aria-label="Message Body"></div>
+      <div class="composite" tabindex="0"><span>Composite controls</span><button>Remove</button></div>
+      <div class="hidden-wrapper" tabindex="0"><span>Hidden wrapper text</span></div>
+      <div class="empty" tabindex="0"><span></span></div>
+      <div class="overlong" tabindex="0"><span>${'x'.repeat(101)}</span></div>
+    </div>
+  </div>`;
+
+let chromeGmailComposeTree = '';
+
+function assertGmailComposeRecipientTree(tree, label) {
+  const content = String(tree?.pageContent || '');
+  if (!/generic "Alex Russell \(gmail\.com\)" \[ref_\d+\]/.test(content)) {
+    throw new Error(`${label}: selected recipient label missing from visible tree: ${content}`);
+  }
+  if (!/textbox "Subject" \[ref_\d+\]/.test(content)) {
+    throw new Error(`${label}: Subject missing from visible tree: ${content}`);
+  }
+  if (!/textbox "Message Body" \[ref_\d+\]/.test(content)) {
+    throw new Error(`${label}: Message Body missing from visible tree: ${content}`);
+  }
+  for (const forbidden of ['To recipients', 'Hidden stale recipient', 'Opacity hidden override', 'Offscreen hidden override', 'ARIA hidden override', 'Hidden wrapper text', 'generic "Composite controls', 'x'.repeat(101)]) {
+    if (content.includes(forbidden)) throw new Error(`${label}: tree promoted forbidden generic text: ${forbidden}`);
+  }
+  return content;
+}
+
+test('accessibility tree (Chrome): existing Gmail compose exposes the selected recipient chip', async (page) => {
+  await setupAccessibilityTreeHtml(page, gmailComposeRecipientFixture, accessibilityTreeJsPath);
+  const tree = await page.evaluate(() => window.__generateAccessibilityTree('visible', 10, null, null, 1));
+  chromeGmailComposeTree = assertGmailComposeRecipientTree(tree, 'chrome');
+});
+
+test('accessibility tree (Firefox): existing Gmail compose exposes the selected recipient chip with parity', async (page) => {
+  await setupAccessibilityTreeHtml(page, gmailComposeRecipientFixture, firefoxAccessibilityTreeJsPath);
+  const tree = await page.evaluate(() => window.__generateAccessibilityTree('visible', 10, null, null, 1));
+  const firefoxTree = assertGmailComposeRecipientTree(tree, 'firefox');
+  if (firefoxTree !== chromeGmailComposeTree) throw new Error('Chrome/Firefox Gmail compose trees differ');
+});
 
 // ─── modal-scoping ────────────────────────────────────────────────────────
 test('modal scoping: click({text:"Create"}) resolves to dialog Create', async (page) => {

--- a/test/run.js
+++ b/test/run.js
@@ -98,6 +98,12 @@ const { RunUiJournal: RunUiJournalCh } = await import(
 const { RunUiJournal: RunUiJournalFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/run-ui-journal.js').replace(/\\/g, '/')
 );
+const { claimRunError: claimRunErrorCh } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/ui/run-error-dedupe.js').replace(/\\/g, '/')
+);
+const { claimRunError: claimRunErrorFx } = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/ui/run-error-dedupe.js').replace(/\\/g, '/')
+);
 
 // anthropic.js imports cleanly under Node (its chrome.* touches are lazy); we
 // only exercise the pure _convertMessages transform here.
@@ -1212,6 +1218,14 @@ test('matches www.github.com', () => {
 test('matches gmail.com under mail.google.com', () => {
   const a = getActiveAdapter('https://mail.google.com/mail/u/0/#inbox');
   assert.equal(a?.name, 'gmail');
+  assert.match(a?.notes || '', /already-open compose/i);
+  assert.match(a?.notes || '', /named focusable generic\/chip/i);
+  assert.match(a?.notes || '', /proceed directly to Subject and Message Body/i);
+  assert.match(a?.notes || '', /Never enumerate the compose form's generic sibling ref_ids/i);
+  assert.match(a?.notes || '', /focus the recipient row once/i);
+  const firefox = getActiveAdapterFx('https://mail.google.com/mail/u/0/#inbox');
+  assert.equal(firefox?.name, 'gmail');
+  assert.equal(firefox?.notes, a?.notes);
 });
 
 test('matches google search across TLDs and includes udm=14, without hijacking other google apps', () => {
@@ -8521,7 +8535,7 @@ test('sidepanel keeps retry metadata long enough for returned error updates', ()
     const source = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
     assert.match(
       source,
-      /function createActiveChatPayloadState\(retryPayload\) \{[\s\S]*?renderedErrorMessages: new Set\(\)[\s\S]*?\}/,
+      /function createActiveChatPayloadState\(retryPayload, requestId = ''\) \{[\s\S]*?requestId: String\(requestId \|\| ''\)[\s\S]*?renderedErrorMessages: new Set\(\)[\s\S]*?\}/,
       `${label}: active retry metadata should track rendered error messages`,
     );
     assert.match(
@@ -8551,17 +8565,17 @@ test('sidepanel keeps retry metadata long enough for returned error updates', ()
     );
     assert.match(
       source,
-      /const activePayloadState = createActiveChatPayloadState\(retryPayload\);[\s\S]*?activeChatPayloadsByTab\.set\(tabId, activePayloadState\);/,
+      /const activePayloadState = createActiveChatPayloadState\(retryPayload, requestId\);[\s\S]*?activeChatPayloadsByTab\.set\(tabId, activePayloadState\);/,
       `${label}: sendMessage should store retry metadata as an active run state`,
     );
     assert.match(
       source,
-      /const returnedErrorUpdate = Array\.isArray\(res\?\.updates\)[\s\S]*?res\.updates\.find\(u => u\?\.type === 'error'\)[\s\S]*?renderAgentErrorUpdate\(returnedErrorUpdate\.data, tabId\);/,
+      /const returnedErrorUpdate = Array\.isArray\(res\?\.updates\)[\s\S]*?res\.updates\.find\(u => u\?\.type === 'error'\)[\s\S]*?renderAgentErrorUpdate\(returnedErrorUpdate\.data, tabId, requestId\);/,
       `${label}: returned agent error updates should render with retry metadata even if the broadcast is late`,
     );
     assert.match(
       source,
-      /case 'error':[\s\S]*?renderAgentErrorUpdate\(data, currentTabId\);[\s\S]*?break;/,
+      /case 'error':[\s\S]*?renderAgentErrorUpdate\(data, currentTabId, msg\.requestId\);[\s\S]*?break;/,
       `${label}: broadcast agent errors should share the retry-aware renderer`,
     );
     assert.match(
@@ -20726,6 +20740,50 @@ test('run UI journal: concurrent tabs, bounded replay, terminal snapshots, and s
     const remounted = new Journal();
     remounted.restore(1, persisted.get(1));
     assert.equal(remounted.get(1).finalContent, 'A finished', `${label}: service-worker/panel remount should restore the terminal snapshot`);
+  }
+});
+
+test('sidepanel run errors dedupe streamed, returned, and restored copies by tab and request', () => {
+  for (const [label, claimRunError] of [['chrome', claimRunErrorCh], ['firefox', claimRunErrorFx]]) {
+    const seenErrors = new Set();
+    const renderedErrors = [];
+    const base = { seenErrors, renderedErrors, tabId: 41, requestId: 'req-gmail', message: 'Stuck   in a loop.\nStopped.' };
+
+    const streamed = claimRunError(base);
+    assert.equal(streamed.duplicate, false, `${label}: first streamed error should render`);
+    renderedErrors.push({ tabId: streamed.tabId, requestId: streamed.requestId, key: streamed.key });
+
+    const returned = claimRunError({ ...base, message: 'Stuck in a loop. Stopped.' });
+    assert.equal(returned.duplicate, true, `${label}: returned copy should not render twice`);
+
+    const restored = claimRunError({
+      seenErrors: new Set(),
+      renderedErrors,
+      tabId: 41,
+      requestId: 'req-gmail',
+      message: 'Stuck in a loop. Stopped.',
+    });
+    assert.equal(restored.duplicate, true, `${label}: restored HTML should suppress replayed copies`);
+
+    assert.equal(claimRunError({ ...base, message: 'A different failure.' }).duplicate, false, `${label}: distinct errors in one run should render`);
+    assert.equal(claimRunError({ ...base, requestId: 'req-gmail-retry' }).duplicate, false, `${label}: identical errors from separate runs should render`);
+    assert.equal(claimRunError({ ...base, tabId: 42 }).duplicate, false, `${label}: identical errors from separate tabs should render`);
+  }
+});
+
+test('sidepanel routes every run-error path through request-scoped deduplication', () => {
+  for (const [label, panelRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    assert.match(panel, /import \{ claimRunError \} from '\.\/run-error-dedupe\.js';/, `${label}: sidepanel should use the shared deduper`);
+    assert.match(panel, /createActiveChatPayloadState\(retryPayload, requestId\)/, `${label}: active error state should retain request identity`);
+    assert.match(panel, /renderAgentErrorUpdate\(returnedErrorUpdate\.data, tabId, requestId\)/, `${label}: returned errors should use request-scoped rendering`);
+    assert.match(panel, /renderAgentErrorUpdate\(\{ message: e\.message \}, tabId, requestId\)/, `${label}: caught errors should use request-scoped rendering`);
+    assert.match(panel, /renderAgentErrorUpdate\(data, currentTabId, msg\.requestId\)/, `${label}: streamed errors should use message request identity`);
+    assert.match(panel, /msgEl\.dataset\.tabId = active\.tabId;[\s\S]*?msgEl\.dataset\.runRequestId = active\.requestId;[\s\S]*?msgEl\.dataset\.errorMessageKey = active\.key;/, `${label}: persisted error cards should retain their dedupe identity`);
+    assert.match(panel, /if \(active\.duplicate\) return;[\s\S]*?retryPayload: isTabAbortRequested\(tabId\) \? null : active\.retryPayload/, `${label}: only the first copy should retain the Retry action`);
   }
 });
 


### PR DESCRIPTION
## Summary

- expose selected Gmail recipient chips as named accessibility-tree nodes without relying on Gmail-specific classes or hidden metadata
- guide the Gmail adapter to recognize recipients in already-open compose windows
- deduplicate terminal side-panel errors by tab, request, and normalized message across live updates, returned responses, and restored chat
- mirror the runtime and UI changes in Chrome and Firefox

## Root cause

After Gmail selects a recipient, it hides the real `To recipients` combobox and renders the visible contact inside a focusable generic wrapper. WebBrain preserved the wrapper ref but dropped its nested visible label, so the agent searched generic sibling refs instead of acting on the already-visible Subject and Message Body fields.

The tree now promotes short visible descendant text only for focusable, leaf-like generic wrappers. Hidden, offscreen, `aria-hidden`, composite, and oversized content remains excluded.

## Validation

- `npm test`: 737/737 tests passed
- security injection corpus: 60/60 checks passed
- `npm run test:fixtures`: 27/27 browser fixtures passed
- Chrome/Firefox accessibility-tree parity checks passed
- syntax and `git diff --check` passed