### PR TITLE
Fix Gmail compose and scroll loop recovery

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15634,6 +15634,7 @@ const ADAPTERS = [
     match: (url) => /^https?:\/\/mail\.google\.com\//.test(url),
     notes: `
 - Composing: the "Compose" button opens a floating window. The "To" field is a contact picker — type the name and pick from the dropdown, don't just type the raw email.
+- For a task that explicitly starts a new email or saves a new draft, if no compose window is open and the user named a recipient, click Compose immediately and use the To contact picker. Do not inspect the current thread or search the page merely to discover the recipient's raw email first; do that only if the picker fails, returns multiple ambiguous matches, or the user explicitly asked for the address. This fast path does not apply to reply or forward tasks; use the thread's Reply/Forward controls for those.
 - In an already-open compose, Gmail may hide the "To recipients" combobox after turning the selected contact into a named focusable generic/chip immediately above Subject. If that chip matches the requested contact, treat the recipient as confirmed and proceed directly to Subject and Message Body. Never enumerate the compose form's generic sibling ref_ids to find the hidden To field. If neither a named chip nor a visible To field exists, focus the recipient row once and re-read the visible/interactive tree.
 - The body is a contenteditable div (rich text), not a textarea. Click into it before typing.
 - Sending: the "Send" button is bottom-left of the compose window; "Send + Schedule" arrow is next to it for scheduled send.

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -179,6 +179,10 @@ export class Agent {
     // A model can walk ref_1, ref_2, … forever while every call looks unique
     // to the exact-argument loop detector. Track that semantic read pattern.
     this.axReadStates = new Map(); // tabId -> { total, suspicious, nextPage, seenPages, warned }
+    // Scroll calls can keep returning success even when no pane moved. Track
+    // repeated dead-end attempts separately so changing the amount or
+    // interleaving reads cannot evade the generic loop detector.
+    this.noProgressScrolls = new Map(); // tabId -> { key, count }
     this.lastAutoScreenshotTs = new Map(); // tabId -> ms — defensive debounce
     this.lastSeenAdapter = new Map(); // tabId -> adapter name from last enrichment
     // Separate buffer for coordinate-based click attempts. The general loop
@@ -702,6 +706,7 @@ export class Agent {
     this.loopNudges.delete(tabId);
     this.healthyCallsSinceLoop.delete(tabId);
     this.axReadStates.delete(tabId);
+    this.noProgressScrolls.delete(tabId);
     this.recentCoordClicks.delete(tabId);
     this.bulkApiMutationClicks.delete(tabId);
     this.bulkApiMutationHints.delete(tabId);
@@ -763,6 +768,67 @@ export class Agent {
       return {
         kind: 'nudge',
         warning: '[ACCESSIBILITY READ LOOP: Stop enumerating sibling or generic ref_ids. If the result has hasMore/nextPage, request exactly that page. If the needed textbox/button is already visible, use set_field, type_ax, or click_ax now. Otherwise switch once to read_page/extract_data or finish with what you have. Do not call another arbitrary ref_id subtree.]',
+      };
+    }
+    return { kind: 'none' };
+  }
+
+  _noProgressScrollKey(args = {}, result = {}) {
+    const direction = String(args?.direction || '').trim().toLowerCase() || 'unspecified';
+    const refId = String(args?.ref_id || '').trim();
+    if (refId) return `${direction}|ref:${refId}`;
+
+    const x = Number(args?.x);
+    const y = Number(args?.y);
+    if (args?.x != null && args?.y != null && Number.isFinite(x) && Number.isFinite(y)) {
+      return `${direction}|xy:${Math.round(x)},${Math.round(y)}`;
+    }
+
+    // For implicit scrolling, distinguish panes using the element that
+    // supplied the runtime's last-interaction origin. This avoids combining
+    // no-movement results from two different panes while deliberately
+    // ignoring `amount`, which is not a meaningful recovery at a hard edge.
+    const origin = result?.originElement;
+    if (origin && typeof origin === 'object') {
+      const rect = origin.rect || {};
+      const text = String(origin.text || '').trim().replace(/\s+/g, ' ').slice(0, 80);
+      return `${direction}|origin:${String(result?.origin || '')}:${String(origin.tag || '')}:${String(origin.role || '')}:${Math.round(Number(rect.x) || 0)},${Math.round(Number(rect.y) || 0)},${Math.round(Number(rect.w) || 0)},${Math.round(Number(rect.h) || 0)}:${text}`;
+    }
+    return `${direction}|auto`;
+  }
+
+  _checkNoProgressScroll(tabId, name, args, result) {
+    // Preserve a dead-scroll streak across reads or other unrelated calls;
+    // only a successful scroll or a different scroll target/direction proves
+    // that this particular recovery path changed.
+    if (name !== 'scroll') {
+      // Accessibility refs and coordinate targets are document-scoped. A
+      // successful navigation can reuse the same ref_id/coordinates for a
+      // completely different page, so it must break the old scroll streak.
+      if (result?.pageUrlChanged === true) this.noProgressScrolls.delete(tabId);
+      return { kind: 'none' };
+    }
+    if (result?.moved !== false) {
+      this.noProgressScrolls.delete(tabId);
+      return { kind: 'none' };
+    }
+
+    const key = this._noProgressScrollKey(args, result);
+    const previous = this.noProgressScrolls.get(tabId);
+    const count = previous?.key === key ? previous.count + 1 : 1;
+    this.noProgressScrolls.set(tabId, { key, count });
+
+    if (count >= 3) {
+      this.noProgressScrolls.delete(tabId);
+      return {
+        kind: 'stop',
+        message: 'Stopped: I repeated the same scroll direction on the same target three times, but the page or pane did not move. That scroll surface is already at its limit. Re-read the current view, choose a different pane or direction, act on an element already visible, or ask for help.',
+      };
+    }
+    if (count >= 2) {
+      return {
+        kind: 'nudge',
+        warning: '[NO-PROGRESS SCROLL: The same target did not move twice. Do not repeat this scroll direction or merely change the amount. Re-read the current view, use the opposite direction or a different ref_id/x/y pane, act on an element already visible, or finish.]',
       };
     }
     return { kind: 'none' };
@@ -2292,12 +2358,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         coordCheck = this._checkCoordClickLoop(tabId, fnArgs.x, fnArgs.y);
       }
       const axReadCheck = this._checkAccessibilityReadLoop(tabId, fnName, fnArgs, toolResult);
+      const scrollCheck = this._checkNoProgressScroll(tabId, fnName, fnArgs, toolResult);
 
       // Combine: stop > nudge > none.
       let effectiveKind = 'none';
       let nudgeWarning = '';
       let stopMessage = '';
-      if (loopCheck.kind === 'stop' || coordCheck.kind === 'stop' || axReadCheck.kind === 'stop') {
+      if (loopCheck.kind === 'stop' || coordCheck.kind === 'stop' || axReadCheck.kind === 'stop' || scrollCheck.kind === 'stop') {
         effectiveKind = 'stop';
         if (coordCheck.kind === 'stop') {
           // Show the model's actual args, not _checkCoordClickLoop's 5px
@@ -2305,15 +2372,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           // rounds to (0, 0) and the message reads as if we'd clicked the
           // top-left corner, hiding what really happened.
           stopMessage = `Stopped: I clicked at (or near) coordinates (${fnArgs.x}, ${fnArgs.y}) multiple times and the page never responded. That position is hitting empty space, an overlay, or the wrong element. Please give a different instruction or check the page yourself.`;
+        } else if (scrollCheck.kind === 'stop') {
+          stopMessage = scrollCheck.message;
         } else if (axReadCheck.kind === 'stop') {
           stopMessage = axReadCheck.message;
         } else {
           stopMessage = loopCheck.message;
         }
-      } else if (loopCheck.kind === 'nudge' || coordCheck.kind === 'nudge' || axReadCheck.kind === 'nudge') {
+      } else if (loopCheck.kind === 'nudge' || coordCheck.kind === 'nudge' || axReadCheck.kind === 'nudge' || scrollCheck.kind === 'nudge') {
         effectiveKind = 'nudge';
         if (coordCheck.kind === 'nudge') {
           nudgeWarning = this._coordinateClickRecoveryWarning(fnArgs, allowedToolNames);
+        } else if (scrollCheck.kind === 'nudge') {
+          nudgeWarning = scrollCheck.warning;
         } else if (axReadCheck.kind === 'nudge') {
           nudgeWarning = axReadCheck.warning;
         } else {
@@ -2431,6 +2502,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
 
       if (effectiveKind === 'stop') {
+        // Keep the persisted assistant tool_calls turn structurally valid.
+        // Providers reject a later request when any call lacks a tool result.
+        this._appendSyntheticToolResults(
+          tabId, toolCalls, toolIndex + 1, messages, onUpdate, step,
+          () => ({ success: false, skipped: true, error: 'skipped: run stopped by loop detector' })
+        );
         messages.push({ role: 'assistant', content: stopMessage });
         onUpdate('text', { content: stopMessage });
         onUpdate('error', { message: 'Stuck in a loop. Stopped.' });

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1986,6 +1986,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return `Coordinates (${args.x}, ${args.y}) look like normalized values (0-1 fractions of the viewport), not CSS pixels. The click tool expects CSS pixels (e.g. {x: 437, y: 156}). Prefer click_ax({ref_id}) after get_accessibility_tree or click({text: "..."}) over pixel clicks. If you must use pixels, ${pixelSourceHint}`;
   }
 
+  _isNavigationProneToolCall(toolName, args = {}) {
+    if (Agent.NAV_PRONE_TOOLS.has(toolName)) return true;
+    if (toolName === 'press_keys') return String(args?.key || '').toLowerCase() === 'enter';
+    if (toolName === 'set_field') return args?.submit === true;
+    return false;
+  }
+
   async _executeToolBatch(tabId, toolCalls, messages, onUpdate, provider, partialAssistantText = null, allowedToolNames = AGENT_TOOL_NAMES, step = null) {
     let didStateChange = false;
     // Set of tools whose side effect can navigate the page. We snapshot the
@@ -2212,9 +2219,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }
       }
 
-      // Snapshot URL before nav-prone tools.
+      // Snapshot URL before nav-prone calls. Some tools are conditional:
+      // Enter and set_field({submit:true}) can navigate, while other key
+      // presses and ordinary field edits should avoid the URL-check delay.
+      const navigationProneCall = this._isNavigationProneToolCall(fnName, fnArgs);
       let beforeUrl = '';
-      if (Agent.NAV_PRONE_TOOLS.has(fnName)) {
+      if (navigationProneCall) {
         beforeUrl = await this._currentUrl(tabId);
       }
 
@@ -2250,7 +2260,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
       // Detect unintended navigation. Give the page a beat to fire SPA
       // history events / commit a real nav before re-reading the URL.
-      if (Agent.NAV_PRONE_TOOLS.has(fnName) && beforeUrl && !toolResult?.error) {
+      if (navigationProneCall && beforeUrl && !toolResult?.error) {
         await new Promise(r => setTimeout(r, 200));
         const afterUrl = await this._currentUrl(tabId);
         const beforeNorm = this._normalizeUrlPath(beforeUrl);

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2263,21 +2263,24 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (navigationProneCall && beforeUrl && !toolResult?.error) {
         await new Promise(r => setTimeout(r, 200));
         const afterUrl = await this._currentUrl(tabId);
-        const beforeNorm = this._normalizeUrlPath(beforeUrl);
-        const afterNorm = this._normalizeUrlPath(afterUrl);
-        if (beforeNorm && afterNorm && beforeNorm !== afterNorm) {
-          if (toolResult && typeof toolResult === 'object') {
-            toolResult.pageUrlChanged = true;
-            toolResult.previousUrl = beforeUrl;
-            toolResult.currentUrl = afterUrl;
-          }
-          // Explicit navigation tools (navigate / go_back / go_forward)
-          // intentionally go somewhere — don't warn. For everything else
-          // (click, execute_js, iframe_click) the nav is a side effect the
-          // model may not have anticipated.
-          if (!Agent.NAV_TOOLS.has(fnName)) {
-            navNotices.push({ before: beforeUrl, after: afterUrl, viaTool: fnName });
-          }
+        const beforeFull = this._normalizeUrl(beforeUrl);
+        const afterFull = this._normalizeUrl(afterUrl);
+        const fullUrlChanged = beforeFull && afterFull && beforeFull !== afterFull;
+        if (fullUrlChanged && toolResult && typeof toolResult === 'object') {
+          // Scroll refs/coordinates are scoped to the current route, including
+          // SPA views distinguished only by query/hash.
+          toolResult.pageUrlChanged = true;
+          toolResult.previousUrl = beforeUrl;
+          toolResult.currentUrl = afterUrl;
+        }
+
+        const beforePath = this._normalizeUrlPath(beforeUrl);
+        const afterPath = this._normalizeUrlPath(afterUrl);
+        // Explicit navigation tools intentionally go somewhere. For implicit
+        // navigation, retain the less noisy path-level warning policy: query /
+        // hash-only SPA changes reset state but do not force a re-plan notice.
+        if (beforePath && afterPath && beforePath !== afterPath && !Agent.NAV_TOOLS.has(fnName)) {
+          navNotices.push({ before: beforeUrl, after: afterUrl, viaTool: fnName });
         }
       }
       if (toolResult && typeof toolResult === 'object' && !toolResult.done) {

--- a/src/chrome/src/agent/planner.js
+++ b/src/chrome/src/agent/planner.js
@@ -44,6 +44,7 @@ Rules:
   schedule: schedule_task (future/recurring work the user explicitly asked for), schedule_resume (pause CURRENT run blocked on external event)
   finish: done
 - For repeated same-kind UI mutations (for example following many users), plan visible UI first with bounded batches, verification, progress_update, and wait_for_stable pacing; do not plan one huge same-shape click/tool batch.
+- Do not invent a prerequisite to discover a raw identifier (email address, account ID, username, or similar) when the target UI provides a name-based contact/entity picker and the user already supplied a human-readable name. Plan to use the picker first. Inspect surrounding pages or messages for the raw identifier only if the picker fails, returns multiple ambiguous matches, or the user explicitly asked for the identifier itself.
 - Set confidence from 0.0 to 1.0 for how clear and safe this plan is. Use 0.90+ only when the task, page state, and next steps are straightforward; use lower scores for ambiguity, destructive changes, payments, credentials, bulk mutations, or uncertain page state.
 - scheduling.tool = schedule_task when the user wants reminders, monitors, or recurring checks later.
 - scheduling.tool = schedule_resume only when the CURRENT task must pause until an external event (deploy finishes, email arrives) — not for generic waits (use wait_for_stable).

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -267,7 +267,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'scroll',
-      description: 'Scroll in a given direction. By default, targets the nearest scrollable pane around the last interaction/focus when available, then falls back to the window. For split panes, sticky filters, dropdowns, or virtualized lists, pass ref_id from get_accessibility_tree or CSS-pixel x/y inside the pane so the correct container scrolls. The result reports movedWindow/movedContainer plus warnings when no movement or an almost-blank viewport suggests the wrong scroll surface.',
+      description: 'Scroll in a given direction. By default, targets the nearest scrollable pane around the last interaction/focus when available, then falls back to the window. For split panes, sticky filters, dropdowns, or virtualized lists, pass ref_id from get_accessibility_tree or CSS-pixel x/y inside the pane so the correct container scrolls. The result reports movedWindow/movedContainer plus warnings when no movement or an almost-blank viewport suggests the wrong scroll surface. If moved is false, do not repeat the same target and direction; choose a different pane/direction, re-read, act, or finish.',
       parameters: {
         type: 'object',
         properties: {

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15634,6 +15634,7 @@ const ADAPTERS = [
     match: (url) => /^https?:\/\/mail\.google\.com\//.test(url),
     notes: `
 - Composing: the "Compose" button opens a floating window. The "To" field is a contact picker — type the name and pick from the dropdown, don't just type the raw email.
+- For a task that explicitly starts a new email or saves a new draft, if no compose window is open and the user named a recipient, click Compose immediately and use the To contact picker. Do not inspect the current thread or search the page merely to discover the recipient's raw email first; do that only if the picker fails, returns multiple ambiguous matches, or the user explicitly asked for the address. This fast path does not apply to reply or forward tasks; use the thread's Reply/Forward controls for those.
 - In an already-open compose, Gmail may hide the "To recipients" combobox after turning the selected contact into a named focusable generic/chip immediately above Subject. If that chip matches the requested contact, treat the recipient as confirmed and proceed directly to Subject and Message Body. Never enumerate the compose form's generic sibling ref_ids to find the hidden To field. If neither a named chip nor a visible To field exists, focus the recipient row once and re-read the visible/interactive tree.
 - The body is a contenteditable div (rich text), not a textarea. Click into it before typing.
 - Sending: the "Send" button is bottom-left of the compose window; "Send + Schedule" arrow is next to it for scheduled send.

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1619,6 +1619,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return `Coordinates (${args.x}, ${args.y}) look like normalized values (0-1 fractions of the viewport), not CSS pixels. The click tool expects CSS pixels (e.g. {x: 437, y: 156}). Prefer click_ax({ref_id}) after get_accessibility_tree or click({text: "..."}) over pixel clicks. If you must use pixels, ${pixelSourceHint}`;
   }
 
+  _isNavigationProneToolCall(toolName, args = {}) {
+    if (Agent.NAV_PRONE_TOOLS.has(toolName)) return true;
+    if (toolName === 'press_keys') return String(args?.key || '').toLowerCase() === 'enter';
+    if (toolName === 'set_field') return args?.submit === true;
+    return false;
+  }
+
   async _executeToolBatch(tabId, toolCalls, messages, onUpdate, provider, partialAssistantText = null, allowedToolNames = AGENT_TOOL_NAMES, step = null) {
     let didStateChange = false;
     const navNotices = [];
@@ -1839,8 +1846,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }
       }
 
+      // Snapshot URL before nav-prone calls. Some tools are conditional:
+      // Enter and set_field({submit:true}) can navigate, while other key
+      // presses and ordinary field edits should avoid the URL-check delay.
+      const navigationProneCall = this._isNavigationProneToolCall(fnName, fnArgs);
       let beforeUrl = '';
-      if (Agent.NAV_PRONE_TOOLS.has(fnName)) {
+      if (navigationProneCall) {
         beforeUrl = await this._currentUrl(tabId);
       }
 
@@ -1874,7 +1885,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }
       }
 
-      if (Agent.NAV_PRONE_TOOLS.has(fnName) && beforeUrl && !toolResult?.error) {
+      if (navigationProneCall && beforeUrl && !toolResult?.error) {
         await new Promise(r => setTimeout(r, 200));
         const afterUrl = await this._currentUrl(tabId);
         const beforeNorm = this._normalizeUrlPath(beforeUrl);

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -141,6 +141,10 @@ export class Agent {
     // A model can walk ref_1, ref_2, … forever while every call looks unique
     // to the exact-argument loop detector. Track that semantic read pattern.
     this.axReadStates = new Map();
+    // Scroll calls can keep returning success even when no pane moved. Track
+    // repeated dead-end attempts separately so changing the amount or
+    // interleaving reads cannot evade the generic loop detector.
+    this.noProgressScrolls = new Map();
     // Local screenshot redaction (issue #312). When true, screenshots sent
     // to a Vision endpoint are pixelated over DOM-detected PII regions
     // (form fields + email/phone text) BEFORE leaving the extension. Off by
@@ -667,6 +671,7 @@ export class Agent {
     this.loopNudges.delete(tabId);
     this.healthyCallsSinceLoop.delete(tabId);
     this.axReadStates.delete(tabId);
+    this.noProgressScrolls.delete(tabId);
     this.recentCoordClicks.delete(tabId);
     this.bulkApiMutationClicks.delete(tabId);
     this.bulkApiMutationHints.delete(tabId);
@@ -728,6 +733,67 @@ export class Agent {
       return {
         kind: 'nudge',
         warning: '[ACCESSIBILITY READ LOOP: Stop enumerating sibling or generic ref_ids. If the result has hasMore/nextPage, request exactly that page. If the needed textbox/button is already visible, use set_field, type_ax, or click_ax now. Otherwise switch once to read_page/extract_data or finish with what you have. Do not call another arbitrary ref_id subtree.]',
+      };
+    }
+    return { kind: 'none' };
+  }
+
+  _noProgressScrollKey(args = {}, result = {}) {
+    const direction = String(args?.direction || '').trim().toLowerCase() || 'unspecified';
+    const refId = String(args?.ref_id || '').trim();
+    if (refId) return `${direction}|ref:${refId}`;
+
+    const x = Number(args?.x);
+    const y = Number(args?.y);
+    if (args?.x != null && args?.y != null && Number.isFinite(x) && Number.isFinite(y)) {
+      return `${direction}|xy:${Math.round(x)},${Math.round(y)}`;
+    }
+
+    // For implicit scrolling, distinguish panes using the element that
+    // supplied the runtime's last-interaction origin. This avoids combining
+    // no-movement results from two different panes while deliberately
+    // ignoring `amount`, which is not a meaningful recovery at a hard edge.
+    const origin = result?.originElement;
+    if (origin && typeof origin === 'object') {
+      const rect = origin.rect || {};
+      const text = String(origin.text || '').trim().replace(/\s+/g, ' ').slice(0, 80);
+      return `${direction}|origin:${String(result?.origin || '')}:${String(origin.tag || '')}:${String(origin.role || '')}:${Math.round(Number(rect.x) || 0)},${Math.round(Number(rect.y) || 0)},${Math.round(Number(rect.w) || 0)},${Math.round(Number(rect.h) || 0)}:${text}`;
+    }
+    return `${direction}|auto`;
+  }
+
+  _checkNoProgressScroll(tabId, name, args, result) {
+    // Preserve a dead-scroll streak across reads or other unrelated calls;
+    // only a successful scroll or a different scroll target/direction proves
+    // that this particular recovery path changed.
+    if (name !== 'scroll') {
+      // Accessibility refs and coordinate targets are document-scoped. A
+      // successful navigation can reuse the same ref_id/coordinates for a
+      // completely different page, so it must break the old scroll streak.
+      if (result?.pageUrlChanged === true) this.noProgressScrolls.delete(tabId);
+      return { kind: 'none' };
+    }
+    if (result?.moved !== false) {
+      this.noProgressScrolls.delete(tabId);
+      return { kind: 'none' };
+    }
+
+    const key = this._noProgressScrollKey(args, result);
+    const previous = this.noProgressScrolls.get(tabId);
+    const count = previous?.key === key ? previous.count + 1 : 1;
+    this.noProgressScrolls.set(tabId, { key, count });
+
+    if (count >= 3) {
+      this.noProgressScrolls.delete(tabId);
+      return {
+        kind: 'stop',
+        message: 'Stopped: I repeated the same scroll direction on the same target three times, but the page or pane did not move. That scroll surface is already at its limit. Re-read the current view, choose a different pane or direction, act on an element already visible, or ask for help.',
+      };
+    }
+    if (count >= 2) {
+      return {
+        kind: 'nudge',
+        warning: '[NO-PROGRESS SCROLL: The same target did not move twice. Do not repeat this scroll direction or merely change the amount. Re-read the current view, use the opposite direction or a different ref_id/x/y pane, act on an element already visible, or finish.]',
       };
     }
     return { kind: 'none' };
@@ -1914,11 +1980,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         coordCheck = this._checkCoordClickLoop(tabId, fnArgs.x, fnArgs.y);
       }
       const axReadCheck = this._checkAccessibilityReadLoop(tabId, fnName, fnArgs, toolResult);
+      const scrollCheck = this._checkNoProgressScroll(tabId, fnName, fnArgs, toolResult);
 
       let effectiveKind = 'none';
       let nudgeWarning = '';
       let stopMessage = '';
-      if (loopCheck.kind === 'stop' || coordCheck.kind === 'stop' || axReadCheck.kind === 'stop') {
+      if (loopCheck.kind === 'stop' || coordCheck.kind === 'stop' || axReadCheck.kind === 'stop' || scrollCheck.kind === 'stop') {
         effectiveKind = 'stop';
         // Show the model's actual args, not _checkCoordClickLoop's 5px
         // bucket — for fractional inputs like (0.911, 0.331) the bucket
@@ -1926,16 +1993,20 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         // top-left corner, hiding what really happened.
         stopMessage = coordCheck.kind === 'stop'
           ? `Stopped: I clicked at (or near) coordinates (${fnArgs.x}, ${fnArgs.y}) multiple times and the page never responded. That position is hitting empty space, an overlay, or the wrong element. Please give a different instruction or check the page yourself.`
-          : axReadCheck.kind === 'stop'
-            ? axReadCheck.message
-            : loopCheck.message;
-      } else if (loopCheck.kind === 'nudge' || coordCheck.kind === 'nudge' || axReadCheck.kind === 'nudge') {
+          : scrollCheck.kind === 'stop'
+            ? scrollCheck.message
+            : axReadCheck.kind === 'stop'
+              ? axReadCheck.message
+              : loopCheck.message;
+      } else if (loopCheck.kind === 'nudge' || coordCheck.kind === 'nudge' || axReadCheck.kind === 'nudge' || scrollCheck.kind === 'nudge') {
         effectiveKind = 'nudge';
         nudgeWarning = coordCheck.kind === 'nudge'
           ? this._coordinateClickRecoveryWarning(fnArgs, allowedToolNames)
-          : axReadCheck.kind === 'nudge'
-            ? axReadCheck.warning
-            : loopCheck.warning;
+          : scrollCheck.kind === 'nudge'
+            ? scrollCheck.warning
+            : axReadCheck.kind === 'nudge'
+              ? axReadCheck.warning
+              : loopCheck.warning;
       }
 
       // Strip `_attachImage` BEFORE stringifying the tool result — otherwise
@@ -2024,6 +2095,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         });
       }
       if (effectiveKind === 'stop') {
+        // Keep the persisted assistant tool_calls turn structurally valid.
+        // Providers reject a later request when any call lacks a tool result.
+        this._appendSyntheticToolResults(
+          tabId, toolCalls, toolIndex + 1, messages, onUpdate, step,
+          () => ({ success: false, skipped: true, error: 'skipped: run stopped by loop detector' })
+        );
         messages.push({ role: 'assistant', content: stopMessage });
         onUpdate('text', { content: stopMessage });
         onUpdate('error', { message: 'Stuck in a loop. Stopped.' });

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1888,17 +1888,24 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (navigationProneCall && beforeUrl && !toolResult?.error) {
         await new Promise(r => setTimeout(r, 200));
         const afterUrl = await this._currentUrl(tabId);
-        const beforeNorm = this._normalizeUrlPath(beforeUrl);
-        const afterNorm = this._normalizeUrlPath(afterUrl);
-        if (beforeNorm && afterNorm && beforeNorm !== afterNorm) {
-          if (toolResult && typeof toolResult === 'object') {
-            toolResult.pageUrlChanged = true;
-            toolResult.previousUrl = beforeUrl;
-            toolResult.currentUrl = afterUrl;
-          }
-          if (!Agent.NAV_TOOLS.has(fnName)) {
-            navNotices.push({ before: beforeUrl, after: afterUrl, viaTool: fnName });
-          }
+        const beforeFull = this._normalizeUrl(beforeUrl);
+        const afterFull = this._normalizeUrl(afterUrl);
+        const fullUrlChanged = beforeFull && afterFull && beforeFull !== afterFull;
+        if (fullUrlChanged && toolResult && typeof toolResult === 'object') {
+          // Scroll refs/coordinates are scoped to the current route, including
+          // SPA views distinguished only by query/hash.
+          toolResult.pageUrlChanged = true;
+          toolResult.previousUrl = beforeUrl;
+          toolResult.currentUrl = afterUrl;
+        }
+
+        const beforePath = this._normalizeUrlPath(beforeUrl);
+        const afterPath = this._normalizeUrlPath(afterUrl);
+        // Explicit navigation tools intentionally go somewhere. For implicit
+        // navigation, retain the less noisy path-level warning policy: query /
+        // hash-only SPA changes reset state but do not force a re-plan notice.
+        if (beforePath && afterPath && beforePath !== afterPath && !Agent.NAV_TOOLS.has(fnName)) {
+          navNotices.push({ before: beforeUrl, after: afterUrl, viaTool: fnName });
         }
       }
       if (toolResult && typeof toolResult === 'object' && !toolResult.done) {

--- a/src/firefox/src/agent/planner.js
+++ b/src/firefox/src/agent/planner.js
@@ -44,6 +44,7 @@ Rules:
   schedule: schedule_task (future/recurring work the user explicitly asked for), schedule_resume (pause CURRENT run blocked on external event)
   finish: done
 - For repeated same-kind UI mutations (for example following many users), plan visible UI first with bounded batches, verification, progress_update, and wait_for_stable pacing; do not plan one huge same-shape click/tool batch.
+- Do not invent a prerequisite to discover a raw identifier (email address, account ID, username, or similar) when the target UI provides a name-based contact/entity picker and the user already supplied a human-readable name. Plan to use the picker first. Inspect surrounding pages or messages for the raw identifier only if the picker fails, returns multiple ambiguous matches, or the user explicitly asked for the identifier itself.
 - Set confidence from 0.0 to 1.0 for how clear and safe this plan is. Use 0.90+ only when the task, page state, and next steps are straightforward; use lower scores for ambiguity, destructive changes, payments, credentials, bulk mutations, or uncertain page state.
 - scheduling.tool = schedule_task when the user wants reminders, monitors, or recurring checks later.
 - scheduling.tool = schedule_resume only when the CURRENT task must pause until an external event (deploy finishes, email arrives) — not for generic waits (use wait_for_stable).

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -267,7 +267,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'scroll',
-      description: 'Scroll in a given direction. By default, targets the nearest scrollable pane around the last interaction/focus when available, then falls back to the window. For split panes, sticky filters, dropdowns, or virtualized lists, pass ref_id from get_accessibility_tree or CSS-pixel x/y inside the pane so the correct container scrolls. The result reports movedWindow/movedContainer plus warnings when no movement or an almost-blank viewport suggests the wrong scroll surface.',
+      description: 'Scroll in a given direction. By default, targets the nearest scrollable pane around the last interaction/focus when available, then falls back to the window. For split panes, sticky filters, dropdowns, or virtualized lists, pass ref_id from get_accessibility_tree or CSS-pixel x/y inside the pane so the correct container scrolls. The result reports movedWindow/movedContainer plus warnings when no movement or an almost-blank viewport suggests the wrong scroll surface. If moved is false, do not repeat the same target and direction; choose a different pane/direction, re-read, act, or finish.',
       parameters: {
         type: 'object',
         properties: {

--- a/test/run.js
+++ b/test/run.js
@@ -503,6 +503,7 @@ class LoopDetectorShim {
     this.healthyCallsSinceLoop = new Map();
     this.recentCoordClicks = new Map();
     this.axReadStates = new Map();
+    this.noProgressScrolls = new Map();
   }
   _checkCoordClickLoop(tabId, x, y) {
     const bx = Math.round(x / 5) * 5;
@@ -617,6 +618,43 @@ class LoopDetectorShim {
       state.warned = true;
       return { kind: 'nudge' };
     }
+    return { kind: 'none' };
+  }
+  _noProgressScrollKey(args = {}, result = {}) {
+    const direction = String(args?.direction || '').trim().toLowerCase() || 'unspecified';
+    const refId = String(args?.ref_id || '').trim();
+    if (refId) return `${direction}|ref:${refId}`;
+    const x = Number(args?.x);
+    const y = Number(args?.y);
+    if (args?.x != null && args?.y != null && Number.isFinite(x) && Number.isFinite(y)) {
+      return `${direction}|xy:${Math.round(x)},${Math.round(y)}`;
+    }
+    const origin = result?.originElement;
+    if (origin && typeof origin === 'object') {
+      const rect = origin.rect || {};
+      const text = String(origin.text || '').trim().replace(/\s+/g, ' ').slice(0, 80);
+      return `${direction}|origin:${String(result?.origin || '')}:${String(origin.tag || '')}:${String(origin.role || '')}:${Math.round(Number(rect.x) || 0)},${Math.round(Number(rect.y) || 0)},${Math.round(Number(rect.w) || 0)},${Math.round(Number(rect.h) || 0)}:${text}`;
+    }
+    return `${direction}|auto`;
+  }
+  _checkNoProgressScroll(tabId, name, args, result) {
+    if (name !== 'scroll') {
+      if (result?.pageUrlChanged === true) this.noProgressScrolls.delete(tabId);
+      return { kind: 'none' };
+    }
+    if (result?.moved !== false) {
+      this.noProgressScrolls.delete(tabId);
+      return { kind: 'none' };
+    }
+    const key = this._noProgressScrollKey(args, result);
+    const previous = this.noProgressScrolls.get(tabId);
+    const count = previous?.key === key ? previous.count + 1 : 1;
+    this.noProgressScrolls.set(tabId, { key, count });
+    if (count >= 3) {
+      this.noProgressScrolls.delete(tabId);
+      return { kind: 'stop' };
+    }
+    if (count >= 2) return { kind: 'nudge' };
     return { kind: 'none' };
   }
   _detectApiShortcut(tabId, loop, buf) {
@@ -1218,6 +1256,13 @@ test('matches www.github.com', () => {
 test('matches gmail.com under mail.google.com', () => {
   const a = getActiveAdapter('https://mail.google.com/mail/u/0/#inbox');
   assert.equal(a?.name, 'gmail');
+  assert.match(a?.notes || '', /explicitly starts a new email or saves a new draft/i);
+  assert.match(a?.notes || '', /no compose window is open/i);
+  assert.match(a?.notes || '', /click Compose immediately/i);
+  assert.match(a?.notes || '', /Do not inspect the current thread or search the page merely to discover/i);
+  assert.match(a?.notes || '', /picker fails, returns multiple ambiguous matches/i);
+  assert.match(a?.notes || '', /does not apply to reply or forward tasks/i);
+  assert.match(a?.notes || '', /Reply\/Forward controls/i);
   assert.match(a?.notes || '', /already-open compose/i);
   assert.match(a?.notes || '', /named focusable generic\/chip/i);
   assert.match(a?.notes || '', /proceed directly to Subject and Message Body/i);
@@ -1670,6 +1715,116 @@ test('tabs are isolated from each other', () => {
   d._checkLoop(10, 'click', { selector: '#x' }, { success: true });
   const result = d._checkLoop(20, 'click', { selector: '#x' }, { success: true });
   assert.equal(result.kind, 'none');
+});
+
+test('no-progress scroll warns on the second same-target miss and stops on the third', () => {
+  const origin = {
+    origin: 'last_interaction',
+    originElement: {
+      tag: 'p',
+      role: '',
+      text: 'The last visible paragraph',
+      rect: { x: 368, y: 123, w: 594, h: 78 },
+    },
+  };
+  for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+    const agent = new AgentClass({});
+    const tab = label === 'chrome' ? 81 : 82;
+    assert.equal(agent._checkNoProgressScroll(tab, 'scroll', { direction: 'down', amount: 300 }, { moved: false, ...origin }).kind, 'none', `${label}: first miss`);
+    const warning = agent._checkNoProgressScroll(tab, 'scroll', { direction: 'down', amount: 500 }, { moved: false, ...origin });
+    assert.equal(warning.kind, 'nudge', `${label}: second miss should warn despite a changed amount`);
+    assert.match(warning.warning, /Do not repeat this scroll direction/i);
+    const stopped = agent._checkNoProgressScroll(tab, 'scroll', { direction: 'down', amount: 700 }, { moved: false, ...origin });
+    assert.equal(stopped.kind, 'stop', `${label}: third miss should stop`);
+    assert.match(stopped.message, /same scroll direction on the same target three times/i);
+  }
+});
+
+test('no-progress scroll is pane-, direction-, tab-, and run-scoped', () => {
+  for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+    const agent = new AgentClass({});
+    const tab = 83;
+    const dead = { moved: false };
+    assert.equal(agent._checkNoProgressScroll(tab, 'scroll', { direction: 'down', ref_id: 'ref_pane_a' }, dead).kind, 'none');
+    assert.equal(agent._checkNoProgressScroll(tab, 'read_page', {}, { success: true }).kind, 'none');
+    assert.equal(agent._checkNoProgressScroll(tab, 'scroll', { direction: 'down', ref_id: 'ref_pane_a' }, dead).kind, 'nudge', `${label}: an interleaved read must not evade the warning`);
+    assert.equal(agent._checkNoProgressScroll(tab, 'scroll', { direction: 'up', ref_id: 'ref_pane_a' }, dead).kind, 'none', `${label}: opposite direction is a new recovery path`);
+    assert.equal(agent._checkNoProgressScroll(tab, 'scroll', { direction: 'down', ref_id: 'ref_pane_b' }, dead).kind, 'none', `${label}: another pane is isolated`);
+    assert.equal(agent._checkNoProgressScroll(tab + 1, 'scroll', { direction: 'down', ref_id: 'ref_pane_b' }, dead).kind, 'none', `${label}: tabs are isolated`);
+    assert.equal(agent._checkNoProgressScroll(tab, 'scroll', { direction: 'down', ref_id: 'ref_pane_b' }, { moved: true }).kind, 'none');
+    assert.equal(agent.noProgressScrolls.has(tab), false, `${label}: movement should reset the streak`);
+    assert.equal(agent._checkNoProgressScroll(tab, 'scroll', { direction: 'down', ref_id: 'ref_reused' }, dead).kind, 'none');
+    assert.equal(agent._checkNoProgressScroll(tab, 'click_ax', { ref_id: 'ref_link' }, { success: true, pageUrlChanged: true }).kind, 'none');
+    assert.equal(agent.noProgressScrolls.has(tab), false, `${label}: document navigation should reset the streak`);
+    assert.equal(agent._checkNoProgressScroll(tab, 'scroll', { direction: 'down', ref_id: 'ref_reused' }, dead).kind, 'none', `${label}: a reused ref on the new page starts fresh`);
+    agent._checkNoProgressScroll(tab, 'scroll', { direction: 'down', ref_id: 'ref_pane_a' }, dead);
+    agent._clearLoopState(tab);
+    assert.equal(agent.noProgressScrolls.has(tab), false, `${label}: run cleanup should reset the streak`);
+  }
+});
+
+test('no-progress scroll enforcement is wired into both agent loops', () => {
+  for (const browserName of ['chrome', 'firefox']) {
+    const source = fs.readFileSync(path.join(ROOT, `src/${browserName}/src/agent/agent.js`), 'utf8');
+    assert.match(source, /const scrollCheck = this\._checkNoProgressScroll\(tabId, fnName, fnArgs, toolResult\)/, `${browserName}: evaluate each result`);
+    assert.match(source, /scrollCheck\.kind === 'stop'/, `${browserName}: stop result must win`);
+    assert.match(source, /scrollCheck\.kind === 'nudge'/, `${browserName}: warning must reach the model`);
+    assert.match(source, /this\.noProgressScrolls\.delete\(tabId\)/, `${browserName}: run cleanup must clear state`);
+  }
+});
+
+test('no-progress scroll stop synthesizes results for the rest of a tool batch', async () => {
+  for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+    const agent = new AgentClass({ getVisionProvider: async () => null });
+    const tabId = label === 'chrome' ? 85 : 86;
+    const messages = [];
+    const executed = [];
+    agent._ensureGateSetting = async () => {};
+    agent._skipPermissionGate = true;
+    agent._rememberMastodonObservation = async () => null;
+    agent._recordProgressObservation = async () => null;
+    agent._autoRecordProgressAction = () => null;
+    agent._persist = () => {};
+    agent.executeTool = async (_tabId, name, args) => {
+      executed.push(args.amount);
+      return {
+        success: true,
+        moved: false,
+        origin: 'last_interaction',
+        originElement: {
+          tag: 'p', role: '', text: 'Last visible paragraph',
+          rect: { x: 100, y: 200, w: 300, h: 40 },
+        },
+      };
+    };
+    const toolCalls = [300, 400, 500, 600].map((amount, index) => ({
+      id: `scroll_${index}`,
+      function: { name: 'scroll', arguments: JSON.stringify({ direction: 'down', amount }) },
+    }));
+
+    const result = await agent._executeToolBatch(
+      tabId,
+      toolCalls,
+      messages,
+      () => {},
+      { supportsVision: false },
+      null,
+      new Set(['scroll']),
+      1,
+    );
+
+    assert.equal(result.action, 'return', `${label}: the third dead scroll should stop the run`);
+    assert.deepEqual(executed, [300, 400, 500], `${label}: later calls must not execute after stop`);
+    const toolMessages = messages.filter(message => message.role === 'tool');
+    assert.equal(toolMessages.length, toolCalls.length, `${label}: every tool call must receive a result`);
+    const skipped = toolMessages.find(message => message.tool_call_id === 'scroll_3');
+    assert.ok(skipped, `${label}: remaining tool call needs a synthetic result`);
+    assert.deepEqual(JSON.parse(skipped.content), {
+      success: false,
+      skipped: true,
+      error: 'skipped: run stopped by loop detector',
+    });
+  }
 });
 
 test('accessibility-tree ref enumeration nudges at three and stops at six', () => {
@@ -3875,6 +4030,14 @@ test('getToolsForMode: progress_update advertises canonical progress actions', (
     const action = progressUpdate.function.parameters.properties.items.items.properties.action;
     assert.match(action.description, /process_item/);
     assert.doesNotMatch(action.description, /\bscrape\b/);
+  }
+});
+
+test('getToolsForMode: scroll warns against repeating a no-movement path', () => {
+  for (const [label, getTools] of [['chrome', getToolsForModeCh], ['firefox', getToolsForModeFx]]) {
+    const scroll = getTools('act').find(t => t.function.name === 'scroll');
+    assert.ok(scroll, `${label}: scroll tool must be present in act mode`);
+    assert.match(scroll.function.description, /If moved is false, do not repeat the same target and direction/);
   }
 });
 
@@ -19563,6 +19726,9 @@ test('planner: prompt treats page context as untrusted data', () => {
   assert.match(PLANNER_SYSTEM_PROMPT, /ignore previous instructions/);
   assert.match(PLANNER_SYSTEM_PROMPT, /bounded batches/);
   assert.match(PLANNER_SYSTEM_PROMPT, /wait_for_stable pacing/);
+  assert.match(PLANNER_SYSTEM_PROMPT, /Do not invent a prerequisite to discover a raw identifier/);
+  assert.match(PLANNER_SYSTEM_PROMPT, /name-based contact\/entity picker/);
+  assert.match(PLANNER_SYSTEM_PROMPT, /picker fails, returns multiple ambiguous matches/);
   assert.match(PLANNER_SYSTEM_PROMPT, /read: get_accessibility_tree, read_page, extract_data, fetch_url, research_url/);
   assert.match(PLANNER_SYSTEM_PROMPT, /attached JSON\/TXT\/CSV text file content/);
   assert.match(PLANNER_SYSTEM_PROMPT, /brief neutral scratchpad_notes/);

--- a/test/run.js
+++ b/test/run.js
@@ -924,10 +924,15 @@ test('ref-id action tools are state changes in both browser agents', () => {
   }
 });
 
-test('click_ax is nav-prone but non-submitting set_field is not', () => {
+test('navigation-prone detection includes only submit-capable key and field calls', () => {
   for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+    const agent = new AgentClass({});
     assert.equal(AgentClass.NAV_PRONE_TOOLS.has('click_ax'), true, `${label} missing click_ax from NAV_PRONE_TOOLS`);
     assert.equal(AgentClass.NAV_PRONE_TOOLS.has('set_field'), false, `${label} should not treat set_field as nav-prone`);
+    assert.equal(agent._isNavigationProneToolCall('press_keys', { key: 'Enter' }), true, `${label}: Enter can submit and navigate`);
+    assert.equal(agent._isNavigationProneToolCall('press_keys', { key: 'ArrowDown' }), false, `${label}: arrows should avoid URL probes`);
+    assert.equal(agent._isNavigationProneToolCall('set_field', { submit: true }), true, `${label}: submitting fields can navigate`);
+    assert.equal(agent._isNavigationProneToolCall('set_field', { submit: false }), false, `${label}: ordinary field edits should avoid URL probes`);
   }
 });
 
@@ -1824,6 +1829,54 @@ test('no-progress scroll stop synthesizes results for the rest of a tool batch',
       skipped: true,
       error: 'skipped: run stopped by loop detector',
     });
+  }
+});
+
+test('Enter navigation resets dead-scroll state before refs are reused', async () => {
+  for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+    const agent = new AgentClass({ getVisionProvider: async () => null });
+    const tabId = label === 'chrome' ? 87 : 88;
+    const messages = [];
+    const executed = [];
+    let currentUrl = 'https://example.com/old';
+    agent._ensureGateSetting = async () => {};
+    agent._skipPermissionGate = true;
+    agent._currentUrl = async () => currentUrl;
+    agent._rememberMastodonObservation = async () => null;
+    agent._recordProgressObservation = async () => null;
+    agent._autoRecordProgressAction = () => null;
+    agent._persist = () => {};
+    agent.executeTool = async (_tabId, name) => {
+      executed.push(name);
+      if (name === 'press_keys') {
+        currentUrl = 'https://example.com/new';
+        return { success: true };
+      }
+      return { success: true, moved: false };
+    };
+    const toolCalls = [
+      { id: 'old_scroll', function: { name: 'scroll', arguments: JSON.stringify({ direction: 'down', amount: 300, ref_id: 'ref_5' }) } },
+      { id: 'enter', function: { name: 'press_keys', arguments: JSON.stringify({ key: 'Enter' }) } },
+      { id: 'new_scroll_1', function: { name: 'scroll', arguments: JSON.stringify({ direction: 'down', amount: 400, ref_id: 'ref_5' }) } },
+      { id: 'new_scroll_2', function: { name: 'scroll', arguments: JSON.stringify({ direction: 'down', amount: 500, ref_id: 'ref_5' }) } },
+    ];
+
+    const result = await agent._executeToolBatch(
+      tabId,
+      toolCalls,
+      messages,
+      () => {},
+      { supportsVision: false },
+      null,
+      new Set(['scroll', 'press_keys']),
+      1,
+    );
+
+    assert.equal(result.action, 'continue', `${label}: reused refs on the new document must not hard-stop`);
+    assert.deepEqual(executed, ['scroll', 'press_keys', 'scroll', 'scroll'], `${label}: the full batch should execute`);
+    assert.equal(agent.noProgressScrolls.get(tabId)?.count, 2, `${label}: only new-document misses should remain`);
+    const secondNewScroll = messages.find(message => message.tool_call_id === 'new_scroll_2');
+    assert.match(secondNewScroll?.content || '', /NO-PROGRESS SCROLL/, `${label}: second miss on the new page should only nudge`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -1832,13 +1832,13 @@ test('no-progress scroll stop synthesizes results for the rest of a tool batch',
   }
 });
 
-test('Enter navigation resets dead-scroll state before refs are reused', async () => {
+test('Enter SPA route changes reset dead-scroll state before refs are reused', async () => {
   for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
     const agent = new AgentClass({ getVisionProvider: async () => null });
     const tabId = label === 'chrome' ? 87 : 88;
     const messages = [];
     const executed = [];
-    let currentUrl = 'https://example.com/old';
+    let currentUrl = 'https://example.com/inbox?view=old#thread-1';
     agent._ensureGateSetting = async () => {};
     agent._skipPermissionGate = true;
     agent._currentUrl = async () => currentUrl;
@@ -1849,7 +1849,7 @@ test('Enter navigation resets dead-scroll state before refs are reused', async (
     agent.executeTool = async (_tabId, name) => {
       executed.push(name);
       if (name === 'press_keys') {
-        currentUrl = 'https://example.com/new';
+        currentUrl = 'https://example.com/inbox?view=new#thread-2';
         return { success: true };
       }
       return { success: true, moved: false };
@@ -1877,6 +1877,7 @@ test('Enter navigation resets dead-scroll state before refs are reused', async (
     assert.equal(agent.noProgressScrolls.get(tabId)?.count, 2, `${label}: only new-document misses should remain`);
     const secondNewScroll = messages.find(message => message.tool_call_id === 'new_scroll_2');
     assert.match(secondNewScroll?.content || '', /NO-PROGRESS SCROLL/, `${label}: second miss on the new page should only nudge`);
+    assert.equal(messages.some(message => message.role === 'user' && /NAVIGATION OCCURRED/.test(String(message.content || ''))), false, `${label}: query/hash-only changes should not emit a path-level navigation warning`);
   }
 });
 


### PR DESCRIPTION
## Summary

- route explicit new Gmail email/draft tasks directly through Compose and the name-based recipient picker while preserving Reply/Forward flows
- add generic planner guidance against inventing raw-identifier discovery when a name picker is available
- detect repeated no-movement scrolls per tab/run, warn after the second attempt, and stop on the third
- reset dead-scroll identity after verified navigation and synthesize remaining batched tool results before stopping
- mirror runtime, adapter, tool guidance, and tests across Chrome and Firefox

## Root cause

With Gmail Compose closed, the planner invented a prerequisite to discover the recipient's exact email address even though Gmail already provides a name-based contact picker. The agent then searched the open thread, reached the bottom of the scroll pane, and kept issuing successful-looking scroll calls whose results reported `moved: false`.

The existing generic loop detector stopped this only after substantial repetition because the runtime lacked a semantic no-progress scroll guard.

## Impact

New-message tasks can take the direct Gmail picker path without unnecessary thread inspection. More generally, browser tasks now recover quickly from dead scroll surfaces without conflating targets across navigation or leaving orphaned tool calls in persisted history.

## Validation

- `npm test`: 742 unit/behavior tests and 60 injection-security checks passed
- `npm run test:fixtures`: 27 browser fixtures passed
- syntax checks for touched JavaScript files passed
- `git diff --check` passed
