### PR TITLE
Add subscription resume action

### DIFF
--- a/src/chrome/src/ui/locales/ar.js
+++ b/src/chrome/src/ui/locales/ar.js
@@ -111,6 +111,7 @@ export default {
   'sp.error_prefix': 'خطأ: {msg}',
   'sp.subscribe.allowance_used': 'تم استخدام الحصة اليومية المجانية من WebBrain Cloud.',
   'sp.subscribe.btn': 'اشترك',
+  'sp.subscribe.resume': 'اشتركت — أعد المحاولة',
   'sp.stopped_by_user': '[أوقفه المستخدم]',
   'sp.stopped_by_user_html': '<em>أوقفه المستخدم.</em>',
 

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -202,6 +202,7 @@ export default {
   'sp.error_prefix': 'Error: {msg}',
   'sp.subscribe.allowance_used': 'Daily free WebBrain Cloud allowance used.',
   'sp.subscribe.btn': 'Subscribe',
+  'sp.subscribe.resume': 'I’ve subscribed — retry',
   'sp.stopped_by_user': '[Stopped by user]',
   'sp.stopped_by_user_html': '<em>Stopped by user.</em>',
 

--- a/src/chrome/src/ui/locales/es.js
+++ b/src/chrome/src/ui/locales/es.js
@@ -111,6 +111,7 @@ export default {
   'sp.error_prefix': 'Error: {msg}',
   'sp.subscribe.allowance_used': 'Se agotó la asignación diaria gratuita de WebBrain Cloud.',
   'sp.subscribe.btn': 'Suscribirse',
+  'sp.subscribe.resume': 'Ya me suscribí — reintentar',
   'sp.stopped_by_user': '[Detenido por el usuario]',
   'sp.stopped_by_user_html': '<em>Detenido por el usuario.</em>',
 

--- a/src/chrome/src/ui/locales/fr.js
+++ b/src/chrome/src/ui/locales/fr.js
@@ -111,6 +111,7 @@ export default {
   'sp.error_prefix': 'Erreur : {msg}',
   'sp.subscribe.allowance_used': 'Quota quotidien gratuit de WebBrain Cloud épuisé.',
   'sp.subscribe.btn': 'S’abonner',
+  'sp.subscribe.resume': 'Abonnement effectué — réessayer',
   'sp.stopped_by_user': '[Arrêté par l\'utilisateur]',
   'sp.stopped_by_user_html': '<em>Arrêté par l\'utilisateur.</em>',
 

--- a/src/chrome/src/ui/locales/he.js
+++ b/src/chrome/src/ui/locales/he.js
@@ -191,6 +191,7 @@ export default {
   "sp.error_prefix": "שגיאה: {msg}",
   "sp.subscribe.allowance_used": "חינם מדי יום WebBrain נעשה שימוש בקצבת ענן.",
   "sp.subscribe.btn": "הירשם",
+  "sp.subscribe.resume": "נרשמתי — נסה שוב",
   "sp.stopped_by_user": "[נעצר על ידי משתמש]",
   "sp.stopped_by_user_html": "<em>נעצר על ידי משתמש.</em>",
   "sp.continue_bar": "הגיע למגבלת הצעדים ({steps} צעדים). רוצה שאמשיך?",

--- a/src/chrome/src/ui/locales/id.js
+++ b/src/chrome/src/ui/locales/id.js
@@ -111,6 +111,7 @@ export default {
   'sp.error_prefix': 'Galat: {msg}',
   'sp.subscribe.allowance_used': 'Kuota harian gratis WebBrain Cloud telah habis.',
   'sp.subscribe.btn': 'Berlangganan',
+  'sp.subscribe.resume': 'Sudah berlangganan — coba lagi',
   'sp.stopped_by_user': '[Dihentikan oleh pengguna]',
   'sp.stopped_by_user_html': '<em>Dihentikan oleh pengguna.</em>',
 

--- a/src/chrome/src/ui/locales/ja.js
+++ b/src/chrome/src/ui/locales/ja.js
@@ -111,6 +111,7 @@ export default {
   'sp.error_prefix': 'エラー: {msg}',
   'sp.subscribe.allowance_used': 'WebBrain Cloud の無料の1日あたりの利用枠を使い切りました。',
   'sp.subscribe.btn': '購読する',
+  'sp.subscribe.resume': '購読しました — 再試行',
   'sp.stopped_by_user': '[ユーザーが停止]',
   'sp.stopped_by_user_html': '<em>ユーザーが停止しました。</em>',
 

--- a/src/chrome/src/ui/locales/ko.js
+++ b/src/chrome/src/ui/locales/ko.js
@@ -111,6 +111,7 @@ export default {
   'sp.error_prefix': '오류: {msg}',
   'sp.subscribe.allowance_used': 'WebBrain Cloud의 무료 일일 사용량을 모두 사용했습니다.',
   'sp.subscribe.btn': '구독하기',
+  'sp.subscribe.resume': '구독했습니다 — 다시 시도',
   'sp.stopped_by_user': '[사용자가 중지함]',
   'sp.stopped_by_user_html': '<em>사용자가 중지했습니다.</em>',
 

--- a/src/chrome/src/ui/locales/ms.js
+++ b/src/chrome/src/ui/locales/ms.js
@@ -111,6 +111,7 @@ export default {
   'sp.error_prefix': 'Ralat: {msg}',
   'sp.subscribe.allowance_used': 'Peruntukan harian percuma WebBrain Cloud telah digunakan.',
   'sp.subscribe.btn': 'Langgan',
+  'sp.subscribe.resume': 'Saya sudah melanggan — cuba lagi',
   'sp.stopped_by_user': '[Dihentikan oleh pengguna]',
   'sp.stopped_by_user_html': '<em>Dihentikan oleh pengguna.</em>',
 

--- a/src/chrome/src/ui/locales/pl.js
+++ b/src/chrome/src/ui/locales/pl.js
@@ -152,6 +152,7 @@ export default {
   'sp.error_prefix': 'Błąd: {msg}',
   'sp.subscribe.allowance_used': 'Wykorzystano dzienny darmowy limit WebBrain Cloud.',
   'sp.subscribe.btn': 'Subskrybuj',
+  'sp.subscribe.resume': 'Subskrypcja gotowa — spróbuj ponownie',
   'sp.stopped_by_user': '[Zatrzymane przez użytkownika]',
   'sp.stopped_by_user_html': '<em>Zatrzymane przez użytkownika.</em>',
   'sp.continue_bar': 'Osiągnięto limit kroków ({steps} kroków). Mam kontynuować?',

--- a/src/chrome/src/ui/locales/ru.js
+++ b/src/chrome/src/ui/locales/ru.js
@@ -111,6 +111,7 @@ export default {
   'sp.error_prefix': 'Ошибка: {msg}',
   'sp.subscribe.allowance_used': 'Бесплатный дневной лимит WebBrain Cloud исчерпан.',
   'sp.subscribe.btn': 'Оформить подписку',
+  'sp.subscribe.resume': 'Подписка оформлена — повторить',
   'sp.stopped_by_user': '[Остановлено пользователем]',
   'sp.stopped_by_user_html': '<em>Остановлено пользователем.</em>',
 

--- a/src/chrome/src/ui/locales/th.js
+++ b/src/chrome/src/ui/locales/th.js
@@ -111,6 +111,7 @@ export default {
   'sp.error_prefix': 'ข้อผิดพลาด: {msg}',
   'sp.subscribe.allowance_used': 'ใช้โควตารายวันฟรีของ WebBrain Cloud หมดแล้ว',
   'sp.subscribe.btn': 'สมัครสมาชิก',
+  'sp.subscribe.resume': 'สมัครแล้ว — ลองอีกครั้ง',
   'sp.stopped_by_user': '[ผู้ใช้หยุด]',
   'sp.stopped_by_user_html': '<em>ผู้ใช้หยุดแล้ว</em>',
 

--- a/src/chrome/src/ui/locales/tl.js
+++ b/src/chrome/src/ui/locales/tl.js
@@ -111,6 +111,7 @@ export default {
   'sp.error_prefix': 'Error: {msg}',
   'sp.subscribe.allowance_used': 'Naubos na ang libreng pang-araw-araw na alokasyon ng WebBrain Cloud.',
   'sp.subscribe.btn': 'Mag-subscribe',
+  'sp.subscribe.resume': 'Naka-subscribe na — subukan muli',
   'sp.stopped_by_user': '[Itinigil ng user]',
   'sp.stopped_by_user_html': '<em>Itinigil ng user.</em>',
 

--- a/src/chrome/src/ui/locales/tr.js
+++ b/src/chrome/src/ui/locales/tr.js
@@ -142,6 +142,7 @@ export default {
   'sp.error_prefix': 'Hata: {msg}',
   'sp.subscribe.allowance_used': 'Ücretsiz günlük WebBrain Cloud kullanım hakkınız doldu.',
   'sp.subscribe.btn': 'Abone ol',
+  'sp.subscribe.resume': 'Abone oldum — yeniden dene',
   'sp.stopped_by_user': '[Kullanıcı durdurdu]',
   'sp.stopped_by_user_html': '<em>Kullanıcı durdurdu.</em>',
 

--- a/src/chrome/src/ui/locales/uk.js
+++ b/src/chrome/src/ui/locales/uk.js
@@ -111,6 +111,7 @@ export default {
   'sp.error_prefix': 'Помилка: {msg}',
   'sp.subscribe.allowance_used': 'Безкоштовний денний ліміт WebBrain Cloud вичерпано.',
   'sp.subscribe.btn': 'Оформити підписку',
+  'sp.subscribe.resume': 'Підписку оформлено — повторити',
   'sp.stopped_by_user': '[Зупинено користувачем]',
   'sp.stopped_by_user_html': '<em>Зупинено користувачем.</em>',
 

--- a/src/chrome/src/ui/locales/zh.js
+++ b/src/chrome/src/ui/locales/zh.js
@@ -111,6 +111,7 @@ export default {
   'sp.error_prefix': '错误：{msg}',
   'sp.subscribe.allowance_used': '今日免费的 WebBrain Cloud 额度已用完。',
   'sp.subscribe.btn': '订阅',
+  'sp.subscribe.resume': '已订阅 — 重试',
   'sp.stopped_by_user': '[用户已停止]',
   'sp.stopped_by_user_html': '<em>用户已停止。</em>',
 

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -3034,6 +3034,7 @@ function renderAgentErrorUpdate(data, tabId = currentTabId, requestId = '') {
   if (active.duplicate) return;
   const msgEl = addMessage('error', t('sp.error_prefix', { msg: message }), {
     retryPayload: isTabAbortRequested(tabId) ? null : active.retryPayload,
+    subscribeResumeMode: active.retryPayload?.mode,
   });
   if (active.requestId) {
     msgEl.dataset.tabId = active.tabId;
@@ -5166,7 +5167,7 @@ function openSubscribeUrl(url) {
 // caller can skip its normal markdown rendering. The URL is stashed on the
 // button's dataset so it survives chat-history restore (messagesEl.innerHTML),
 // where the click closure is lost and rebindSubscribeButtons re-attaches it.
-function renderSubscribeError(textEl, content) {
+function renderSubscribeError(textEl, content, resumeMode = '') {
   const parsed = parseSubscribeError(content);
   if (!parsed) return false;
 
@@ -5194,7 +5195,9 @@ function renderSubscribeError(textEl, content) {
   resumeBtn.type = 'button';
   resumeBtn.className = 'subscribe-resume-btn';
   resumeBtn.textContent = t('sp.subscribe.resume');
-  resumeBtn.dataset.resumeMode = textEl.closest('.message.assistant')?.dataset.runMode || agentMode;
+  resumeBtn.dataset.resumeMode = ['ask', 'act', 'dev'].includes(resumeMode)
+    ? resumeMode
+    : (textEl.closest('.message.assistant')?.dataset.runMode || agentMode);
   resumeBtn.dataset.bound = 'true';
   resumeBtn.addEventListener('click', () => resumeAfterSubscription(resumeBtn));
   actions.appendChild(resumeBtn);
@@ -5245,7 +5248,7 @@ function addMessage(role, content, options = {}) {
   } else if (role === 'system') {
     if (isSystemHtml(content)) textEl.innerHTML = content.__systemHtml;
     else textEl.textContent = content || '';
-  } else if (!renderSubscribeError(textEl, content)) {
+  } else if (!renderSubscribeError(textEl, content, options.subscribeResumeMode)) {
     textEl.innerHTML = content ? formatMarkdown(content) : '';
   }
 

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -4420,7 +4420,7 @@ function handleAgentUpdateMessage(msg) {
         const textEl = currentAssistantEl.querySelector('.message-text');
         if (textEl && !textEl.textContent.trim()) {
           if (data.status === 'stopped' || data.status === 'cancelled') textEl.innerHTML = t('sp.stopped_by_user_html');
-          else textEl.innerHTML = formatMarkdown(data.finalContent);
+          else if (!renderSubscribeError(textEl, data.finalContent)) textEl.innerHTML = formatMarkdown(data.finalContent);
           addMessageCopyButton(currentAssistantEl);
         }
       }

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -2910,6 +2910,18 @@ function rebindScheduleComposers() {
   });
 }
 
+function resumeAfterSubscription(btn) {
+  if (isProcessing) {
+    showComposerToast(t('sp.retry.busy'), { duration: 4000 });
+    return;
+  }
+  const mode = ['ask', 'act', 'dev'].includes(btn?.dataset?.resumeMode)
+    ? btn.dataset.resumeMode
+    : agentMode;
+  setMode(mode);
+  void continueAgent({ mode });
+}
+
 function rebindSubscribeButtons() {
   document.querySelectorAll('.subscribe-btn').forEach(btn => {
     if (btn.dataset.bound) return;
@@ -2919,13 +2931,7 @@ function rebindSubscribeButtons() {
   document.querySelectorAll('.subscribe-resume-btn').forEach(btn => {
     if (btn.dataset.bound) return;
     btn.dataset.bound = 'true';
-    btn.addEventListener('click', () => {
-      if (isProcessing) {
-        showComposerToast(t('sp.retry.busy'), { duration: 4000 });
-        return;
-      }
-      void continueAgent({ mode: btn.dataset.resumeMode });
-    });
+    btn.addEventListener('click', () => resumeAfterSubscription(btn));
   });
 }
 
@@ -5190,13 +5196,7 @@ function renderSubscribeError(textEl, content) {
   resumeBtn.textContent = t('sp.subscribe.resume');
   resumeBtn.dataset.resumeMode = textEl.closest('.message.assistant')?.dataset.runMode || agentMode;
   resumeBtn.dataset.bound = 'true';
-  resumeBtn.addEventListener('click', () => {
-    if (isProcessing) {
-      showComposerToast(t('sp.retry.busy'), { duration: 4000 });
-      return;
-    }
-    void continueAgent({ mode: resumeBtn.dataset.resumeMode });
-  });
+  resumeBtn.addEventListener('click', () => resumeAfterSubscription(resumeBtn));
   actions.appendChild(resumeBtn);
 
   textEl.appendChild(actions);

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -2916,6 +2916,17 @@ function rebindSubscribeButtons() {
     btn.dataset.bound = 'true';
     btn.addEventListener('click', () => openSubscribeUrl(btn.dataset.subscribeUrl));
   });
+  document.querySelectorAll('.subscribe-resume-btn').forEach(btn => {
+    if (btn.dataset.bound) return;
+    btn.dataset.bound = 'true';
+    btn.addEventListener('click', () => {
+      if (isProcessing) {
+        showComposerToast(t('sp.retry.busy'), { duration: 4000 });
+        return;
+      }
+      void continueAgent({ mode: btn.dataset.resumeMode });
+    });
+  });
 }
 
 function retryPayloadFromButton(btn) {
@@ -3921,6 +3932,7 @@ async function sendMessage(extraChatParams = {}) {
     showActivity(t('sp.activity.thinking'));
     assistantEl = addMessage('assistant', '');
     assistantEl.dataset.runRequestId = requestId;
+    assistantEl.dataset.runMode = modeForSend;
     assistantEl.dataset.lastRenderedSeq = '0';
     currentAssistantEl = assistantEl;
   }
@@ -5019,6 +5031,13 @@ function renderAssistantTextUpdate(assistantEl, content) {
     return;
   }
 
+  if (renderSubscribeError(textEl, content)) {
+    clearStreamedAssistantText(textEl);
+    delete textEl.dataset.suppressToolCallStream;
+    if (!assistantEl.querySelector('.msg-copy-btn')) addMessageCopyButton(assistantEl);
+    return;
+  }
+
   const streamedText = getStreamedAssistantText(textEl);
   const isDuplicateStreamFinal = streamedText && streamedText === String(content);
 
@@ -5136,7 +5155,7 @@ function openSubscribeUrl(url) {
   catch { window.open(url, '_blank', 'noopener'); }
 }
 
-// Render the quota error as a card with a one-click Subscribe button. Returns
+// Render the quota error as a card with Subscribe and explicit resume actions. Returns
 // true when `content` matched and the card was rendered into `textEl`, so the
 // caller can skip its normal markdown rendering. The URL is stashed on the
 // button's dataset so it survives chat-history restore (messagesEl.innerHTML),
@@ -5153,13 +5172,34 @@ function renderSubscribeError(textEl, content) {
   msg.textContent = parsed.message || t('sp.subscribe.allowance_used');
   textEl.appendChild(msg);
 
+  const actions = document.createElement('div');
+  actions.className = 'subscribe-actions';
+
   const btn = document.createElement('button');
+  btn.type = 'button';
   btn.className = 'subscribe-btn';
   btn.textContent = t('sp.subscribe.btn');
   btn.dataset.subscribeUrl = parsed.url;
   btn.dataset.bound = 'true';
   btn.addEventListener('click', () => openSubscribeUrl(btn.dataset.subscribeUrl));
-  textEl.appendChild(btn);
+  actions.appendChild(btn);
+
+  const resumeBtn = document.createElement('button');
+  resumeBtn.type = 'button';
+  resumeBtn.className = 'subscribe-resume-btn';
+  resumeBtn.textContent = t('sp.subscribe.resume');
+  resumeBtn.dataset.resumeMode = textEl.closest('.message.assistant')?.dataset.runMode || agentMode;
+  resumeBtn.dataset.bound = 'true';
+  resumeBtn.addEventListener('click', () => {
+    if (isProcessing) {
+      showComposerToast(t('sp.retry.busy'), { duration: 4000 });
+      return;
+    }
+    void continueAgent({ mode: resumeBtn.dataset.resumeMode });
+  });
+  actions.appendChild(resumeBtn);
+
+  textEl.appendChild(actions);
   return true;
 }
 
@@ -5299,10 +5339,10 @@ function showContinueButton() {
   document.getElementById('btn-continue').addEventListener('click', continueAgent);
 }
 
-async function continueAgent() {
+async function continueAgent(options = {}) {
   const tabId = currentTabId;
   const requestId = createRunRequestId(tabId);
-  const modeForSend = agentMode;
+  const modeForSend = ['ask', 'act', 'dev'].includes(options?.mode) ? options.mode : agentMode;
   clearActiveChatPayloadForTab(tabId);
 
   setTabProcessing(tabId, true);
@@ -5321,6 +5361,7 @@ async function continueAgent() {
 
     assistantEl = addMessage('assistant', '');
     assistantEl.dataset.runRequestId = requestId;
+    assistantEl.dataset.runMode = modeForSend;
     assistantEl.dataset.lastRenderedSeq = '0';
     currentAssistantEl = assistantEl;
     showActivity(t('sp.activity.continuing'));

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -1942,21 +1942,52 @@ body {
   line-height: 1.45;
 }
 
-.subscribe-btn {
-  background: var(--accent);
-  color: #fff;
-  border: none;
+.subscribe-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.subscribe-btn,
+.subscribe-resume-btn {
   padding: 8px 22px;
   border-radius: 6px;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
   white-space: nowrap;
-  transition: background 0.15s;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.subscribe-btn {
+  background: var(--accent);
+  color: #fff;
+  border: 1px solid var(--accent);
 }
 
 .subscribe-btn:hover {
   background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+.subscribe-resume-btn {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  max-width: 100%;
+  white-space: normal;
+}
+
+.subscribe-resume-btn:hover,
+.subscribe-resume-btn:focus-visible {
+  background: var(--accent-dim);
+  color: var(--text-primary);
+}
+
+.subscribe-btn:focus-visible,
+.subscribe-resume-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* Clarify card — agent paused to ask user a question */

--- a/src/firefox/src/ui/locales/ar.js
+++ b/src/firefox/src/ui/locales/ar.js
@@ -109,6 +109,7 @@ export default {
   'sp.error_prefix': 'خطأ: {msg}',
   'sp.subscribe.allowance_used': 'تم استخدام الحصة اليومية المجانية من WebBrain Cloud.',
   'sp.subscribe.btn': 'اشترك',
+  'sp.subscribe.resume': 'اشتركت — أعد المحاولة',
   'sp.stopped_by_user': '[أوقفه المستخدم]',
   'sp.stopped_by_user_html': '<em>أوقفه المستخدم.</em>',
 

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -187,6 +187,7 @@ export default {
   'sp.error_prefix': 'Error: {msg}',
   'sp.subscribe.allowance_used': 'Daily free WebBrain Cloud allowance used.',
   'sp.subscribe.btn': 'Subscribe',
+  'sp.subscribe.resume': 'I’ve subscribed — retry',
   'sp.stopped_by_user': '[Stopped by user]',
   'sp.stopped_by_user_html': '<em>Stopped by user.</em>',
 

--- a/src/firefox/src/ui/locales/es.js
+++ b/src/firefox/src/ui/locales/es.js
@@ -109,6 +109,7 @@ export default {
   'sp.error_prefix': 'Error: {msg}',
   'sp.subscribe.allowance_used': 'Se agotó la asignación diaria gratuita de WebBrain Cloud.',
   'sp.subscribe.btn': 'Suscribirse',
+  'sp.subscribe.resume': 'Ya me suscribí — reintentar',
   'sp.stopped_by_user': '[Detenido por el usuario]',
   'sp.stopped_by_user_html': '<em>Detenido por el usuario.</em>',
 

--- a/src/firefox/src/ui/locales/fr.js
+++ b/src/firefox/src/ui/locales/fr.js
@@ -109,6 +109,7 @@ export default {
   'sp.error_prefix': 'Erreur : {msg}',
   'sp.subscribe.allowance_used': 'Quota quotidien gratuit de WebBrain Cloud épuisé.',
   'sp.subscribe.btn': 'S’abonner',
+  'sp.subscribe.resume': 'Abonnement effectué — réessayer',
   'sp.stopped_by_user': '[Arrêté par l\'utilisateur]',
   'sp.stopped_by_user_html': '<em>Arrêté par l\'utilisateur.</em>',
 

--- a/src/firefox/src/ui/locales/he.js
+++ b/src/firefox/src/ui/locales/he.js
@@ -191,6 +191,7 @@ export default {
   "sp.error_prefix": "שגיאה: {msg}",
   "sp.subscribe.allowance_used": "חינם מדי יום WebBrain נעשה שימוש בקצבת ענן.",
   "sp.subscribe.btn": "הירשם",
+  "sp.subscribe.resume": "נרשמתי — נסה שוב",
   "sp.stopped_by_user": "[נעצר על ידי משתמש]",
   "sp.stopped_by_user_html": "<em>נעצר על ידי משתמש.</em>",
   "sp.continue_bar": "הגיע למגבלת הצעדים ({steps} צעדים). רוצה שאמשיך?",

--- a/src/firefox/src/ui/locales/id.js
+++ b/src/firefox/src/ui/locales/id.js
@@ -109,6 +109,7 @@ export default {
   'sp.error_prefix': 'Galat: {msg}',
   'sp.subscribe.allowance_used': 'Kuota harian gratis WebBrain Cloud telah habis.',
   'sp.subscribe.btn': 'Berlangganan',
+  'sp.subscribe.resume': 'Sudah berlangganan — coba lagi',
   'sp.stopped_by_user': '[Dihentikan oleh pengguna]',
   'sp.stopped_by_user_html': '<em>Dihentikan oleh pengguna.</em>',
 

--- a/src/firefox/src/ui/locales/ja.js
+++ b/src/firefox/src/ui/locales/ja.js
@@ -109,6 +109,7 @@ export default {
   'sp.error_prefix': 'エラー: {msg}',
   'sp.subscribe.allowance_used': 'WebBrain Cloud の無料の1日あたりの利用枠を使い切りました。',
   'sp.subscribe.btn': '購読する',
+  'sp.subscribe.resume': '購読しました — 再試行',
   'sp.stopped_by_user': '[ユーザーが停止]',
   'sp.stopped_by_user_html': '<em>ユーザーが停止しました。</em>',
 

--- a/src/firefox/src/ui/locales/ko.js
+++ b/src/firefox/src/ui/locales/ko.js
@@ -109,6 +109,7 @@ export default {
   'sp.error_prefix': '오류: {msg}',
   'sp.subscribe.allowance_used': 'WebBrain Cloud의 무료 일일 사용량을 모두 사용했습니다.',
   'sp.subscribe.btn': '구독하기',
+  'sp.subscribe.resume': '구독했습니다 — 다시 시도',
   'sp.stopped_by_user': '[사용자가 중지함]',
   'sp.stopped_by_user_html': '<em>사용자가 중지했습니다.</em>',
 

--- a/src/firefox/src/ui/locales/ms.js
+++ b/src/firefox/src/ui/locales/ms.js
@@ -109,6 +109,7 @@ export default {
   'sp.error_prefix': 'Ralat: {msg}',
   'sp.subscribe.allowance_used': 'Peruntukan harian percuma WebBrain Cloud telah digunakan.',
   'sp.subscribe.btn': 'Langgan',
+  'sp.subscribe.resume': 'Saya sudah melanggan — cuba lagi',
   'sp.stopped_by_user': '[Dihentikan oleh pengguna]',
   'sp.stopped_by_user_html': '<em>Dihentikan oleh pengguna.</em>',
 

--- a/src/firefox/src/ui/locales/pl.js
+++ b/src/firefox/src/ui/locales/pl.js
@@ -144,6 +144,7 @@ export default {
   'sp.error_prefix': 'Błąd: {msg}',
   'sp.subscribe.allowance_used': 'Wykorzystano dzienny darmowy limit WebBrain Cloud.',
   'sp.subscribe.btn': 'Subskrybuj',
+  'sp.subscribe.resume': 'Subskrypcja gotowa — spróbuj ponownie',
   'sp.stopped_by_user': '[Zatrzymane przez użytkownika]',
   'sp.stopped_by_user_html': '<em>Zatrzymane przez użytkownika.</em>',
   'sp.continue_bar': 'Osiągnięto limit kroków ({steps} kroków). Mam kontynuować?',

--- a/src/firefox/src/ui/locales/ru.js
+++ b/src/firefox/src/ui/locales/ru.js
@@ -109,6 +109,7 @@ export default {
   'sp.error_prefix': 'Ошибка: {msg}',
   'sp.subscribe.allowance_used': 'Бесплатный дневной лимит WebBrain Cloud исчерпан.',
   'sp.subscribe.btn': 'Оформить подписку',
+  'sp.subscribe.resume': 'Подписка оформлена — повторить',
   'sp.stopped_by_user': '[Остановлено пользователем]',
   'sp.stopped_by_user_html': '<em>Остановлено пользователем.</em>',
 

--- a/src/firefox/src/ui/locales/th.js
+++ b/src/firefox/src/ui/locales/th.js
@@ -109,6 +109,7 @@ export default {
   'sp.error_prefix': 'ข้อผิดพลาด: {msg}',
   'sp.subscribe.allowance_used': 'ใช้โควตารายวันฟรีของ WebBrain Cloud หมดแล้ว',
   'sp.subscribe.btn': 'สมัครสมาชิก',
+  'sp.subscribe.resume': 'สมัครแล้ว — ลองอีกครั้ง',
   'sp.stopped_by_user': '[ผู้ใช้หยุด]',
   'sp.stopped_by_user_html': '<em>ผู้ใช้หยุดแล้ว</em>',
 

--- a/src/firefox/src/ui/locales/tl.js
+++ b/src/firefox/src/ui/locales/tl.js
@@ -109,6 +109,7 @@ export default {
   'sp.error_prefix': 'Error: {msg}',
   'sp.subscribe.allowance_used': 'Naubos na ang libreng pang-araw-araw na alokasyon ng WebBrain Cloud.',
   'sp.subscribe.btn': 'Mag-subscribe',
+  'sp.subscribe.resume': 'Naka-subscribe na — subukan muli',
   'sp.stopped_by_user': '[Itinigil ng user]',
   'sp.stopped_by_user_html': '<em>Itinigil ng user.</em>',
 

--- a/src/firefox/src/ui/locales/tr.js
+++ b/src/firefox/src/ui/locales/tr.js
@@ -140,6 +140,7 @@ export default {
   'sp.error_prefix': 'Hata: {msg}',
   'sp.subscribe.allowance_used': 'Ücretsiz günlük WebBrain Cloud kullanım hakkınız doldu.',
   'sp.subscribe.btn': 'Abone ol',
+  'sp.subscribe.resume': 'Abone oldum — yeniden dene',
   'sp.stopped_by_user': '[Kullanıcı durdurdu]',
   'sp.stopped_by_user_html': '<em>Kullanıcı durdurdu.</em>',
 

--- a/src/firefox/src/ui/locales/uk.js
+++ b/src/firefox/src/ui/locales/uk.js
@@ -109,6 +109,7 @@ export default {
   'sp.error_prefix': 'Помилка: {msg}',
   'sp.subscribe.allowance_used': 'Безкоштовний денний ліміт WebBrain Cloud вичерпано.',
   'sp.subscribe.btn': 'Оформити підписку',
+  'sp.subscribe.resume': 'Підписку оформлено — повторити',
   'sp.stopped_by_user': '[Зупинено користувачем]',
   'sp.stopped_by_user_html': '<em>Зупинено користувачем.</em>',
 

--- a/src/firefox/src/ui/locales/zh.js
+++ b/src/firefox/src/ui/locales/zh.js
@@ -109,6 +109,7 @@ export default {
   'sp.error_prefix': '错误：{msg}',
   'sp.subscribe.allowance_used': '今日免费的 WebBrain Cloud 额度已用完。',
   'sp.subscribe.btn': '订阅',
+  'sp.subscribe.resume': '已订阅 — 重试',
   'sp.stopped_by_user': '[用户已停止]',
   'sp.stopped_by_user_html': '<em>用户已停止。</em>',
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -2985,6 +2985,7 @@ function renderAgentErrorUpdate(data, tabId = currentTabId, requestId = '') {
   if (active.duplicate) return;
   const msgEl = addMessage('error', t('sp.error_prefix', { msg: message }), {
     retryPayload: isTabAbortRequested(tabId) ? null : active.retryPayload,
+    subscribeResumeMode: active.retryPayload?.mode,
   });
   if (active.requestId) {
     msgEl.dataset.tabId = active.tabId;
@@ -4806,7 +4807,7 @@ function openSubscribeUrl(url) {
 // caller can skip its normal markdown rendering. The URL is stashed on the
 // button's dataset so it survives chat-history restore (messagesEl.innerHTML),
 // where the click closure is lost and rebindSubscribeButtons re-attaches it.
-function renderSubscribeError(textEl, content) {
+function renderSubscribeError(textEl, content, resumeMode = '') {
   const parsed = parseSubscribeError(content);
   if (!parsed) return false;
 
@@ -4834,7 +4835,9 @@ function renderSubscribeError(textEl, content) {
   resumeBtn.type = 'button';
   resumeBtn.className = 'subscribe-resume-btn';
   resumeBtn.textContent = t('sp.subscribe.resume');
-  resumeBtn.dataset.resumeMode = textEl.closest('.message.assistant')?.dataset.runMode || agentMode;
+  resumeBtn.dataset.resumeMode = ['ask', 'act', 'dev'].includes(resumeMode)
+    ? resumeMode
+    : (textEl.closest('.message.assistant')?.dataset.runMode || agentMode);
   resumeBtn.dataset.bound = 'true';
   resumeBtn.addEventListener('click', () => resumeAfterSubscription(resumeBtn));
   actions.appendChild(resumeBtn);
@@ -4885,7 +4888,7 @@ function addMessage(role, content, options = {}) {
   } else if (role === 'system') {
     if (isSystemHtml(content)) textEl.innerHTML = content.__systemHtml;
     else textEl.textContent = content || '';
-  } else if (!renderSubscribeError(textEl, content)) {
+  } else if (!renderSubscribeError(textEl, content, options.subscribeResumeMode)) {
     textEl.innerHTML = content ? formatMarkdown(content) : '';
   }
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -4070,7 +4070,7 @@ function handleAgentUpdateMessage(msg) {
         const textEl = currentAssistantEl.querySelector('.message-text');
         if (textEl && !textEl.textContent.trim()) {
           if (data.status === 'stopped' || data.status === 'cancelled') textEl.innerHTML = t('sp.stopped_by_user_html');
-          else textEl.innerHTML = formatMarkdown(data.finalContent);
+          else if (!renderSubscribeError(textEl, data.finalContent)) textEl.innerHTML = formatMarkdown(data.finalContent);
           addMessageCopyButton(currentAssistantEl);
         }
       }

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -2861,6 +2861,18 @@ function rebindScheduleComposers() {
   });
 }
 
+function resumeAfterSubscription(btn) {
+  if (isProcessing) {
+    showComposerToast(t('sp.retry.busy'), { duration: 4000 });
+    return;
+  }
+  const mode = ['ask', 'act', 'dev'].includes(btn?.dataset?.resumeMode)
+    ? btn.dataset.resumeMode
+    : agentMode;
+  setMode(mode);
+  void continueAgent({ mode });
+}
+
 function rebindSubscribeButtons() {
   document.querySelectorAll('.subscribe-btn').forEach(btn => {
     if (btn.dataset.bound) return;
@@ -2870,13 +2882,7 @@ function rebindSubscribeButtons() {
   document.querySelectorAll('.subscribe-resume-btn').forEach(btn => {
     if (btn.dataset.bound) return;
     btn.dataset.bound = 'true';
-    btn.addEventListener('click', () => {
-      if (isProcessing) {
-        showComposerToast(t('sp.retry.busy'), { duration: 4000 });
-        return;
-      }
-      void continueAgent({ mode: btn.dataset.resumeMode });
-    });
+    btn.addEventListener('click', () => resumeAfterSubscription(btn));
   });
 }
 
@@ -4830,13 +4836,7 @@ function renderSubscribeError(textEl, content) {
   resumeBtn.textContent = t('sp.subscribe.resume');
   resumeBtn.dataset.resumeMode = textEl.closest('.message.assistant')?.dataset.runMode || agentMode;
   resumeBtn.dataset.bound = 'true';
-  resumeBtn.addEventListener('click', () => {
-    if (isProcessing) {
-      showComposerToast(t('sp.retry.busy'), { duration: 4000 });
-      return;
-    }
-    void continueAgent({ mode: resumeBtn.dataset.resumeMode });
-  });
+  resumeBtn.addEventListener('click', () => resumeAfterSubscription(resumeBtn));
   actions.appendChild(resumeBtn);
 
   textEl.appendChild(actions);

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -2867,6 +2867,17 @@ function rebindSubscribeButtons() {
     btn.dataset.bound = 'true';
     btn.addEventListener('click', () => openSubscribeUrl(btn.dataset.subscribeUrl));
   });
+  document.querySelectorAll('.subscribe-resume-btn').forEach(btn => {
+    if (btn.dataset.bound) return;
+    btn.dataset.bound = 'true';
+    btn.addEventListener('click', () => {
+      if (isProcessing) {
+        showComposerToast(t('sp.retry.busy'), { duration: 4000 });
+        return;
+      }
+      void continueAgent({ mode: btn.dataset.resumeMode });
+    });
+  });
 }
 
 function retryPayloadFromButton(btn) {
@@ -3776,6 +3787,7 @@ async function sendMessage(extraChatParams = {}) {
     showActivity(t('sp.activity.thinking'));
     assistantEl = addMessage('assistant', '');
     assistantEl.dataset.runRequestId = requestId;
+    assistantEl.dataset.runMode = modeForSend;
     assistantEl.dataset.lastRenderedSeq = '0';
     currentAssistantEl = assistantEl;
   }
@@ -4659,6 +4671,13 @@ function renderAssistantTextUpdate(assistantEl, content) {
     return;
   }
 
+  if (renderSubscribeError(textEl, content)) {
+    clearStreamedAssistantText(textEl);
+    delete textEl.dataset.suppressToolCallStream;
+    if (!assistantEl.querySelector('.msg-copy-btn')) addMessageCopyButton(assistantEl);
+    return;
+  }
+
   const streamedText = getStreamedAssistantText(textEl);
   const isDuplicateStreamFinal = streamedText && streamedText === String(content);
 
@@ -4776,7 +4795,7 @@ function openSubscribeUrl(url) {
   catch { window.open(url, '_blank', 'noopener'); }
 }
 
-// Render the quota error as a card with a one-click Subscribe button. Returns
+// Render the quota error as a card with Subscribe and explicit resume actions. Returns
 // true when `content` matched and the card was rendered into `textEl`, so the
 // caller can skip its normal markdown rendering. The URL is stashed on the
 // button's dataset so it survives chat-history restore (messagesEl.innerHTML),
@@ -4793,13 +4812,34 @@ function renderSubscribeError(textEl, content) {
   msg.textContent = parsed.message || t('sp.subscribe.allowance_used');
   textEl.appendChild(msg);
 
+  const actions = document.createElement('div');
+  actions.className = 'subscribe-actions';
+
   const btn = document.createElement('button');
+  btn.type = 'button';
   btn.className = 'subscribe-btn';
   btn.textContent = t('sp.subscribe.btn');
   btn.dataset.subscribeUrl = parsed.url;
   btn.dataset.bound = 'true';
   btn.addEventListener('click', () => openSubscribeUrl(btn.dataset.subscribeUrl));
-  textEl.appendChild(btn);
+  actions.appendChild(btn);
+
+  const resumeBtn = document.createElement('button');
+  resumeBtn.type = 'button';
+  resumeBtn.className = 'subscribe-resume-btn';
+  resumeBtn.textContent = t('sp.subscribe.resume');
+  resumeBtn.dataset.resumeMode = textEl.closest('.message.assistant')?.dataset.runMode || agentMode;
+  resumeBtn.dataset.bound = 'true';
+  resumeBtn.addEventListener('click', () => {
+    if (isProcessing) {
+      showComposerToast(t('sp.retry.busy'), { duration: 4000 });
+      return;
+    }
+    void continueAgent({ mode: resumeBtn.dataset.resumeMode });
+  });
+  actions.appendChild(resumeBtn);
+
+  textEl.appendChild(actions);
   return true;
 }
 
@@ -4939,10 +4979,10 @@ function showContinueButton() {
   document.getElementById('btn-continue').addEventListener('click', continueAgent);
 }
 
-async function continueAgent() {
+async function continueAgent(options = {}) {
   const tabId = currentTabId;
   const requestId = createRunRequestId(tabId);
-  const modeForSend = agentMode;
+  const modeForSend = ['ask', 'act', 'dev'].includes(options?.mode) ? options.mode : agentMode;
   clearActiveChatPayloadForTab(tabId);
 
   setTabProcessing(tabId, true);
@@ -4960,6 +5000,7 @@ async function continueAgent() {
 
     assistantEl = addMessage('assistant', '');
     assistantEl.dataset.runRequestId = requestId;
+    assistantEl.dataset.runMode = modeForSend;
     assistantEl.dataset.lastRenderedSeq = '0';
     currentAssistantEl = assistantEl;
     showActivity(t('sp.activity.continuing'));

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -1948,21 +1948,52 @@ body {
   line-height: 1.45;
 }
 
-.subscribe-btn {
-  background: var(--accent);
-  color: #fff;
-  border: none;
+.subscribe-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.subscribe-btn,
+.subscribe-resume-btn {
   padding: 8px 22px;
   border-radius: 6px;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
   white-space: nowrap;
-  transition: background 0.15s;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.subscribe-btn {
+  background: var(--accent);
+  color: #fff;
+  border: 1px solid var(--accent);
 }
 
 .subscribe-btn:hover {
   background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+.subscribe-resume-btn {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  max-width: 100%;
+  white-space: normal;
+}
+
+.subscribe-resume-btn:hover,
+.subscribe-resume-btn:focus-visible {
+  background: var(--accent-dim);
+  color: var(--text-primary);
+}
+
+.subscribe-btn:focus-visible,
+.subscribe-resume-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* Clarify card — agent paused to ask user a question */

--- a/test/run.js
+++ b/test/run.js
@@ -7127,7 +7127,9 @@ test('sidepanel subscribe error card clears DOM without HTML reinterpretation', 
     assert.match(body, /actions\.className = 'subscribe-actions';/, `${label}: subscribe actions should share a responsive row`);
     assert.match(body, /resumeBtn\.textContent = t\('sp\.subscribe\.resume'\);/, `${label}: subscribe card should render a localized resume action`);
     assert.match(body, /resumeBtn\.dataset\.resumeMode = textEl\.closest\('\.message\.assistant'\)\?\.dataset\.runMode \|\| agentMode;/, `${label}: resume action should preserve the failed run mode`);
-    assert.match(body, /continueAgent\(\{ mode: resumeBtn\.dataset\.resumeMode \}\)/, `${label}: subscribe resume should use the durable continuation path`);
+    assert.match(body, /resumeAfterSubscription\(resumeBtn\)/, `${label}: subscribe card should use the shared resume handler`);
+    assert.match(panel, /function resumeAfterSubscription\(btn\) \{[\s\S]*?const mode = \['ask', 'act', 'dev'\]\.includes\(btn\?\.dataset\?\.resumeMode\)[\s\S]*?setMode\(mode\);[\s\S]*?continueAgent\(\{ mode \}\);[\s\S]*?\}/, `${label}: subscribe resume should synchronize the visible mode before continuing`);
+    assert.match(panel, /btn\.addEventListener\('click', \(\) => resumeAfterSubscription\(btn\)\);/, `${label}: restored subscribe cards should use the shared resume handler`);
     assert.match(panel, /async function continueAgent\(options = \{\}\) \{[\s\S]*?includes\(options\?\.mode\) \? options\.mode : agentMode;/, `${label}: continuation should accept a preserved mode`);
     assert.match(styles, /\.subscribe-actions\s*\{[\s\S]*?flex-wrap:\s*wrap;/, `${label}: subscribe actions should wrap in narrow panels`);
     assert.match(styles, /\.subscribe-resume-btn\s*\{[\s\S]*?background:\s*transparent;[\s\S]*?border:\s*1px solid var\(--accent\);/, `${label}: resume action should use secondary styling`);

--- a/test/run.js
+++ b/test/run.js
@@ -7116,7 +7116,7 @@ test('sidepanel subscribe error card clears DOM without HTML reinterpretation', 
   ]) {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
     const styles = fs.readFileSync(path.join(ROOT, styleRel), 'utf8');
-    const start = panel.indexOf('function renderSubscribeError(textEl, content) {');
+    const start = panel.indexOf("function renderSubscribeError(textEl, content, resumeMode = '') {");
     assert.notEqual(start, -1, `${label}: renderSubscribeError missing`);
     const end = panel.indexOf('\n}\n\nfunction addMessage', start);
     assert.notEqual(end, -1, `${label}: renderSubscribeError boundary missing`);
@@ -7126,10 +7126,17 @@ test('sidepanel subscribe error card clears DOM without HTML reinterpretation', 
     assert.match(body, /msg\.textContent = parsed\.message \|\| t\('sp\.subscribe\.allowance_used'\);/, `${label}: subscribe message must remain textContent`);
     assert.match(body, /actions\.className = 'subscribe-actions';/, `${label}: subscribe actions should share a responsive row`);
     assert.match(body, /resumeBtn\.textContent = t\('sp\.subscribe\.resume'\);/, `${label}: subscribe card should render a localized resume action`);
-    assert.match(body, /resumeBtn\.dataset\.resumeMode = textEl\.closest\('\.message\.assistant'\)\?\.dataset\.runMode \|\| agentMode;/, `${label}: resume action should preserve the failed run mode`);
+    assert.match(body, /resumeBtn\.dataset\.resumeMode = \['ask', 'act', 'dev'\]\.includes\(resumeMode\)[\s\S]*?\? resumeMode[\s\S]*?: \(textEl\.closest\('\.message\.assistant'\)\?\.dataset\.runMode \|\| agentMode\);/, `${label}: resume action should prefer an explicitly captured failed run mode`);
     assert.match(body, /resumeAfterSubscription\(resumeBtn\)/, `${label}: subscribe card should use the shared resume handler`);
     assert.match(panel, /function resumeAfterSubscription\(btn\) \{[\s\S]*?const mode = \['ask', 'act', 'dev'\]\.includes\(btn\?\.dataset\?\.resumeMode\)[\s\S]*?setMode\(mode\);[\s\S]*?continueAgent\(\{ mode \}\);[\s\S]*?\}/, `${label}: subscribe resume should synchronize the visible mode before continuing`);
     assert.match(panel, /btn\.addEventListener\('click', \(\) => resumeAfterSubscription\(btn\)\);/, `${label}: restored subscribe cards should use the shared resume handler`);
+    const errorUpdateStart = panel.indexOf('function renderAgentErrorUpdate(');
+    const errorUpdateEnd = panel.indexOf('\n}\n\nfunction rebindRestoredMessageControls', errorUpdateStart);
+    assert.notEqual(errorUpdateStart, -1, `${label}: renderAgentErrorUpdate missing`);
+    assert.notEqual(errorUpdateEnd, -1, `${label}: renderAgentErrorUpdate boundary missing`);
+    const errorUpdateBody = panel.slice(errorUpdateStart, errorUpdateEnd);
+    assert.match(errorUpdateBody, /subscribeResumeMode: active\.retryPayload\?\.mode,/, `${label}: structured error cards should receive the request-scoped run mode`);
+    assert.match(panel, /renderSubscribeError\(textEl, content, options\.subscribeResumeMode\)/, `${label}: error messages should forward their captured run mode to the subscribe card`);
     assert.match(panel, /async function continueAgent\(options = \{\}\) \{[\s\S]*?includes\(options\?\.mode\) \? options\.mode : agentMode;/, `${label}: continuation should accept a preserved mode`);
     const runCompleteStart = panel.indexOf("case 'run_complete':");
     const runCompleteEnd = panel.indexOf("case 'context_compacted':", runCompleteStart);

--- a/test/run.js
+++ b/test/run.js
@@ -7131,6 +7131,12 @@ test('sidepanel subscribe error card clears DOM without HTML reinterpretation', 
     assert.match(panel, /function resumeAfterSubscription\(btn\) \{[\s\S]*?const mode = \['ask', 'act', 'dev'\]\.includes\(btn\?\.dataset\?\.resumeMode\)[\s\S]*?setMode\(mode\);[\s\S]*?continueAgent\(\{ mode \}\);[\s\S]*?\}/, `${label}: subscribe resume should synchronize the visible mode before continuing`);
     assert.match(panel, /btn\.addEventListener\('click', \(\) => resumeAfterSubscription\(btn\)\);/, `${label}: restored subscribe cards should use the shared resume handler`);
     assert.match(panel, /async function continueAgent\(options = \{\}\) \{[\s\S]*?includes\(options\?\.mode\) \? options\.mode : agentMode;/, `${label}: continuation should accept a preserved mode`);
+    const runCompleteStart = panel.indexOf("case 'run_complete':");
+    const runCompleteEnd = panel.indexOf("case 'context_compacted':", runCompleteStart);
+    assert.notEqual(runCompleteStart, -1, `${label}: run_complete handler missing`);
+    assert.notEqual(runCompleteEnd, -1, `${label}: run_complete boundary missing`);
+    const runCompleteBody = panel.slice(runCompleteStart, runCompleteEnd);
+    assert.match(runCompleteBody, /else if \(!renderSubscribeError\(textEl, data\.finalContent\)\) textEl\.innerHTML = formatMarkdown\(data\.finalContent\);/, `${label}: restored run finals should render subscribe actions before markdown fallback`);
     assert.match(styles, /\.subscribe-actions\s*\{[\s\S]*?flex-wrap:\s*wrap;/, `${label}: subscribe actions should wrap in narrow panels`);
     assert.match(styles, /\.subscribe-resume-btn\s*\{[\s\S]*?background:\s*transparent;[\s\S]*?border:\s*1px solid var\(--accent\);/, `${label}: resume action should use secondary styling`);
   }

--- a/test/run.js
+++ b/test/run.js
@@ -7110,11 +7110,12 @@ test('sidepanel escapes dynamic system-message interpolation before raw HTML ins
 });
 
 test('sidepanel subscribe error card clears DOM without HTML reinterpretation', () => {
-  for (const [label, panelRel] of [
-    ['chrome', 'src/chrome/src/ui/sidepanel.js'],
-    ['firefox', 'src/firefox/src/ui/sidepanel.js'],
+  for (const [label, panelRel, styleRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js', 'src/chrome/styles/sidepanel.css'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js', 'src/firefox/styles/sidepanel.css'],
   ]) {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    const styles = fs.readFileSync(path.join(ROOT, styleRel), 'utf8');
     const start = panel.indexOf('function renderSubscribeError(textEl, content) {');
     assert.notEqual(start, -1, `${label}: renderSubscribeError missing`);
     const end = panel.indexOf('\n}\n\nfunction addMessage', start);
@@ -7123,6 +7124,13 @@ test('sidepanel subscribe error card clears DOM without HTML reinterpretation', 
     assert.match(body, /textEl\.replaceChildren\(\);/, `${label}: subscribe card should clear via DOM APIs`);
     assert.doesNotMatch(body, /textEl\.innerHTML\s*=\s*'';/, `${label}: subscribe card should not clear via innerHTML`);
     assert.match(body, /msg\.textContent = parsed\.message \|\| t\('sp\.subscribe\.allowance_used'\);/, `${label}: subscribe message must remain textContent`);
+    assert.match(body, /actions\.className = 'subscribe-actions';/, `${label}: subscribe actions should share a responsive row`);
+    assert.match(body, /resumeBtn\.textContent = t\('sp\.subscribe\.resume'\);/, `${label}: subscribe card should render a localized resume action`);
+    assert.match(body, /resumeBtn\.dataset\.resumeMode = textEl\.closest\('\.message\.assistant'\)\?\.dataset\.runMode \|\| agentMode;/, `${label}: resume action should preserve the failed run mode`);
+    assert.match(body, /continueAgent\(\{ mode: resumeBtn\.dataset\.resumeMode \}\)/, `${label}: subscribe resume should use the durable continuation path`);
+    assert.match(panel, /async function continueAgent\(options = \{\}\) \{[\s\S]*?includes\(options\?\.mode\) \? options\.mode : agentMode;/, `${label}: continuation should accept a preserved mode`);
+    assert.match(styles, /\.subscribe-actions\s*\{[\s\S]*?flex-wrap:\s*wrap;/, `${label}: subscribe actions should wrap in narrow panels`);
+    assert.match(styles, /\.subscribe-resume-btn\s*\{[\s\S]*?background:\s*transparent;[\s\S]*?border:\s*1px solid var\(--accent\);/, `${label}: resume action should use secondary styling`);
   }
 });
 
@@ -7755,7 +7763,7 @@ test('sidepanel flushes run chat before queue settlement after immediate tab swi
     assert.notEqual(sendDrainIdx, -1, `${label}: send completion should drain pending tab switches`);
     assert.equal(sendFlushIdx < sendDrainIdx, true, `${label}: send completion must flush before deferred tab switching`);
 
-    const continueMatch = panel.match(/async function continueAgent\(\) \{[\s\S]*?finally \{([\s\S]*?)\n  \}\n\}/);
+    const continueMatch = panel.match(/async function continueAgent\(options = \{\}\) \{[\s\S]*?finally \{([\s\S]*?)\n  \}\n\}/);
     assert.ok(continueMatch, `${label}: continueAgent finally block missing`);
     const continueFinally = continueMatch[1];
     const continueFlushIdx = continueFinally.indexOf('flushRenderedTabChat()');
@@ -8822,7 +8830,7 @@ test('sidepanel keeps retry metadata long enough for returned error updates', ()
     );
     assert.match(
       source,
-      /async function continueAgent\(\) \{[\s\S]*?const tabId = currentTabId;[\s\S]*?clearActiveChatPayloadForTab\(tabId\);[\s\S]*?setTabProcessing\(tabId, true\);/,
+      /async function continueAgent\(options = \{\}\) \{[\s\S]*?const tabId = currentTabId;[\s\S]*?clearActiveChatPayloadForTab\(tabId\);[\s\S]*?setTabProcessing\(tabId, true\);/,
       `${label}: Continue runs should clear stale chat retry metadata before starting`,
     );
   }
@@ -8965,10 +8973,10 @@ test('sidepanel continue runs use the initiating tab state', () => {
     ['firefox', 'src/firefox/src/ui/sidepanel.js'],
   ]) {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
-    const match = panel.match(/async function continueAgent\(\) \{[\s\S]*?\n\}/);
+    const match = panel.match(/async function continueAgent\(options = \{\}\) \{[\s\S]*?\n\}/);
     assert.ok(match, `${label}: continueAgent missing`);
     const body = match[0];
-    assert.match(body, /const tabId = currentTabId;[\s\S]*?const modeForSend = agentMode;[\s\S]*?sendToBackground\('continue', \{[\s\S]*?tabId,[\s\S]*?mode: modeForSend,/, `${label}: Continue should send with the tab and mode captured before awaiting`);
+    assert.match(body, /const tabId = currentTabId;[\s\S]*?const modeForSend = \['ask', 'act', 'dev'\]\.includes\(options\?\.mode\) \? options\.mode : agentMode;[\s\S]*?sendToBackground\('continue', \{[\s\S]*?tabId,[\s\S]*?mode: modeForSend,/, `${label}: Continue should send with the tab and requested-or-current mode captured before awaiting`);
     assert.doesNotMatch(body, /sendToBackground\('continue', \{[\s\S]*?tabId: currentTabId/, `${label}: Continue should not read currentTabId inside the async send payload`);
     assert.doesNotMatch(body, /sendToBackground\('continue', \{[\s\S]*?mode: agentMode/, `${label}: Continue should not read agentMode inside the async send payload`);
     assert.match(body, /await prepareChatHistoryForTurn\(tabId, modeForSend\);[\s\S]*?if \(isTabAbortRequested\(tabId\)\) return false;[\s\S]*?if \(!sameTabId\(currentTabId, tabId\) \|\| !sameTabId\(renderedTabId, tabId\)\) return false;[\s\S]*?assistantEl = addMessage\('assistant', ''\);/, `${label}: Continue should hydrate history, honor aborts, and re-check the initiating tab before rendering`);
@@ -8985,7 +8993,7 @@ test('sidepanel drains queued context-menu prompts after pending tab switches on
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
     const completions = [
       ['sendMessage', /async function sendMessage\([^)]*\) \{[\s\S]*?finally \{([\s\S]*?)\n  \}\n  return accepted;/],
-      ['continueAgent', /async function continueAgent\(\) \{[\s\S]*?finally \{([\s\S]*?)\n  \}\n\}/],
+      ['continueAgent', /async function continueAgent\(options = \{\}\) \{[\s\S]*?finally \{([\s\S]*?)\n  \}\n\}/],
     ];
     for (const [fnName, pattern] of completions) {
       const match = panel.match(pattern);


### PR DESCRIPTION
## Summary

- add an “I’ve subscribed — retry” action beside Subscribe on WebBrain Cloud quota errors
- resume the durable agent conversation in the original Ask, Act, or Dev mode instead of replaying completed actions
- mirror the behavior and responsive secondary styling across Chrome and Firefox
- localize the new action across all supported languages
- extend regression coverage for restored controls, mode preservation, and narrow-panel layout

## Why

After subscribing in the newly opened checkout tab, users returned to the side panel with no direct way to resume the interrupted run. They had to type a manual continuation such as “go on,” and retrying the original request could repeat already-completed browser actions.

## Impact

Users can now return from checkout and explicitly continue where the agent stopped. If subscription activation is still pending, the quota card is rendered again and can be retried without losing the run context.

## Validation

- `npm test`
  - 743 unit/integration checks passed
  - 60/60 prompt-injection security checks passed
- `git diff --check`
