### PR TITLE
Harden managed cloud bridge lifecycle

### DIFF
--- a/src/chrome/src/cloud-runs.js
+++ b/src/chrome/src/cloud-runs.js
@@ -103,6 +103,7 @@ function cloudSnapshot(run, { includeUpdates = true } = {}) {
     task: run.task,
     structured: run.structured ?? !!run.outputSchema,
     result: run.result,
+    persistenceTruncated: run.persistenceTruncated,
     summary: run.summary,
     content: run.content,
     finalUrl: run.finalUrl,

--- a/src/chrome/src/cloud-runs.js
+++ b/src/chrome/src/cloud-runs.js
@@ -2,6 +2,9 @@ const DEFAULT_CLOUD_BRIDGE_URL = 'ws://127.0.0.1:17373/extension';
 const CLOUD_RUN_STORAGE_KEY = 'webbrainCloudRunSnapshots';
 const CLOUD_UPDATE_LIMIT = 200;
 const CLOUD_RUN_LIMIT = 50;
+const CLOUD_STRING_LIMIT = 16 * 1024;
+const CLOUD_RUN_PERSIST_BYTES_LIMIT = 256 * 1024;
+const CLOUD_PERSIST_BYTES_LIMIT = 4 * 1024 * 1024;
 const TERMINAL_STATUSES = new Set(['completed', 'failed', 'aborted']);
 
 export function normalizeCloudBridgeUrl(value = DEFAULT_CLOUD_BRIDGE_URL) {
@@ -22,11 +25,73 @@ function scrubCloudValue(value) {
       if ((key === '_attachImage' || key === 'screenshot') && typeof item === 'string' && item.length > 500) {
         return `[large payload omitted: ${item.length} chars]`;
       }
+      if (typeof item === 'string' && item.length > CLOUD_STRING_LIMIT) {
+        return `${item.slice(0, CLOUD_STRING_LIMIT)}\n[truncated ${item.length - CLOUD_STRING_LIMIT} chars for cloud persistence]`;
+      }
       return item;
     }));
   } catch {
     return { unserializable: true };
   }
+}
+
+function serializedBytes(value) {
+  return new TextEncoder().encode(JSON.stringify(value)).length;
+}
+
+function compactCloudRunForPersistence(run) {
+  const row = scrubCloudValue(run);
+  row.structured = row.structured ?? !!run?.outputSchema;
+  if (serializedBytes(row) <= CLOUD_RUN_PERSIST_BYTES_LIMIT) return row;
+
+  const omittedUpdates = Array.isArray(row.updates) ? row.updates.length : 0;
+  row.updates = [];
+  row.persistenceTruncated = { omittedUpdates };
+  if (serializedBytes(row) <= CLOUD_RUN_PERSIST_BYTES_LIMIT) return row;
+
+  row.content = '';
+  row.outputSchema = null;
+  row.persistenceTruncated.omittedContent = true;
+  row.persistenceTruncated.omittedSchema = true;
+  if (serializedBytes(row) <= CLOUD_RUN_PERSIST_BYTES_LIMIT) return row;
+
+  delete row.result;
+  row.persistenceTruncated.omittedResult = true;
+  if (serializedBytes(row) <= CLOUD_RUN_PERSIST_BYTES_LIMIT) return row;
+
+  return scrubCloudValue({
+    runId: run?.runId,
+    status: run?.status,
+    tabId: run?.tabId,
+    task: run?.task,
+    structured: !!run?.outputSchema || run?.structured === true,
+    summary: run?.summary,
+    content: '',
+    finalUrl: run?.finalUrl,
+    error: run?.error,
+    createdAt: run?.createdAt,
+    updatedAt: run?.updatedAt,
+    completedAt: run?.completedAt,
+    updates: [],
+    persistenceTruncated: { omittedUpdates, omittedResult: true, omittedSchema: true },
+  });
+}
+
+export function buildCloudPersistenceRows(runs) {
+  const values = Array.isArray(runs) ? [...runs] : [...(runs?.values?.() || [])];
+  const candidates = values
+    .sort((a, b) => String(b?.createdAt || '').localeCompare(String(a?.createdAt || '')))
+    .slice(0, CLOUD_RUN_LIMIT)
+    .map(compactCloudRunForPersistence);
+  const rows = [];
+  let totalBytes = 2;
+  for (const row of candidates) {
+    const rowBytes = serializedBytes(row) + (rows.length ? 1 : 0);
+    if (totalBytes + rowBytes > CLOUD_PERSIST_BYTES_LIMIT) continue;
+    rows.push(row);
+    totalBytes += rowBytes;
+  }
+  return rows;
 }
 
 function cloudSnapshot(run, { includeUpdates = true } = {}) {
@@ -36,7 +101,7 @@ function cloudSnapshot(run, { includeUpdates = true } = {}) {
     status: run.status,
     tabId: run.tabId,
     task: run.task,
-    structured: !!run.outputSchema,
+    structured: run.structured ?? !!run.outputSchema,
     result: run.result,
     summary: run.summary,
     content: run.content,
@@ -79,10 +144,7 @@ export function createCloudRunController({
 
   async function persist() {
     if (!api.storage?.session?.set) return;
-    const rows = [...runs.values()]
-      .sort((a, b) => String(b.createdAt).localeCompare(String(a.createdAt)))
-      .slice(0, CLOUD_RUN_LIMIT)
-      .map(run => scrubCloudValue(run));
+    const rows = buildCloudPersistenceRows(runs);
     persistQueue = persistQueue
       .catch(() => {})
       .then(() => api.storage.session.set({ [CLOUD_RUN_STORAGE_KEY]: rows }));

--- a/src/chrome/src/offscreen/cloud-bridge.js
+++ b/src/chrome/src/offscreen/cloud-bridge.js
@@ -7,6 +7,7 @@
  */
 
 (() => {
+  const ALLOWED_BRIDGE_ACTIONS = new Set(['cloud_run', 'cloud_status', 'cloud_abort']);
   let socket = null;
   let bridgeUrl = null;
   let enabled = false;
@@ -34,10 +35,10 @@
     };
   }
 
-  function sendJson(obj) {
-    if (!socket || socket.readyState !== WebSocket.OPEN) return;
+  function sendJson(obj, target = socket) {
+    if (!target || target.readyState !== WebSocket.OPEN) return;
     try {
-      socket.send(JSON.stringify(obj));
+      target.send(JSON.stringify(obj));
     } catch (e) {
       lastError = e.message || String(e);
     }
@@ -56,18 +57,21 @@
     if (!enabled || !bridgeUrl) return;
     if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) return;
     try {
-      socket = new WebSocket(bridgeUrl);
-      socket.addEventListener('open', () => {
+      const nextSocket = new WebSocket(bridgeUrl);
+      socket = nextSocket;
+      nextSocket.addEventListener('open', () => {
+        if (socket !== nextSocket) return;
         reconnectAttempt = 0;
         lastError = '';
-        sendJson({ type: 'hello', client: 'webbrain-extension', status: status() });
+        sendJson({ type: 'hello', client: 'webbrain-extension', status: status() }, nextSocket);
       });
-      socket.addEventListener('message', async (event) => {
+      nextSocket.addEventListener('message', async (event) => {
+        if (socket !== nextSocket) return;
         let msg;
         try {
           msg = JSON.parse(event.data);
         } catch (e) {
-          sendJson({ ok: false, error: `Invalid JSON message: ${e.message}` });
+          sendJson({ ok: false, error: `Invalid JSON message: ${e.message}` }, nextSocket);
           return;
         }
 
@@ -75,7 +79,11 @@
         const action = msg.action || msg.command;
         const payload = msg.payload || msg;
         if (!action) {
-          sendJson({ id, ok: false, error: 'Missing action' });
+          sendJson({ id, ok: false, error: 'Missing action' }, nextSocket);
+          return;
+        }
+        if (!ALLOWED_BRIDGE_ACTIONS.has(action)) {
+          sendJson({ id, ok: false, error: `Unsupported cloud bridge action: ${action}` }, nextSocket);
           return;
         }
 
@@ -85,20 +93,25 @@
             target: 'background',
             action,
           });
-          if (response && response.error) {
-            sendJson({ id, ok: false, error: response.error });
+          const isRunSnapshot = !!response
+            && (response.runId != null || response.run_id != null)
+            && typeof response.status === 'string';
+          if (response?.error && !isRunSnapshot) {
+            sendJson({ id, ok: false, error: response.error }, nextSocket);
           } else {
-            sendJson({ id, ok: true, result: response });
+            sendJson({ id, ok: true, result: response }, nextSocket);
           }
         } catch (e) {
-          sendJson({ id, ok: false, error: e.message || String(e) });
+          sendJson({ id, ok: false, error: e.message || String(e) }, nextSocket);
         }
       });
-      socket.addEventListener('close', () => {
+      nextSocket.addEventListener('close', () => {
+        if (socket !== nextSocket) return;
         socket = null;
         scheduleReconnect();
       });
-      socket.addEventListener('error', () => {
+      nextSocket.addEventListener('error', () => {
+        if (socket !== nextSocket) return;
         lastError = 'WebSocket error';
       });
     } catch (e) {
@@ -122,8 +135,9 @@
       enabled = true;
       bridgeUrl = nextUrl;
       if (changed && socket) {
-        try { socket.close(); } catch {}
+        const previousSocket = socket;
         socket = null;
+        try { previousSocket.close(); } catch {}
       }
       connect();
       sendResponse(status());
@@ -135,9 +149,10 @@
       reconnectTimer = null;
       reconnectAttempt = 0;
       if (socket) {
-        try { socket.close(); } catch {}
+        const previousSocket = socket;
+        socket = null;
+        try { previousSocket.close(); } catch {}
       }
-      socket = null;
       sendResponse(status());
       return false;
     }

--- a/test/run.js
+++ b/test/run.js
@@ -98,7 +98,7 @@ const { RunUiJournal: RunUiJournalCh } = await import(
 const { RunUiJournal: RunUiJournalFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/run-ui-journal.js').replace(/\\/g, '/')
 );
-const { createCloudRunController, normalizeCloudBridgeUrl } = await import(
+const { buildCloudPersistenceRows, createCloudRunController, normalizeCloudBridgeUrl } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/cloud-runs.js').replace(/\\/g, '/')
 );
 const { handleDoneJson: handleDoneJsonCh } = await import(
@@ -4225,6 +4225,39 @@ test('cloud run controller fails interrupted runs after service-worker restart',
   assert.match(restored.error, /service worker restarted/i);
 });
 
+test('cloud run persistence caps oversized strings, runs, and total snapshot bytes', () => {
+  const oversized = 'x'.repeat(32 * 1024);
+  const makeRun = (index, chunkCount = 12) => ({
+    runId: `run_${String(index).padStart(2, '0')}`,
+    status: index === 99 ? 'failed' : 'completed',
+    tabId: index,
+    task: oversized,
+    outputSchema: { result: 'string' },
+    result: { chunks: Array.from({ length: chunkCount }, () => oversized) },
+    summary: oversized,
+    content: oversized,
+    finalUrl: `https://example.com/${index}`,
+    error: index === 99 ? 'Expected failure survives compaction.' : '',
+    updates: Array.from({ length: 20 }, () => ({ type: 'tool_result', data: { text: oversized } })),
+    createdAt: new Date(Date.UTC(2026, 0, 1, 0, index === 99 ? 59 : index)).toISOString(),
+    updatedAt: '2026-01-01T01:00:00.000Z',
+    completedAt: '2026-01-01T01:00:00.000Z',
+  });
+  const runs = [makeRun(99, 40), ...Array.from({ length: 49 }, (_, index) => makeRun(index))];
+
+  const rows = buildCloudPersistenceRows(runs);
+  const bytes = new TextEncoder().encode(JSON.stringify(rows)).length;
+
+  assert.ok(bytes <= 4 * 1024 * 1024, `persisted cloud rows exceeded byte budget: ${bytes}`);
+  assert.ok(rows.length < runs.length, 'total byte budget should omit the oldest oversized snapshots');
+  assert.equal(rows[0].runId, 'run_99', 'newest run must survive storage compaction');
+  assert.equal(rows[0].status, 'failed');
+  assert.equal(rows[0].error, 'Expected failure survives compaction.');
+  assert.equal(rows[0].structured, true);
+  assert.equal(rows[0].persistenceTruncated?.omittedResult, true, 'oversized single-run payload should fall back to a minimal restart snapshot');
+  assert.ok(!JSON.stringify(rows).includes(oversized), 'raw oversized strings must not reach storage.session');
+});
+
 test('cloud bridge accepts only loopback WebSocket URLs', () => {
   assert.equal(normalizeCloudBridgeUrl('ws://127.0.0.1:17373/extension'), 'ws://127.0.0.1:17373/extension');
   assert.equal(normalizeCloudBridgeUrl('ws://localhost:17373/extension'), 'ws://localhost:17373/extension');
@@ -4232,14 +4265,16 @@ test('cloud bridge accepts only loopback WebSocket URLs', () => {
   assert.throws(() => normalizeCloudBridgeUrl('ws://192.168.1.10/extension'), /localhost/);
 });
 
-test('offscreen cloud bridge reconnects with backoff and rejects remote control URLs', () => {
+function createOffscreenCloudBridgeHarness({ sendMessage = async () => ({}), closeSynchronously = true } = {}) {
   const source = fs.readFileSync(path.join(ROOT, 'src/chrome/src/offscreen/cloud-bridge.js'), 'utf8');
   const sockets = [];
   const timers = [];
+  const runtimeCalls = [];
   let listener = null;
   class FakeWebSocket {
     static CONNECTING = 0;
     static OPEN = 1;
+    static CLOSING = 2;
     static CLOSED = 3;
     constructor(url) {
       this.url = url;
@@ -4250,22 +4285,42 @@ test('offscreen cloud bridge reconnects with backoff and rejects remote control 
     }
     addEventListener(type, callback) { this.listeners.set(type, callback); }
     send(value) { this.sent.push(JSON.parse(value)); }
-    close() { this.readyState = FakeWebSocket.CLOSED; this.listeners.get('close')?.(); }
-    emit(type, value = {}) { this.listeners.get(type)?.(value); }
+    close() {
+      this.readyState = FakeWebSocket.CLOSING;
+      if (closeSynchronously) this.emit('close');
+    }
+    emit(type, value = {}) {
+      if (type === 'open') this.readyState = FakeWebSocket.OPEN;
+      if (type === 'close') this.readyState = FakeWebSocket.CLOSED;
+      this.listeners.get(type)?.(value);
+    }
   }
   vm.runInNewContext(source, {
     URL,
     WebSocket: FakeWebSocket,
-    chrome: { runtime: { onMessage: { addListener: callback => { listener = callback; } }, sendMessage: async () => ({}) } },
+    chrome: {
+      runtime: {
+        onMessage: { addListener: callback => { listener = callback; } },
+        sendMessage: async message => {
+          runtimeCalls.push(message);
+          return await sendMessage(message);
+        },
+      },
+    },
     setTimeout: (callback, delay) => { timers.push({ callback, delay }); return timers.length; },
     clearTimeout: () => {},
   });
+
+  return { listener: (...args) => listener(...args), runtimeCalls, sockets, timers };
+}
+
+test('offscreen cloud bridge reconnects with backoff and rejects remote control URLs', () => {
+  const { listener, sockets, timers } = createOffscreenCloudBridgeHarness();
 
   let started;
   listener({ type: 'cloud-bridge-start', url: 'ws://127.0.0.1:17373/extension' }, null, value => { started = value; });
   assert.equal(started.enabled, true);
   assert.equal(sockets.length, 1);
-  sockets[0].readyState = FakeWebSocket.OPEN;
   sockets[0].emit('open');
   assert.equal(sockets[0].sent[0].type, 'hello');
   sockets[0].close();
@@ -4277,6 +4332,75 @@ test('offscreen cloud bridge reconnects with backoff and rejects remote control 
   listener({ type: 'cloud-bridge-start', url: 'wss://attacker.example/extension' }, null, value => { rejected = value; });
   assert.match(rejected.error, /localhost/);
   assert.equal(sockets.length, 2);
+});
+
+test('offscreen cloud bridge preserves failed run envelopes and rejects unauthorized actions', async () => {
+  const failed = { runId: 'run_failed', status: 'failed', error: 'Agent failed.' };
+  const aborting = { runId: 'run_abort', status: 'aborting', error: 'Abort requested.' };
+  const { listener, runtimeCalls, sockets } = createOffscreenCloudBridgeHarness({
+    sendMessage: async message => {
+      if (message.action === 'cloud_status' && message.runId === 'run_failed') return failed;
+      if (message.action === 'cloud_status') return { error: 'Unknown cloud run.' };
+      if (message.action === 'cloud_abort') return aborting;
+      return {};
+    },
+  });
+  listener({ type: 'cloud-bridge-start', url: 'ws://127.0.0.1:17373/extension' }, null, () => {});
+  const socket = sockets[0];
+  socket.emit('open');
+
+  socket.emit('message', {
+    data: JSON.stringify({ id: 'status-1', action: 'cloud_status', payload: { runId: 'run_failed' } }),
+  });
+  await new Promise(resolve => setImmediate(resolve));
+  const statusResponse = socket.sent.find(message => message.id === 'status-1');
+  assert.equal(statusResponse.ok, true, 'failed run snapshots are domain results, not bridge failures');
+  assert.equal(statusResponse.result.status, 'failed');
+  assert.equal(statusResponse.result.error, 'Agent failed.');
+
+  socket.emit('message', {
+    data: JSON.stringify({ id: 'abort-1', action: 'cloud_abort', payload: { runId: 'run_abort' } }),
+  });
+  await new Promise(resolve => setImmediate(resolve));
+  const abortResponse = socket.sent.find(message => message.id === 'abort-1');
+  assert.equal(abortResponse.ok, true, 'aborting snapshots with an error explanation must remain successful protocol responses');
+  assert.equal(abortResponse.result.status, 'aborting');
+
+  socket.emit('message', {
+    data: JSON.stringify({ id: 'missing-1', action: 'cloud_status', payload: { runId: 'run_missing' } }),
+  });
+  await new Promise(resolve => setImmediate(resolve));
+  const missing = socket.sent.find(message => message.id === 'missing-1');
+  assert.equal(missing.ok, false, 'background exception envelopes must still reject the bridge request');
+  assert.equal(missing.error, 'Unknown cloud run.');
+
+  const callCount = runtimeCalls.length;
+  socket.emit('message', {
+    data: JSON.stringify({ id: 'forbidden-1', action: 'get_providers', payload: {} }),
+  });
+  await new Promise(resolve => setImmediate(resolve));
+  const forbidden = socket.sent.find(message => message.id === 'forbidden-1');
+  assert.equal(forbidden.ok, false);
+  assert.match(forbidden.error, /unsupported cloud bridge action/i);
+  assert.equal(runtimeCalls.length, callCount, 'unauthorized bridge actions must not reach the background handler');
+});
+
+test('offscreen cloud bridge ignores asynchronous close events from replaced sockets', () => {
+  const { listener, sockets, timers } = createOffscreenCloudBridgeHarness({ closeSynchronously: false });
+  listener({ type: 'cloud-bridge-start', url: 'ws://127.0.0.1:17373/extension' }, null, () => {});
+  const first = sockets[0];
+  first.emit('open');
+
+  listener({ type: 'cloud-bridge-start', url: 'ws://localhost:17374/extension' }, null, () => {});
+  const replacement = sockets[1];
+  assert.ok(replacement, 'URL change should create a replacement WebSocket');
+
+  first.emit('close');
+  replacement.emit('open');
+
+  assert.equal(sockets.length, 2, 'stale close must not create a duplicate connection');
+  assert.equal(timers.length, 0, 'stale close must not schedule reconnect for the replacement');
+  assert.equal(replacement.sent.filter(message => message.type === 'hello').length, 1, 'replacement socket should remain current and announce itself');
 });
 
 test('getToolsForMode: `done` outcome is exposed only in full and mid action modes', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -4258,6 +4258,45 @@ test('cloud run persistence caps oversized strings, runs, and total snapshot byt
   assert.ok(!JSON.stringify(rows).includes(oversized), 'raw oversized strings must not reach storage.session');
 });
 
+test('cloud run status exposes persistence truncation after service-worker restart', async () => {
+  const oversized = 'x'.repeat(32 * 1024);
+  const [row] = buildCloudPersistenceRows([{
+    runId: 'run_truncated',
+    status: 'completed',
+    tabId: 7,
+    task: 'Return a large structured result',
+    outputSchema: { chunks: 'string[]' },
+    result: { chunks: Array.from({ length: 40 }, () => oversized) },
+    summary: 'Completed with a result too large to persist.',
+    content: '',
+    finalUrl: 'https://example.com/',
+    error: '',
+    updates: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:01:00.000Z',
+    completedAt: '2026-01-01T00:01:00.000Z',
+  }]);
+  const session = { webbrainCloudRunSnapshots: [row] };
+  const controller = createCloudRunController({
+    chromeApi: {
+      tabs: {},
+      storage: {
+        local: { get: async () => ({}) },
+        session: { get: async key => ({ [key]: session[key] }), set: async value => Object.assign(session, value) },
+      },
+      runtime: { sendMessage: async () => ({}) },
+    },
+    agent: {},
+    ensureOffscreen: async () => {},
+  });
+
+  const restored = await controller.status({ runId: 'run_truncated' });
+  assert.equal(restored.status, 'completed');
+  assert.equal(restored.structured, true);
+  assert.equal(restored.result, undefined);
+  assert.equal(restored.persistenceTruncated?.omittedResult, true);
+});
+
 test('cloud bridge accepts only loopback WebSocket URLs', () => {
   assert.equal(normalizeCloudBridgeUrl('ws://127.0.0.1:17373/extension'), 'ws://127.0.0.1:17373/extension');
   assert.equal(normalizeCloudBridgeUrl('ws://localhost:17373/extension'), 'ws://localhost:17373/extension');


### PR DESCRIPTION
## Summary

- preserve failed and aborting run snapshots as successful bridge protocol responses while still rejecting genuine background exceptions
- restrict loopback bridge commands to `cloud_run`, `cloud_status`, and `cloud_abort`
- make WebSocket callbacks instance-safe so stale close events cannot disconnect or duplicate a replacement connection
- bound persisted cloud-run state by string, per-run, and total byte budgets while retaining a minimal restart-safe snapshot

## Root causes

The bridge previously treated any response containing `error` as a transport failure, even though failed and aborting run snapshots intentionally carry an error explanation. It also forwarded arbitrary action names into the central background handler and allowed callbacks from replaced sockets to mutate the current socket. Persistence limited update count but not serialized bytes, allowing large raw tool results to exceed `chrome.storage.session` capacity.

## Tests

Added regression coverage for:

- failed and aborting status envelopes plus genuine error-envelope rejection
- unauthorized bridge actions never reaching the background handler
- asynchronous stale-socket close events
- oversized strings, individual runs, and total persistence snapshots

Validation:

- `npm test`: 762 core tests passed
- prompt-injection corpus: 60/60 passed
- `node --check` for changed JavaScript files
- `git diff --check`

## Impact

These changes affect only managed Chrome cloud-browser bridge execution and persistence. Normal consumer side-panel runs remain unchanged.