### PR TITLE
Fix duplicate WebBrain Cloud quota errors

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -576,7 +576,12 @@ export class Agent {
   }
 
   _isCostAllowanceError(err) {
-    return err?.code === 'WB_COST_ALLOWANCE';
+    // WebBrain Cloud's free-tier 402 is also an allowance terminal, but it
+    // originates in the provider rather than _costAllowanceError(). Treat it
+    // like the local cost cap so the agent does not retry it and then emit a
+    // second generic error card beside the actionable Subscribe prompt.
+    return err?.code === 'WB_COST_ALLOWANCE'
+      || /Subscribe for more usage:\s*https?:\/\/\S+/i.test(String(err?.message || ''));
   }
 
   async _chatWithCostAllowance(provider, messages, options, costState) {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -561,7 +561,12 @@ export class Agent {
   }
 
   _isCostAllowanceError(err) {
-    return err?.code === 'WB_COST_ALLOWANCE';
+    // WebBrain Cloud's free-tier 402 is also an allowance terminal, but it
+    // originates in the provider rather than _costAllowanceError(). Treat it
+    // like the local cost cap so the agent does not retry it and then emit a
+    // second generic error card beside the actionable Subscribe prompt.
+    return err?.code === 'WB_COST_ALLOWANCE'
+      || /Subscribe for more usage:\s*https?:\/\/\S+/i.test(String(err?.message || ''));
   }
 
   async _chatWithCostAllowance(provider, messages, options, costState) {

--- a/test/run.js
+++ b/test/run.js
@@ -21956,6 +21956,53 @@ test('sidepanel routes every run-error path through request-scoped deduplication
   }
 });
 
+test('WebBrain Cloud subscription 402 renders as one terminal assistant prompt', async () => {
+  for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+    const subscriptionMessage = 'webbrain-cloud error 402: Daily free WebBrain Cloud allowance used.\n'
+      + 'Subscribe for more usage: https://webbrain.one/subscribe?client_reference_id=device-guid';
+    let providerCalls = 0;
+    const provider = {
+      supportsTools: true,
+      supportsVision: false,
+      promptTier: 'full',
+      contextWindow: 128000,
+      model: 'webbrain-cloud 1.0',
+      name: 'webbrain-cloud',
+      chat: async () => {
+        providerCalls += 1;
+        throw new Error(subscriptionMessage);
+      },
+    };
+    const agent = new AgentClass({
+      getActive: () => provider,
+      getVisionProvider: async () => null,
+    });
+    const tabId = label === 'chrome' ? 9401 : 9402;
+    agent.planBeforeAct = false;
+    agent.maxSteps = 2;
+    agent._manageContext = async () => {};
+    agent._enrichUserMessageWithCurrentPage = async (_tabId, _messages, content) => ({ role: 'user', content });
+    agent._maybeReinjectAdapter = async () => {};
+    agent._persist = () => {};
+    agent._startTraceRun = async () => null;
+    agent._endTraceRun = () => {};
+
+    const updates = [];
+    const final = await agent.processMessage(tabId, 'hello', (type, data) => {
+      updates.push({ type, data });
+    }, 'ask');
+
+    assert.equal(providerCalls, 1, `${label}: subscription 402 should not be retried`);
+    assert.equal(final, subscriptionMessage, `${label}: subscription prompt should remain the terminal assistant content`);
+    assert.equal(updates.filter(update => update.type === 'error').length, 0, `${label}: subscription 402 should not emit a generic error card`);
+    assert.equal(
+      updates.filter(update => update.type === 'warning' && update.data?.message === subscriptionMessage).length,
+      1,
+      `${label}: subscription 402 should emit one non-duplicating terminal warning`,
+    );
+  }
+});
+
 test('plan review: cancellation emits plan_resolved and timeout has an explicit terminal decision', async () => {
   await withPlannerBrowserGlobals(async () => {
     for (const [label, AgentClass, sourceRel] of [


### PR DESCRIPTION
## Summary

- treat WebBrain Cloud free-tier 402 subscription prompts as terminal allowance results in Chrome and Firefox
- avoid the unnecessary automatic retry and duplicate generic error card
- add regression coverage for the complete agent update path

## Root cause

The agent recognized only locally generated `WB_COST_ALLOWANCE` errors as terminal. Provider-generated WebBrain Cloud 402 responses therefore entered the transient retry path, which emitted a generic error update before returning the same subscription prompt as assistant content.

## User impact

Quota exhaustion now produces one actionable subscription card instead of a white subscription card plus a duplicate red error card.

## Validation

- `npm test` (773 tests plus the security injection corpus)
- `node --check` on both agent files and `test/run.js`
- `git diff --check`