### PR TITLE
Add sidebar Markdown syntax highlighting

### DIFF
--- a/src/chrome/src/ui/markdown-render.js
+++ b/src/chrome/src/ui/markdown-render.js
@@ -1,0 +1,214 @@
+/**
+ * Small, dependency-free helpers for the sidepanel's chat Markdown output.
+ * Highlighting always escapes source code before adding fixed token spans.
+ */
+
+const LANGUAGE_ALIASES = Object.freeze({
+  js: 'javascript', javascript: 'javascript', jsx: 'javascript',
+  ts: 'javascript', typescript: 'javascript', tsx: 'javascript',
+  css: 'css', scss: 'css', less: 'css',
+  html: 'markup', htm: 'markup', xml: 'markup', svg: 'markup',
+  json: 'json', jsonc: 'json',
+  py: 'python', python: 'python',
+  sh: 'shell', shell: 'shell', bash: 'shell', zsh: 'shell',
+  sql: 'sql',
+  yaml: 'yaml', yml: 'yaml',
+  c: 'clike', h: 'clike', cpp: 'clike', 'c++': 'clike',
+  cs: 'clike', 'c#': 'clike', java: 'clike', kotlin: 'clike', kt: 'clike',
+  go: 'clike', rust: 'clike', rs: 'clike', swift: 'clike',
+  php: 'clike', ruby: 'clike', rb: 'clike',
+});
+
+const JS_KEYWORDS = new Set(('abstract as async await break case catch class const continue debugger declare default delete do else enum export extends finally for from function get if implements import in infer instanceof interface keyof let namespace new of private protected public readonly return satisfies set static super switch throw try type typeof var void while with yield').split(' '));
+const JS_CONSTANTS = new Set(('true false null undefined NaN Infinity').split(' '));
+const JS_BUILTINS = new Set(('Array BigInt Boolean Date Error Intl JSON Map Math Number Object Promise Proxy Reflect RegExp Set String Symbol WeakMap WeakSet console document globalThis window').split(' '));
+const PYTHON_KEYWORDS = new Set(('and as assert async await break case class continue def del elif else except False finally for from global if import in is lambda match None nonlocal not or pass raise return True try while with yield').split(' '));
+const PYTHON_BUILTINS = new Set(('bool bytes dict enumerate filter float int len list map max min open print range reversed set sorted str sum super tuple type zip').split(' '));
+const SHELL_KEYWORDS = new Set(('case do done elif else esac export fi for function if in local readonly select then time until while').split(' '));
+const CLIKE_KEYWORDS = new Set(('abstract alignas async await bool break byte case catch char class const constexpr continue default defer delete do double else enum explicit export extends extern false final finally float fn for foreach from func function go goto if implements import in inline int interface internal is let long match namespace new nil null nullptr operator override package private protected protocol public raise readonly ref return sealed short signed sizeof static struct super switch template this throw throws trait true try type typedef typeof union unsigned use using var virtual void volatile where while yield').split(' '));
+const CLIKE_TYPES = new Set(('Array Boolean Error List Map Object Option Promise Result Set String Vec').split(' '));
+const CSS_BUILTINS = new Set(('calc clamp currentColor inherit initial linear-gradient min max none radial-gradient repeat revert transparent unset url var').split(' '));
+
+const JS_TOKENS = /\/\*[\s\S]*?\*\/|\/\/[^\n]*|`(?:\\[\s\S]|[^\\`])*`|"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|\b(?:0[xX][\da-fA-F]+|0[bB][01]+|0[oO][0-7]+|\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)n?\b|\b[A-Za-z_$][\w$]*\b|===|!==|=>|\?\?|\?\.|\+\+|--|&&|\|\||[+\-*\/%=&|^!<>?:~]+|[{}\[\]();,.]/g;
+const CSS_TOKENS = /\/\*[\s\S]*?\*\/|"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|#[\da-fA-F]{3,8}\b|[.#][-_a-zA-Z][\w-]*|@[\w-]+|--[\w-]+|-?\d*\.?\d+(?:[a-zA-Z%]+)?|-?[_a-zA-Z][\w-]*|[{}[\]():;,>+~*=!]/g;
+const MARKUP_TOKENS = /<!--[\s\S]*?-->|<!DOCTYPE[^>]*>|<\/?[A-Za-z][^>]*>|&(?:#\d+|#x[\da-fA-F]+|[A-Za-z][\w]+);/gi;
+const JSON_TOKENS = /\/\*[\s\S]*?\*\/|\/\/[^\n]*|"(?:\\[\s\S]|[^"\\])*"|-?\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b|\b(?:true|false|null)\b|[{}[\],:]/g;
+const PYTHON_TOKENS = /#[^\n]*|'''[\s\S]*?'''|"""[\s\S]*?"""|"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|@[A-Za-z_][\w.]*|\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?j?\b|\b[A-Za-z_]\w*\b|:=|==|!=|<=|>=|\*\*|\/\/|->|[-+*\/%=&|^~<>:]+|[{}\[\]();,.]/g;
+const SHELL_TOKENS = /#[^\n]*|"(?:\\[\s\S]|[^"\\])*"|'[^']*'|\$\{[^}]+\}|\$[A-Za-z_][\w]*|\b\d+(?:\.\d+)?\b|\b[A-Za-z_]\w*\b|&&|\|\||<<|>>|;;|[-+*\/%=&|!<>]+|[{}\[\]();]/g;
+const SQL_TOKENS = /--[^\n]*|\/\*[\s\S]*?\*\/|'(?:''|[^'])*'|"(?:""|[^"])*"|\b\d+(?:\.\d+)?\b|\b[A-Za-z_]\w*\b|<>|!=|<=|>=|::|[-+*\/%=<>]+|[(),.;]/gi;
+const YAML_TOKENS = /#[^\n]*|"(?:\\[\s\S]|[^"\\])*"|'(?:''|[^'])*'|&[\w-]+|\*[\w-]+|![\w!-]+|-?\b\d+(?:\.\d+)?\b|\b(?:true|false|null|yes|no|on|off)\b|(?:^|\n)[ \t-]*[\w.-]+(?=\s*:)|[\[\]{},:|>]/gi;
+const CLIKE_TOKENS = /^[ \t]*#[^\n]*|\/\*[\s\S]*?\*\/|\/\/[^\n]*|"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|\$[A-Za-z_]\w*|\b(?:0[xX][\da-fA-F]+|\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\b|\b[A-Za-z_]\w*\b|::|=>|->|===|!==|==|!=|<=|>=|&&|\|\||\+\+|--|[-+*\/%=&|^!<>?:~]+|[{}\[\]();,.]/gm;
+
+export function escapeCodeHtml(value) {
+  return String(value == null ? '' : value).replace(/[&<>"']/g, (character) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[character]));
+}
+
+export function normalizeCodeLanguage(language) {
+  return LANGUAGE_ALIASES[String(language || '').trim().toLowerCase()] || '';
+}
+
+function tokenSpan(type, value) {
+  const escaped = escapeCodeHtml(value);
+  return type ? `<span class="syntax-${type}">${escaped}</span>` : escaped;
+}
+
+function tokenize(source, pattern, classify) {
+  let output = '';
+  let cursor = 0;
+  pattern.lastIndex = 0;
+  for (const match of source.matchAll(pattern)) {
+    output += escapeCodeHtml(source.slice(cursor, match.index));
+    output += tokenSpan(classify(match[0], match.index, source), match[0]);
+    cursor = match.index + match[0].length;
+  }
+  return output + escapeCodeHtml(source.slice(cursor));
+}
+
+function quoted(token) {
+  return token.startsWith('"') || token.startsWith("'") || token.startsWith('`');
+}
+
+function punctuation(token) {
+  return token.length === 1 && '{}[]();,.'.includes(token);
+}
+
+function highlightJavascript(source) {
+  return tokenize(source, JS_TOKENS, (token, index, input) => {
+    if (token.startsWith('//') || token.startsWith('/*')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (/^(?:\d|0[xXbBoO])/.test(token)) return 'number';
+    if (JS_KEYWORDS.has(token)) return 'keyword';
+    if (JS_CONSTANTS.has(token)) return 'constant';
+    if (JS_BUILTINS.has(token)) return 'builtin';
+    if (/^[A-Za-z_$]/.test(token) && /^\s*\(/.test(input.slice(index + token.length))) return 'function';
+    return punctuation(token) ? 'punctuation' : (/^[\w$]+$/.test(token) ? '' : 'operator');
+  });
+}
+
+function highlightCss(source) {
+  return tokenize(source, CSS_TOKENS, (token, index, input) => {
+    if (token.startsWith('/*')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (/^#[\da-fA-F]{3,8}$/.test(token)) return 'constant';
+    if (/^[.#]/.test(token)) return 'selector';
+    if (token.startsWith('@')) return 'keyword';
+    if (token.startsWith('--')) return 'variable';
+    if (/^-?\d/.test(token)) return 'number';
+    if (CSS_BUILTINS.has(token)) return 'builtin';
+    if (/^[-_a-zA-Z]/.test(token) && /^\s*:/.test(input.slice(index + token.length))) return 'property';
+    return /^[{}[\]():;,>+~*=!]$/.test(token) ? 'punctuation' : '';
+  });
+}
+
+function highlightMarkup(source) {
+  return tokenize(source, MARKUP_TOKENS, (token) => {
+    if (token.startsWith('<!--')) return 'comment';
+    if (/^<!doctype/i.test(token)) return 'keyword';
+    if (token.startsWith('&')) return 'constant';
+    return 'tag';
+  });
+}
+
+function highlightJson(source) {
+  return tokenize(source, JSON_TOKENS, (token, index, input) => {
+    if (token.startsWith('//') || token.startsWith('/*')) return 'comment';
+    if (token.startsWith('"')) return /^\s*:/.test(input.slice(index + token.length)) ? 'property' : 'string';
+    if (/^-?\d/.test(token)) return 'number';
+    if (/^(?:true|false|null)$/.test(token)) return 'constant';
+    return 'punctuation';
+  });
+}
+
+function highlightPython(source) {
+  return tokenize(source, PYTHON_TOKENS, (token, index, input) => {
+    if (token.startsWith('#')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (token.startsWith('@')) return 'decorator';
+    if (/^\d/.test(token)) return 'number';
+    if (PYTHON_KEYWORDS.has(token)) return 'keyword';
+    if (PYTHON_BUILTINS.has(token)) return 'builtin';
+    if (/^[A-Za-z_]/.test(token) && /^\s*\(/.test(input.slice(index + token.length))) return 'function';
+    return punctuation(token) ? 'punctuation' : (/^\w+$/.test(token) ? '' : 'operator');
+  });
+}
+
+function highlightShell(source) {
+  return tokenize(source, SHELL_TOKENS, (token) => {
+    if (token.startsWith('#')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (token.startsWith('$')) return 'variable';
+    if (/^\d/.test(token)) return 'number';
+    if (SHELL_KEYWORDS.has(token)) return 'keyword';
+    return punctuation(token) ? 'punctuation' : (/^\w+$/.test(token) ? '' : 'operator');
+  });
+}
+
+function highlightSql(source) {
+  return tokenize(source, SQL_TOKENS, (token) => {
+    const lower = token.toLowerCase();
+    if (token.startsWith('--') || token.startsWith('/*')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (/^\d/.test(token)) return 'number';
+    if (('add all alter and as asc begin between by case check column commit constraint create database default delete desc distinct drop else end exists foreign from full grant group having if in index inner insert into is join key left like limit not null on or order outer primary references right rollback select set table then union unique update values view when where with').split(' ').includes(lower)) return 'keyword';
+    return /^\w+$/.test(token) ? '' : 'operator';
+  });
+}
+
+function highlightYaml(source) {
+  return tokenize(source, YAML_TOKENS, (token) => {
+    if (token.startsWith('#')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (/^[&*!]/.test(token)) return 'variable';
+    if (/^-?\d/.test(token)) return 'number';
+    if (/^(?:true|false|null|yes|no|on|off)$/i.test(token)) return 'constant';
+    if (/:\s*$/.test(token) || /^[\s-]*[\w.-]+$/.test(token)) return 'property';
+    return 'punctuation';
+  });
+}
+
+function highlightClike(source) {
+  return tokenize(source, CLIKE_TOKENS, (token, index, input) => {
+    if (/^\s*#/.test(token)) return 'keyword';
+    if (token.startsWith('//') || token.startsWith('/*')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (token.startsWith('$')) return 'variable';
+    if (/^\d/.test(token)) return 'number';
+    if (CLIKE_KEYWORDS.has(token)) return 'keyword';
+    if (CLIKE_TYPES.has(token) || /^[A-Z][A-Za-z0-9_]*$/.test(token)) return 'type';
+    if (/^[A-Za-z_]/.test(token) && /^\s*\(/.test(input.slice(index + token.length))) return 'function';
+    return punctuation(token) ? 'punctuation' : (/^\w+$/.test(token) ? '' : 'operator');
+  });
+}
+
+export function highlightCode(code, language) {
+  const source = String(code == null ? '' : code);
+  switch (normalizeCodeLanguage(language)) {
+    case 'javascript': return highlightJavascript(source);
+    case 'css': return highlightCss(source);
+    case 'markup': return highlightMarkup(source);
+    case 'json': return highlightJson(source);
+    case 'python': return highlightPython(source);
+    case 'shell': return highlightShell(source);
+    case 'sql': return highlightSql(source);
+    case 'yaml': return highlightYaml(source);
+    case 'clike': return highlightClike(source);
+    default: return escapeCodeHtml(source);
+  }
+}
+
+/** Convert escaped ATX heading lines while leaving inline formatting for the caller. */
+export function renderMarkdownHeadings(text) {
+  return String(text == null ? '' : text).replace(
+    /^(#{1,6})[ \t]+(.+?)(?:[ \t]+#+[ \t]*)?(?:\r?\n|$)/gm,
+    (_match, hashes, content) => {
+      const level = hashes.length;
+      return `<h${level}>${content.replace(/[ \t]+$/, '')}</h${level}>`;
+    }
+  );
+}

--- a/src/chrome/src/ui/markdown-render.js
+++ b/src/chrome/src/ui/markdown-render.js
@@ -53,6 +53,10 @@ export function normalizeCodeLanguage(language) {
   return LANGUAGE_ALIASES[String(language || '').trim().toLowerCase()] || '';
 }
 
+export function codeFenceLanguage(infoString) {
+  return String(infoString || '').trim().split(/\s+/, 1)[0] || '';
+}
+
 function tokenSpan(type, value) {
   const escaped = escapeCodeHtml(value);
   return type ? `<span class="syntax-${type}">${escaped}</span>` : escaped;

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -5,6 +5,7 @@
 
 import { t, getLocale, setLocale, LANGUAGES, applyDOMTranslations } from './i18n.js';
 import { sanitizeMarkdownLinks } from './markdown-link.js';
+import { highlightCode, renderMarkdownHeadings } from './markdown-render.js';
 import { applyMode, loadMode, watch } from './theme.js';
 import { buildRecommendedActions, shouldShowRecommendedActions } from './recommended-actions.js';
 import { createContextMenuPromptHandler } from './context-menu-prompts.js';
@@ -5551,7 +5552,7 @@ function formatMarkdown(text) {
 
   // 1. Extract fenced code blocks BEFORE escaping HTML
   const codeBlocks = [];
-  text = text.replace(/```(\w*)\n?([\s\S]*?)```/g, (_match, lang, code) => {
+  text = text.replace(/```[ \t]*([^\s`\r\n]*)[ \t]*\r?\n([\s\S]*?)```/g, (_match, lang, code) => {
     const id = `__CODEBLOCK_${codeBlocks.length}__`;
     codeBlocks.push({ lang: lang || '', code });
     return id;
@@ -5571,10 +5572,10 @@ function formatMarkdown(text) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 
-  // 4. Inline formatting (bold + italic), then markdown link sanitization,
-  // then newline → <br>. Links are handled by the dedicated markdown-link
-  // module (unit-tested in test/run.js) — see that file for the rationale
-  // and threat model.
+  // 4. Block headings, inline formatting, markdown link sanitization, then
+  // newline → <br>. Code and inline-code placeholders were extracted above,
+  // so Markdown-looking source inside them is not interpreted here.
+  text = renderMarkdownHeadings(text);
   text = text
     .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
     .replace(/\*(.+?)\*/g, '<em>$1</em>');
@@ -5591,13 +5592,13 @@ function formatMarkdown(text) {
 
   // 6. Restore fenced code blocks with copy button
   codeBlocks.forEach((block, i) => {
-    const escaped = block.code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const highlighted = highlightCode(block.code, block.lang);
     const langLabel = block.lang ? `<span class="code-lang">${escapeHtml(block.lang)}</span>` : '';
     const copyBtn = `<button class="code-copy-btn" data-code-index="${i}" title="${escapeHtml(t('sp.copy.code.title'))}">${escapeHtml(t('sp.copy'))}</button>`;
     const header = `<div class="code-block-header">${langLabel}${copyBtn}</div>`;
     text = text.replace(
       `__CODEBLOCK_${i}__`,
-      () => `<div class="code-block-wrapper">${header}<pre><code>${escaped}</code></pre></div>`
+      () => `<div class="code-block-wrapper">${header}<pre><code>${highlighted}</code></pre></div>`
     );
   });
 

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -5,7 +5,7 @@
 
 import { t, getLocale, setLocale, LANGUAGES, applyDOMTranslations } from './i18n.js';
 import { sanitizeMarkdownLinks } from './markdown-link.js';
-import { highlightCode, renderMarkdownHeadings } from './markdown-render.js';
+import { codeFenceLanguage, highlightCode, renderMarkdownHeadings } from './markdown-render.js';
 import { applyMode, loadMode, watch } from './theme.js';
 import { buildRecommendedActions, shouldShowRecommendedActions } from './recommended-actions.js';
 import { createContextMenuPromptHandler } from './context-menu-prompts.js';
@@ -5552,7 +5552,8 @@ function formatMarkdown(text) {
 
   // 1. Extract fenced code blocks BEFORE escaping HTML
   const codeBlocks = [];
-  text = text.replace(/```[ \t]*([^\s`\r\n]*)[ \t]*\r?\n([\s\S]*?)```/g, (_match, lang, code) => {
+  text = text.replace(/```[ \t]*([^`\r\n]*)\r?\n([\s\S]*?)```/g, (_match, info, code) => {
+    const lang = codeFenceLanguage(info);
     const id = `__CODEBLOCK_${codeBlocks.length}__`;
     codeBlocks.push({ lang: lang || '', code });
     return id;

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -26,6 +26,16 @@
   --tint-medium: rgba(255, 255, 255, 0.08);
   --overlay-bg: rgba(0, 0, 0, 0.30);
   --overlay-bg-strong: rgba(0, 0, 0, 0.40);
+  --syntax-comment: #8796a5;
+  --syntax-keyword: #c792ea;
+  --syntax-string: #c3e88d;
+  --syntax-number: #f78c6c;
+  --syntax-function: #82aaff;
+  --syntax-property: #80cbc4;
+  --syntax-tag: #f07178;
+  --syntax-constant: #ffcb6b;
+  --syntax-operator: #89ddff;
+  --syntax-variable: #f78c6c;
   --radius: 12px;
   --radius-sm: 8px;
   --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
@@ -53,6 +63,16 @@
   --tint-medium: rgba(89, 55, 25, 0.10);
   --overlay-bg: rgba(89, 55, 25, 0.10);
   --overlay-bg-strong: rgba(89, 55, 25, 0.18);
+  --syntax-comment: #776b5d;
+  --syntax-keyword: #7138a8;
+  --syntax-string: #2f7135;
+  --syntax-number: #a94e13;
+  --syntax-function: #2457a7;
+  --syntax-property: #08737d;
+  --syntax-tag: #b4233c;
+  --syntax-constant: #8a5a00;
+  --syntax-operator: #0e6f7d;
+  --syntax-variable: #a23e48;
   --shadow: 0 2px 8px rgba(89, 55, 25, 0.10);
   color-scheme: light;
 }
@@ -1744,6 +1764,34 @@ body {
 }
 
 /* Code blocks */
+.message-content h1,
+.message-content h2,
+.message-content h3,
+.message-content h4,
+.message-content h5,
+.message-content h6 {
+  margin: 14px 0 6px;
+  color: var(--text-primary);
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.message-content h1:first-child,
+.message-content h2:first-child,
+.message-content h3:first-child,
+.message-content h4:first-child,
+.message-content h5:first-child,
+.message-content h6:first-child {
+  margin-top: 0;
+}
+
+.message-content h1 { font-size: 17px; }
+.message-content h2 { font-size: 15px; }
+.message-content h3 { font-size: 14px; }
+.message-content h4,
+.message-content h5,
+.message-content h6 { font-size: 13px; }
+
 .message-content code {
   background: var(--overlay-bg);
   padding: 1px 4px;
@@ -1766,6 +1814,22 @@ body {
   padding: 0;
   white-space: pre;
 }
+
+.syntax-comment { color: var(--syntax-comment); font-style: italic; }
+.syntax-keyword,
+.syntax-decorator { color: var(--syntax-keyword); }
+.syntax-string { color: var(--syntax-string); }
+.syntax-number,
+.syntax-variable { color: var(--syntax-number); }
+.syntax-function,
+.syntax-builtin { color: var(--syntax-function); }
+.syntax-property { color: var(--syntax-property); }
+.syntax-tag { color: var(--syntax-tag); }
+.syntax-constant,
+.syntax-selector,
+.syntax-type { color: var(--syntax-constant); }
+.syntax-operator { color: var(--syntax-operator); }
+.syntax-punctuation { color: var(--text-secondary); }
 
 /* Fenced code block wrapper with header */
 .code-block-wrapper {

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -1819,8 +1819,8 @@ body {
 .syntax-keyword,
 .syntax-decorator { color: var(--syntax-keyword); }
 .syntax-string { color: var(--syntax-string); }
-.syntax-number,
-.syntax-variable { color: var(--syntax-number); }
+.syntax-number { color: var(--syntax-number); }
+.syntax-variable { color: var(--syntax-variable); }
 .syntax-function,
 .syntax-builtin { color: var(--syntax-function); }
 .syntax-property { color: var(--syntax-property); }

--- a/src/firefox/src/ui/markdown-render.js
+++ b/src/firefox/src/ui/markdown-render.js
@@ -1,0 +1,214 @@
+/**
+ * Small, dependency-free helpers for the sidepanel's chat Markdown output.
+ * Highlighting always escapes source code before adding fixed token spans.
+ */
+
+const LANGUAGE_ALIASES = Object.freeze({
+  js: 'javascript', javascript: 'javascript', jsx: 'javascript',
+  ts: 'javascript', typescript: 'javascript', tsx: 'javascript',
+  css: 'css', scss: 'css', less: 'css',
+  html: 'markup', htm: 'markup', xml: 'markup', svg: 'markup',
+  json: 'json', jsonc: 'json',
+  py: 'python', python: 'python',
+  sh: 'shell', shell: 'shell', bash: 'shell', zsh: 'shell',
+  sql: 'sql',
+  yaml: 'yaml', yml: 'yaml',
+  c: 'clike', h: 'clike', cpp: 'clike', 'c++': 'clike',
+  cs: 'clike', 'c#': 'clike', java: 'clike', kotlin: 'clike', kt: 'clike',
+  go: 'clike', rust: 'clike', rs: 'clike', swift: 'clike',
+  php: 'clike', ruby: 'clike', rb: 'clike',
+});
+
+const JS_KEYWORDS = new Set(('abstract as async await break case catch class const continue debugger declare default delete do else enum export extends finally for from function get if implements import in infer instanceof interface keyof let namespace new of private protected public readonly return satisfies set static super switch throw try type typeof var void while with yield').split(' '));
+const JS_CONSTANTS = new Set(('true false null undefined NaN Infinity').split(' '));
+const JS_BUILTINS = new Set(('Array BigInt Boolean Date Error Intl JSON Map Math Number Object Promise Proxy Reflect RegExp Set String Symbol WeakMap WeakSet console document globalThis window').split(' '));
+const PYTHON_KEYWORDS = new Set(('and as assert async await break case class continue def del elif else except False finally for from global if import in is lambda match None nonlocal not or pass raise return True try while with yield').split(' '));
+const PYTHON_BUILTINS = new Set(('bool bytes dict enumerate filter float int len list map max min open print range reversed set sorted str sum super tuple type zip').split(' '));
+const SHELL_KEYWORDS = new Set(('case do done elif else esac export fi for function if in local readonly select then time until while').split(' '));
+const CLIKE_KEYWORDS = new Set(('abstract alignas async await bool break byte case catch char class const constexpr continue default defer delete do double else enum explicit export extends extern false final finally float fn for foreach from func function go goto if implements import in inline int interface internal is let long match namespace new nil null nullptr operator override package private protected protocol public raise readonly ref return sealed short signed sizeof static struct super switch template this throw throws trait true try type typedef typeof union unsigned use using var virtual void volatile where while yield').split(' '));
+const CLIKE_TYPES = new Set(('Array Boolean Error List Map Object Option Promise Result Set String Vec').split(' '));
+const CSS_BUILTINS = new Set(('calc clamp currentColor inherit initial linear-gradient min max none radial-gradient repeat revert transparent unset url var').split(' '));
+
+const JS_TOKENS = /\/\*[\s\S]*?\*\/|\/\/[^\n]*|`(?:\\[\s\S]|[^\\`])*`|"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|\b(?:0[xX][\da-fA-F]+|0[bB][01]+|0[oO][0-7]+|\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)n?\b|\b[A-Za-z_$][\w$]*\b|===|!==|=>|\?\?|\?\.|\+\+|--|&&|\|\||[+\-*\/%=&|^!<>?:~]+|[{}\[\]();,.]/g;
+const CSS_TOKENS = /\/\*[\s\S]*?\*\/|"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|#[\da-fA-F]{3,8}\b|[.#][-_a-zA-Z][\w-]*|@[\w-]+|--[\w-]+|-?\d*\.?\d+(?:[a-zA-Z%]+)?|-?[_a-zA-Z][\w-]*|[{}[\]():;,>+~*=!]/g;
+const MARKUP_TOKENS = /<!--[\s\S]*?-->|<!DOCTYPE[^>]*>|<\/?[A-Za-z][^>]*>|&(?:#\d+|#x[\da-fA-F]+|[A-Za-z][\w]+);/gi;
+const JSON_TOKENS = /\/\*[\s\S]*?\*\/|\/\/[^\n]*|"(?:\\[\s\S]|[^"\\])*"|-?\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b|\b(?:true|false|null)\b|[{}[\],:]/g;
+const PYTHON_TOKENS = /#[^\n]*|'''[\s\S]*?'''|"""[\s\S]*?"""|"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|@[A-Za-z_][\w.]*|\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?j?\b|\b[A-Za-z_]\w*\b|:=|==|!=|<=|>=|\*\*|\/\/|->|[-+*\/%=&|^~<>:]+|[{}\[\]();,.]/g;
+const SHELL_TOKENS = /#[^\n]*|"(?:\\[\s\S]|[^"\\])*"|'[^']*'|\$\{[^}]+\}|\$[A-Za-z_][\w]*|\b\d+(?:\.\d+)?\b|\b[A-Za-z_]\w*\b|&&|\|\||<<|>>|;;|[-+*\/%=&|!<>]+|[{}\[\]();]/g;
+const SQL_TOKENS = /--[^\n]*|\/\*[\s\S]*?\*\/|'(?:''|[^'])*'|"(?:""|[^"])*"|\b\d+(?:\.\d+)?\b|\b[A-Za-z_]\w*\b|<>|!=|<=|>=|::|[-+*\/%=<>]+|[(),.;]/gi;
+const YAML_TOKENS = /#[^\n]*|"(?:\\[\s\S]|[^"\\])*"|'(?:''|[^'])*'|&[\w-]+|\*[\w-]+|![\w!-]+|-?\b\d+(?:\.\d+)?\b|\b(?:true|false|null|yes|no|on|off)\b|(?:^|\n)[ \t-]*[\w.-]+(?=\s*:)|[\[\]{},:|>]/gi;
+const CLIKE_TOKENS = /^[ \t]*#[^\n]*|\/\*[\s\S]*?\*\/|\/\/[^\n]*|"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|\$[A-Za-z_]\w*|\b(?:0[xX][\da-fA-F]+|\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\b|\b[A-Za-z_]\w*\b|::|=>|->|===|!==|==|!=|<=|>=|&&|\|\||\+\+|--|[-+*\/%=&|^!<>?:~]+|[{}\[\]();,.]/gm;
+
+export function escapeCodeHtml(value) {
+  return String(value == null ? '' : value).replace(/[&<>"']/g, (character) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[character]));
+}
+
+export function normalizeCodeLanguage(language) {
+  return LANGUAGE_ALIASES[String(language || '').trim().toLowerCase()] || '';
+}
+
+function tokenSpan(type, value) {
+  const escaped = escapeCodeHtml(value);
+  return type ? `<span class="syntax-${type}">${escaped}</span>` : escaped;
+}
+
+function tokenize(source, pattern, classify) {
+  let output = '';
+  let cursor = 0;
+  pattern.lastIndex = 0;
+  for (const match of source.matchAll(pattern)) {
+    output += escapeCodeHtml(source.slice(cursor, match.index));
+    output += tokenSpan(classify(match[0], match.index, source), match[0]);
+    cursor = match.index + match[0].length;
+  }
+  return output + escapeCodeHtml(source.slice(cursor));
+}
+
+function quoted(token) {
+  return token.startsWith('"') || token.startsWith("'") || token.startsWith('`');
+}
+
+function punctuation(token) {
+  return token.length === 1 && '{}[]();,.'.includes(token);
+}
+
+function highlightJavascript(source) {
+  return tokenize(source, JS_TOKENS, (token, index, input) => {
+    if (token.startsWith('//') || token.startsWith('/*')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (/^(?:\d|0[xXbBoO])/.test(token)) return 'number';
+    if (JS_KEYWORDS.has(token)) return 'keyword';
+    if (JS_CONSTANTS.has(token)) return 'constant';
+    if (JS_BUILTINS.has(token)) return 'builtin';
+    if (/^[A-Za-z_$]/.test(token) && /^\s*\(/.test(input.slice(index + token.length))) return 'function';
+    return punctuation(token) ? 'punctuation' : (/^[\w$]+$/.test(token) ? '' : 'operator');
+  });
+}
+
+function highlightCss(source) {
+  return tokenize(source, CSS_TOKENS, (token, index, input) => {
+    if (token.startsWith('/*')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (/^#[\da-fA-F]{3,8}$/.test(token)) return 'constant';
+    if (/^[.#]/.test(token)) return 'selector';
+    if (token.startsWith('@')) return 'keyword';
+    if (token.startsWith('--')) return 'variable';
+    if (/^-?\d/.test(token)) return 'number';
+    if (CSS_BUILTINS.has(token)) return 'builtin';
+    if (/^[-_a-zA-Z]/.test(token) && /^\s*:/.test(input.slice(index + token.length))) return 'property';
+    return /^[{}[\]():;,>+~*=!]$/.test(token) ? 'punctuation' : '';
+  });
+}
+
+function highlightMarkup(source) {
+  return tokenize(source, MARKUP_TOKENS, (token) => {
+    if (token.startsWith('<!--')) return 'comment';
+    if (/^<!doctype/i.test(token)) return 'keyword';
+    if (token.startsWith('&')) return 'constant';
+    return 'tag';
+  });
+}
+
+function highlightJson(source) {
+  return tokenize(source, JSON_TOKENS, (token, index, input) => {
+    if (token.startsWith('//') || token.startsWith('/*')) return 'comment';
+    if (token.startsWith('"')) return /^\s*:/.test(input.slice(index + token.length)) ? 'property' : 'string';
+    if (/^-?\d/.test(token)) return 'number';
+    if (/^(?:true|false|null)$/.test(token)) return 'constant';
+    return 'punctuation';
+  });
+}
+
+function highlightPython(source) {
+  return tokenize(source, PYTHON_TOKENS, (token, index, input) => {
+    if (token.startsWith('#')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (token.startsWith('@')) return 'decorator';
+    if (/^\d/.test(token)) return 'number';
+    if (PYTHON_KEYWORDS.has(token)) return 'keyword';
+    if (PYTHON_BUILTINS.has(token)) return 'builtin';
+    if (/^[A-Za-z_]/.test(token) && /^\s*\(/.test(input.slice(index + token.length))) return 'function';
+    return punctuation(token) ? 'punctuation' : (/^\w+$/.test(token) ? '' : 'operator');
+  });
+}
+
+function highlightShell(source) {
+  return tokenize(source, SHELL_TOKENS, (token) => {
+    if (token.startsWith('#')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (token.startsWith('$')) return 'variable';
+    if (/^\d/.test(token)) return 'number';
+    if (SHELL_KEYWORDS.has(token)) return 'keyword';
+    return punctuation(token) ? 'punctuation' : (/^\w+$/.test(token) ? '' : 'operator');
+  });
+}
+
+function highlightSql(source) {
+  return tokenize(source, SQL_TOKENS, (token) => {
+    const lower = token.toLowerCase();
+    if (token.startsWith('--') || token.startsWith('/*')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (/^\d/.test(token)) return 'number';
+    if (('add all alter and as asc begin between by case check column commit constraint create database default delete desc distinct drop else end exists foreign from full grant group having if in index inner insert into is join key left like limit not null on or order outer primary references right rollback select set table then union unique update values view when where with').split(' ').includes(lower)) return 'keyword';
+    return /^\w+$/.test(token) ? '' : 'operator';
+  });
+}
+
+function highlightYaml(source) {
+  return tokenize(source, YAML_TOKENS, (token) => {
+    if (token.startsWith('#')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (/^[&*!]/.test(token)) return 'variable';
+    if (/^-?\d/.test(token)) return 'number';
+    if (/^(?:true|false|null|yes|no|on|off)$/i.test(token)) return 'constant';
+    if (/:\s*$/.test(token) || /^[\s-]*[\w.-]+$/.test(token)) return 'property';
+    return 'punctuation';
+  });
+}
+
+function highlightClike(source) {
+  return tokenize(source, CLIKE_TOKENS, (token, index, input) => {
+    if (/^\s*#/.test(token)) return 'keyword';
+    if (token.startsWith('//') || token.startsWith('/*')) return 'comment';
+    if (quoted(token)) return 'string';
+    if (token.startsWith('$')) return 'variable';
+    if (/^\d/.test(token)) return 'number';
+    if (CLIKE_KEYWORDS.has(token)) return 'keyword';
+    if (CLIKE_TYPES.has(token) || /^[A-Z][A-Za-z0-9_]*$/.test(token)) return 'type';
+    if (/^[A-Za-z_]/.test(token) && /^\s*\(/.test(input.slice(index + token.length))) return 'function';
+    return punctuation(token) ? 'punctuation' : (/^\w+$/.test(token) ? '' : 'operator');
+  });
+}
+
+export function highlightCode(code, language) {
+  const source = String(code == null ? '' : code);
+  switch (normalizeCodeLanguage(language)) {
+    case 'javascript': return highlightJavascript(source);
+    case 'css': return highlightCss(source);
+    case 'markup': return highlightMarkup(source);
+    case 'json': return highlightJson(source);
+    case 'python': return highlightPython(source);
+    case 'shell': return highlightShell(source);
+    case 'sql': return highlightSql(source);
+    case 'yaml': return highlightYaml(source);
+    case 'clike': return highlightClike(source);
+    default: return escapeCodeHtml(source);
+  }
+}
+
+/** Convert escaped ATX heading lines while leaving inline formatting for the caller. */
+export function renderMarkdownHeadings(text) {
+  return String(text == null ? '' : text).replace(
+    /^(#{1,6})[ \t]+(.+?)(?:[ \t]+#+[ \t]*)?(?:\r?\n|$)/gm,
+    (_match, hashes, content) => {
+      const level = hashes.length;
+      return `<h${level}>${content.replace(/[ \t]+$/, '')}</h${level}>`;
+    }
+  );
+}

--- a/src/firefox/src/ui/markdown-render.js
+++ b/src/firefox/src/ui/markdown-render.js
@@ -53,6 +53,10 @@ export function normalizeCodeLanguage(language) {
   return LANGUAGE_ALIASES[String(language || '').trim().toLowerCase()] || '';
 }
 
+export function codeFenceLanguage(infoString) {
+  return String(infoString || '').trim().split(/\s+/, 1)[0] || '';
+}
+
 function tokenSpan(type, value) {
   const escaped = escapeCodeHtml(value);
   return type ? `<span class="syntax-${type}">${escaped}</span>` : escaped;

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -5,6 +5,7 @@
 
 import { t, getLocale, setLocale, LANGUAGES, applyDOMTranslations } from './i18n.js';
 import { sanitizeMarkdownLinks } from './markdown-link.js';
+import { highlightCode, renderMarkdownHeadings } from './markdown-render.js';
 import { applyMode, loadMode, watch } from './theme.js';
 import { buildRecommendedActions, shouldShowRecommendedActions } from './recommended-actions.js';
 import { createContextMenuPromptHandler } from './context-menu-prompts.js';
@@ -5322,7 +5323,7 @@ function formatMarkdown(text) {
 
   // 1. Extract fenced code blocks BEFORE escaping HTML
   const codeBlocks = [];
-  text = text.replace(/```(\w*)\n?([\s\S]*?)```/g, (_match, lang, code) => {
+  text = text.replace(/```[ \t]*([^\s`\r\n]*)[ \t]*\r?\n([\s\S]*?)```/g, (_match, lang, code) => {
     const id = `__CODEBLOCK_${codeBlocks.length}__`;
     codeBlocks.push({ lang: lang || '', code });
     return id;
@@ -5342,10 +5343,10 @@ function formatMarkdown(text) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 
-  // 4. Inline formatting (bold + italic), then markdown link sanitization,
-  // then newline → <br>. Links are handled by the dedicated markdown-link
-  // module (unit-tested in test/run.js) — see that file for the rationale
-  // and threat model.
+  // 4. Block headings, inline formatting, markdown link sanitization, then
+  // newline → <br>. Code and inline-code placeholders were extracted above,
+  // so Markdown-looking source inside them is not interpreted here.
+  text = renderMarkdownHeadings(text);
   text = text
     .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
     .replace(/\*(.+?)\*/g, '<em>$1</em>');
@@ -5362,13 +5363,13 @@ function formatMarkdown(text) {
 
   // 6. Restore fenced code blocks with copy button
   codeBlocks.forEach((block, i) => {
-    const escaped = block.code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const highlighted = highlightCode(block.code, block.lang);
     const langLabel = block.lang ? `<span class="code-lang">${escapeHtml(block.lang)}</span>` : '';
     const copyBtn = `<button class="code-copy-btn" data-code-index="${i}" title="${escapeHtml(t('sp.copy.code.title'))}">${escapeHtml(t('sp.copy'))}</button>`;
     const header = `<div class="code-block-header">${langLabel}${copyBtn}</div>`;
     text = text.replace(
       `__CODEBLOCK_${i}__`,
-      () => `<div class="code-block-wrapper">${header}<pre><code>${escaped}</code></pre></div>`
+      () => `<div class="code-block-wrapper">${header}<pre><code>${highlighted}</code></pre></div>`
     );
   });
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -5,7 +5,7 @@
 
 import { t, getLocale, setLocale, LANGUAGES, applyDOMTranslations } from './i18n.js';
 import { sanitizeMarkdownLinks } from './markdown-link.js';
-import { highlightCode, renderMarkdownHeadings } from './markdown-render.js';
+import { codeFenceLanguage, highlightCode, renderMarkdownHeadings } from './markdown-render.js';
 import { applyMode, loadMode, watch } from './theme.js';
 import { buildRecommendedActions, shouldShowRecommendedActions } from './recommended-actions.js';
 import { createContextMenuPromptHandler } from './context-menu-prompts.js';
@@ -5323,7 +5323,8 @@ function formatMarkdown(text) {
 
   // 1. Extract fenced code blocks BEFORE escaping HTML
   const codeBlocks = [];
-  text = text.replace(/```[ \t]*([^\s`\r\n]*)[ \t]*\r?\n([\s\S]*?)```/g, (_match, lang, code) => {
+  text = text.replace(/```[ \t]*([^`\r\n]*)\r?\n([\s\S]*?)```/g, (_match, info, code) => {
+    const lang = codeFenceLanguage(info);
     const id = `__CODEBLOCK_${codeBlocks.length}__`;
     codeBlocks.push({ lang: lang || '', code });
     return id;

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -26,6 +26,16 @@
   --tint-medium: rgba(255, 255, 255, 0.08);
   --overlay-bg: rgba(0, 0, 0, 0.30);
   --overlay-bg-strong: rgba(0, 0, 0, 0.40);
+  --syntax-comment: #8796a5;
+  --syntax-keyword: #c792ea;
+  --syntax-string: #c3e88d;
+  --syntax-number: #f78c6c;
+  --syntax-function: #82aaff;
+  --syntax-property: #80cbc4;
+  --syntax-tag: #f07178;
+  --syntax-constant: #ffcb6b;
+  --syntax-operator: #89ddff;
+  --syntax-variable: #f78c6c;
   --radius: 12px;
   --radius-sm: 8px;
   --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
@@ -53,6 +63,16 @@
   --tint-medium: rgba(89, 55, 25, 0.10);
   --overlay-bg: rgba(89, 55, 25, 0.10);
   --overlay-bg-strong: rgba(89, 55, 25, 0.18);
+  --syntax-comment: #776b5d;
+  --syntax-keyword: #7138a8;
+  --syntax-string: #2f7135;
+  --syntax-number: #a94e13;
+  --syntax-function: #2457a7;
+  --syntax-property: #08737d;
+  --syntax-tag: #b4233c;
+  --syntax-constant: #8a5a00;
+  --syntax-operator: #0e6f7d;
+  --syntax-variable: #a23e48;
   --shadow: 0 2px 8px rgba(89, 55, 25, 0.10);
   color-scheme: light;
 }
@@ -1737,6 +1757,34 @@ body {
 }
 
 /* Code blocks */
+.message-content h1,
+.message-content h2,
+.message-content h3,
+.message-content h4,
+.message-content h5,
+.message-content h6 {
+  margin: 14px 0 6px;
+  color: var(--text-primary);
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.message-content h1:first-child,
+.message-content h2:first-child,
+.message-content h3:first-child,
+.message-content h4:first-child,
+.message-content h5:first-child,
+.message-content h6:first-child {
+  margin-top: 0;
+}
+
+.message-content h1 { font-size: 17px; }
+.message-content h2 { font-size: 15px; }
+.message-content h3 { font-size: 14px; }
+.message-content h4,
+.message-content h5,
+.message-content h6 { font-size: 13px; }
+
 .message-content code {
   background: var(--overlay-bg);
   padding: 1px 4px;
@@ -1759,6 +1807,22 @@ body {
   padding: 0;
   white-space: pre;
 }
+
+.syntax-comment { color: var(--syntax-comment); font-style: italic; }
+.syntax-keyword,
+.syntax-decorator { color: var(--syntax-keyword); }
+.syntax-string { color: var(--syntax-string); }
+.syntax-number,
+.syntax-variable { color: var(--syntax-number); }
+.syntax-function,
+.syntax-builtin { color: var(--syntax-function); }
+.syntax-property { color: var(--syntax-property); }
+.syntax-tag { color: var(--syntax-tag); }
+.syntax-constant,
+.syntax-selector,
+.syntax-type { color: var(--syntax-constant); }
+.syntax-operator { color: var(--syntax-operator); }
+.syntax-punctuation { color: var(--text-secondary); }
 
 /* Fenced code block wrapper with header */
 .code-block-wrapper {

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -1812,8 +1812,8 @@ body {
 .syntax-keyword,
 .syntax-decorator { color: var(--syntax-keyword); }
 .syntax-string { color: var(--syntax-string); }
-.syntax-number,
-.syntax-variable { color: var(--syntax-number); }
+.syntax-number { color: var(--syntax-number); }
+.syntax-variable { color: var(--syntax-variable); }
 .syntax-function,
 .syntax-builtin { color: var(--syntax-function); }
 .syntax-property { color: var(--syntax-property); }

--- a/test/run.js
+++ b/test/run.js
@@ -110,6 +110,9 @@ const { validateFetchUrl: validateFetchUrlFx, registrableDomain: registrableDoma
 const { sanitizeLink, sanitizeMarkdownLinks } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/ui/markdown-link.js').replace(/\\/g, '/')
 );
+const { highlightCode, renderMarkdownHeadings } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/ui/markdown-render.js').replace(/\\/g, '/')
+);
 
 const { RunUiJournal: RunUiJournalCh } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/run-ui-journal.js').replace(/\\/g, '/')
@@ -177,6 +180,9 @@ const {
 );
 const { sanitizeMarkdownLinks: sanitizeMarkdownLinksFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/ui/markdown-link.js').replace(/\\/g, '/')
+);
+const { highlightCode: highlightCodeFx, renderMarkdownHeadings: renderMarkdownHeadingsFx } = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/ui/markdown-render.js').replace(/\\/g, '/')
 );
 const {
   buildContextMenuPrompt: buildContextMenuPromptCh,
@@ -2970,6 +2976,74 @@ test('firefox port has the same sanitizer behavior', () => {
       sanitizeMarkdownLinks(inp),
       `firefox sanitizer diverged on input: ${inp}`,
     );
+  }
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Sidepanel Markdown rendering
+// ────────────────────────────────────────────────────────────────────────
+
+console.log('\nsidepanel markdown rendering');
+
+test('language-tagged JavaScript fences receive safe syntax token spans', () => {
+  const source = 'const style = document.createElement("style");\nstyle.textContent = "<b>safe</b>";';
+  const out = highlightCode(source, 'js');
+  assert.match(out, /<span class="syntax-keyword">const<\/span>/);
+  assert.match(out, /<span class="syntax-builtin">document<\/span>/);
+  assert.match(out, /<span class="syntax-function">createElement<\/span>/);
+  assert.match(out, /<span class="syntax-string">&quot;/);
+  assert.doesNotMatch(out, /<b>safe<\/b>/, 'code source must remain escaped instead of becoming live HTML');
+  assert.match(out, /&lt;b&gt;safe&lt;\/b&gt;/);
+});
+
+test('unknown or missing code languages stay escaped and unstyled', () => {
+  const source = '<img src=x onerror=alert(1)> & text';
+  const expected = '&lt;img src=x onerror=alert(1)&gt; &amp; text';
+  assert.equal(highlightCode(source, ''), expected);
+  assert.equal(highlightCode(source, 'not-a-language'), expected);
+});
+
+test('common code-language aliases select their syntax grammar', () => {
+  assert.match(highlightCode('interface User { id: number }', 'ts'), /syntax-keyword/);
+  assert.match(highlightCode('.nav { display: grid; }', 'css'), /syntax-(?:selector|property)/);
+  assert.match(highlightCode('{"ok": true}', 'json'), /syntax-property/);
+  assert.match(highlightCode('def run():\n    return True', 'py'), /syntax-keyword/);
+  assert.match(highlightCode('SELECT * FROM users', 'sql'), /syntax-keyword/);
+  assert.match(highlightCode('std::vector<int> ids;', 'c++'), /syntax-/);
+});
+
+test('ATX headings render as semantic headings and preserve inline Markdown', () => {
+  const out = renderMarkdownHeadings('### Option A — **Center the tabs**\n\nRun this first');
+  assert.equal(out, '<h3>Option A — **Center the tabs**</h3>\nRun this first');
+  assert.equal(renderMarkdownHeadings('## C#\nText'), '<h2>C#</h2>Text');
+});
+
+test('Chrome and Firefox Markdown rendering helpers stay in parity', () => {
+  const samples = [
+    ['const x = "<tag>";', 'javascript'],
+    ['.nav { color: #fff; }', 'scss'],
+    ['{"enabled": false}', 'jsonc'],
+    ['#!/bin/zsh\necho "$HOME"', 'zsh'],
+  ];
+  for (const [source, language] of samples) {
+    assert.equal(highlightCodeFx(source, language), highlightCode(source, language), `highlighting diverged for ${language}`);
+  }
+  const heading = '### **Option A**\nBody';
+  assert.equal(renderMarkdownHeadingsFx(heading), renderMarkdownHeadings(heading));
+});
+
+test('sidepanels wire highlighting and heading rendering into fenced Markdown', () => {
+  for (const [label, panelRel, cssRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js', 'src/chrome/styles/sidepanel.css'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js', 'src/firefox/styles/sidepanel.css'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    const css = fs.readFileSync(path.join(ROOT, cssRel), 'utf8');
+    assert.match(panel, /import \{ highlightCode, renderMarkdownHeadings \} from '\.\/markdown-render\.js';/, `${label}: renderer helpers should be imported`);
+    assert.match(panel, /const highlighted = highlightCode\(block\.code, block\.lang\);/, `${label}: fenced code should be highlighted by its language`);
+    assert.match(panel, /text = renderMarkdownHeadings\(text\);/, `${label}: ATX headings should be rendered`);
+    assert.match(css, /\.syntax-keyword[\s\S]*?var\(--syntax-keyword\)/, `${label}: token colors should be styled`);
+    assert.match(css, /\.message-content h3 \{ font-size: 14px; \}/, `${label}: level-three headings should be visually distinct`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -110,7 +110,7 @@ const { validateFetchUrl: validateFetchUrlFx, registrableDomain: registrableDoma
 const { sanitizeLink, sanitizeMarkdownLinks } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/ui/markdown-link.js').replace(/\\/g, '/')
 );
-const { highlightCode, renderMarkdownHeadings } = await import(
+const { codeFenceLanguage, highlightCode, renderMarkdownHeadings } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/ui/markdown-render.js').replace(/\\/g, '/')
 );
 
@@ -181,7 +181,7 @@ const {
 const { sanitizeMarkdownLinks: sanitizeMarkdownLinksFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/ui/markdown-link.js').replace(/\\/g, '/')
 );
-const { highlightCode: highlightCodeFx, renderMarkdownHeadings: renderMarkdownHeadingsFx } = await import(
+const { codeFenceLanguage: codeFenceLanguageFx, highlightCode: highlightCodeFx, renderMarkdownHeadings: renderMarkdownHeadingsFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/ui/markdown-render.js').replace(/\\/g, '/')
 );
 const {
@@ -3012,6 +3012,13 @@ test('common code-language aliases select their syntax grammar', () => {
   assert.match(highlightCode('std::vector<int> ids;', 'c++'), /syntax-/);
 });
 
+test('fenced code info strings use their first token as the language', () => {
+  assert.equal(codeFenceLanguage('js title="example.js"'), 'js');
+  assert.equal(codeFenceLanguage(' javascript {.numberLines}'), 'javascript');
+  assert.equal(codeFenceLanguage('c++ linenos'), 'c++');
+  assert.equal(codeFenceLanguage('   '), '');
+});
+
 test('ATX headings render as semantic headings and preserve inline Markdown', () => {
   const out = renderMarkdownHeadings('### Option A — **Center the tabs**\n\nRun this first');
   assert.equal(out, '<h3>Option A — **Center the tabs**</h3>\nRun this first');
@@ -3030,6 +3037,7 @@ test('Chrome and Firefox Markdown rendering helpers stay in parity', () => {
   }
   const heading = '### **Option A**\nBody';
   assert.equal(renderMarkdownHeadingsFx(heading), renderMarkdownHeadings(heading));
+  assert.equal(codeFenceLanguageFx('js title="example.js"'), codeFenceLanguage('js title="example.js"'));
 });
 
 test('sidepanels wire highlighting and heading rendering into fenced Markdown', () => {
@@ -3039,10 +3047,12 @@ test('sidepanels wire highlighting and heading rendering into fenced Markdown', 
   ]) {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
     const css = fs.readFileSync(path.join(ROOT, cssRel), 'utf8');
-    assert.match(panel, /import \{ highlightCode, renderMarkdownHeadings \} from '\.\/markdown-render\.js';/, `${label}: renderer helpers should be imported`);
+    assert.match(panel, /import \{ codeFenceLanguage, highlightCode, renderMarkdownHeadings \} from '\.\/markdown-render\.js';/, `${label}: renderer helpers should be imported`);
+    assert.match(panel, /const lang = codeFenceLanguage\(info\);/, `${label}: fenced code should tolerate metadata after its language token`);
     assert.match(panel, /const highlighted = highlightCode\(block\.code, block\.lang\);/, `${label}: fenced code should be highlighted by its language`);
     assert.match(panel, /text = renderMarkdownHeadings\(text\);/, `${label}: ATX headings should be rendered`);
     assert.match(css, /\.syntax-keyword[\s\S]*?var\(--syntax-keyword\)/, `${label}: token colors should be styled`);
+    assert.match(css, /\.syntax-variable \{ color: var\(--syntax-variable\); \}/, `${label}: variables should use their dedicated theme color`);
     assert.match(css, /\.message-content h3 \{ font-size: 14px; \}/, `${label}: level-three headings should be visually distinct`);
   }
 });


### PR DESCRIPTION
## Summary

- add dependency-free, escape-first syntax highlighting for language-tagged fenced code blocks
- render ATX headings such as `### Option A` as semantic, visually distinct headings while preserving inline bold text
- mirror the renderer and theme-aware token colors across Chrome and Firefox
- add regression coverage for supported aliases, HTML escaping, headings, and browser parity

## Why

The sidebar already displayed a fenced block's language label, but the code itself remained monochrome. ATX headings were also displayed with their literal `###` markers, which made structured answers harder to scan.

## Impact

Language-tagged code blocks now distinguish keywords, strings, functions, properties, comments, and other common token types. Copy buttons still return the original code text, unknown languages safely fall back to escaped plain code, and both light and dark themes have dedicated token colors.

## Validation

- `npm test` — 787 main-suite tests passed
- prompt-injection corpus — 60/60 checks passed
- `node --check` on both browser renderer and sidepanel modules
- `git diff --check`
- visual light-theme preview of the JavaScript fence and level-three heading