### PR TITLE
Fix selection shortcut keyboard isolation and highlighting

### DIFF
--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -43,10 +43,14 @@
         "src/content/accessibility-tree.js",
         "src/content/content.js",
         "src/content/agent-visual-indicator.js",
-        "src/content/selection-shortcut.js",
         "src/content/ollama-launch-handoff.js"
       ],
       "run_at": "document_idle"
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["src/content/selection-shortcut.js"],
+      "run_at": "document_start"
     },
     {
       "matches": ["<all_urls>"],

--- a/src/chrome/src/content/selection-shortcut.js
+++ b/src/chrome/src/content/selection-shortcut.js
@@ -29,6 +29,7 @@
   let snapshot = null;
   let host = null;
   let shadow = null;
+  let highlightLayer = null;
   let shortcut = null;
   let popup = null;
   let question = null;
@@ -48,6 +49,17 @@
 
   function isSupportedTranslationLanguage(value) {
     return TRANSLATION_LANGUAGES.includes(value);
+  }
+
+  function serializeRect(rect) {
+    return {
+      left: rect.left,
+      top: rect.top,
+      right: rect.right,
+      bottom: rect.bottom,
+      width: rect.width,
+      height: rect.height,
+    };
   }
 
   function resolveInterfaceLanguage(value) {
@@ -75,14 +87,8 @@
     if (!rect || (!rect.width && !rect.height)) return null;
     return {
       text,
-      rect: {
-        left: rect.left,
-        top: rect.top,
-        right: rect.right,
-        bottom: rect.bottom,
-        width: rect.width,
-        height: rect.height,
-      },
+      rect: serializeRect(rect),
+      rects: (rects.length ? rects : [rect]).map(serializeRect),
     };
   }
 
@@ -103,6 +109,10 @@
         * { box-sizing:border-box; }
         button,textarea { font:inherit; }
         [hidden] { display:none !important; }
+        .selection-highlight {
+          position:fixed; border-radius:3px; pointer-events:none;
+          background:rgba(108,99,255,.3); box-shadow:inset 0 0 0 1px rgba(85,76,242,.18);
+        }
         .shortcut {
           position:fixed; width:${BUTTON_SIZE}px; height:${BUTTON_SIZE}px; display:grid;
           place-items:center; padding:0; border:1px solid rgba(108,99,255,.34);
@@ -164,6 +174,7 @@
         }
         @media (prefers-reduced-motion:reduce) { .shortcut { transition:none; } }
       </style>
+      <div class="selection-highlights" aria-hidden="true"></div>
       <button class="shortcut" type="button" aria-label="Ask WebBrain about selected text" title="Ask WebBrain" hidden>
         <span class="shortcut-icon" aria-hidden="true">?</span>
       </button>
@@ -189,6 +200,7 @@
       <div class="toast" role="status" aria-live="polite" hidden></div>
     `;
 
+    highlightLayer = shadow.querySelector('.selection-highlights');
     shortcut = shadow.querySelector('.shortcut');
     popup = shadow.querySelector('.popup');
     question = shadow.querySelector('textarea');
@@ -221,11 +233,14 @@
       if (event.isTrusted) disableShortcut();
     });
     shadow.addEventListener('keydown', (event) => {
+      event.stopPropagation();
       if (event.key !== 'Escape') return;
       event.preventDefault();
       if (!popup.hidden) closePopup(true);
       else dismissSurface();
     });
+    shadow.addEventListener('keypress', (event) => event.stopPropagation());
+    shadow.addEventListener('keyup', (event) => event.stopPropagation());
     host.addEventListener('pointerdown', () => { interacting = true; }, true);
     host.addEventListener('pointerup', () => {
       setTimeout(() => { interacting = false; }, 0);
@@ -258,8 +273,28 @@
     popup.style.top = `${Math.round(top)}px`;
   }
 
+  function clearSelectionHighlight() {
+    highlightLayer?.replaceChildren();
+  }
+
+  function showSelectionHighlight() {
+    clearSelectionHighlight();
+    if (!highlightLayer || !snapshot) return;
+    const rects = snapshot.rects?.length ? snapshot.rects : [snapshot.rect];
+    for (const rect of rects) {
+      const highlight = document.createElement('span');
+      highlight.className = 'selection-highlight';
+      highlight.style.left = `${rect.left}px`;
+      highlight.style.top = `${rect.top}px`;
+      highlight.style.width = `${rect.width}px`;
+      highlight.style.height = `${rect.height}px`;
+      highlightLayer.appendChild(highlight);
+    }
+  }
+
   function showShortcut(nextSnapshot) {
     ensureSurface();
+    clearSelectionHighlight();
     snapshot = nextSnapshot;
     popup.hidden = true;
     question.value = '';
@@ -275,6 +310,7 @@
     popup.style.visibility = 'hidden';
     positionPopup();
     popup.style.visibility = '';
+    showSelectionHighlight();
     shadow.querySelector('[data-action="summarize"]')?.focus();
   }
 
@@ -283,10 +319,12 @@
     popup.hidden = true;
     question.value = '';
     sendButton.disabled = true;
+    clearSelectionHighlight();
     if (restoreFocus && shortcut && !shortcut.hidden) shortcut.focus();
   }
 
   function dismissSurface() {
+    clearSelectionHighlight();
     snapshot = null;
     if (shortcut) shortcut.hidden = true;
     if (popup) popup.hidden = true;
@@ -297,7 +335,7 @@
   function destroySurface() {
     hideToast();
     host?.remove();
-    host = shadow = shortcut = popup = question = sendButton = toast = null;
+    host = shadow = highlightLayer = shortcut = popup = question = sendButton = toast = null;
     snapshot = null;
   }
 
@@ -417,6 +455,7 @@
       hasSelection: !!snapshot?.text,
       shortcutVisible: !!shortcut && !shortcut.hidden,
       popupVisible: !!popup && !popup.hidden,
+      highlightRectCount: highlightLayer?.childElementCount || 0,
       toastVisible: !!toast && !toast.hidden,
       shortcutRect: shortcut && !shortcut.hidden ? shortcut.getBoundingClientRect().toJSON() : null,
       summarizeRect: popup && !popup.hidden
@@ -425,6 +464,8 @@
       translateRect: popup && !popup.hidden
         ? shadow.querySelector('[data-action="translate"]')?.getBoundingClientRect().toJSON() || null
         : null,
+      questionRect: popup && !popup.hidden ? question?.getBoundingClientRect().toJSON() || null : null,
+      questionValue: question?.value || '',
     }),
   };
 })();

--- a/src/chrome/src/content/selection-shortcut.js
+++ b/src/chrome/src/content/selection-shortcut.js
@@ -220,27 +220,12 @@
     question.addEventListener('input', () => {
       sendButton.disabled = !question.value.trim();
     });
-    question.addEventListener('keydown', (event) => {
-      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
-        event.preventDefault();
-        submitSelection('custom', question.value);
-      }
-    });
     sendButton.addEventListener('click', (event) => {
       if (event.isTrusted) submitSelection('custom', question.value);
     });
     shadow.querySelector('.hide').addEventListener('click', (event) => {
       if (event.isTrusted) disableShortcut();
     });
-    shadow.addEventListener('keydown', (event) => {
-      event.stopPropagation();
-      if (event.key !== 'Escape') return;
-      event.preventDefault();
-      if (!popup.hidden) closePopup(true);
-      else dismissSurface();
-    });
-    shadow.addEventListener('keypress', (event) => event.stopPropagation());
-    shadow.addEventListener('keyup', (event) => event.stopPropagation());
     host.addEventListener('pointerdown', () => { interacting = true; }, true);
     host.addEventListener('pointerup', () => {
       setTimeout(() => { interacting = false; }, 0);
@@ -289,6 +274,20 @@
       highlight.style.width = `${rect.width}px`;
       highlight.style.height = `${rect.height}px`;
       highlightLayer.appendChild(highlight);
+    }
+  }
+
+  function containSurfaceKeyboardEvent(event) {
+    if (!host || !event.composedPath?.().includes(host)) return;
+    event.stopImmediatePropagation();
+    if (event.type !== 'keydown') return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      if (!popup.hidden) closePopup(true);
+      else dismissSurface();
+    } else if (event.key === 'Enter' && (event.metaKey || event.ctrlKey) && shadow?.activeElement === question) {
+      event.preventDefault();
+      submitSelection('custom', question.value);
     }
   }
 
@@ -412,6 +411,9 @@
     if (!event.composedPath?.().includes(host)) dismissSurface();
   }, true);
   window.addEventListener('resize', dismissSurface);
+  window.addEventListener('keydown', containSurfaceKeyboardEvent, true);
+  window.addEventListener('keypress', containSurfaceKeyboardEvent, true);
+  window.addEventListener('keyup', containSurfaceKeyboardEvent, true);
 
   api.runtime.onMessage.addListener((message) => {
     if (message?.type === 'WB_HIDE_FOR_TOOL_USE') {

--- a/src/chrome/src/content/selection-shortcut.js
+++ b/src/chrome/src/content/selection-shortcut.js
@@ -17,6 +17,7 @@
   const GAP = 8;
   const BUTTON_SIZE = 44;
   const POPUP_WIDTH = 316;
+  const MAX_SELECTION_HIGHLIGHT_RECTS = 200;
   const TRANSLATION_LANGUAGES = Object.freeze([
     'en', 'es', 'fr', 'tr', 'zh', 'ru', 'uk', 'ar',
     'ja', 'ko', 'id', 'th', 'ms', 'tl', 'pl', 'he',
@@ -62,6 +63,20 @@
     };
   }
 
+  function collectVisibleHighlightRects(rects) {
+    const visibleRects = [];
+    for (const rect of rects) {
+      const isVisible = rect.bottom > 0
+        && rect.right > 0
+        && rect.top < window.innerHeight
+        && rect.left < window.innerWidth;
+      if (!isVisible) continue;
+      visibleRects.push(rect);
+      if (visibleRects.length >= MAX_SELECTION_HIGHLIGHT_RECTS) break;
+    }
+    return visibleRects;
+  }
+
   function resolveInterfaceLanguage(value) {
     const preferred = String(value || '').trim().toLowerCase();
     if (isSupportedTranslationLanguage(preferred)) return preferred;
@@ -85,10 +100,11 @@
     const rects = Array.from(range.getClientRects()).filter((rect) => rect.width > 0 && rect.height > 0);
     const rect = rects.at(-1) || range.getBoundingClientRect();
     if (!rect || (!rect.width && !rect.height)) return null;
+    const highlightRects = collectVisibleHighlightRects(rects);
     return {
       text,
       rect: serializeRect(rect),
-      rects: (rects.length ? rects : [rect]).map(serializeRect),
+      rects: (highlightRects.length ? highlightRects : [rect]).map(serializeRect),
     };
   }
 

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -38,10 +38,14 @@
         "src/content/accessibility-tree.js",
         "src/content/content.js",
         "src/content/agent-visual-indicator.js",
-        "src/content/selection-shortcut.js",
         "src/content/ollama-launch-handoff.js"
       ],
       "run_at": "document_idle"
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["src/content/selection-shortcut.js"],
+      "run_at": "document_start"
     },
     {
       "matches": ["<all_urls>"],

--- a/src/firefox/src/content/selection-shortcut.js
+++ b/src/firefox/src/content/selection-shortcut.js
@@ -29,6 +29,7 @@
   let snapshot = null;
   let host = null;
   let shadow = null;
+  let highlightLayer = null;
   let shortcut = null;
   let popup = null;
   let question = null;
@@ -48,6 +49,17 @@
 
   function isSupportedTranslationLanguage(value) {
     return TRANSLATION_LANGUAGES.includes(value);
+  }
+
+  function serializeRect(rect) {
+    return {
+      left: rect.left,
+      top: rect.top,
+      right: rect.right,
+      bottom: rect.bottom,
+      width: rect.width,
+      height: rect.height,
+    };
   }
 
   function resolveInterfaceLanguage(value) {
@@ -75,14 +87,8 @@
     if (!rect || (!rect.width && !rect.height)) return null;
     return {
       text,
-      rect: {
-        left: rect.left,
-        top: rect.top,
-        right: rect.right,
-        bottom: rect.bottom,
-        width: rect.width,
-        height: rect.height,
-      },
+      rect: serializeRect(rect),
+      rects: (rects.length ? rects : [rect]).map(serializeRect),
     };
   }
 
@@ -103,6 +109,10 @@
         * { box-sizing:border-box; }
         button,textarea { font:inherit; }
         [hidden] { display:none !important; }
+        .selection-highlight {
+          position:fixed; border-radius:3px; pointer-events:none;
+          background:rgba(108,99,255,.3); box-shadow:inset 0 0 0 1px rgba(85,76,242,.18);
+        }
         .shortcut {
           position:fixed; width:${BUTTON_SIZE}px; height:${BUTTON_SIZE}px; display:grid;
           place-items:center; padding:0; border:1px solid rgba(108,99,255,.34);
@@ -164,6 +174,7 @@
         }
         @media (prefers-reduced-motion:reduce) { .shortcut { transition:none; } }
       </style>
+      <div class="selection-highlights" aria-hidden="true"></div>
       <button class="shortcut" type="button" aria-label="Ask WebBrain about selected text" title="Ask WebBrain" hidden>
         <span class="shortcut-icon" aria-hidden="true">?</span>
       </button>
@@ -189,6 +200,7 @@
       <div class="toast" role="status" aria-live="polite" hidden></div>
     `;
 
+    highlightLayer = shadow.querySelector('.selection-highlights');
     shortcut = shadow.querySelector('.shortcut');
     popup = shadow.querySelector('.popup');
     question = shadow.querySelector('textarea');
@@ -221,11 +233,14 @@
       if (event.isTrusted) disableShortcut();
     });
     shadow.addEventListener('keydown', (event) => {
+      event.stopPropagation();
       if (event.key !== 'Escape') return;
       event.preventDefault();
       if (!popup.hidden) closePopup(true);
       else dismissSurface();
     });
+    shadow.addEventListener('keypress', (event) => event.stopPropagation());
+    shadow.addEventListener('keyup', (event) => event.stopPropagation());
     host.addEventListener('pointerdown', () => { interacting = true; }, true);
     host.addEventListener('pointerup', () => {
       setTimeout(() => { interacting = false; }, 0);
@@ -258,8 +273,28 @@
     popup.style.top = `${Math.round(top)}px`;
   }
 
+  function clearSelectionHighlight() {
+    highlightLayer?.replaceChildren();
+  }
+
+  function showSelectionHighlight() {
+    clearSelectionHighlight();
+    if (!highlightLayer || !snapshot) return;
+    const rects = snapshot.rects?.length ? snapshot.rects : [snapshot.rect];
+    for (const rect of rects) {
+      const highlight = document.createElement('span');
+      highlight.className = 'selection-highlight';
+      highlight.style.left = `${rect.left}px`;
+      highlight.style.top = `${rect.top}px`;
+      highlight.style.width = `${rect.width}px`;
+      highlight.style.height = `${rect.height}px`;
+      highlightLayer.appendChild(highlight);
+    }
+  }
+
   function showShortcut(nextSnapshot) {
     ensureSurface();
+    clearSelectionHighlight();
     snapshot = nextSnapshot;
     popup.hidden = true;
     question.value = '';
@@ -275,6 +310,7 @@
     popup.style.visibility = 'hidden';
     positionPopup();
     popup.style.visibility = '';
+    showSelectionHighlight();
     shadow.querySelector('[data-action="summarize"]')?.focus();
   }
 
@@ -283,10 +319,12 @@
     popup.hidden = true;
     question.value = '';
     sendButton.disabled = true;
+    clearSelectionHighlight();
     if (restoreFocus && shortcut && !shortcut.hidden) shortcut.focus();
   }
 
   function dismissSurface() {
+    clearSelectionHighlight();
     snapshot = null;
     if (shortcut) shortcut.hidden = true;
     if (popup) popup.hidden = true;
@@ -297,7 +335,7 @@
   function destroySurface() {
     hideToast();
     host?.remove();
-    host = shadow = shortcut = popup = question = sendButton = toast = null;
+    host = shadow = highlightLayer = shortcut = popup = question = sendButton = toast = null;
     snapshot = null;
   }
 
@@ -417,6 +455,7 @@
       hasSelection: !!snapshot?.text,
       shortcutVisible: !!shortcut && !shortcut.hidden,
       popupVisible: !!popup && !popup.hidden,
+      highlightRectCount: highlightLayer?.childElementCount || 0,
       toastVisible: !!toast && !toast.hidden,
       shortcutRect: shortcut && !shortcut.hidden ? shortcut.getBoundingClientRect().toJSON() : null,
       summarizeRect: popup && !popup.hidden
@@ -425,6 +464,8 @@
       translateRect: popup && !popup.hidden
         ? shadow.querySelector('[data-action="translate"]')?.getBoundingClientRect().toJSON() || null
         : null,
+      questionRect: popup && !popup.hidden ? question?.getBoundingClientRect().toJSON() || null : null,
+      questionValue: question?.value || '',
     }),
   };
 })();

--- a/src/firefox/src/content/selection-shortcut.js
+++ b/src/firefox/src/content/selection-shortcut.js
@@ -220,27 +220,12 @@
     question.addEventListener('input', () => {
       sendButton.disabled = !question.value.trim();
     });
-    question.addEventListener('keydown', (event) => {
-      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
-        event.preventDefault();
-        submitSelection('custom', question.value);
-      }
-    });
     sendButton.addEventListener('click', (event) => {
       if (event.isTrusted) submitSelection('custom', question.value);
     });
     shadow.querySelector('.hide').addEventListener('click', (event) => {
       if (event.isTrusted) disableShortcut();
     });
-    shadow.addEventListener('keydown', (event) => {
-      event.stopPropagation();
-      if (event.key !== 'Escape') return;
-      event.preventDefault();
-      if (!popup.hidden) closePopup(true);
-      else dismissSurface();
-    });
-    shadow.addEventListener('keypress', (event) => event.stopPropagation());
-    shadow.addEventListener('keyup', (event) => event.stopPropagation());
     host.addEventListener('pointerdown', () => { interacting = true; }, true);
     host.addEventListener('pointerup', () => {
       setTimeout(() => { interacting = false; }, 0);
@@ -289,6 +274,20 @@
       highlight.style.width = `${rect.width}px`;
       highlight.style.height = `${rect.height}px`;
       highlightLayer.appendChild(highlight);
+    }
+  }
+
+  function containSurfaceKeyboardEvent(event) {
+    if (!host || !event.composedPath?.().includes(host)) return;
+    event.stopImmediatePropagation();
+    if (event.type !== 'keydown') return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      if (!popup.hidden) closePopup(true);
+      else dismissSurface();
+    } else if (event.key === 'Enter' && (event.metaKey || event.ctrlKey) && shadow?.activeElement === question) {
+      event.preventDefault();
+      submitSelection('custom', question.value);
     }
   }
 
@@ -412,6 +411,9 @@
     if (!event.composedPath?.().includes(host)) dismissSurface();
   }, true);
   window.addEventListener('resize', dismissSurface);
+  window.addEventListener('keydown', containSurfaceKeyboardEvent, true);
+  window.addEventListener('keypress', containSurfaceKeyboardEvent, true);
+  window.addEventListener('keyup', containSurfaceKeyboardEvent, true);
 
   api.runtime.onMessage.addListener((message) => {
     if (message?.type === 'WB_HIDE_FOR_TOOL_USE') {

--- a/src/firefox/src/content/selection-shortcut.js
+++ b/src/firefox/src/content/selection-shortcut.js
@@ -17,6 +17,7 @@
   const GAP = 8;
   const BUTTON_SIZE = 44;
   const POPUP_WIDTH = 316;
+  const MAX_SELECTION_HIGHLIGHT_RECTS = 200;
   const TRANSLATION_LANGUAGES = Object.freeze([
     'en', 'es', 'fr', 'tr', 'zh', 'ru', 'uk', 'ar',
     'ja', 'ko', 'id', 'th', 'ms', 'tl', 'pl', 'he',
@@ -62,6 +63,20 @@
     };
   }
 
+  function collectVisibleHighlightRects(rects) {
+    const visibleRects = [];
+    for (const rect of rects) {
+      const isVisible = rect.bottom > 0
+        && rect.right > 0
+        && rect.top < window.innerHeight
+        && rect.left < window.innerWidth;
+      if (!isVisible) continue;
+      visibleRects.push(rect);
+      if (visibleRects.length >= MAX_SELECTION_HIGHLIGHT_RECTS) break;
+    }
+    return visibleRects;
+  }
+
   function resolveInterfaceLanguage(value) {
     const preferred = String(value || '').trim().toLowerCase();
     if (isSupportedTranslationLanguage(preferred)) return preferred;
@@ -85,10 +100,11 @@
     const rects = Array.from(range.getClientRects()).filter((rect) => rect.width > 0 && rect.height > 0);
     const rect = rects.at(-1) || range.getBoundingClientRect();
     if (!rect || (!rect.width && !rect.height)) return null;
+    const highlightRects = collectVisibleHighlightRects(rects);
     return {
       text,
       rect: serializeRect(rect),
-      rects: (rects.length ? rects : [rect]).map(serializeRect),
+      rects: (highlightRects.length ? highlightRects : [rect]).map(serializeRect),
     };
   }
 

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -201,6 +201,45 @@ for (const [label, sourcePath, manualOpen] of [
     }
   });
 
+  test(`${label}: selection dialog contains page shortcuts and keeps the selected text highlighted`, async (page) => {
+    await setupSelectionShortcut(page, sourcePath, { requiresManualOpen: manualOpen });
+    await page.evaluate(() => {
+      window.__selectionPageKeys = [];
+      document.addEventListener('keydown', (event) => window.__selectionPageKeys.push(`down:${event.key}`));
+      document.addEventListener('keypress', (event) => window.__selectionPageKeys.push(`press:${event.key}`));
+      document.addEventListener('keyup', (event) => window.__selectionPageKeys.push(`up:${event.key}`));
+    });
+    const selectedState = await selectFixtureText(page);
+    await page.mouse.click(
+      selectedState.shortcutRect.left + selectedState.shortcutRect.width / 2,
+      selectedState.shortcutRect.top + selectedState.shortcutRect.height / 2,
+    );
+    const openState = await page.evaluate(() => window.__webbrainSelectionShortcut.getState());
+    if (!openState.questionRect || openState.highlightRectCount < 1) {
+      throw new Error(`popup should preserve a visual marker for the selected text: ${JSON.stringify(openState)}`);
+    }
+    await page.mouse.click(
+      openState.questionRect.left + openState.questionRect.width / 2,
+      openState.questionRect.top + openState.questionRect.height / 2,
+    );
+    await page.keyboard.type('j');
+    const typedState = await page.evaluate(() => ({
+      surface: window.__webbrainSelectionShortcut.getState(),
+      pageKeys: window.__selectionPageKeys,
+    }));
+    if (typedState.surface.questionValue !== 'j' || typedState.surface.highlightRectCount < 1) {
+      throw new Error(`typing should keep the custom question and sticky highlight: ${JSON.stringify(typedState)}`);
+    }
+    if (typedState.pageKeys.length) {
+      throw new Error(`dialog keystrokes leaked to the page: ${JSON.stringify(typedState.pageKeys)}`);
+    }
+    await page.keyboard.press('Escape');
+    const closedState = await page.evaluate(() => window.__webbrainSelectionShortcut.getState());
+    if (closedState.popupVisible || closedState.highlightRectCount !== 0) {
+      throw new Error(`closing the popup should remove the sticky highlight: ${JSON.stringify(closedState)}`);
+    }
+  });
+
   test(`${label}: selection shortcut submits once and dismisses before delivery`, async (page) => {
     await setupSelectionShortcut(page, sourcePath, { requiresManualOpen: manualOpen });
     const selectedState = await selectFixtureText(page, '#editor');

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -205,6 +205,8 @@ for (const [label, sourcePath, manualOpen] of [
     await setupSelectionShortcut(page, sourcePath, { requiresManualOpen: manualOpen });
     await page.evaluate(() => {
       window.__selectionPageKeys = [];
+      window.addEventListener('keydown', (event) => window.__selectionPageKeys.push(`window-capture:${event.key}`), true);
+      document.addEventListener('keydown', (event) => window.__selectionPageKeys.push(`document-capture:${event.key}`), true);
       document.addEventListener('keydown', (event) => window.__selectionPageKeys.push(`down:${event.key}`));
       document.addEventListener('keypress', (event) => window.__selectionPageKeys.push(`press:${event.key}`));
       document.addEventListener('keyup', (event) => window.__selectionPageKeys.push(`up:${event.key}`));
@@ -237,6 +239,30 @@ for (const [label, sourcePath, manualOpen] of [
     const closedState = await page.evaluate(() => window.__webbrainSelectionShortcut.getState());
     if (closedState.popupVisible || closedState.highlightRectCount !== 0) {
       throw new Error(`closing the popup should remove the sticky highlight: ${JSON.stringify(closedState)}`);
+    }
+    await page.keyboard.press('Enter');
+    await page.waitForFunction(() => window.__webbrainSelectionShortcut.getState().popupVisible);
+    const reopenedState = await page.evaluate(() => window.__webbrainSelectionShortcut.getState());
+    await page.mouse.click(
+      reopenedState.questionRect.left + reopenedState.questionRect.width / 2,
+      reopenedState.questionRect.top + reopenedState.questionRect.height / 2,
+    );
+    await page.keyboard.type('What is the point?');
+    await page.keyboard.press('Control+Enter');
+    await page.waitForFunction(() => window.__selectionMessages.length === 1);
+    const submittedState = await page.evaluate(() => ({
+      message: window.__selectionMessages[0],
+      surface: window.__webbrainSelectionShortcut.getState(),
+      pageKeys: window.__selectionPageKeys,
+    }));
+    if (submittedState.message.action !== 'custom' || submittedState.message.question !== 'What is the point?') {
+      throw new Error(`capture-phase containment broke keyboard submission: ${JSON.stringify(submittedState)}`);
+    }
+    if (submittedState.surface.popupVisible || submittedState.surface.highlightRectCount !== 0) {
+      throw new Error(`keyboard submission should dismiss the surface and highlight: ${JSON.stringify(submittedState)}`);
+    }
+    if (submittedState.pageKeys.length) {
+      throw new Error(`capture-phase dialog keystrokes leaked to the page: ${JSON.stringify(submittedState.pageKeys)}`);
     }
   });
 

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -266,6 +266,37 @@ for (const [label, sourcePath, manualOpen] of [
     }
   });
 
+  test(`${label}: selection highlight stays bounded for long documents`, async (page) => {
+    await setupSelectionShortcut(page, sourcePath, { requiresManualOpen: manualOpen });
+    const rawRectCount = await page.evaluate(() => {
+      const article = document.createElement('article');
+      article.id = 'long-selection';
+      for (let index = 0; index < 600; index += 1) {
+        const line = document.createElement('div');
+        line.textContent = `Selected article line ${index + 1}`;
+        article.appendChild(line);
+      }
+      document.body.appendChild(article);
+      const range = document.createRange();
+      range.selectNodeContents(article);
+      return Array.from(range.getClientRects()).filter((rect) => rect.width > 0 && rect.height > 0).length;
+    });
+    if (rawRectCount <= 200) throw new Error(`fixture should create more than 200 selection rectangles, got ${rawRectCount}`);
+
+    const selectedState = await selectFixtureText(page, '#long-selection');
+    await page.mouse.click(
+      selectedState.shortcutRect.left + selectedState.shortcutRect.width / 2,
+      selectedState.shortcutRect.top + selectedState.shortcutRect.height / 2,
+    );
+    const openState = await page.evaluate(() => window.__webbrainSelectionShortcut.getState());
+    if (openState.highlightRectCount < 1 || openState.highlightRectCount > 200) {
+      throw new Error(`long selections should render 1-200 highlight rectangles: ${JSON.stringify(openState)}`);
+    }
+    if (openState.highlightRectCount >= rawRectCount) {
+      throw new Error(`offscreen selection rectangles should not all render: ${JSON.stringify({ rawRectCount, openState })}`);
+    }
+  });
+
   test(`${label}: selection shortcut submits once and dismisses before delivery`, async (page) => {
     await setupSelectionShortcut(page, sourcePath, { requiresManualOpen: manualOpen });
     const selectedState = await selectFixtureText(page, '#editor');

--- a/test/run.js
+++ b/test/run.js
@@ -10467,6 +10467,11 @@ test('selection shortcut is shipped, enabled by default, and keeps browser-speci
     assert.match(content, /border:1px solid rgba\(108,99,255,\.34\);[\s\S]*?color:var\(--accent\);/, `${label}: shortcut should use the WebBrain purple treatment`);
     assert.doesNotMatch(content, /M6\.8 8\.5 9\.2 14l2\.8-3\.4 2\.8 3\.4 2\.4-5\.5/, `${label}: discarded WebBrain W outline should be removed`);
     assert.doesNotMatch(content, /M12 2\.8c\.65 3\.78/, `${label}: Claude-like sparkle icon should be removed`);
+    assert.match(content, /rects: \(rects\.length \? rects : \[rect\]\)\.map\(serializeRect\)/, `${label}: selection snapshots should retain every visual line of the selected range`);
+    assert.match(content, /function showSelectionHighlight\(\)[\s\S]*?highlightLayer\.appendChild\(highlight\);/, `${label}: opening the dialog should render a sticky selection highlight`);
+    assert.match(content, /shadow\.addEventListener\('keydown', \(event\) => \{\s*event\.stopPropagation\(\);/, `${label}: selection dialog keydown events should not reach page shortcuts`);
+    assert.match(content, /shadow\.addEventListener\('keypress', \(event\) => event\.stopPropagation\(\)\);\s*shadow\.addEventListener\('keyup', \(event\) => event\.stopPropagation\(\)\);/, `${label}: selection dialog keypress and keyup events should not reach the page`);
+    assert.match(content, /function dismissSurface\(\) \{\s*clearSelectionHighlight\(\);/, `${label}: dismissing the selection surface should clear the sticky highlight`);
     assert.match(content, /message\?\.type === 'WB_HIDE_FOR_TOOL_USE'[\s\S]*?suppressed = true;[\s\S]*?message\?\.type === 'WB_SHOW_AFTER_TOOL_USE'[\s\S]*?suppressed = false;/, `${label}: screenshot capture should suppress and restore future shortcut detection`);
     assert.match(content, /submitting = true;\s*dismissSurface\(\);\s*try \{\s*const response = await api\.runtime\.sendMessage\(request\);/, `${label}: submission should dismiss before sending to prevent duplicates`);
 

--- a/test/run.js
+++ b/test/run.js
@@ -10453,8 +10453,12 @@ test('selection shortcut is shipped, enabled by default, and keeps browser-speci
     ['firefox', 'src/firefox', 'browser'],
   ]) {
     const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, prefix, 'manifest.json'), 'utf8'));
-    const scripts = manifest.content_scripts?.flatMap((entry) => entry.js || []) || [];
+    const contentScripts = manifest.content_scripts || [];
+    const scripts = contentScripts.flatMap((entry) => entry.js || []);
     assert.ok(scripts.includes('src/content/selection-shortcut.js'), `${label}: manifest should ship the selection shortcut`);
+    const selectionEntries = contentScripts.filter((entry) => entry.js?.includes('src/content/selection-shortcut.js'));
+    assert.equal(selectionEntries.length, 1, `${label}: selection shortcut should be injected exactly once`);
+    assert.equal(selectionEntries[0].run_at, 'document_start', `${label}: keyboard containment must register before page capture listeners`);
 
     const content = fs.readFileSync(path.join(ROOT, prefix, 'src/content/selection-shortcut.js'), 'utf8');
     assert.match(content, /attachShadow\(\{ mode: 'closed' \}\)/, `${label}: selection UI should use a closed Shadow DOM`);
@@ -10469,8 +10473,8 @@ test('selection shortcut is shipped, enabled by default, and keeps browser-speci
     assert.doesNotMatch(content, /M12 2\.8c\.65 3\.78/, `${label}: Claude-like sparkle icon should be removed`);
     assert.match(content, /rects: \(rects\.length \? rects : \[rect\]\)\.map\(serializeRect\)/, `${label}: selection snapshots should retain every visual line of the selected range`);
     assert.match(content, /function showSelectionHighlight\(\)[\s\S]*?highlightLayer\.appendChild\(highlight\);/, `${label}: opening the dialog should render a sticky selection highlight`);
-    assert.match(content, /shadow\.addEventListener\('keydown', \(event\) => \{\s*event\.stopPropagation\(\);/, `${label}: selection dialog keydown events should not reach page shortcuts`);
-    assert.match(content, /shadow\.addEventListener\('keypress', \(event\) => event\.stopPropagation\(\)\);\s*shadow\.addEventListener\('keyup', \(event\) => event\.stopPropagation\(\)\);/, `${label}: selection dialog keypress and keyup events should not reach the page`);
+    assert.match(content, /function containSurfaceKeyboardEvent\(event\)[\s\S]*?event\.stopImmediatePropagation\(\);/, `${label}: selection dialog keyboard events should stop page capture listeners`);
+    assert.match(content, /window\.addEventListener\('keydown', containSurfaceKeyboardEvent, true\);\s*window\.addEventListener\('keypress', containSurfaceKeyboardEvent, true\);\s*window\.addEventListener\('keyup', containSurfaceKeyboardEvent, true\);/, `${label}: keyboard containment should run during window capture`);
     assert.match(content, /function dismissSurface\(\) \{\s*clearSelectionHighlight\(\);/, `${label}: dismissing the selection surface should clear the sticky highlight`);
     assert.match(content, /message\?\.type === 'WB_HIDE_FOR_TOOL_USE'[\s\S]*?suppressed = true;[\s\S]*?message\?\.type === 'WB_SHOW_AFTER_TOOL_USE'[\s\S]*?suppressed = false;/, `${label}: screenshot capture should suppress and restore future shortcut detection`);
     assert.match(content, /submitting = true;\s*dismissSurface\(\);\s*try \{\s*const response = await api\.runtime\.sendMessage\(request\);/, `${label}: submission should dismiss before sending to prevent duplicates`);

--- a/test/run.js
+++ b/test/run.js
@@ -10471,7 +10471,9 @@ test('selection shortcut is shipped, enabled by default, and keeps browser-speci
     assert.match(content, /border:1px solid rgba\(108,99,255,\.34\);[\s\S]*?color:var\(--accent\);/, `${label}: shortcut should use the WebBrain purple treatment`);
     assert.doesNotMatch(content, /M6\.8 8\.5 9\.2 14l2\.8-3\.4 2\.8 3\.4 2\.4-5\.5/, `${label}: discarded WebBrain W outline should be removed`);
     assert.doesNotMatch(content, /M12 2\.8c\.65 3\.78/, `${label}: Claude-like sparkle icon should be removed`);
-    assert.match(content, /rects: \(rects\.length \? rects : \[rect\]\)\.map\(serializeRect\)/, `${label}: selection snapshots should retain every visual line of the selected range`);
+    assert.match(content, /const MAX_SELECTION_HIGHLIGHT_RECTS = 200;/, `${label}: selection highlights should have a hard DOM-node limit`);
+    assert.match(content, /function collectVisibleHighlightRects\(rects\)[\s\S]*?rect\.top < window\.innerHeight[\s\S]*?visibleRects\.length >= MAX_SELECTION_HIGHLIGHT_RECTS/, `${label}: selection snapshots should retain only a bounded set of visible lines`);
+    assert.match(content, /rects: \(highlightRects\.length \? highlightRects : \[rect\]\)\.map\(serializeRect\)/, `${label}: selection snapshots should use the bounded highlight rectangles`);
     assert.match(content, /function showSelectionHighlight\(\)[\s\S]*?highlightLayer\.appendChild\(highlight\);/, `${label}: opening the dialog should render a sticky selection highlight`);
     assert.match(content, /function containSurfaceKeyboardEvent\(event\)[\s\S]*?event\.stopImmediatePropagation\(\);/, `${label}: selection dialog keyboard events should stop page capture listeners`);
     assert.match(content, /window\.addEventListener\('keydown', containSurfaceKeyboardEvent, true\);\s*window\.addEventListener\('keypress', containSurfaceKeyboardEvent, true\);\s*window\.addEventListener\('keyup', containSurfaceKeyboardEvent, true\);/, `${label}: keyboard containment should run during window capture`);


### PR DESCRIPTION
## Summary

- contain selection-dialog keyboard events so page shortcuts such as X's `j` navigation do not fire while typing
- preserve the selected text visually with a non-interactive highlight overlay while the dialog is open
- keep Chrome and Firefox behavior in sync and clear the overlay on close, dismissal, or submission
- add deterministic browser and source-level regression coverage

## Root cause

The closed Shadow DOM handled Escape but allowed other `keydown`, `keypress`, and `keyup` events to continue bubbling into the host page. X interpreted `j` as its next-post shortcut. Focusing the dialog also removed the browser's visible native selection, even though WebBrain retained the selected text internally.

## User impact

Typing into the selection shortcut now stays inside WebBrain, and the original selected range remains visibly highlighted until the dialog closes or submits.

## Validation

- `npm run test:fixtures` — 35 passed, 0 failed
- `npm run test:security` — 60 passed, 0 failed
- `node --check` on both selection shortcut files and the fixture runner
- `git diff --check`
- `npm test` — 807 passed; 1 unrelated existing failure because package version `23.1.6` is ahead of the newest changelog entry `23.1.2`