### PR TITLE
Add GPT-5.6 Responses API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Base URLs are pre-filled in Settings when you select a provider. Local servers u
 | vLLM (`:8000/v1`) | Optional | (your served model) |
 | SGLang (`:30000/v1`) | Optional | (your served model) |
 | LocalAI (`:8080/v1`) | Optional | (your loaded model) |
-| OpenAI | Required | gpt-5.5 |
+| OpenAI | Required | gpt-5.6-terra |
 | Anthropic Claude | Required | claude-sonnet-4-6 |
 | Google Gemini | Required | gemini-3.1-flash |
 | Cloudflare Workers AI | Required (+ Account ID) | @cf/zai-org/glm-5.2 |

--- a/docs/fr/providers-and-models.md
+++ b/docs/fr/providers-and-models.md
@@ -42,7 +42,7 @@ class BaseLLMProvider {
 | `vllm` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |
 | `sglang` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |
 | `localai` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |
-| `openai` | `openai` | cloud | `gpt-5.5` | Regex nom de modèle |
+| `openai` | `openai` | cloud | `gpt-5.6-terra` | Regex nom de modèle |
 | `anthropic` | `anthropic` | cloud | `claude-sonnet-4-6` | Regex nom de modèle |
 | `claude_subscription` | `anthropic_oauth` | cloud | `claude-sonnet-4-6` | Oui |
 | `gemini` | `openai` | cloud | `gemini-3.1-flash` | Regex nom de modèle |

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -44,7 +44,7 @@ class BaseLLMProvider {
 | `localai` | `openai` | local | (loaded model) | Yes (default on) |
 | `azure_openai` | `azure_openai` | cloud | (deployment) | Manual toggle |
 | `aws_bedrock` | `aws_bedrock` | cloud | (model id) | No |
-| `openai` | `openai` | cloud | `gpt-5.5` | Model-name regex |
+| `openai` | `openai` | cloud | `gpt-5.6-terra` | Model-name regex |
 | `anthropic` | `anthropic` | cloud | `claude-sonnet-4-6` | Model-name regex |
 | `claude_subscription` | `anthropic_oauth` | cloud | `claude-sonnet-4-6` | Yes |
 | `gemini` | `openai` | cloud | `gemini-3.1-flash` | Model-name regex |

--- a/docs/zh-CN/providers-and-models.md
+++ b/docs/zh-CN/providers-and-models.md
@@ -42,7 +42,7 @@ class BaseLLMProvider {
 | `vllm` | `openai` | 本地 | （已加载模型） | 是（默认开启） |
 | `sglang` | `openai` | 本地 | （已加载模型） | 是（默认开启） |
 | `localai` | `openai` | 本地 | （已加载模型） | 是（默认开启） |
-| `openai` | `openai` | 云端 | `gpt-5.5` | 模型名正则 |
+| `openai` | `openai` | 云端 | `gpt-5.6-terra` | 模型名正则 |
 | `anthropic` | `anthropic` | 云端 | `claude-sonnet-4-6` | 模型名正则 |
 | `claude_subscription` | `anthropic_oauth` | 云端 | `claude-sonnet-4-6` | 是 |
 | `gemini` | `openai` | 云端 | `gemini-3.1-flash` | 模型名正则 |

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -7557,6 +7557,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         totalChars += JSON.stringify(msg.content || '').length;
       }
       if (msg.tool_calls) totalChars += JSON.stringify(msg.tool_calls).length;
+      if (msg.response_items) totalChars += JSON.stringify(msg.response_items).length;
     }
     if (hasImage) totalChars += Agent.IMAGE_CHAR_COST;
     return totalChars;
@@ -12909,6 +12910,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           role: 'assistant',
           content: result.content || null,
           tool_calls: result.toolCalls,
+          ...(Array.isArray(result.responseItems) && result.responseItems.length
+            ? { response_items: result.responseItems }
+            : {}),
         });
 
         const batchResult = await this._executeToolBatch(
@@ -13196,6 +13200,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         let fullText = '';
         let toolCallsAccumulator = {};
         let hasToolCalls = false;
+        let responseItems = null;
 
         const streamOpts = this._cloudGenerationOptions(provider, {
           tools: provider.supportsTools ? tools : undefined,
@@ -13244,6 +13249,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               toolCallsAccumulator[idx].function.arguments += String(chunk.content ?? '');
             }
           } else if (chunk.type === 'done') {
+            if (Array.isArray(chunk.responseItems) && chunk.responseItems.length) {
+              responseItems = chunk.responseItems;
+            }
             break;
           }
         }
@@ -13276,6 +13284,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             role: 'assistant',
             content: fullText || null,
             tool_calls: toolCalls,
+            ...(responseItems ? { response_items: responseItems } : {}),
           });
 
           const batchResult = await this._executeToolBatch(

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -618,6 +618,12 @@ export class Agent {
     return result;
   }
 
+  _withResponseItems(message, responseItems) {
+    return Array.isArray(responseItems) && responseItems.length
+      ? { ...message, response_items: responseItems }
+      : message;
+  }
+
   /**
    * Toggle the per-tab API-mutation allowlist. Called by background.js
    * when the sidebar reports the user typed /allow-api.
@@ -12906,14 +12912,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
 
       if (result.toolCalls && result.toolCalls.length > 0) {
-        messages.push({
+        messages.push(this._withResponseItems({
           role: 'assistant',
           content: result.content || null,
           tool_calls: result.toolCalls,
-          ...(Array.isArray(result.responseItems) && result.responseItems.length
-            ? { response_items: result.responseItems }
-            : {}),
-        });
+        }, result.responseItems));
 
         const batchResult = await this._executeToolBatch(
           tabId, result.toolCalls, messages, onUpdate, provider, result.content, allowedToolNames, steps
@@ -12951,7 +12954,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (this._isActionMode(mode) && this._isCompressionPlaceholderResponse(result.content)) {
         if (!compressionPlaceholderRecoveryAttempted) {
           compressionPlaceholderRecoveryAttempted = true;
-          messages.push({ role: 'assistant', content: result.content });
+          messages.push(this._withResponseItems({ role: 'assistant', content: result.content }, result.responseItems));
           messages.push({
             role: 'user',
             content: '[System nudge: your previous response was a context-compression placeholder, not a real final answer or tool call. Continue the active browser task with tool calls. Do not output "[compressed]".]',
@@ -13002,7 +13005,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // Genuine final answer — emit and exit.
       const progressFinalBlock = this._plainFinalProgressBlock(tabId);
       if (progressFinalBlock) {
-        messages.push({ role: 'assistant', content: result.content });
+        messages.push(this._withResponseItems({ role: 'assistant', content: result.content }, result.responseItems));
         messages.push({ role: 'user', content: progressFinalBlock });
         onUpdate('warning', { message: 'Progress ledger has unresolved rows; continuing.' });
         this._persist(tabId);
@@ -13011,7 +13014,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       finalResponse = result.costAllowanceMessage
         ? `${result.content}\n\n${result.costAllowanceMessage}`
         : result.content;
-      messages.push({ role: 'assistant', content: finalResponse });
+      messages.push(this._withResponseItems({ role: 'assistant', content: finalResponse }, result.responseItems));
       onUpdate('text', { content: finalResponse });
       break;
     }
@@ -13280,12 +13283,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           }
           const toolCalls = Object.values(toolCallsAccumulator);
           this._logDebug({ type: 'llm_stream_response', step: steps, content: fullText, toolCalls });
-          messages.push({
+          messages.push(this._withResponseItems({
             role: 'assistant',
             content: fullText || null,
             tool_calls: toolCalls,
-            ...(responseItems ? { response_items: responseItems } : {}),
-          });
+          }, responseItems));
 
           const batchResult = await this._executeToolBatch(
             tabId, toolCalls, messages, onUpdate, provider, fullText, allowedToolNames, steps
@@ -13334,7 +13336,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (this._isActionMode(mode) && this._isCompressionPlaceholderResponse(fullText)) {
           if (!compressionPlaceholderRecoveryAttempted) {
             compressionPlaceholderRecoveryAttempted = true;
-            messages.push({ role: 'assistant', content: fullText });
+            messages.push(this._withResponseItems({ role: 'assistant', content: fullText }, responseItems));
             messages.push({
               role: 'user',
               content: '[System nudge: your previous response was a context-compression placeholder, not a real final answer or tool call. Continue the active browser task with tool calls. Do not output "[compressed]".]',
@@ -13359,7 +13361,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         compressionPlaceholderRecoveryAttempted = false;
         const progressFinalBlock = this._plainFinalProgressBlock(tabId);
         if (progressFinalBlock) {
-          messages.push({ role: 'assistant', content: fullText });
+          messages.push(this._withResponseItems({ role: 'assistant', content: fullText }, responseItems));
           messages.push({ role: 'user', content: progressFinalBlock });
           onUpdate('warning', { message: 'Progress ledger has unresolved rows; continuing.' });
           this._persist(tabId);
@@ -13369,7 +13371,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           onUpdate('text_delta', { content: `\n\n${costStopMessage}` });
           fullText = `${fullText}\n\n${costStopMessage}`;
         }
-        messages.push({ role: 'assistant', content: fullText });
+        messages.push(this._withResponseItems({ role: 'assistant', content: fullText }, responseItems));
         this._persist(tabId);
         return finish(fullText);
 

--- a/src/chrome/src/providers/context-windows.js
+++ b/src/chrome/src/providers/context-windows.js
@@ -243,6 +243,7 @@ export function inferContextWindow(config = {}) {
   if (!model) return DEFAULT_CLOUD_CONTEXT_WINDOW;
 
   // OpenAI
+  if (/^gpt-5\.6(?:[.\-]|$)/.test(model) || model.includes('/gpt-5.6')) return 1050000;
   if (model.includes('gpt-5.5-pro')) return 1050000;
   if (/^gpt-5(?:[.\-]|$)/.test(model) || model.includes('/gpt-5')) return 400000;
 

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -30,6 +30,8 @@ const WEBBRAIN_DEVICE_GUID_KEY = 'webbrainDeviceGuid';
 const HELP_IMPROVE_WEBBRAIN_KEY = 'helpImproveWebBrain';
 const OPENROUTER_DEFAULT_MODEL = 'openrouter/free';
 const OPENROUTER_LEGACY_DEFAULT_MODEL = 'stepfun/step-3.7-flash';
+const OPENAI_DEFAULT_MODEL = 'gpt-5.6-terra';
+const OPENAI_LEGACY_DEFAULT_MODEL = 'gpt-5.5';
 const SUPPORTED_PROVIDER_TYPES = new Set(['llamacpp', 'openai', 'azure_openai', 'aws_bedrock', 'anthropic', 'anthropic_oauth']);
 const SAFE_PROVIDER_ID_RE = /^[A-Za-z0-9_-]+$/;
 const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface', 'fireworks', 'together'];
@@ -287,9 +289,9 @@ export class ProviderManager {
         label: 'OpenAI',
         providerName: 'openai',
         baseUrl: 'https://api.openai.com/v1',
-        model: 'gpt-5.5',
-        inputCostPerMillionUsd: 5,
-        outputCostPerMillionUsd: 22.5,
+        model: OPENAI_DEFAULT_MODEL,
+        inputCostPerMillionUsd: 2.5,
+        outputCostPerMillionUsd: 15,
         supportsStreamUsageOptions: true,
         apiKey: '',
         apiKeyUrl: 'https://platform.openai.com/api-keys',
@@ -479,6 +481,22 @@ export class ProviderManager {
 
   _migrateStoredProviderConfigs(stored) {
     const migrated = { ...stored };
+    const storedOpenAi = migrated.openai;
+    const openAiBaseUrl = String(storedOpenAi?.baseUrl || 'https://api.openai.com/v1').replace(/\/+$/, '');
+    const untouchedOpenAiDefault = storedOpenAi?.model === OPENAI_LEGACY_DEFAULT_MODEL
+      && storedOpenAi?.configured !== true
+      && !String(storedOpenAi?.apiKey || '').trim()
+      && openAiBaseUrl === 'https://api.openai.com/v1'
+      && (storedOpenAi?.inputCostPerMillionUsd == null || Number(storedOpenAi.inputCostPerMillionUsd) === 5)
+      && (storedOpenAi?.outputCostPerMillionUsd == null || Number(storedOpenAi.outputCostPerMillionUsd) === 22.5);
+    if (untouchedOpenAiDefault) {
+      migrated.openai = {
+        ...storedOpenAi,
+        model: OPENAI_DEFAULT_MODEL,
+        inputCostPerMillionUsd: 2.5,
+        outputCostPerMillionUsd: 15,
+      };
+    }
     if (migrated.openrouter?.model === OPENROUTER_LEGACY_DEFAULT_MODEL) {
       migrated.openrouter = {
         ...migrated.openrouter,

--- a/src/chrome/src/providers/openai.js
+++ b/src/chrome/src/providers/openai.js
@@ -21,7 +21,11 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
   }
 
   get model() {
-    return this.config.model || 'gpt-4o';
+    if (this.config.model) return this.config.model;
+    return String(this.config.providerName || '').toLowerCase() === 'openai'
+      && this._isOfficialOpenAIBaseUrl()
+      ? 'gpt-5.6-terra'
+      : 'gpt-4o';
   }
 
   get supportsTools() {
@@ -175,10 +179,359 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     }
   }
 
-  async chat(messages, options = {}) {
+  /**
+   * GPT-5.6 combines reasoning and function tools through the Responses API.
+   * Keep this route deliberately narrow: older OpenAI models and every
+   * OpenAI-compatible provider retain their existing Chat Completions wire
+   * format. A custom base URL also stays on Chat Completions because there is
+   * no guarantee that the proxy implements /v1/responses.
+   */
+  _usesResponsesApi() {
+    if (String(this.config.providerName || '').toLowerCase() !== 'openai') return false;
+    const model = String(this.model || '').trim().toLowerCase();
+    if (!/^gpt-5\.6(?:$|-(?:sol|terra|luna)(?:$|-))/.test(model)) return false;
+    return this._isOfficialOpenAIBaseUrl();
+  }
+
+  _isOfficialOpenAIBaseUrl() {
+    try {
+      const url = new URL(this.baseUrl);
+      return url.protocol === 'https:'
+        && url.hostname === 'api.openai.com'
+        && url.pathname.replace(/\/+$/, '') === '/v1';
+    } catch {
+      return false;
+    }
+  }
+
+  _responsesUrl() {
+    return `${this.baseUrl.replace(/\/+$/, '')}/responses`;
+  }
+
+  _chatMessages(messages) {
+    return (Array.isArray(messages) ? messages : []).map((message) => {
+      if (!message || !Object.hasOwn(message, 'response_items')) return message;
+      const { response_items: _responseItems, ...chatMessage } = message;
+      return chatMessage;
+    });
+  }
+
+  _responsesContent(content) {
+    if (!Array.isArray(content)) return content == null ? '' : String(content);
+    return content.map((block) => {
+      if (!block || typeof block !== 'object') {
+        return { type: 'input_text', text: String(block ?? '') };
+      }
+      if (block.type === 'input_text' || block.type === 'input_image') return block;
+      if (block.type === 'text') {
+        return { type: 'input_text', text: String(block.text || '') };
+      }
+      if (block.type === 'image_url') {
+        const imageUrl = typeof block.image_url === 'string'
+          ? block.image_url
+          : block.image_url?.url;
+        return {
+          type: 'input_image',
+          image_url: imageUrl || '',
+          ...(block.image_url?.detail ? { detail: block.image_url.detail } : {}),
+        };
+      }
+      return { type: 'input_text', text: block.text || JSON.stringify(block) };
+    });
+  }
+
+  _responsesInput(messages) {
+    const input = [];
+    for (const message of Array.isArray(messages) ? messages : []) {
+      // These are the exact output Items returned by a prior stateless
+      // Responses call. Replaying them preserves encrypted reasoning state,
+      // which OpenAI requires when a reasoning turn emitted function calls.
+      if (Array.isArray(message?.response_items) && message.response_items.length) {
+        input.push(...message.response_items);
+        continue;
+      }
+
+      if (message?.role === 'tool') {
+        input.push({
+          type: 'function_call_output',
+          call_id: String(message.tool_call_id || ''),
+          output: typeof message.content === 'string'
+            ? message.content
+            : JSON.stringify(message.content ?? ''),
+        });
+        continue;
+      }
+
+      if (message?.role === 'assistant' && Array.isArray(message.tool_calls)) {
+        if (message.content) {
+          input.push({ role: 'assistant', content: this._responsesContent(message.content) });
+        }
+        for (const toolCall of message.tool_calls) {
+          const fn = toolCall?.function || {};
+          input.push({
+            type: 'function_call',
+            call_id: String(toolCall?.id || ''),
+            name: String(fn.name || ''),
+            arguments: typeof fn.arguments === 'string'
+              ? fn.arguments
+              : JSON.stringify(fn.arguments || {}),
+          });
+        }
+        continue;
+      }
+
+      input.push({
+        role: message?.role || 'user',
+        content: this._responsesContent(message?.content),
+      });
+    }
+    return input;
+  }
+
+  _responsesTools(tools) {
+    return (Array.isArray(tools) ? tools : []).map((tool) => {
+      if (tool?.type !== 'function' || !tool.function) return tool;
+      const fn = tool.function;
+      return {
+        type: 'function',
+        name: fn.name,
+        description: fn.description,
+        parameters: fn.parameters || { type: 'object', properties: {} },
+        // Chat Completions is non-strict by default. Preserve that behavior
+        // unless a WebBrain tool explicitly opted into strict schemas.
+        strict: fn.strict === true,
+      };
+    });
+  }
+
+  _responsesToolChoice(toolChoice) {
+    if (!toolChoice || typeof toolChoice === 'string') return toolChoice || 'auto';
+    const name = toolChoice.function?.name || toolChoice.name;
+    return name ? { type: 'function', name } : 'auto';
+  }
+
+  _responsesBody(messages, options, stream) {
     const body = {
       model: this.model,
-      messages,
+      input: this._responsesInput(messages),
+      stream,
+      store: false,
+      max_output_tokens: options.maxTokens ?? 4096,
+      // Keep reasoning enabled. `none` would recreate the workaround the
+      // Responses migration is specifically intended to avoid.
+      reasoning: {
+        effort: options.reasoningEffort || this.config.reasoningEffort || 'medium',
+      },
+    };
+
+    if (this._shouldSendTools(messages, options)) {
+      body.tools = this._responsesTools(options.tools);
+      body.tool_choice = this._responsesToolChoice(options.toolChoice);
+    }
+
+    const extra = options.extraBody;
+    if (extra && typeof extra === 'object') {
+      if (typeof extra.reasoning_effort === 'string') {
+        body.reasoning = { effort: extra.reasoning_effort };
+      } else if (extra.reasoning && typeof extra.reasoning === 'object') {
+        body.reasoning = { ...body.reasoning, ...extra.reasoning };
+      }
+      if (extra.response_format?.type === 'json_schema' && extra.response_format.json_schema) {
+        const schema = extra.response_format.json_schema;
+        body.text = {
+          format: {
+            type: 'json_schema',
+            name: schema.name,
+            schema: schema.schema,
+            strict: schema.strict === true,
+          },
+        };
+      }
+    }
+    return body;
+  }
+
+  _normalizeResponsesUsage(usage) {
+    if (!usage || typeof usage !== 'object') return usage || null;
+    return {
+      ...usage,
+      prompt_tokens: usage.prompt_tokens ?? usage.input_tokens ?? 0,
+      completion_tokens: usage.completion_tokens ?? usage.output_tokens ?? 0,
+      total_tokens: usage.total_tokens ??
+        ((usage.input_tokens || 0) + (usage.output_tokens || 0)),
+    };
+  }
+
+  _responseText(output) {
+    const text = [];
+    for (const item of Array.isArray(output) ? output : []) {
+      if (item?.type !== 'message') continue;
+      for (const part of Array.isArray(item.content) ? item.content : []) {
+        if (part?.type === 'output_text' && part.text) text.push(part.text);
+        if (part?.type === 'refusal' && part.refusal) text.push(part.refusal);
+      }
+    }
+    return text.join('');
+  }
+
+  _responseToolCall(item, index = 0) {
+    if (item?.type !== 'function_call') return null;
+    return {
+      index,
+      id: item.call_id,
+      type: 'function',
+      function: {
+        name: item.name || '',
+        arguments: item.arguments || '',
+      },
+    };
+  }
+
+  _responsesResult(data) {
+    const output = Array.isArray(data?.output) ? data.output : [];
+    const toolCalls = output
+      .map((item, index) => this._responseToolCall(item, index))
+      .filter(Boolean);
+    const reasoningContent = output
+      .filter(item => item?.type === 'reasoning')
+      .flatMap(item => Array.isArray(item.summary) ? item.summary : [])
+      .map(part => part?.text || '')
+      .join('');
+    return {
+      content: this._responseText(output),
+      reasoningContent,
+      toolCalls: toolCalls.length ? toolCalls : null,
+      usage: this._normalizeResponsesUsage(data?.usage),
+      responseItems: output,
+      raw: data,
+    };
+  }
+
+  async _chatResponses(messages, options) {
+    const url = this._responsesUrl();
+    let res;
+    try {
+      res = await fetchWithFallback(url, {
+        method: 'POST',
+        headers: this._headers(),
+        body: JSON.stringify(this._responsesBody(messages, options, false)),
+      });
+    } catch (e) {
+      throw new Error(`${this.name} network error — could not reach ${url} (${e.message}). Is the server running?`);
+    }
+    if (!res.ok) {
+      let err = '';
+      try { err = (await res.text()).slice(0, 500); } catch {}
+      throw new Error(`${this.name} error ${res.status}: ${this._formatHttpError(res.status, err)}`);
+    }
+    let data;
+    try { data = await res.json(); } catch {
+      throw new Error(`${this.name} returned invalid JSON in Responses response.`);
+    }
+    return this._responsesResult(data);
+  }
+
+  async *_chatResponsesStream(messages, options) {
+    const url = this._responsesUrl();
+    let res;
+    try {
+      res = await fetchWithFallback(url, {
+        method: 'POST',
+        headers: this._headers(),
+        body: JSON.stringify(this._responsesBody(messages, options, true)),
+      });
+    } catch (e) {
+      throw new Error(`${this.name} network error — could not reach ${url} (${e.message}). Is the server running?`);
+    }
+    if (!res.ok) {
+      const err = await res.text();
+      throw new Error(`${this.name} stream error ${res.status}: ${this._formatHttpError(res.status, err)}`);
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    const toolItems = new Map();
+    const emittedToolIndexes = new Set();
+    let buffer = '';
+
+    const finalToolCalls = (response) => {
+      const calls = [];
+      for (const [index, item] of (response?.output || []).entries()) {
+        if (emittedToolIndexes.has(index)) continue;
+        const call = this._responseToolCall(item, index);
+        if (call) {
+          emittedToolIndexes.add(index);
+          calls.push(call);
+        }
+      }
+      return calls;
+    };
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith('data: ')) continue;
+        const payload = trimmed.slice(6);
+        if (payload === '[DONE]') {
+          yield { type: 'done', content: '', responseItems: [] };
+          return;
+        }
+        try {
+          const event = JSON.parse(payload);
+          if ((event.type === 'response.output_text.delta' || event.type === 'response.refusal.delta') && event.delta) {
+            yield { type: 'text', content: event.delta };
+          } else if (event.type === 'response.output_item.added' && event.item?.type === 'function_call') {
+            toolItems.set(event.output_index, { ...event.item });
+          } else if (event.type === 'response.function_call_arguments.delta') {
+            const item = toolItems.get(event.output_index);
+            if (item) item.arguments = `${item.arguments || ''}${event.delta || ''}`;
+          } else if (event.type === 'response.function_call_arguments.done') {
+            const item = toolItems.get(event.output_index);
+            if (item && typeof event.arguments === 'string') item.arguments = event.arguments;
+          } else if (event.type === 'response.output_item.done' && event.item?.type === 'function_call') {
+            const index = event.output_index ?? 0;
+            if (!emittedToolIndexes.has(index)) {
+              emittedToolIndexes.add(index);
+              const call = this._responseToolCall(event.item, index);
+              if (call) yield { type: 'tool_call', content: [call] };
+            }
+          } else if (event.type === 'response.completed' || event.type === 'response.incomplete') {
+            const response = event.response || {};
+            const remaining = finalToolCalls(response);
+            if (remaining.length) yield { type: 'tool_call', content: remaining };
+            if (response.usage) {
+              yield { type: 'usage', usage: this._normalizeResponsesUsage(response.usage) };
+            }
+            yield { type: 'done', content: '', responseItems: response.output || [] };
+            return;
+          } else if (event.type === 'response.failed' || event.type === 'error') {
+            const message = event.response?.error?.message || event.error?.message || event.message || 'Responses stream failed.';
+            const streamError = new Error(message);
+            streamError.isResponsesStreamError = true;
+            throw streamError;
+          }
+        } catch (e) {
+          if (e?.isResponsesStreamError) throw e;
+          console.warn(`[${this.name}] malformed Responses SSE chunk skipped:`, payload?.slice(0, 120), e?.message);
+        }
+      }
+    }
+    yield { type: 'done', content: '', responseItems: [] };
+  }
+
+  async chat(messages, options = {}) {
+    if (this._usesResponsesApi()) {
+      return this._chatResponses(messages, options);
+    }
+    const body = {
+      model: this.model,
+      messages: this._chatMessages(messages),
       stream: false,
     };
     this._addTemperature(body, options);
@@ -229,9 +582,13 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
   }
 
   async *chatStream(messages, options = {}) {
+    if (this._usesResponsesApi()) {
+      yield* this._chatResponsesStream(messages, options);
+      return;
+    }
     const body = {
       model: this.model,
-      messages,
+      messages: this._chatMessages(messages),
       stream: true,
     };
     this._addTemperature(body, options);

--- a/src/chrome/src/providers/openai.js
+++ b/src/chrome/src/providers/openai.js
@@ -316,6 +316,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
       input: this._responsesInput(messages),
       stream,
       store: false,
+      include: ['reasoning.encrypted_content'],
       max_output_tokens: options.maxTokens ?? 4096,
       // Keep reasoning enabled. `none` would recreate the workaround the
       // Responses migration is specifically intended to avoid.

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1787,8 +1787,8 @@ function renderProviders() {
     openai: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-...' },
-        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-5.5',
-          suggestions: ['gpt-5.5', 'gpt-5.4', 'gpt-5.2', 'gpt-5.3-codex'] },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-5.6-terra',
+          suggestions: ['gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6', 'gpt-5.5', 'gpt-5.4', 'gpt-5.2', 'gpt-5.3-codex'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.openai.com/v1' },
         ...COST_ESTIMATE_FIELDS,
       ],

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -603,6 +603,12 @@ export class Agent {
     return result;
   }
 
+  _withResponseItems(message, responseItems) {
+    return Array.isArray(responseItems) && responseItems.length
+      ? { ...message, response_items: responseItems }
+      : message;
+  }
+
   setApiMutationsAllowed(tabId, allowed) {
     if (allowed) {
       this.apiAllowedTabs.add(tabId);
@@ -9648,14 +9654,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
 
       if (result.toolCalls && result.toolCalls.length > 0) {
-        messages.push({
+        messages.push(this._withResponseItems({
           role: 'assistant',
           content: result.content || null,
           tool_calls: result.toolCalls,
-          ...(Array.isArray(result.responseItems) && result.responseItems.length
-            ? { response_items: result.responseItems }
-            : {}),
-        });
+        }, result.responseItems));
 
         const batchResult = await this._executeToolBatch(
           tabId, result.toolCalls, messages, onUpdate, provider, result.content, allowedToolNames, steps
@@ -9686,7 +9689,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (this._isActionMode(mode) && this._isCompressionPlaceholderResponse(result.content)) {
         if (!compressionPlaceholderRecoveryAttempted) {
           compressionPlaceholderRecoveryAttempted = true;
-          messages.push({ role: 'assistant', content: result.content });
+          messages.push(this._withResponseItems({ role: 'assistant', content: result.content }, result.responseItems));
           messages.push({
             role: 'user',
             content: '[System nudge: your previous response was a context-compression placeholder, not a real final answer or tool call. Continue the active browser task with tool calls. Do not output "[compressed]".]',
@@ -9735,7 +9738,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
       const progressFinalBlock = this._plainFinalProgressBlock(tabId);
       if (progressFinalBlock) {
-        messages.push({ role: 'assistant', content: result.content });
+        messages.push(this._withResponseItems({ role: 'assistant', content: result.content }, result.responseItems));
         messages.push({ role: 'user', content: progressFinalBlock });
         onUpdate('warning', { message: 'Progress ledger has unresolved rows; continuing.' });
         this._persist(tabId);
@@ -9744,7 +9747,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       finalResponse = result.costAllowanceMessage
         ? `${result.content}\n\n${result.costAllowanceMessage}`
         : result.content;
-      messages.push({ role: 'assistant', content: finalResponse });
+      messages.push(this._withResponseItems({ role: 'assistant', content: finalResponse }, result.responseItems));
       onUpdate('text', { content: finalResponse });
       break;
     }
@@ -10005,12 +10008,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           }
           const toolCalls = Object.values(toolCallsAccumulator);
           this._logDebug({ type: 'llm_stream_response', step: steps, content: fullText, toolCalls });
-          messages.push({
+          messages.push(this._withResponseItems({
             role: 'assistant',
             content: fullText || null,
             tool_calls: toolCalls,
-            ...(responseItems ? { response_items: responseItems } : {}),
-          });
+          }, responseItems));
           const batchResult = await this._executeToolBatch(
             tabId, toolCalls, messages, onUpdate, provider, fullText, allowedToolNames, steps
           );
@@ -10058,7 +10060,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (this._isActionMode(mode) && this._isCompressionPlaceholderResponse(fullText)) {
           if (!compressionPlaceholderRecoveryAttempted) {
             compressionPlaceholderRecoveryAttempted = true;
-            messages.push({ role: 'assistant', content: fullText });
+            messages.push(this._withResponseItems({ role: 'assistant', content: fullText }, responseItems));
             messages.push({
               role: 'user',
               content: '[System nudge: your previous response was a context-compression placeholder, not a real final answer or tool call. Continue the active browser task with tool calls. Do not output "[compressed]".]',
@@ -10082,7 +10084,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         compressionPlaceholderRecoveryAttempted = false;
         const progressFinalBlock = this._plainFinalProgressBlock(tabId);
         if (progressFinalBlock) {
-          messages.push({ role: 'assistant', content: fullText });
+          messages.push(this._withResponseItems({ role: 'assistant', content: fullText }, responseItems));
           messages.push({ role: 'user', content: progressFinalBlock });
           onUpdate('warning', { message: 'Progress ledger has unresolved rows; continuing.' });
           this._persist(tabId);
@@ -10092,7 +10094,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           onUpdate('text_delta', { content: `\n\n${costStopMessage}` });
           fullText = `${fullText}\n\n${costStopMessage}`;
         }
-        messages.push({ role: 'assistant', content: fullText });
+        messages.push(this._withResponseItems({ role: 'assistant', content: fullText }, responseItems));
         this._persist(tabId);
         return finish(fullText);
 

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -6699,6 +6699,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         totalChars += JSON.stringify(msg.content || '').length;
       }
       if (msg.tool_calls) totalChars += JSON.stringify(msg.tool_calls).length;
+      if (msg.response_items) totalChars += JSON.stringify(msg.response_items).length;
     }
     if (hasImage) totalChars += Agent.IMAGE_CHAR_COST;
     return totalChars;
@@ -9651,6 +9652,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           role: 'assistant',
           content: result.content || null,
           tool_calls: result.toolCalls,
+          ...(Array.isArray(result.responseItems) && result.responseItems.length
+            ? { response_items: result.responseItems }
+            : {}),
         });
 
         const batchResult = await this._executeToolBatch(
@@ -9921,6 +9925,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         let fullText = '';
         let toolCallsAccumulator = {};
         let hasToolCalls = false;
+        let responseItems = null;
 
         const streamOpts = this._cloudGenerationOptions(provider, {
           tools: provider.supportsTools ? tools : undefined,
@@ -9969,6 +9974,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               toolCallsAccumulator[idx].function.arguments += String(chunk.content ?? '');
             }
           } else if (chunk.type === 'done') {
+            if (Array.isArray(chunk.responseItems) && chunk.responseItems.length) {
+              responseItems = chunk.responseItems;
+            }
             break;
           }
         }
@@ -10001,6 +10009,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             role: 'assistant',
             content: fullText || null,
             tool_calls: toolCalls,
+            ...(responseItems ? { response_items: responseItems } : {}),
           });
           const batchResult = await this._executeToolBatch(
             tabId, toolCalls, messages, onUpdate, provider, fullText, allowedToolNames, steps

--- a/src/firefox/src/providers/context-windows.js
+++ b/src/firefox/src/providers/context-windows.js
@@ -243,6 +243,7 @@ export function inferContextWindow(config = {}) {
   if (!model) return DEFAULT_CLOUD_CONTEXT_WINDOW;
 
   // OpenAI
+  if (/^gpt-5\.6(?:[.\-]|$)/.test(model) || model.includes('/gpt-5.6')) return 1050000;
   if (model.includes('gpt-5.5-pro')) return 1050000;
   if (/^gpt-5(?:[.\-]|$)/.test(model) || model.includes('/gpt-5')) return 400000;
 

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -23,6 +23,8 @@ const WEBBRAIN_DEVICE_GUID_KEY = 'webbrainDeviceGuid';
 const HELP_IMPROVE_WEBBRAIN_KEY = 'helpImproveWebBrain';
 const OPENROUTER_DEFAULT_MODEL = 'openrouter/free';
 const OPENROUTER_LEGACY_DEFAULT_MODEL = 'stepfun/step-3.7-flash';
+const OPENAI_DEFAULT_MODEL = 'gpt-5.6-terra';
+const OPENAI_LEGACY_DEFAULT_MODEL = 'gpt-5.5';
 const SUPPORTED_PROVIDER_TYPES = new Set(['llamacpp', 'openai', 'azure_openai', 'aws_bedrock', 'anthropic', 'anthropic_oauth']);
 const SAFE_PROVIDER_ID_RE = /^[A-Za-z0-9_-]+$/;
 const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface', 'fireworks', 'together'];
@@ -269,9 +271,9 @@ export class ProviderManager {
         label: 'OpenAI',
         providerName: 'openai',
         baseUrl: 'https://api.openai.com/v1',
-        model: 'gpt-5.5',
-        inputCostPerMillionUsd: 5,
-        outputCostPerMillionUsd: 22.5,
+        model: OPENAI_DEFAULT_MODEL,
+        inputCostPerMillionUsd: 2.5,
+        outputCostPerMillionUsd: 15,
         supportsStreamUsageOptions: true,
         apiKey: '',
         apiKeyUrl: 'https://platform.openai.com/api-keys',
@@ -457,6 +459,22 @@ export class ProviderManager {
 
   _migrateStoredProviderConfigs(stored) {
     const migrated = { ...stored };
+    const storedOpenAi = migrated.openai;
+    const openAiBaseUrl = String(storedOpenAi?.baseUrl || 'https://api.openai.com/v1').replace(/\/+$/, '');
+    const untouchedOpenAiDefault = storedOpenAi?.model === OPENAI_LEGACY_DEFAULT_MODEL
+      && storedOpenAi?.configured !== true
+      && !String(storedOpenAi?.apiKey || '').trim()
+      && openAiBaseUrl === 'https://api.openai.com/v1'
+      && (storedOpenAi?.inputCostPerMillionUsd == null || Number(storedOpenAi.inputCostPerMillionUsd) === 5)
+      && (storedOpenAi?.outputCostPerMillionUsd == null || Number(storedOpenAi.outputCostPerMillionUsd) === 22.5);
+    if (untouchedOpenAiDefault) {
+      migrated.openai = {
+        ...storedOpenAi,
+        model: OPENAI_DEFAULT_MODEL,
+        inputCostPerMillionUsd: 2.5,
+        outputCostPerMillionUsd: 15,
+      };
+    }
     if (migrated.openrouter?.model === OPENROUTER_LEGACY_DEFAULT_MODEL) {
       migrated.openrouter = {
         ...migrated.openrouter,

--- a/src/firefox/src/providers/openai.js
+++ b/src/firefox/src/providers/openai.js
@@ -21,7 +21,11 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
   }
 
   get model() {
-    return this.config.model || 'gpt-5';
+    if (this.config.model) return this.config.model;
+    return String(this.config.providerName || '').toLowerCase() === 'openai'
+      && this._isOfficialOpenAIBaseUrl()
+      ? 'gpt-5.6-terra'
+      : 'gpt-4o';
   }
 
   get supportsTools() {
@@ -166,10 +170,352 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     }
   }
 
-  async chat(messages, options = {}) {
+  /**
+   * GPT-5.6 combines reasoning and function tools through the Responses API.
+   * Keep this route deliberately narrow: older OpenAI models and every
+   * OpenAI-compatible provider retain their existing Chat Completions wire
+   * format. A custom base URL also stays on Chat Completions because there is
+   * no guarantee that the proxy implements /v1/responses.
+   */
+  _usesResponsesApi() {
+    if (String(this.config.providerName || '').toLowerCase() !== 'openai') return false;
+    const model = String(this.model || '').trim().toLowerCase();
+    if (!/^gpt-5\.6(?:$|-(?:sol|terra|luna)(?:$|-))/.test(model)) return false;
+    return this._isOfficialOpenAIBaseUrl();
+  }
+
+  _isOfficialOpenAIBaseUrl() {
+    try {
+      const url = new URL(this.baseUrl);
+      return url.protocol === 'https:'
+        && url.hostname === 'api.openai.com'
+        && url.pathname.replace(/\/+$/, '') === '/v1';
+    } catch {
+      return false;
+    }
+  }
+
+  _responsesUrl() {
+    return `${this.baseUrl.replace(/\/+$/, '')}/responses`;
+  }
+
+  _chatMessages(messages) {
+    return (Array.isArray(messages) ? messages : []).map((message) => {
+      if (!message || !Object.hasOwn(message, 'response_items')) return message;
+      const { response_items: _responseItems, ...chatMessage } = message;
+      return chatMessage;
+    });
+  }
+
+  _responsesContent(content) {
+    if (!Array.isArray(content)) return content == null ? '' : String(content);
+    return content.map((block) => {
+      if (!block || typeof block !== 'object') {
+        return { type: 'input_text', text: String(block ?? '') };
+      }
+      if (block.type === 'input_text' || block.type === 'input_image') return block;
+      if (block.type === 'text') {
+        return { type: 'input_text', text: String(block.text || '') };
+      }
+      if (block.type === 'image_url') {
+        const imageUrl = typeof block.image_url === 'string'
+          ? block.image_url
+          : block.image_url?.url;
+        return {
+          type: 'input_image',
+          image_url: imageUrl || '',
+          ...(block.image_url?.detail ? { detail: block.image_url.detail } : {}),
+        };
+      }
+      return { type: 'input_text', text: block.text || JSON.stringify(block) };
+    });
+  }
+
+  _responsesInput(messages) {
+    const input = [];
+    for (const message of Array.isArray(messages) ? messages : []) {
+      if (Array.isArray(message?.response_items) && message.response_items.length) {
+        input.push(...message.response_items);
+        continue;
+      }
+
+      if (message?.role === 'tool') {
+        input.push({
+          type: 'function_call_output',
+          call_id: String(message.tool_call_id || ''),
+          output: typeof message.content === 'string'
+            ? message.content
+            : JSON.stringify(message.content ?? ''),
+        });
+        continue;
+      }
+
+      if (message?.role === 'assistant' && Array.isArray(message.tool_calls)) {
+        if (message.content) {
+          input.push({ role: 'assistant', content: this._responsesContent(message.content) });
+        }
+        for (const toolCall of message.tool_calls) {
+          const fn = toolCall?.function || {};
+          input.push({
+            type: 'function_call',
+            call_id: String(toolCall?.id || ''),
+            name: String(fn.name || ''),
+            arguments: typeof fn.arguments === 'string'
+              ? fn.arguments
+              : JSON.stringify(fn.arguments || {}),
+          });
+        }
+        continue;
+      }
+
+      input.push({
+        role: message?.role || 'user',
+        content: this._responsesContent(message?.content),
+      });
+    }
+    return input;
+  }
+
+  _responsesTools(tools) {
+    return (Array.isArray(tools) ? tools : []).map((tool) => {
+      if (tool?.type !== 'function' || !tool.function) return tool;
+      const fn = tool.function;
+      return {
+        type: 'function',
+        name: fn.name,
+        description: fn.description,
+        parameters: fn.parameters || { type: 'object', properties: {} },
+        strict: fn.strict === true,
+      };
+    });
+  }
+
+  _responsesToolChoice(toolChoice) {
+    if (!toolChoice || typeof toolChoice === 'string') return toolChoice || 'auto';
+    const name = toolChoice.function?.name || toolChoice.name;
+    return name ? { type: 'function', name } : 'auto';
+  }
+
+  _responsesBody(messages, options, stream) {
     const body = {
       model: this.model,
-      messages,
+      input: this._responsesInput(messages),
+      stream,
+      store: false,
+      max_output_tokens: options.maxTokens ?? 4096,
+      reasoning: {
+        effort: options.reasoningEffort || this.config.reasoningEffort || 'medium',
+      },
+    };
+
+    if (this._shouldSendTools(messages, options)) {
+      body.tools = this._responsesTools(options.tools);
+      body.tool_choice = this._responsesToolChoice(options.toolChoice);
+    }
+
+    const extra = options.extraBody;
+    if (extra && typeof extra === 'object') {
+      if (typeof extra.reasoning_effort === 'string') {
+        body.reasoning = { effort: extra.reasoning_effort };
+      } else if (extra.reasoning && typeof extra.reasoning === 'object') {
+        body.reasoning = { ...body.reasoning, ...extra.reasoning };
+      }
+      if (extra.response_format?.type === 'json_schema' && extra.response_format.json_schema) {
+        const schema = extra.response_format.json_schema;
+        body.text = {
+          format: {
+            type: 'json_schema',
+            name: schema.name,
+            schema: schema.schema,
+            strict: schema.strict === true,
+          },
+        };
+      }
+    }
+    return body;
+  }
+
+  _normalizeResponsesUsage(usage) {
+    if (!usage || typeof usage !== 'object') return usage || null;
+    return {
+      ...usage,
+      prompt_tokens: usage.prompt_tokens ?? usage.input_tokens ?? 0,
+      completion_tokens: usage.completion_tokens ?? usage.output_tokens ?? 0,
+      total_tokens: usage.total_tokens ??
+        ((usage.input_tokens || 0) + (usage.output_tokens || 0)),
+    };
+  }
+
+  _responseText(output) {
+    const text = [];
+    for (const item of Array.isArray(output) ? output : []) {
+      if (item?.type !== 'message') continue;
+      for (const part of Array.isArray(item.content) ? item.content : []) {
+        if (part?.type === 'output_text' && part.text) text.push(part.text);
+        if (part?.type === 'refusal' && part.refusal) text.push(part.refusal);
+      }
+    }
+    return text.join('');
+  }
+
+  _responseToolCall(item, index = 0) {
+    if (item?.type !== 'function_call') return null;
+    return {
+      index,
+      id: item.call_id,
+      type: 'function',
+      function: {
+        name: item.name || '',
+        arguments: item.arguments || '',
+      },
+    };
+  }
+
+  _responsesResult(data) {
+    const output = Array.isArray(data?.output) ? data.output : [];
+    const toolCalls = output
+      .map((item, index) => this._responseToolCall(item, index))
+      .filter(Boolean);
+    const reasoningContent = output
+      .filter(item => item?.type === 'reasoning')
+      .flatMap(item => Array.isArray(item.summary) ? item.summary : [])
+      .map(part => part?.text || '')
+      .join('');
+    return {
+      content: this._responseText(output),
+      reasoningContent,
+      toolCalls: toolCalls.length ? toolCalls : null,
+      usage: this._normalizeResponsesUsage(data?.usage),
+      responseItems: output,
+      raw: data,
+    };
+  }
+
+  async _chatResponses(messages, options) {
+    const url = this._responsesUrl();
+    let res;
+    try {
+      res = await fetchWithTimeout(url, {
+        method: 'POST',
+        headers: this._headers(),
+        body: JSON.stringify(this._responsesBody(messages, options, false)),
+      });
+    } catch (e) {
+      throw new Error(`${this.name} network error — could not reach ${url} (${e.message}). Is the server running?`);
+    }
+    if (!res.ok) {
+      let err = '';
+      try { err = (await res.text()).slice(0, 500); } catch {}
+      throw new Error(`${this.name} error ${res.status}: ${this._formatHttpError(res.status, err)}`);
+    }
+    let data;
+    try { data = await res.json(); } catch {
+      throw new Error(`${this.name} returned invalid JSON in Responses response.`);
+    }
+    return this._responsesResult(data);
+  }
+
+  async *_chatResponsesStream(messages, options) {
+    const url = this._responsesUrl();
+    let res;
+    try {
+      res = await fetchWithTimeout(url, {
+        method: 'POST',
+        headers: this._headers(),
+        body: JSON.stringify(this._responsesBody(messages, options, true)),
+      });
+    } catch (e) {
+      throw new Error(`${this.name} network error — could not reach ${url} (${e.message}). Is the server running?`);
+    }
+    if (!res.ok) {
+      const err = await res.text();
+      throw new Error(`${this.name} stream error ${res.status}: ${this._formatHttpError(res.status, err)}`);
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    const toolItems = new Map();
+    const emittedToolIndexes = new Set();
+    let buffer = '';
+
+    const finalToolCalls = (response) => {
+      const calls = [];
+      for (const [index, item] of (response?.output || []).entries()) {
+        if (emittedToolIndexes.has(index)) continue;
+        const call = this._responseToolCall(item, index);
+        if (call) {
+          emittedToolIndexes.add(index);
+          calls.push(call);
+        }
+      }
+      return calls;
+    };
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith('data: ')) continue;
+        const payload = trimmed.slice(6);
+        if (payload === '[DONE]') {
+          yield { type: 'done', content: '', responseItems: [] };
+          return;
+        }
+        try {
+          const event = JSON.parse(payload);
+          if ((event.type === 'response.output_text.delta' || event.type === 'response.refusal.delta') && event.delta) {
+            yield { type: 'text', content: event.delta };
+          } else if (event.type === 'response.output_item.added' && event.item?.type === 'function_call') {
+            toolItems.set(event.output_index, { ...event.item });
+          } else if (event.type === 'response.function_call_arguments.delta') {
+            const item = toolItems.get(event.output_index);
+            if (item) item.arguments = `${item.arguments || ''}${event.delta || ''}`;
+          } else if (event.type === 'response.function_call_arguments.done') {
+            const item = toolItems.get(event.output_index);
+            if (item && typeof event.arguments === 'string') item.arguments = event.arguments;
+          } else if (event.type === 'response.output_item.done' && event.item?.type === 'function_call') {
+            const index = event.output_index ?? 0;
+            if (!emittedToolIndexes.has(index)) {
+              emittedToolIndexes.add(index);
+              const call = this._responseToolCall(event.item, index);
+              if (call) yield { type: 'tool_call', content: [call] };
+            }
+          } else if (event.type === 'response.completed' || event.type === 'response.incomplete') {
+            const response = event.response || {};
+            const remaining = finalToolCalls(response);
+            if (remaining.length) yield { type: 'tool_call', content: remaining };
+            if (response.usage) {
+              yield { type: 'usage', usage: this._normalizeResponsesUsage(response.usage) };
+            }
+            yield { type: 'done', content: '', responseItems: response.output || [] };
+            return;
+          } else if (event.type === 'response.failed' || event.type === 'error') {
+            const message = event.response?.error?.message || event.error?.message || event.message || 'Responses stream failed.';
+            const streamError = new Error(message);
+            streamError.isResponsesStreamError = true;
+            throw streamError;
+          }
+        } catch (e) {
+          if (e?.isResponsesStreamError) throw e;
+          console.warn(`[${this.name}] malformed Responses SSE chunk skipped:`, payload?.slice(0, 120), e?.message);
+        }
+      }
+    }
+    yield { type: 'done', content: '', responseItems: [] };
+  }
+
+  async chat(messages, options = {}) {
+    if (this._usesResponsesApi()) {
+      return this._chatResponses(messages, options);
+    }
+    const body = {
+      model: this.model,
+      messages: this._chatMessages(messages),
       stream: false,
     };
     this._addTemperature(body, options);
@@ -220,9 +566,13 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
   }
 
   async *chatStream(messages, options = {}) {
+    if (this._usesResponsesApi()) {
+      yield* this._chatResponsesStream(messages, options);
+      return;
+    }
     const body = {
       model: this.model,
-      messages,
+      messages: this._chatMessages(messages),
       stream: true,
     };
     this._addTemperature(body, options);

--- a/src/firefox/src/providers/openai.js
+++ b/src/firefox/src/providers/openai.js
@@ -302,6 +302,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
       input: this._responsesInput(messages),
       stream,
       store: false,
+      include: ['reasoning.encrypted_content'],
       max_output_tokens: options.maxTokens ?? 4096,
       reasoning: {
         effort: options.reasoningEffort || this.config.reasoningEffort || 'medium',

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1743,8 +1743,8 @@ function renderProviders() {
     openai: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-...' },
-        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-5.5',
-          suggestions: ['gpt-5.5', 'gpt-5.4', 'gpt-5.2', 'gpt-5.3-codex'] },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-5.6-terra',
+          suggestions: ['gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6', 'gpt-5.5', 'gpt-5.4', 'gpt-5.2', 'gpt-5.3-codex'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.openai.com/v1' },
         ...COST_ESTIMATE_FIELDS,
       ],

--- a/test/run.js
+++ b/test/run.js
@@ -14411,6 +14411,9 @@ test('inferContextWindow: model-aware cloud/router defaults and local 16k fallba
     for (const providerName of ['lmstudio', 'jan', 'vllm', 'sglang', 'localai']) {
       assert.equal(infer({ category: 'local', providerName, model: 'qwen3.7-plus' }), 16384);
     }
+    for (const model of ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+      assert.equal(infer({ category: 'cloud', providerName: 'openai', model }), 1050000);
+    }
     assert.equal(infer({ category: 'cloud', providerName: 'openai', model: 'gpt-5.5-pro' }), 1050000);
     assert.equal(infer({ category: 'cloud', providerName: 'openai', model: 'gpt-5.5' }), 400000);
     assert.equal(infer({ category: 'cloud', providerName: 'anthropic', model: 'claude-opus-4-8' }), 1000000);
@@ -15824,6 +15827,69 @@ test('_defaultConfigs: OpenRouter defaults to openrouter/free and migrates legac
   }
 });
 
+test('_defaultConfigs: OpenAI defaults to GPT-5.6 Terra and safely migrates the prior shipped default', () => {
+  for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
+    const mgr = new PM();
+    const defaults = mgr._defaultConfigs();
+    assert.equal(defaults.openai.model, 'gpt-5.6-terra');
+    assert.equal(defaults.openai.inputCostPerMillionUsd, 2.5);
+    assert.equal(defaults.openai.outputCostPerMillionUsd, 15);
+
+    const migrated = mgr._migrateStoredProviderConfigs({
+      openai: {
+        model: 'gpt-5.5',
+        inputCostPerMillionUsd: 5,
+        outputCostPerMillionUsd: 22.5,
+        apiKey: '',
+        configured: false,
+      },
+    });
+    assert.equal(migrated.openai.model, 'gpt-5.6-terra');
+    assert.equal(migrated.openai.inputCostPerMillionUsd, 2.5);
+    assert.equal(migrated.openai.outputCostPerMillionUsd, 15);
+    assert.equal(migrated.openai.configured, false);
+
+    const customModel = mgr._migrateStoredProviderConfigs({
+      openai: { model: 'gpt-5.4', inputCostPerMillionUsd: 99 },
+    });
+    assert.deepEqual(customModel.openai, { model: 'gpt-5.4', inputCostPerMillionUsd: 99 });
+
+    const customCosts = mgr._migrateStoredProviderConfigs({
+      openai: {
+        model: 'gpt-5.5',
+        inputCostPerMillionUsd: 7,
+        outputCostPerMillionUsd: 8,
+      },
+    });
+    assert.equal(customCosts.openai.model, 'gpt-5.5');
+    assert.equal(customCosts.openai.inputCostPerMillionUsd, 7);
+    assert.equal(customCosts.openai.outputCostPerMillionUsd, 8);
+
+    for (const configured of [
+      { model: 'gpt-5.5', configured: true, apiKey: 'kept' },
+      { model: 'gpt-5.5', configured: false, baseUrl: 'https://proxy.example.test/v1' },
+    ]) {
+      assert.deepEqual(
+        mgr._migrateStoredProviderConfigs({ openai: configured }).openai,
+        configured,
+        'configured and custom-endpoint GPT-5.5 selections must remain untouched',
+      );
+    }
+  }
+});
+
+test('OpenAI settings list every GPT-5.6 family model with Terra first', () => {
+  for (const prefix of ['src/chrome', 'src/firefox']) {
+    const source = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/settings.js'), 'utf8');
+    assert.match(source, /placeholder: 'gpt-5\.6-terra'/, `${prefix}: Terra should be the OpenAI placeholder`);
+    const terra = source.indexOf("'gpt-5.6-terra'");
+    const sol = source.indexOf("'gpt-5.6-sol'", terra);
+    const luna = source.indexOf("'gpt-5.6-luna'", terra);
+    const alias = source.indexOf("'gpt-5.6'", terra);
+    assert.ok(terra >= 0 && sol > terra && luna > sol && alias > luna, `${prefix}: GPT-5.6 suggestions should lead with Terra, Sol, Luna, and the Sol alias`);
+  }
+});
+
 test('_defaultConfigs: chrome and firefox share the same provider set', () => {
   const chDefaults = new ProviderManagerCh()._defaultConfigs();
   const fxDefaults = new ProviderManagerFx()._defaultConfigs();
@@ -15857,6 +15923,286 @@ test('WebBrain Cloud sends the Help Improve preference without leaking it to BYO
     const bringYourOwn = new Provider({ providerName: 'openai', apiKey: 'test-key' });
     assert.equal(bringYourOwn._headers()['X-WebBrain-Help-Improve'], undefined);
     assert.equal(bringYourOwn._headers()['X-WebBrain-Client'], undefined);
+  }
+});
+
+test('official OpenAI GPT-5.6 alone routes to Responses API', () => {
+  for (const Provider of [OpenAIProviderCh, OpenAIProviderFx]) {
+    assert.equal(new Provider({ providerName: 'openai' }).model, 'gpt-5.6-terra');
+    assert.equal(new Provider({ providerName: 'openrouter' }).model, 'gpt-4o');
+    assert.equal(new Provider({ providerName: 'openai', baseUrl: 'https://proxy.example.test/v1' }).model, 'gpt-4o');
+    for (const model of ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.6-terra-2026-07-15']) {
+      const provider = new Provider({
+        providerName: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        model,
+      });
+      assert.equal(provider._usesResponsesApi(), true, `${model} should use Responses`);
+      assert.equal(provider._responsesUrl(), 'https://api.openai.com/v1/responses');
+    }
+
+    for (const config of [
+      { providerName: 'openai', baseUrl: 'https://api.openai.com/v1', model: 'gpt-5.5' },
+      { providerName: 'openrouter', baseUrl: 'https://openrouter.ai/api/v1', model: 'openai/gpt-5.6-terra' },
+      { providerName: 'openai', baseUrl: 'https://proxy.example.test/v1', model: 'gpt-5.6-terra' },
+      { providerName: 'lmstudio', category: 'local', baseUrl: 'http://localhost:1234/v1', model: 'gpt-5.6-terra' },
+    ]) {
+      assert.equal(new Provider(config)._usesResponsesApi(), false, `${config.providerName}/${config.model} should keep Chat Completions`);
+    }
+  }
+});
+
+test('GPT-5.6 Responses request preserves reasoning and converts messages and tools', () => {
+  const reasoningItem = {
+    id: 'rs_1',
+    type: 'reasoning',
+    encrypted_content: 'opaque-reasoning-state',
+    summary: [],
+  };
+  const priorCall = {
+    id: 'fc_1',
+    type: 'function_call',
+    call_id: 'call_1',
+    name: 'click',
+    arguments: '{"x":1}',
+    status: 'completed',
+  };
+  const messages = [
+    { role: 'system', content: 'Use tools carefully.' },
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Inspect this image.' },
+        { type: 'image_url', image_url: { url: 'data:image/png;base64,AA==', detail: 'high' } },
+      ],
+    },
+    { role: 'assistant', content: null, tool_calls: [{ id: 'ignored-chat-copy' }], response_items: [reasoningItem, priorCall] },
+    { role: 'tool', tool_call_id: 'call_1', content: { ok: true } },
+  ];
+  const options = {
+    maxTokens: 1234,
+    tools: [{
+      type: 'function',
+      function: {
+        name: 'click',
+        description: 'Click a point.',
+        parameters: { type: 'object', properties: { x: { type: 'number' } }, required: ['x'] },
+      },
+    }],
+    toolChoice: { type: 'function', function: { name: 'click' } },
+  };
+
+  for (const Provider of [OpenAIProviderCh, OpenAIProviderFx]) {
+    const provider = new Provider({
+      providerName: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-5.6-terra',
+    });
+    const body = provider._responsesBody(messages, options, true);
+    assert.equal(body.model, 'gpt-5.6-terra');
+    assert.equal(body.stream, true);
+    assert.equal(body.store, false);
+    assert.equal(body.max_output_tokens, 1234);
+    assert.deepEqual(body.reasoning, { effort: 'medium' });
+    assert.equal(body.messages, undefined);
+    assert.equal(body.max_completion_tokens, undefined);
+    assert.equal(body.reasoning_effort, undefined);
+    assert.deepEqual(body.tools, [{
+      type: 'function',
+      name: 'click',
+      description: 'Click a point.',
+      parameters: { type: 'object', properties: { x: { type: 'number' } }, required: ['x'] },
+      strict: false,
+    }]);
+    assert.deepEqual(body.tool_choice, { type: 'function', name: 'click' });
+    assert.deepEqual(body.input[1].content, [
+      { type: 'input_text', text: 'Inspect this image.' },
+      { type: 'input_image', image_url: 'data:image/png;base64,AA==', detail: 'high' },
+    ]);
+    assert.equal(body.input[2], reasoningItem, 'the encrypted reasoning item should be replayed exactly');
+    assert.equal(body.input[3], priorCall, 'the matching function call item should be replayed exactly');
+    assert.deepEqual(body.input[4], {
+      type: 'function_call_output',
+      call_id: 'call_1',
+      output: '{"ok":true}',
+    });
+
+    const disabled = provider._responsesBody([], { extraBody: { reasoning_effort: 'none' } }, false);
+    assert.deepEqual(disabled.reasoning, { effort: 'none' }, 'an explicit none remains an opt-out, not the default');
+  }
+});
+
+test('GPT-5.6 Responses results normalize text, calls, usage, and replay items', () => {
+  const output = [
+    { id: 'rs_2', type: 'reasoning', encrypted_content: 'opaque', summary: [{ type: 'summary_text', text: 'Checked. ' }] },
+    { id: 'fc_2', type: 'function_call', call_id: 'call_2', name: 'read_page', arguments: '{"tabId":1}', status: 'completed' },
+    { id: 'msg_2', type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'Done.' }] },
+  ];
+  for (const Provider of [OpenAIProviderCh, OpenAIProviderFx]) {
+    const provider = new Provider({ providerName: 'openai', model: 'gpt-5.6-terra' });
+    const result = provider._responsesResult({
+      output,
+      usage: { input_tokens: 10, output_tokens: 4, total_tokens: 14 },
+    });
+    assert.equal(result.content, 'Done.');
+    assert.equal(result.reasoningContent, 'Checked. ');
+    assert.deepEqual(result.toolCalls, [{
+      index: 1,
+      id: 'call_2',
+      type: 'function',
+      function: { name: 'read_page', arguments: '{"tabId":1}' },
+    }]);
+    assert.equal(result.usage.prompt_tokens, 10);
+    assert.equal(result.usage.completion_tokens, 4);
+    assert.equal(result.usage.total_tokens, 14);
+    assert.equal(result.responseItems, output);
+  }
+});
+
+test('GPT-5.6 uses /responses while older and compatible-provider calls keep /chat/completions', async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    for (const Provider of [OpenAIProviderCh, OpenAIProviderFx]) {
+      const requests = [];
+      globalThis.fetch = async (url, init) => {
+        requests.push({ url: String(url), body: JSON.parse(init.body) });
+        if (String(url).endsWith('/responses')) {
+          return new Response(JSON.stringify({
+            output: [{ type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'terra' }] }],
+            usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 },
+          }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+        }
+        return new Response(JSON.stringify({
+          choices: [{ message: { content: 'legacy' } }],
+          usage: { prompt_tokens: 2, completion_tokens: 1, total_tokens: 3 },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      };
+
+      const tool = { type: 'function', function: { name: 'read_page', parameters: { type: 'object', properties: {} } } };
+      const terra = new Provider({ providerName: 'openai', baseUrl: 'https://api.openai.com/v1', model: 'gpt-5.6-terra' });
+      const terraResult = await terra.chat([{ role: 'user', content: 'hello' }], { tools: [tool] });
+      assert.equal(terraResult.content, 'terra');
+      assert.equal(requests.at(-1).url, 'https://api.openai.com/v1/responses');
+      assert.equal(requests.at(-1).body.reasoning.effort, 'medium');
+      assert.equal(requests.at(-1).body.tools[0].name, 'read_page');
+      assert.equal(requests.at(-1).body.messages, undefined);
+
+      const legacy = new Provider({ providerName: 'openai', baseUrl: 'https://api.openai.com/v1', model: 'gpt-5.5' });
+      const legacyResult = await legacy.chat([{
+        role: 'user',
+        content: 'hello',
+        response_items: [{ type: 'reasoning', encrypted_content: 'internal-only' }],
+      }], { tools: [tool] });
+      assert.equal(legacyResult.content, 'legacy');
+      assert.equal(requests.at(-1).url, 'https://api.openai.com/v1/chat/completions');
+      assert.deepEqual(requests.at(-1).body.messages, [{ role: 'user', content: 'hello' }]);
+      assert.equal(requests.at(-1).body.tools[0].function.name, 'read_page');
+      assert.equal(requests.at(-1).body.reasoning, undefined);
+
+      const proxy = new Provider({ providerName: 'openai', baseUrl: 'https://proxy.example.test/v1', model: 'gpt-5.6-terra' });
+      await proxy.chat([{ role: 'user', content: 'hello' }], { tools: [tool] });
+      assert.equal(requests.at(-1).url, 'https://proxy.example.test/v1/chat/completions');
+      assert.equal(requests.at(-1).body.tools[0].function.name, 'read_page');
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('GPT-5.6 Responses streaming emits text, tool calls, usage, and replay items', async () => {
+  const originalFetch = globalThis.fetch;
+  const output = [
+    { id: 'rs_stream', type: 'reasoning', encrypted_content: 'opaque', summary: [] },
+    { id: 'fc_stream', type: 'function_call', call_id: 'call_stream', name: 'click', arguments: '{"x":9}', status: 'completed' },
+  ];
+  const events = [
+    { type: 'response.output_text.delta', delta: 'Working' },
+    { type: 'response.output_item.added', output_index: 1, item: { id: 'fc_stream', type: 'function_call', call_id: 'call_stream', name: 'click', arguments: '' } },
+    { type: 'response.function_call_arguments.delta', output_index: 1, delta: '{"x":9}' },
+    { type: 'response.output_item.done', output_index: 1, item: output[1] },
+    { type: 'response.completed', response: { output, usage: { input_tokens: 8, output_tokens: 3, total_tokens: 11 } } },
+  ];
+  const sse = events.map(event => `data: ${JSON.stringify(event)}\n\n`).join('');
+  try {
+    globalThis.fetch = async () => new Response(sse, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+    for (const Provider of [OpenAIProviderCh, OpenAIProviderFx]) {
+      const provider = new Provider({
+        providerName: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5.6-terra',
+      });
+      const chunks = [];
+      for await (const chunk of provider.chatStream([{ role: 'user', content: 'click it' }], { tools: [] })) {
+        chunks.push(chunk);
+      }
+      assert.deepEqual(chunks[0], { type: 'text', content: 'Working' });
+      assert.deepEqual(chunks[1], {
+        type: 'tool_call',
+        content: [{
+          index: 1,
+          id: 'call_stream',
+          type: 'function',
+          function: { name: 'click', arguments: '{"x":9}' },
+        }],
+      });
+      assert.equal(chunks[2].type, 'usage');
+      assert.equal(chunks[2].usage.prompt_tokens, 8);
+      assert.equal(chunks[3].type, 'done');
+      assert.deepEqual(chunks[3].responseItems, output);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('GPT-5.6 Responses streaming preserves refusal text', async () => {
+  const originalFetch = globalThis.fetch;
+  const events = [
+    { type: 'response.refusal.delta', delta: 'I cannot help with that.' },
+    {
+      type: 'response.completed',
+      response: {
+        output: [{
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'refusal', refusal: 'I cannot help with that.' }],
+        }],
+      },
+    },
+  ];
+  const sse = events.map(event => `data: ${JSON.stringify(event)}\n\n`).join('');
+  try {
+    globalThis.fetch = async () => new Response(sse, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+    for (const Provider of [OpenAIProviderCh, OpenAIProviderFx]) {
+      const provider = new Provider({
+        providerName: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5.6-terra',
+      });
+      const chunks = [];
+      for await (const chunk of provider.chatStream([{ role: 'user', content: 'hello' }])) {
+        chunks.push(chunk);
+      }
+      assert.deepEqual(chunks[0], { type: 'text', content: 'I cannot help with that.' });
+      assert.equal(chunks[1].type, 'done');
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('Agent tool loops preserve Responses reasoning items on both execution paths', () => {
+  for (const prefix of ['src/chrome', 'src/firefox']) {
+    const source = fs.readFileSync(path.join(ROOT, prefix, 'src/agent/agent.js'), 'utf8');
+    assert.match(source, /Array\.isArray\(result\.responseItems\).*response_items: result\.responseItems/s, `${prefix}: non-stream tool loop should retain response Items`);
+    assert.match(source, /chunk\.responseItems.*response_items: responseItems/s, `${prefix}: stream tool loop should retain response Items`);
+    assert.match(source, /if \(msg\.response_items\) totalChars \+= JSON\.stringify\(msg\.response_items\)\.length/, `${prefix}: context budgeting should include encrypted reasoning Items`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -16201,8 +16201,13 @@ test('GPT-5.6 Responses streaming preserves refusal text', async () => {
 test('Agent tool loops preserve Responses reasoning items on both execution paths', () => {
   for (const prefix of ['src/chrome', 'src/firefox']) {
     const source = fs.readFileSync(path.join(ROOT, prefix, 'src/agent/agent.js'), 'utf8');
-    assert.match(source, /Array\.isArray\(result\.responseItems\).*response_items: result\.responseItems/s, `${prefix}: non-stream tool loop should retain response Items`);
-    assert.match(source, /chunk\.responseItems.*response_items: responseItems/s, `${prefix}: stream tool loop should retain response Items`);
+    assert.match(source, /_withResponseItems\(message, responseItems\)[\s\S]*response_items: responseItems/, `${prefix}: assistant helper should retain Responses output Items`);
+    assert.match(source, /content: result\.content \|\| null,[\s\S]*tool_calls: result\.toolCalls,[\s\S]*}, result\.responseItems\)/, `${prefix}: non-stream tool loop should retain response Items`);
+    assert.match(source, /content: result\.content \}, result\.responseItems\)[\s\S]*messages\.push\(\{ role: 'user', content: progressFinalBlock \}/, `${prefix}: non-stream progress continuations should retain response Items`);
+    assert.match(source, /content: finalResponse \}, result\.responseItems\)/, `${prefix}: non-stream final answers should retain response Items`);
+    assert.match(source, /chunk\.responseItems[\s\S]*content: fullText \|\| null,[\s\S]*tool_calls: toolCalls,[\s\S]*}, responseItems\)/, `${prefix}: stream tool loop should retain response Items`);
+    assert.match(source, /content: fullText \}, responseItems\)[\s\S]*messages\.push\(\{ role: 'user', content: progressFinalBlock \}/, `${prefix}: stream progress continuations should retain response Items`);
+    assert.match(source, /content: fullText \}, responseItems\)[\s\S]*return finish\(fullText\)/, `${prefix}: stream final answers should retain response Items`);
     assert.match(source, /if \(msg\.response_items\) totalChars \+= JSON\.stringify\(msg\.response_items\)\.length/, `${prefix}: context budgeting should include encrypted reasoning Items`);
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -16002,6 +16002,7 @@ test('GPT-5.6 Responses request preserves reasoning and converts messages and to
     assert.equal(body.model, 'gpt-5.6-terra');
     assert.equal(body.stream, true);
     assert.equal(body.store, false);
+    assert.deepEqual(body.include, ['reasoning.encrypted_content']);
     assert.equal(body.max_output_tokens, 1234);
     assert.deepEqual(body.reasoning, { effort: 'medium' });
     assert.equal(body.messages, undefined);


### PR DESCRIPTION
## Summary

- Route official OpenAI GPT-5.6 models through `/v1/responses` so reasoning and function tools work together.
- Add Terra, Sol, Luna, and the GPT-5.6 alias to provider settings, with `gpt-5.6-terra` as the default.
- Preserve stateless Responses output items across tool loops, including streaming text, tool calls, usage, and refusal text.
- Keep older OpenAI models, custom OpenAI endpoints, and other OpenAI-compatible providers on Chat Completions.
- Mirror the implementation across Chrome and Firefox and update provider documentation.

## Why

GPT-5.6 Terra rejects function tools combined with `reasoning_effort` on `/v1/chat/completions`. Setting reasoning effort to `none` avoids the error by disabling reasoning, but loses the behavior the model was selected for. The Responses API supports reasoning and tools together, so the adapter now uses that endpoint only for official GPT-5.6 requests.

## User impact

Users can select the GPT-5.6 family and use tools with reasoning enabled. Existing providers, older OpenAI models, configured custom endpoints, and customized provider settings retain their previous behavior.

## Validation

- `git diff --check origin/main...HEAD`
- `node test/run.js`: 848 passed; one pre-existing repository version check remains (`package.json` 23.3.7 vs newest changelog entry 23.3.6)
- `npm run test:security`: 60/60 passed
