### PR TITLE
Add Mozilla add-on submission adapter

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15610,6 +15610,18 @@ const ADAPTERS = [
 - The sidebar collapses on narrow viewports — scroll horizontally or expand it before clicking sidebar items.`,
   },
   {
+    name: 'mozilla-addons-developer',
+    category: 'general',
+    match: (url) => /^https?:\/\/addons\.mozilla\.org\/(?:[a-z]{2,3}(?:-[a-z]{2})?\/)?developers(?:\/|$)/i.test(url),
+    notes: `
+- For an existing add-on, use its "Upload New Version" flow. Do not start from "Submit a New Add-on"; the existing manifest ID will fail validation as a duplicate add-on ID.
+- On WebBrain's "Describe Version" step, both "Release Notes" (changelog) and "Notes to Reviewer" are optional. Leave both empty unless the user explicitly asks to provide text; do not generate or paste content merely because the fields are present.
+- If those textareas must be inspected, trust their DOM field names over visual order or a possibly misleading label: \`release_notes...\` is the public release-notes field and \`approval_notes\` is the reviewer-notes field. Call \`verify_form\` before final submission.
+- On a WebBrain URL matching \`/addon/webbrain/versions/submit/<id>/source\`, answer "No" to "Do You Need to Submit Source Code?" Select the radio labeled "No", then verify the page says "You do not need to submit Source Code" before continuing.
+- After navigation or scrolling, re-read the accessibility tree and use the current ref_id. Never reuse or guess a ref_id from an earlier page state.
+- Continue past package validation only when it reports no errors. Read any rejection-related warnings, then use the existing version-submission flow rather than restarting as a new add-on.`,
+  },
+  {
     name: 'stackoverflow',
     category: 'general',
     match: (url) => /^https?:\/\/(.*\.)?stackoverflow\.com\//.test(url) || /^https?:\/\/(.*\.)?stackexchange\.com\//.test(url),

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15615,9 +15615,9 @@ const ADAPTERS = [
     match: (url) => /^https?:\/\/addons\.mozilla\.org\/(?:[a-z]{2,3}(?:-[a-z]{2})?\/)?developers(?:\/|$)/i.test(url),
     notes: `
 - For an existing add-on, use its "Upload New Version" flow. Do not start from "Submit a New Add-on"; the existing manifest ID will fail validation as a duplicate add-on ID.
-- On WebBrain's "Describe Version" step, both "Release Notes" (changelog) and "Notes to Reviewer" are optional. Leave both empty unless the user explicitly asks to provide text; do not generate or paste content merely because the fields are present.
+- On the "Describe Version" step, both "Release Notes" (changelog) and "Notes to Reviewer" are optional. Leave both empty unless the user explicitly asks to provide text; do not generate or paste content merely because the fields are present.
 - If those textareas must be inspected, trust their DOM field names over visual order or a possibly misleading label: \`release_notes...\` is the public release-notes field and \`approval_notes\` is the reviewer-notes field. Call \`verify_form\` before final submission.
-- On a WebBrain URL matching \`/addon/webbrain/versions/submit/<id>/source\`, answer "No" to "Do You Need to Submit Source Code?" Select the radio labeled "No", then verify the page says "You do not need to submit Source Code" before continuing.
+- On a URL matching \`/addon/<addon-slug>/versions/submit/<id>/source\`, answer "No" to "Do You Need to Submit Source Code?" Select the radio labeled "No", then verify the page says "You do not need to submit Source Code" before continuing.
 - After navigation or scrolling, re-read the accessibility tree and use the current ref_id. Never reuse or guess a ref_id from an earlier page state.
 - Continue past package validation only when it reports no errors. Read any rejection-related warnings, then use the existing version-submission flow rather than restarting as a new add-on.`,
   },

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15610,6 +15610,18 @@ const ADAPTERS = [
 - The sidebar collapses on narrow viewports — scroll horizontally or expand it before clicking sidebar items.`,
   },
   {
+    name: 'mozilla-addons-developer',
+    category: 'general',
+    match: (url) => /^https?:\/\/addons\.mozilla\.org\/(?:[a-z]{2,3}(?:-[a-z]{2})?\/)?developers(?:\/|$)/i.test(url),
+    notes: `
+- For an existing add-on, use its "Upload New Version" flow. Do not start from "Submit a New Add-on"; the existing manifest ID will fail validation as a duplicate add-on ID.
+- On WebBrain's "Describe Version" step, both "Release Notes" (changelog) and "Notes to Reviewer" are optional. Leave both empty unless the user explicitly asks to provide text; do not generate or paste content merely because the fields are present.
+- If those textareas must be inspected, trust their DOM field names over visual order or a possibly misleading label: \`release_notes...\` is the public release-notes field and \`approval_notes\` is the reviewer-notes field. Call \`verify_form\` before final submission.
+- On a WebBrain URL matching \`/addon/webbrain/versions/submit/<id>/source\`, answer "No" to "Do You Need to Submit Source Code?" Select the radio labeled "No", then verify the page says "You do not need to submit Source Code" before continuing.
+- After navigation or scrolling, re-read the accessibility tree and use the current ref_id. Never reuse or guess a ref_id from an earlier page state.
+- Continue past package validation only when it reports no errors. Read any rejection-related warnings, then use the existing version-submission flow rather than restarting as a new add-on.`,
+  },
+  {
     name: 'stackoverflow',
     category: 'general',
     match: (url) => /^https?:\/\/(.*\.)?stackoverflow\.com\//.test(url) || /^https?:\/\/(.*\.)?stackexchange\.com\//.test(url),

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15615,9 +15615,9 @@ const ADAPTERS = [
     match: (url) => /^https?:\/\/addons\.mozilla\.org\/(?:[a-z]{2,3}(?:-[a-z]{2})?\/)?developers(?:\/|$)/i.test(url),
     notes: `
 - For an existing add-on, use its "Upload New Version" flow. Do not start from "Submit a New Add-on"; the existing manifest ID will fail validation as a duplicate add-on ID.
-- On WebBrain's "Describe Version" step, both "Release Notes" (changelog) and "Notes to Reviewer" are optional. Leave both empty unless the user explicitly asks to provide text; do not generate or paste content merely because the fields are present.
+- On the "Describe Version" step, both "Release Notes" (changelog) and "Notes to Reviewer" are optional. Leave both empty unless the user explicitly asks to provide text; do not generate or paste content merely because the fields are present.
 - If those textareas must be inspected, trust their DOM field names over visual order or a possibly misleading label: \`release_notes...\` is the public release-notes field and \`approval_notes\` is the reviewer-notes field. Call \`verify_form\` before final submission.
-- On a WebBrain URL matching \`/addon/webbrain/versions/submit/<id>/source\`, answer "No" to "Do You Need to Submit Source Code?" Select the radio labeled "No", then verify the page says "You do not need to submit Source Code" before continuing.
+- On a URL matching \`/addon/<addon-slug>/versions/submit/<id>/source\`, answer "No" to "Do You Need to Submit Source Code?" Select the radio labeled "No", then verify the page says "You do not need to submit Source Code" before continuing.
 - After navigation or scrolling, re-read the accessibility tree and use the current ref_id. Never reuse or guess a ref_id from an earlier page state.
 - Continue past package validation only when it reports no errors. Read any rejection-related warnings, then use the existing version-submission flow rather than restarting as a new add-on.`,
   },

--- a/test/run.js
+++ b/test/run.js
@@ -1441,6 +1441,30 @@ test('matches www.github.com', () => {
   assert.equal(a?.name, 'github');
 });
 
+test('matches Mozilla Add-ons Developer Hub and guides WebBrain version submission', () => {
+  const sourceUrl = 'https://addons.mozilla.org/en-US/developers/addon/webbrain/versions/submit/6358210/source';
+  const chromeAdapter = getActiveAdapter(sourceUrl);
+  const firefoxAdapter = getActiveAdapterFx(sourceUrl);
+
+  assert.equal(chromeAdapter?.name, 'mozilla-addons-developer');
+  assert.equal(firefoxAdapter?.name, 'mozilla-addons-developer');
+  assert.equal(firefoxAdapter?.notes, chromeAdapter?.notes);
+  assert.equal(getActiveAdapter('https://addons.mozilla.org/de/developers/addon/webbrain/versions/submit/1/source')?.name, 'mozilla-addons-developer');
+  assert.equal(getActiveAdapter('https://addons.mozilla.org/developers/addons')?.name, 'mozilla-addons-developer');
+  assert.notEqual(getActiveAdapter('https://addons.mozilla.org/en-US/firefox/addon/webbrain/moz-addon-ratings/')?.name, 'mozilla-addons-developer');
+  assert.notEqual(getActiveAdapter('https://addons.mozilla.org.evil.example/en-US/developers/')?.name, 'mozilla-addons-developer');
+
+  assert.match(chromeAdapter?.notes || '', /Upload New Version/);
+  assert.match(chromeAdapter?.notes || '', /duplicate add-on ID/i);
+  assert.match(chromeAdapter?.notes || '', /Release Notes.*Notes to Reviewer.*optional/s);
+  assert.match(chromeAdapter?.notes || '', /Leave both empty unless the user explicitly asks/i);
+  assert.match(chromeAdapter?.notes || '', /release_notes\.\.\..*approval_notes.*verify_form/s);
+  assert.match(chromeAdapter?.notes || '', /\/addon\/webbrain\/versions\/submit\/<id>\/source/);
+  assert.match(chromeAdapter?.notes || '', /answer "No".*Do You Need to Submit Source Code/s);
+  assert.match(chromeAdapter?.notes || '', /You do not need to submit Source Code/);
+  assert.match(chromeAdapter?.notes || '', /re-read the accessibility tree.*current ref_id/s);
+});
+
 test('matches gmail.com under mail.google.com', () => {
   const a = getActiveAdapter('https://mail.google.com/mail/u/0/#inbox');
   assert.equal(a?.name, 'gmail');

--- a/test/run.js
+++ b/test/run.js
@@ -1441,15 +1441,15 @@ test('matches www.github.com', () => {
   assert.equal(a?.name, 'github');
 });
 
-test('matches Mozilla Add-ons Developer Hub and guides WebBrain version submission', () => {
-  const sourceUrl = 'https://addons.mozilla.org/en-US/developers/addon/webbrain/versions/submit/6358210/source';
+test('matches Mozilla Add-ons Developer Hub and guides version submission', () => {
+  const sourceUrl = 'https://addons.mozilla.org/en-US/developers/addon/example-addon/versions/submit/6358210/source';
   const chromeAdapter = getActiveAdapter(sourceUrl);
   const firefoxAdapter = getActiveAdapterFx(sourceUrl);
 
   assert.equal(chromeAdapter?.name, 'mozilla-addons-developer');
   assert.equal(firefoxAdapter?.name, 'mozilla-addons-developer');
   assert.equal(firefoxAdapter?.notes, chromeAdapter?.notes);
-  assert.equal(getActiveAdapter('https://addons.mozilla.org/de/developers/addon/webbrain/versions/submit/1/source')?.name, 'mozilla-addons-developer');
+  assert.equal(getActiveAdapter('https://addons.mozilla.org/de/developers/addon/another-addon/versions/submit/1/source')?.name, 'mozilla-addons-developer');
   assert.equal(getActiveAdapter('https://addons.mozilla.org/developers/addons')?.name, 'mozilla-addons-developer');
   assert.notEqual(getActiveAdapter('https://addons.mozilla.org/en-US/firefox/addon/webbrain/moz-addon-ratings/')?.name, 'mozilla-addons-developer');
   assert.notEqual(getActiveAdapter('https://addons.mozilla.org.evil.example/en-US/developers/')?.name, 'mozilla-addons-developer');
@@ -1459,7 +1459,7 @@ test('matches Mozilla Add-ons Developer Hub and guides WebBrain version submissi
   assert.match(chromeAdapter?.notes || '', /Release Notes.*Notes to Reviewer.*optional/s);
   assert.match(chromeAdapter?.notes || '', /Leave both empty unless the user explicitly asks/i);
   assert.match(chromeAdapter?.notes || '', /release_notes\.\.\..*approval_notes.*verify_form/s);
-  assert.match(chromeAdapter?.notes || '', /\/addon\/webbrain\/versions\/submit\/<id>\/source/);
+  assert.match(chromeAdapter?.notes || '', /\/addon\/<addon-slug>\/versions\/submit\/<id>\/source/);
   assert.match(chromeAdapter?.notes || '', /answer "No".*Do You Need to Submit Source Code/s);
   assert.match(chromeAdapter?.notes || '', /You do not need to submit Source Code/);
   assert.match(chromeAdapter?.notes || '', /re-read the accessibility tree.*current ref_id/s);


### PR DESCRIPTION
## Summary

- add an AMO Developer Hub adapter for existing add-on version submissions
- leave optional release notes and reviewer notes empty unless explicitly requested
- guide all `/addon/<addon-slug>/versions/submit/<id>/source` steps to select **No** and verify the confirmation
- mirror the adapter across Chrome and Firefox with regression coverage using multiple add-on slugs

## Why

The traced AMO submission entered the new-add-on flow, confused the release-notes and reviewer-notes fields, reused stale accessibility references, and stopped before final submission. The adapter gives future AMO version submissions stable page-specific guidance without tying it to one add-on slug.

## Validation

- `git diff --check`
- syntax checks for both adapter files and `test/run.js`
- `node test/security/injection-corpus.mjs` — 60/60 passed
- `node test/run.js` — 855 passed, 1 unrelated existing failure: package version is 24.0.1 while the newest changelog entry is 24.0.0