### PR TITLE
Add sidepanel composer history navigation

### DIFF
--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -1004,6 +1004,7 @@ const TAB_CHAT_PREFIX = 'tabChat:';
 const tabChatOperations = new Map();
 const tabInputDrafts = new Map();
 const queuedComposerMessagesByTab = new Map();
+const composerHistoryNavigationByTab = new Map();
 let queuedComposerMessageSeq = 0;
 
 function enqueueTabChatOperation(tabId, fn) {
@@ -1190,6 +1191,7 @@ function setQueuedComposerMessages(tabId, messages) {
   if (!Number.isFinite(numericTabId)) return;
   if (messages.length) {
     queuedComposerMessagesByTab.set(numericTabId, messages);
+    resetComposerHistoryNavigation(numericTabId);
   } else {
     queuedComposerMessagesByTab.delete(numericTabId);
   }
@@ -1294,6 +1296,7 @@ function editQueuedComposerMessage(tabId, queueId) {
   if (!sameTabId(currentTabId, tabId)) return;
   const item = removeQueuedComposerMessage(tabId, queueId);
   if (!item) return;
+  resetComposerHistoryNavigation(tabId);
   inputEl.value = item.text;
   saveInputDraftForTab(tabId, item.text);
   autoResizeInput();
@@ -1306,12 +1309,167 @@ function editQueuedComposerMessage(tabId, queueId) {
 function editLastQueuedComposerMessageForCurrentTab() {
   if (!inputEl || currentTabId == null) return false;
   const atStart = inputEl.selectionStart === 0 && inputEl.selectionEnd === 0;
-  if (inputEl.value.trim() || !atStart) return false;
+  if (inputEl.value !== '' || !atStart) return false;
   const queue = getQueuedComposerMessages(currentTabId);
   const item = queue[queue.length - 1];
   if (!item) return false;
   editQueuedComposerMessage(currentTabId, item.id);
   return true;
+}
+
+function resetComposerHistoryNavigation(tabId = currentTabId) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return;
+  composerHistoryNavigationByTab.delete(numericTabId);
+}
+
+function getComposerHistoryTextFromMessage(messageEl) {
+  const protectedText = messageEl.dataset.composerHistoryText;
+  if (typeof protectedText === 'string') return protectedText;
+
+  const displayText = String(messageEl.querySelector('.message-text')?.textContent || '');
+  // Older saved selection bubbles predate the protected recall payload. Their
+  // display text no longer contains the untrusted-content boundary, so omit
+  // those ambiguous entries rather than resend page text as a trusted prompt.
+  const isLegacySelectionDisplay = messageEl.dataset.composerHistoryVerbatim !== 'true'
+    && /(?:^|\n\n)Selected text:\n/.test(displayText);
+  return isLegacySelectionDisplay ? '' : displayText;
+}
+
+function getComposerHistoryEntriesForCurrentTab() {
+  if (!messagesEl || !sameTabId(currentTabId, renderedTabId)) return [];
+  return Array.from(messagesEl.querySelectorAll(':scope > .message.user'))
+    .map(getComposerHistoryTextFromMessage)
+    .filter((text) => text.trim());
+}
+
+const COMPOSER_MIRROR_STYLE_PROPERTIES = [
+  'direction',
+  'fontFamily',
+  'fontSize',
+  'fontStyle',
+  'fontVariant',
+  'fontWeight',
+  'letterSpacing',
+  'lineHeight',
+  'overflowWrap',
+  'paddingBottom',
+  'paddingLeft',
+  'paddingRight',
+  'paddingTop',
+  'tabSize',
+  'textAlign',
+  'textIndent',
+  'textTransform',
+  'whiteSpace',
+  'wordBreak',
+  'wordSpacing',
+];
+
+function measureComposerCaretTop(position, computedStyle) {
+  const mirror = document.createElement('div');
+  for (const property of COMPOSER_MIRROR_STYLE_PROPERTIES) {
+    mirror.style[property] = computedStyle[property];
+  }
+  mirror.style.position = 'fixed';
+  mirror.style.left = '-100000px';
+  mirror.style.top = '0';
+  mirror.style.boxSizing = 'border-box';
+  mirror.style.width = `${inputEl.clientWidth}px`;
+  mirror.style.height = 'auto';
+  mirror.style.minHeight = '0';
+  mirror.style.maxHeight = 'none';
+  mirror.style.margin = '0';
+  mirror.style.border = '0';
+  mirror.style.overflow = 'hidden';
+  mirror.style.visibility = 'hidden';
+  mirror.style.pointerEvents = 'none';
+  mirror.textContent = inputEl.value.slice(0, position);
+
+  const marker = document.createElement('span');
+  marker.textContent = inputEl.value.slice(position) || '\u200b';
+  mirror.appendChild(marker);
+  document.body.appendChild(mirror);
+  const top = marker.offsetTop;
+  mirror.remove();
+  return top;
+}
+
+function getComposerCaretRowBoundary() {
+  if (!inputEl || inputEl.selectionStart !== inputEl.selectionEnd || inputEl.clientWidth <= 0) {
+    return null;
+  }
+  const computedStyle = getComputedStyle(inputEl);
+  const caretTop = measureComposerCaretTop(inputEl.selectionStart, computedStyle);
+  const firstTop = measureComposerCaretTop(0, computedStyle);
+  const lastTop = measureComposerCaretTop(inputEl.value.length, computedStyle);
+  const parsedLineHeight = Number.parseFloat(computedStyle.lineHeight);
+  const parsedFontSize = Number.parseFloat(computedStyle.fontSize);
+  const lineHeight = Number.isFinite(parsedLineHeight)
+    ? parsedLineHeight
+    : (Number.isFinite(parsedFontSize) ? parsedFontSize * 1.4 : 16);
+  const tolerance = Math.max(1, lineHeight / 3);
+  return {
+    atFirstRow: Math.abs(caretTop - firstTop) < tolerance,
+    atLastRow: Math.abs(caretTop - lastTop) < tolerance,
+  };
+}
+
+function applyComposerHistoryText(tabId, text) {
+  inputEl.value = text;
+  saveInputDraftForTab(tabId, text);
+  autoResizeInput();
+  updateSlashCommandAutocomplete();
+  syncSendButtonState();
+  inputEl.focus();
+  inputEl.setSelectionRange(inputEl.value.length, inputEl.value.length);
+}
+
+function navigateComposerHistory(direction) {
+  if (!inputEl || currentTabId == null || !sameTabId(currentTabId, renderedTabId)) return false;
+  const numericTabId = Number(currentTabId);
+  if (!Number.isFinite(numericTabId)) return false;
+  if (getQueuedComposerMessages(numericTabId).length) {
+    resetComposerHistoryNavigation(numericTabId);
+    return false;
+  }
+
+  let state = composerHistoryNavigationByTab.get(numericTabId);
+  if (!state) {
+    if (direction !== -1 || inputEl.value !== '') return false;
+    const entries = getComposerHistoryEntriesForCurrentTab();
+    if (!entries.length) return false;
+    state = { entries, index: entries.length };
+    composerHistoryNavigationByTab.set(numericTabId, state);
+  } else {
+    const expectedText = state.entries[state.index] ?? '';
+    if (inputEl.value !== expectedText) {
+      resetComposerHistoryNavigation(numericTabId);
+      return false;
+    }
+  }
+
+  const boundary = getComposerCaretRowBoundary();
+  if (!boundary) return false;
+  if (direction === -1) {
+    if (!boundary.atFirstRow) return false;
+    if (state.index === 0) return true;
+    state.index -= 1;
+    applyComposerHistoryText(numericTabId, state.entries[state.index]);
+    return true;
+  }
+  if (direction === 1) {
+    if (!boundary.atLastRow || state.index >= state.entries.length) return false;
+    if (state.index === state.entries.length - 1) {
+      resetComposerHistoryNavigation(numericTabId);
+      applyComposerHistoryText(numericTabId, '');
+      return true;
+    }
+    state.index += 1;
+    applyComposerHistoryText(numericTabId, state.entries[state.index]);
+    return true;
+  }
+  return false;
 }
 
 function deleteQueuedComposerMessage(tabId, queueId) {
@@ -1327,9 +1485,10 @@ function clearQueuedComposerMessagesForTab(tabId) {
 
 function drainQueuedComposerMessageForCurrentTab() {
   if (isProcessing || currentTabId == null || renderedTabId !== currentTabId) return false;
-  if (inputEl.value.trim()) return false;
+  if (inputEl.value !== '') return false;
   const item = shiftQueuedComposerMessage(currentTabId);
   if (!item) return false;
+  resetComposerHistoryNavigation(currentTabId);
   inputEl.value = item.text;
   autoResizeInput();
   updateSlashCommandAutocomplete();
@@ -1342,6 +1501,7 @@ function drainQueuedComposerMessageForCurrentTab() {
 
 async function renderClearedConversationForTab(tabId) {
   clearCachedTabChat(tabId);
+  resetComposerHistoryNavigation(tabId);
   saveInputDraftForTab(tabId, '');
   clearPendingAttachmentsForTab(tabId);
   clearQueuedComposerMessagesForTab(tabId);
@@ -3624,6 +3784,7 @@ function applySlashCommandCompletion(index = slashCommandSelectedIndex) {
   if (!match || !inputEl) return false;
   const before = inputEl.value.slice(0, match.completionStart);
   const after = inputEl.value.slice(match.completionEnd);
+  resetComposerHistoryNavigation(currentTabId);
   inputEl.value = `${before}${match.value} ${after}`;
   const cursor = before.length + match.value.length + 1;
   inputEl.setSelectionRange(cursor, cursor);
@@ -3637,6 +3798,7 @@ function applySlashCommandCompletion(index = slashCommandSelectedIndex) {
 function activateSlashCommandBaseAction(index = slashCommandSelectedIndex) {
   const match = slashCommandMatches[index];
   if (match?.kind !== 'base-action' || !inputEl) return false;
+  resetComposerHistoryNavigation(currentTabId);
   inputEl.value = inputEl.value.trimEnd();
   hideSlashCommandAutocomplete();
   autoResizeInput();
@@ -3694,6 +3856,7 @@ function handleSlashCommandKeydown(e) {
 }
 
 function handleInput() {
+  resetComposerHistoryNavigation(currentTabId);
   autoResizeInput();
   updateSlashCommandAutocomplete();
   syncSendButtonState();
@@ -4195,6 +4358,7 @@ async function sendMessage(extraChatParams = {}) {
   }
   if (isProcessing) {
     if (isOutOfBandSlashDraft(text)) {
+      resetComposerHistoryNavigation(tabId);
       saveInputDraftForTab(tabId, '');
       hideSlashCommandAutocomplete();
       inputEl.value = '';
@@ -4220,6 +4384,7 @@ async function sendMessage(extraChatParams = {}) {
   const apiMutationsAllowedForSend = retryOptions
     ? !!retryOptions.apiMutationsAllowed
     : isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);
+  resetComposerHistoryNavigation(tabId);
   saveInputDraftForTab(tabId, '');
   hideSlashCommandAutocomplete();
 
@@ -5713,7 +5878,16 @@ function addMessage(role, content, options = {}) {
   if (role === 'user') {
     // Selection/context-menu prompts include model-only untrusted wrappers;
     // show a clean version in the bubble while still sending the full prompt.
-    textEl.textContent = formatSelectionPromptForDisplay(content);
+    const userText = String(content || '');
+    const displayText = formatSelectionPromptForDisplay(userText);
+    textEl.textContent = displayText;
+    if (displayText === userText) {
+      msgEl.dataset.composerHistoryVerbatim = 'true';
+    } else {
+      // Keep the model-facing boundary intact when the bubble is recalled.
+      // Dataset assignment is inert and survives messagesEl.innerHTML restore.
+      msgEl.dataset.composerHistoryText = userText;
+    }
   } else if (role === 'system') {
     if (isSystemHtml(content)) textEl.innerHTML = content.__systemHtml;
     else textEl.textContent = content || '';
@@ -6815,9 +6989,20 @@ queuedMessagesEl?.addEventListener('click', (e) => {
 
 inputEl.addEventListener('keydown', (e) => {
   if (handleSlashCommandKeydown(e)) return;
-  if (e.key === 'ArrowUp' && editLastQueuedComposerMessageForCurrentTab()) {
-    e.preventDefault();
-    return;
+  const isPlainArrow = !e.isComposing && !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
+  if (isPlainArrow) {
+    if (e.key === 'ArrowUp' && editLastQueuedComposerMessageForCurrentTab()) {
+      e.preventDefault();
+      return;
+    }
+    if (e.key === 'ArrowUp' && navigateComposerHistory(-1)) {
+      e.preventDefault();
+      return;
+    }
+    if (e.key === 'ArrowDown' && navigateComposerHistory(1)) {
+      e.preventDefault();
+      return;
+    }
   }
   if (e.key === 'Enter' && !e.shiftKey) {
     e.preventDefault();

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -983,6 +983,7 @@ const TAB_CHAT_PREFIX = 'tabChat:';
 const tabChatOperations = new Map();
 const tabInputDrafts = new Map();
 const queuedComposerMessagesByTab = new Map();
+const composerHistoryNavigationByTab = new Map();
 let queuedComposerMessageSeq = 0;
 
 function enqueueTabChatOperation(tabId, fn) {
@@ -1394,6 +1395,7 @@ function setQueuedComposerMessages(tabId, messages) {
   if (!Number.isFinite(numericTabId)) return;
   if (messages.length) {
     queuedComposerMessagesByTab.set(numericTabId, messages);
+    resetComposerHistoryNavigation(numericTabId);
   } else {
     queuedComposerMessagesByTab.delete(numericTabId);
   }
@@ -1498,6 +1500,7 @@ function editQueuedComposerMessage(tabId, queueId) {
   if (!sameTabId(currentTabId, tabId)) return;
   const item = removeQueuedComposerMessage(tabId, queueId);
   if (!item) return;
+  resetComposerHistoryNavigation(tabId);
   inputEl.value = item.text;
   saveInputDraftForTab(tabId, item.text);
   autoResizeInput();
@@ -1510,12 +1513,167 @@ function editQueuedComposerMessage(tabId, queueId) {
 function editLastQueuedComposerMessageForCurrentTab() {
   if (!inputEl || currentTabId == null) return false;
   const atStart = inputEl.selectionStart === 0 && inputEl.selectionEnd === 0;
-  if (inputEl.value.trim() || !atStart) return false;
+  if (inputEl.value !== '' || !atStart) return false;
   const queue = getQueuedComposerMessages(currentTabId);
   const item = queue[queue.length - 1];
   if (!item) return false;
   editQueuedComposerMessage(currentTabId, item.id);
   return true;
+}
+
+function resetComposerHistoryNavigation(tabId = currentTabId) {
+  const numericTabId = Number(tabId);
+  if (!Number.isFinite(numericTabId)) return;
+  composerHistoryNavigationByTab.delete(numericTabId);
+}
+
+function getComposerHistoryTextFromMessage(messageEl) {
+  const protectedText = messageEl.dataset.composerHistoryText;
+  if (typeof protectedText === 'string') return protectedText;
+
+  const displayText = String(messageEl.querySelector('.message-text')?.textContent || '');
+  // Older saved selection bubbles predate the protected recall payload. Their
+  // display text no longer contains the untrusted-content boundary, so omit
+  // those ambiguous entries rather than resend page text as a trusted prompt.
+  const isLegacySelectionDisplay = messageEl.dataset.composerHistoryVerbatim !== 'true'
+    && /(?:^|\n\n)Selected text:\n/.test(displayText);
+  return isLegacySelectionDisplay ? '' : displayText;
+}
+
+function getComposerHistoryEntriesForCurrentTab() {
+  if (!messagesEl || !sameTabId(currentTabId, renderedTabId)) return [];
+  return Array.from(messagesEl.querySelectorAll(':scope > .message.user'))
+    .map(getComposerHistoryTextFromMessage)
+    .filter((text) => text.trim());
+}
+
+const COMPOSER_MIRROR_STYLE_PROPERTIES = [
+  'direction',
+  'fontFamily',
+  'fontSize',
+  'fontStyle',
+  'fontVariant',
+  'fontWeight',
+  'letterSpacing',
+  'lineHeight',
+  'overflowWrap',
+  'paddingBottom',
+  'paddingLeft',
+  'paddingRight',
+  'paddingTop',
+  'tabSize',
+  'textAlign',
+  'textIndent',
+  'textTransform',
+  'whiteSpace',
+  'wordBreak',
+  'wordSpacing',
+];
+
+function measureComposerCaretTop(position, computedStyle) {
+  const mirror = document.createElement('div');
+  for (const property of COMPOSER_MIRROR_STYLE_PROPERTIES) {
+    mirror.style[property] = computedStyle[property];
+  }
+  mirror.style.position = 'fixed';
+  mirror.style.left = '-100000px';
+  mirror.style.top = '0';
+  mirror.style.boxSizing = 'border-box';
+  mirror.style.width = `${inputEl.clientWidth}px`;
+  mirror.style.height = 'auto';
+  mirror.style.minHeight = '0';
+  mirror.style.maxHeight = 'none';
+  mirror.style.margin = '0';
+  mirror.style.border = '0';
+  mirror.style.overflow = 'hidden';
+  mirror.style.visibility = 'hidden';
+  mirror.style.pointerEvents = 'none';
+  mirror.textContent = inputEl.value.slice(0, position);
+
+  const marker = document.createElement('span');
+  marker.textContent = inputEl.value.slice(position) || '\u200b';
+  mirror.appendChild(marker);
+  document.body.appendChild(mirror);
+  const top = marker.offsetTop;
+  mirror.remove();
+  return top;
+}
+
+function getComposerCaretRowBoundary() {
+  if (!inputEl || inputEl.selectionStart !== inputEl.selectionEnd || inputEl.clientWidth <= 0) {
+    return null;
+  }
+  const computedStyle = getComputedStyle(inputEl);
+  const caretTop = measureComposerCaretTop(inputEl.selectionStart, computedStyle);
+  const firstTop = measureComposerCaretTop(0, computedStyle);
+  const lastTop = measureComposerCaretTop(inputEl.value.length, computedStyle);
+  const parsedLineHeight = Number.parseFloat(computedStyle.lineHeight);
+  const parsedFontSize = Number.parseFloat(computedStyle.fontSize);
+  const lineHeight = Number.isFinite(parsedLineHeight)
+    ? parsedLineHeight
+    : (Number.isFinite(parsedFontSize) ? parsedFontSize * 1.4 : 16);
+  const tolerance = Math.max(1, lineHeight / 3);
+  return {
+    atFirstRow: Math.abs(caretTop - firstTop) < tolerance,
+    atLastRow: Math.abs(caretTop - lastTop) < tolerance,
+  };
+}
+
+function applyComposerHistoryText(tabId, text) {
+  inputEl.value = text;
+  saveInputDraftForTab(tabId, text);
+  autoResizeInput();
+  updateSlashCommandAutocomplete();
+  syncSendButtonState();
+  inputEl.focus();
+  inputEl.setSelectionRange(inputEl.value.length, inputEl.value.length);
+}
+
+function navigateComposerHistory(direction) {
+  if (!inputEl || currentTabId == null || !sameTabId(currentTabId, renderedTabId)) return false;
+  const numericTabId = Number(currentTabId);
+  if (!Number.isFinite(numericTabId)) return false;
+  if (getQueuedComposerMessages(numericTabId).length) {
+    resetComposerHistoryNavigation(numericTabId);
+    return false;
+  }
+
+  let state = composerHistoryNavigationByTab.get(numericTabId);
+  if (!state) {
+    if (direction !== -1 || inputEl.value !== '') return false;
+    const entries = getComposerHistoryEntriesForCurrentTab();
+    if (!entries.length) return false;
+    state = { entries, index: entries.length };
+    composerHistoryNavigationByTab.set(numericTabId, state);
+  } else {
+    const expectedText = state.entries[state.index] ?? '';
+    if (inputEl.value !== expectedText) {
+      resetComposerHistoryNavigation(numericTabId);
+      return false;
+    }
+  }
+
+  const boundary = getComposerCaretRowBoundary();
+  if (!boundary) return false;
+  if (direction === -1) {
+    if (!boundary.atFirstRow) return false;
+    if (state.index === 0) return true;
+    state.index -= 1;
+    applyComposerHistoryText(numericTabId, state.entries[state.index]);
+    return true;
+  }
+  if (direction === 1) {
+    if (!boundary.atLastRow || state.index >= state.entries.length) return false;
+    if (state.index === state.entries.length - 1) {
+      resetComposerHistoryNavigation(numericTabId);
+      applyComposerHistoryText(numericTabId, '');
+      return true;
+    }
+    state.index += 1;
+    applyComposerHistoryText(numericTabId, state.entries[state.index]);
+    return true;
+  }
+  return false;
 }
 
 function deleteQueuedComposerMessage(tabId, queueId) {
@@ -1531,9 +1689,10 @@ function clearQueuedComposerMessagesForTab(tabId) {
 
 function drainQueuedComposerMessageForCurrentTab() {
   if (isProcessing || currentTabId == null || renderedTabId !== currentTabId) return false;
-  if (inputEl.value.trim()) return false;
+  if (inputEl.value !== '') return false;
   const item = shiftQueuedComposerMessage(currentTabId);
   if (!item) return false;
+  resetComposerHistoryNavigation(currentTabId);
   inputEl.value = item.text;
   autoResizeInput();
   updateSlashCommandAutocomplete();
@@ -1546,6 +1705,7 @@ function drainQueuedComposerMessageForCurrentTab() {
 
 async function renderClearedConversationForTab(tabId) {
   clearCachedTabChat(tabId);
+  resetComposerHistoryNavigation(tabId);
   saveInputDraftForTab(tabId, '');
   clearPendingAttachmentsForTab(tabId);
   clearQueuedComposerMessagesForTab(tabId);
@@ -3570,6 +3730,7 @@ function applySlashCommandCompletion(index = slashCommandSelectedIndex) {
   if (!match || !inputEl) return false;
   const before = inputEl.value.slice(0, match.completionStart);
   const after = inputEl.value.slice(match.completionEnd);
+  resetComposerHistoryNavigation(currentTabId);
   inputEl.value = `${before}${match.value} ${after}`;
   const cursor = before.length + match.value.length + 1;
   inputEl.setSelectionRange(cursor, cursor);
@@ -3583,6 +3744,7 @@ function applySlashCommandCompletion(index = slashCommandSelectedIndex) {
 function activateSlashCommandBaseAction(index = slashCommandSelectedIndex) {
   const match = slashCommandMatches[index];
   if (match?.kind !== 'base-action' || !inputEl) return false;
+  resetComposerHistoryNavigation(currentTabId);
   inputEl.value = inputEl.value.trimEnd();
   hideSlashCommandAutocomplete();
   autoResizeInput();
@@ -3640,6 +3802,7 @@ function handleSlashCommandKeydown(e) {
 }
 
 function handleInput() {
+  resetComposerHistoryNavigation(currentTabId);
   autoResizeInput();
   updateSlashCommandAutocomplete();
   syncSendButtonState();
@@ -4051,6 +4214,7 @@ async function sendMessage(extraChatParams = {}) {
   }
   if (isProcessing) {
     if (isOutOfBandSlashDraft(text)) {
+      resetComposerHistoryNavigation(tabId);
       saveInputDraftForTab(tabId, '');
       hideSlashCommandAutocomplete();
       inputEl.value = '';
@@ -4076,6 +4240,7 @@ async function sendMessage(extraChatParams = {}) {
   const apiMutationsAllowedForSend = retryOptions
     ? !!retryOptions.apiMutationsAllowed
     : isApiMutationsAllowedForTab(tabId) || /^\/allow-api\b/i.test(text);
+  resetComposerHistoryNavigation(tabId);
   saveInputDraftForTab(tabId, '');
   hideSlashCommandAutocomplete();
 
@@ -5494,7 +5659,16 @@ function addMessage(role, content, options = {}) {
   if (role === 'user') {
     // Selection/context-menu prompts include model-only untrusted wrappers;
     // show a clean version in the bubble while still sending the full prompt.
-    textEl.textContent = formatSelectionPromptForDisplay(content);
+    const userText = String(content || '');
+    const displayText = formatSelectionPromptForDisplay(userText);
+    textEl.textContent = displayText;
+    if (displayText === userText) {
+      msgEl.dataset.composerHistoryVerbatim = 'true';
+    } else {
+      // Keep the model-facing boundary intact when the bubble is recalled.
+      // Dataset assignment is inert and survives messagesEl.innerHTML restore.
+      msgEl.dataset.composerHistoryText = userText;
+    }
   } else if (role === 'system') {
     if (isSystemHtml(content)) textEl.innerHTML = content.__systemHtml;
     else textEl.textContent = content || '';
@@ -6376,9 +6550,20 @@ queuedMessagesEl?.addEventListener('click', (e) => {
 
 inputEl.addEventListener('keydown', (e) => {
   if (handleSlashCommandKeydown(e)) return;
-  if (e.key === 'ArrowUp' && editLastQueuedComposerMessageForCurrentTab()) {
-    e.preventDefault();
-    return;
+  const isPlainArrow = !e.isComposing && !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
+  if (isPlainArrow) {
+    if (e.key === 'ArrowUp' && editLastQueuedComposerMessageForCurrentTab()) {
+      e.preventDefault();
+      return;
+    }
+    if (e.key === 'ArrowUp' && navigateComposerHistory(-1)) {
+      e.preventDefault();
+      return;
+    }
+    if (e.key === 'ArrowDown' && navigateComposerHistory(1)) {
+      e.preventDefault();
+      return;
+    }
   }
   if (e.key === 'Enter' && !e.shiftKey) {
     e.preventDefault();

--- a/test/run.js
+++ b/test/run.js
@@ -11255,18 +11255,18 @@ test('sidepanel queued composer messages expose edit and delete controls', () =>
     assert.match(panel, /function enqueueQueuedComposerMessage\(tabId, text\) \{[\s\S]*?queue\.push\(\{[\s\S]*?text: queuedText,[\s\S]*?inputEl\.value = '';[\s\S]*?autoResizeInput\(\);[\s\S]*?syncSendButtonState\(\);[\s\S]*?return true;[\s\S]*?\}/, `${label}: busy drafts should be queued, clear the composer, and reset its height`);
     assert.match(panel, /function sameTabId\(a, b\) \{\s*return a != null && b != null && String\(a\) === String\(b\);\s*\}/, `${label}: queued-message tab checks should tolerate equivalent tab id types`);
     assert.match(panel, /function editQueuedComposerMessage\(tabId, queueId\) \{[\s\S]*?!sameTabId\(currentTabId, tabId\)[\s\S]*?removeQueuedComposerMessage\(tabId, queueId\);[\s\S]*?inputEl\.value = item\.text;[\s\S]*?inputEl\.setSelectionRange\(inputEl\.value\.length, inputEl\.value\.length\);[\s\S]*?\}/, `${label}: queued message edit should guard the tab and move text back into the composer`);
-    assert.match(panel, /function editLastQueuedComposerMessageForCurrentTab\(\) \{[\s\S]*?const atStart = inputEl\.selectionStart === 0 && inputEl\.selectionEnd === 0;[\s\S]*?if \(inputEl\.value\.trim\(\) \|\| !atStart\) return false;[\s\S]*?const item = queue\[queue\.length - 1\];[\s\S]*?editQueuedComposerMessage\(currentTabId, item\.id\);[\s\S]*?return true;[\s\S]*?\}/, `${label}: ArrowUp edit should only pull the latest queued message into an empty composer at the start`);
+    assert.match(panel, /function editLastQueuedComposerMessageForCurrentTab\(\) \{[\s\S]*?const atStart = inputEl\.selectionStart === 0 && inputEl\.selectionEnd === 0;[\s\S]*?if \(inputEl\.value !== '' \|\| !atStart\) return false;[\s\S]*?const item = queue\[queue\.length - 1\];[\s\S]*?editQueuedComposerMessage\(currentTabId, item\.id\);[\s\S]*?return true;[\s\S]*?\}/, `${label}: ArrowUp edit should only pull the latest queued message into an exactly empty composer at the start`);
     assert.match(panel, /function deleteQueuedComposerMessage\(tabId, queueId\) \{[\s\S]*?removeQueuedComposerMessage\(tabId, queueId\);[\s\S]*?\}/, `${label}: queued message delete should remove the queued item`);
     assert.match(panel, /queued-message-edit/, `${label}: queued item should render an edit button`);
     assert.match(panel, /queued-message-delete/, `${label}: queued item should render a delete button`);
     assert.match(panel, /queuedMessagesEl\?\.addEventListener\('click', \(e\) => \{[\s\S]*?e\.target\.closest\('button\[data-queue-action\]\[data-queue-id\]'\);[\s\S]*?editQueuedComposerMessage\(currentTabId, queueId\);[\s\S]*?\}\);/, `${label}: queued edit button clicks should call the edit helper`);
-    assert.match(panel, /inputEl\.addEventListener\('keydown', \(e\) => \{[\s\S]*?if \(handleSlashCommandKeydown\(e\)\) return;[\s\S]*?if \(e\.key === 'ArrowUp' && editLastQueuedComposerMessageForCurrentTab\(\)\) \{[\s\S]*?e\.preventDefault\(\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?if \(e\.key === 'Enter' && !e\.shiftKey\)/, `${label}: ArrowUp should edit queued messages before Enter handling`);
+    assert.match(panel, /inputEl\.addEventListener\('keydown', \(e\) => \{[\s\S]*?if \(handleSlashCommandKeydown\(e\)\) return;[\s\S]*?const isPlainArrow = !e\.isComposing[\s\S]*?if \(e\.key === 'ArrowUp' && editLastQueuedComposerMessageForCurrentTab\(\)\) \{[\s\S]*?e\.preventDefault\(\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?if \(e\.key === 'Enter' && !e\.shiftKey\)/, `${label}: plain ArrowUp should edit queued messages before history and Enter handling`);
     const drainStart = panel.indexOf('function drainQueuedComposerMessageForCurrentTab()');
     const drainEnd = panel.indexOf('function renderClearedConversationForTab', drainStart);
     assert.notEqual(drainStart, -1, `${label}: queued composer drain helper should exist`);
     assert.notEqual(drainEnd, -1, `${label}: queued composer drain helper boundary should exist`);
     const drainBody = panel.slice(drainStart, drainEnd);
-    const draftGuardIdx = drainBody.indexOf('if (inputEl.value.trim()) return false;');
+    const draftGuardIdx = drainBody.indexOf("if (inputEl.value !== '') return false;");
     const queueShiftIdx = drainBody.indexOf('const item = shiftQueuedComposerMessage(currentTabId);');
     assert.notEqual(draftGuardIdx, -1, `${label}: queued composer drain should preserve newly typed drafts`);
     assert.notEqual(queueShiftIdx, -1, `${label}: queued composer drain should shift the next queued message`);
@@ -11286,6 +11286,66 @@ test('sidepanel queued composer messages expose edit and delete controls', () =>
     assert.match(css, /\.queued-message-action/, `${label}: queued message controls should be styled`);
     assert.match(locale, /'sp\.queue\.edit': 'Edit queued message'/, `${label}: queued edit label should have an English fallback`);
     assert.match(locale, /'sp\.queue\.delete': 'Delete queued message'/, `${label}: queued delete label should have an English fallback`);
+  }
+});
+
+test('sidepanel composer history navigation is queue-aware and draft-safe', () => {
+  for (const [label, panelRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+
+    assert.match(panel, /const composerHistoryNavigationByTab = new Map\(\);/, `${label}: composer history navigation should be tracked per tab`);
+    assert.match(
+      panel,
+      /function getComposerHistoryEntriesForCurrentTab\(\) \{[\s\S]*?sameTabId\(currentTabId, renderedTabId\)[\s\S]*?querySelectorAll\(':scope > \.message\.user'\)[\s\S]*?map\(getComposerHistoryTextFromMessage\)[\s\S]*?filter\(\(text\) => text\.trim\(\)\);[\s\S]*?\}/,
+      `${label}: history recall should read only non-empty user bubbles from the rendered conversation`,
+    );
+    assert.match(
+      panel,
+      /function getComposerHistoryTextFromMessage\(messageEl\) \{[\s\S]*?dataset\.composerHistoryText[\s\S]*?if \(typeof protectedText === 'string'\) return protectedText;[\s\S]*?querySelector\('\.message-text'\)\?\.textContent[\s\S]*?dataset\.composerHistoryVerbatim !== 'true'[\s\S]*?isLegacySelectionDisplay \? '' : displayText;[\s\S]*?\}/,
+      `${label}: history recall should prefer the protected model-facing payload and omit ambiguous legacy selection bubbles`,
+    );
+    assert.match(
+      panel,
+      /if \(role === 'user'\) \{[\s\S]*?const userText = String\(content \|\| ''\);[\s\S]*?const displayText = formatSelectionPromptForDisplay\(userText\);[\s\S]*?if \(displayText === userText\) \{[\s\S]*?dataset\.composerHistoryVerbatim = 'true';[\s\S]*?\} else \{[\s\S]*?dataset\.composerHistoryText = userText;[\s\S]*?\}/,
+      `${label}: rendered user bubbles should persist either a verbatim marker or their protected recall payload across DOM restores`,
+    );
+    assert.match(
+      panel,
+      /function getComposerCaretRowBoundary\(\) \{[\s\S]*?inputEl\.selectionStart !== inputEl\.selectionEnd[\s\S]*?measureComposerCaretTop\(inputEl\.selectionStart, computedStyle\)[\s\S]*?measureComposerCaretTop\(0, computedStyle\)[\s\S]*?measureComposerCaretTop\(inputEl\.value\.length, computedStyle\)[\s\S]*?atFirstRow:[\s\S]*?atLastRow:[\s\S]*?\}/,
+      `${label}: history recall should measure first and last rendered rows and reject active selections`,
+    );
+
+    const navigationStart = panel.indexOf('function navigateComposerHistory(direction)');
+    const navigationEnd = panel.indexOf('function deleteQueuedComposerMessage', navigationStart);
+    assert.notEqual(navigationStart, -1, `${label}: composer history navigation helper missing`);
+    assert.notEqual(navigationEnd, -1, `${label}: composer history navigation helper boundary missing`);
+    const navigation = panel.slice(navigationStart, navigationEnd);
+    assert.match(navigation, /!sameTabId\(currentTabId, renderedTabId\)/, `${label}: history navigation should stay scoped to the rendered tab`);
+    assert.match(navigation, /getQueuedComposerMessages\(numericTabId\)\.length[\s\S]*?return false;/, `${label}: queued messages should block sent-history navigation`);
+    assert.match(navigation, /if \(direction !== -1 \|\| inputEl\.value !== ''\) return false;/, `${label}: only ArrowUp from an exactly empty composer should start history navigation`);
+    assert.match(navigation, /if \(inputEl\.value !== expectedText\) \{[\s\S]*?resetComposerHistoryNavigation\(numericTabId\);[\s\S]*?return false;/, `${label}: changed recalled text should stop navigation instead of being overwritten`);
+    assert.match(navigation, /if \(state\.index === 0\) return true;[\s\S]*?state\.index -= 1;/, `${label}: ArrowUp should stop at the oldest entry without wrapping`);
+    assert.match(navigation, /if \(state\.index === state\.entries\.length - 1\) \{[\s\S]*?applyComposerHistoryText\(numericTabId, ''\);[\s\S]*?return true;/, `${label}: ArrowDown past the newest entry should restore the empty composer`);
+    assert.match(panel, /function handleInput\(\) \{\s*resetComposerHistoryNavigation\(currentTabId\);/, `${label}: editing recalled text should reset navigation state`);
+    assert.match(panel, /function applySlashCommandCompletion[\s\S]*?resetComposerHistoryNavigation\(currentTabId\);[\s\S]*?inputEl\.value =/, `${label}: slash completion should replace history navigation state explicitly`);
+
+    const keydownStart = panel.indexOf("inputEl.addEventListener('keydown', (e) => {");
+    const keydownEnd = panel.indexOf("inputEl.addEventListener('input', handleInput);", keydownStart);
+    assert.notEqual(keydownStart, -1, `${label}: composer keydown handler missing`);
+    assert.notEqual(keydownEnd, -1, `${label}: composer keydown handler boundary missing`);
+    const keydown = panel.slice(keydownStart, keydownEnd);
+    const slashIdx = keydown.indexOf('handleSlashCommandKeydown(e)');
+    const queueIdx = keydown.indexOf('editLastQueuedComposerMessageForCurrentTab()');
+    const historyUpIdx = keydown.indexOf('navigateComposerHistory(-1)');
+    const historyDownIdx = keydown.indexOf('navigateComposerHistory(1)');
+    const enterIdx = keydown.indexOf("e.key === 'Enter'");
+    assert.ok(slashIdx >= 0 && slashIdx < queueIdx, `${label}: slash autocomplete should keep priority over queued and sent history`);
+    assert.ok(queueIdx < historyUpIdx, `${label}: queued-message editing should keep priority over sent history`);
+    assert.ok(historyUpIdx < historyDownIdx && historyDownIdx < enterIdx, `${label}: history arrows should run before Enter handling`);
+    assert.match(keydown, /const isPlainArrow = !e\.isComposing && !e\.altKey && !e\.ctrlKey && !e\.metaKey && !e\.shiftKey;/, `${label}: modified arrows and IME composition should retain native behavior`);
   }
 });
 


### PR DESCRIPTION
## Summary

- add shell-style ArrowUp/ArrowDown recall for sent user messages in Chrome and Firefox sidepanels
- preserve slash-command and queued-message priority, exact-empty draft gating, visual-row boundaries, and per-tab navigation state
- keep context-menu selection prompts protected by recalling their original model-facing untrusted-content wrapper; omit legacy selection bubbles whose wrapper cannot be recovered
- add mirrored regression coverage for traversal, reset behavior, draft safety, queue exclusion, and protected prompt recall

## User impact

Users can recall previously sent messages from an empty composer without overwriting drafts. Multiline and soft-wrapped text keeps native cursor movement until the caret reaches the first or last rendered row.

## Root cause and security fix

Conversation bubbles store a display-only version of generated selection prompts. Reading bubble text directly for history recall would strip the untrusted-page-content boundary and could resend page-controlled text as trusted user input. New bubbles now persist the original protected payload for recall, while ambiguous legacy selection bubbles are excluded.

## Validation

- `git diff --check`
- `node --check src/chrome/src/ui/sidepanel.js`
- `node --check src/firefox/src/ui/sidepanel.js`
- `node test/run.js` — 856 passed, 1 pre-existing failure because `package.json` is 24.0.1 while the newest `CHANGELOG.md` heading is 24.0.0
- `npm run test:security` — 60/60 checks passed
- `npm test` reaches the same pre-existing version/changelog mismatch before its chained security command