### PR TITLE
Fix double-escaped assistant Markdown responses

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -41,7 +41,7 @@ import {
   messageContentToText,
 } from './planner.js';
 import { extractFirstJsonObject } from './json-extract.js';
-import { sanitizeText as sanitizePlannerText } from './text-sanitize.js';
+import { repairDoubleEscapedAssistantText, sanitizeText as sanitizePlannerText } from './text-sanitize.js';
 import { buildCustomSkillsPrompt, buildSkillLoaderDefinition, buildSkillToolDefinitions, buildSkillToolRegistry, getEligibleCustomSkills, getEligibleSkillCatalog, normalizeCustomSkills } from './skills.js';
 import { publicMediaUrlNeedsExplicitTarget } from './public-media-url.js';
 import { USER_MEMORY_DEFAULT_MAX_PROMPT_CHARS, formatUserMemoryPrompt, normalizeUserMemoryMaxPromptChars, normalizeUserMemoryStore } from './user-memory.js';
@@ -14354,9 +14354,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         onUpdate('warning', { message: finalResponse });
         break;
       }
+      const repairedFinalContent = repairDoubleEscapedAssistantText(result.content);
       finalResponse = result.costAllowanceMessage
-        ? `${result.content}\n\n${result.costAllowanceMessage}`
-        : result.content;
+        ? `${repairedFinalContent}\n\n${result.costAllowanceMessage}`
+        : repairedFinalContent;
       messages.push(this._withResponseItems({ role: 'assistant', content: finalResponse }, result.responseItems, result.reasoningContent, provider));
       onUpdate('text', { content: finalResponse });
       break;
@@ -14745,6 +14746,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           onUpdate('warning', { message: planOnlyDecision.failure });
           this._persist(tabId);
           return finish(planOnlyDecision.failure, planOnlyDecision.status || 'plan_only_output');
+        }
+        const repairedFullText = repairDoubleEscapedAssistantText(fullText);
+        if (repairedFullText !== fullText) {
+          fullText = repairedFullText;
+          // Streaming deltas have already displayed the malformed escapes.
+          // Replace the transient bubble once with the repaired terminal text.
+          onUpdate('text', { content: fullText, replace: true });
         }
         if (costStopMessage) {
           onUpdate('text_delta', { content: `\n\n${costStopMessage}` });

--- a/src/chrome/src/agent/text-sanitize.js
+++ b/src/chrome/src/agent/text-sanitize.js
@@ -15,3 +15,70 @@ export function sanitizeText(value, max = 500, { collapseWhitespace = false } = 
   }
   return out.trim().slice(0, max);
 }
+
+function escapedLineBreakRuns(value) {
+  const runs = [];
+  const pattern = /(^|[^\\])((?:\\r\\n|\\n|\\r)+)/g;
+  let match;
+  while ((match = pattern.exec(value)) !== null) {
+    const start = match.index + match[1].length;
+    const end = start + match[2].length;
+    runs.push({
+      raw: match[2],
+      previous: start > 0 ? value[start - 1] : '',
+      next: end < value.length ? value[end] : '',
+    });
+  }
+  return runs;
+}
+
+/**
+ * Repair one extra JSON-string escaping layer in user-visible assistant text.
+ *
+ * Some OpenAI-compatible model backends occasionally return Markdown as an
+ * encoded string fragment, leaving literal `\n` and `\"` sequences after the
+ * API response itself has already been parsed. Decoding every response would
+ * corrupt legitimate code, paths, and escape-sequence explanations, so repair
+ * only high-confidence cases: no real layout characters, multiple escaped
+ * line breaks, a valid one-level JSON decode, and Markdown-like structure in
+ * the decoded result.
+ */
+export function repairDoubleEscapedAssistantText(value) {
+  if (typeof value !== 'string' || !value) return value;
+  if (/[\r\n\t]/.test(value)) return value;
+
+  const lineBreakRuns = escapedLineBreakRuns(value);
+  const escapedLineBreakCount = lineBreakRuns.reduce(
+    (count, run) => count + (run.raw.match(/\\r\\n|\\n|\\r/g) || []).length,
+    0,
+  );
+  if (escapedLineBreakCount < 2) return value;
+
+  // A run surrounded by whitespace or code delimiters is much more likely to
+  // be an escape-sequence example (for example `/\n\n/` or "write \n here")
+  // than encoded document layout. Fail closed instead of rewriting it.
+  if (lineBreakRuns.some((run) => (
+    (/\s/.test(run.previous) && /\s/.test(run.next))
+    || run.previous === '/'
+    || run.next === '/'
+    || (run.previous === '`' && run.next === '`')
+  ))) return value;
+
+  let decoded;
+  try {
+    decoded = JSON.parse(`"${value}"`);
+  } catch {
+    return value;
+  }
+  if (typeof decoded !== 'string' || decoded === value) return value;
+
+  const decodedLineBreaks = decoded.match(/\r\n|\r|\n/g) || [];
+  if (decodedLineBreaks.length < escapedLineBreakCount) return value;
+
+  const hasMarkdownBlock = /(?:^|[\r\n])[ \t]*(?:#{1,6}[ \t]+|[-*+][ \t]+\S|\d+[.)][ \t]+\S|>{1,3}[ \t]+\S|```|~~~|---[ \t]*(?:$|[\r\n]))/m.test(decoded);
+  const hasInlineMarkdownAcrossParagraphs = /(?:\*\*[^*\r\n]+\*\*|__[^_\r\n]+__|`[^`\r\n]+`|\[[^\]\r\n]+\]\([^)]+\))/.test(decoded)
+    && /\r?\n[ \t]*\r?\n/.test(decoded);
+  if (!hasMarkdownBlock && !hasInlineMarkdownAcrossParagraphs) return value;
+
+  return decoded;
+}

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -42,7 +42,7 @@ import {
   messageContentToText,
 } from './planner.js';
 import { extractFirstJsonObject } from './json-extract.js';
-import { sanitizeText as sanitizePlannerText } from './text-sanitize.js';
+import { repairDoubleEscapedAssistantText, sanitizeText as sanitizePlannerText } from './text-sanitize.js';
 import { buildCustomSkillsPrompt, buildSkillLoaderDefinition, buildSkillToolDefinitions, buildSkillToolRegistry, getEligibleCustomSkills, getEligibleSkillCatalog, normalizeCustomSkills } from './skills.js';
 import { publicMediaUrlNeedsExplicitTarget } from './public-media-url.js';
 import { USER_MEMORY_DEFAULT_MAX_PROMPT_CHARS, formatUserMemoryPrompt, normalizeUserMemoryMaxPromptChars, normalizeUserMemoryStore } from './user-memory.js';
@@ -10398,9 +10398,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         onUpdate('warning', { message: finalResponse });
         break;
       }
+      const repairedFinalContent = repairDoubleEscapedAssistantText(result.content);
       finalResponse = result.costAllowanceMessage
-        ? `${result.content}\n\n${result.costAllowanceMessage}`
-        : result.content;
+        ? `${repairedFinalContent}\n\n${result.costAllowanceMessage}`
+        : repairedFinalContent;
       messages.push(this._withResponseItems({ role: 'assistant', content: finalResponse }, result.responseItems, result.reasoningContent, provider));
       onUpdate('text', { content: finalResponse });
       break;
@@ -10777,6 +10778,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           onUpdate('warning', { message: planOnlyDecision.failure });
           this._persist(tabId);
           return finish(planOnlyDecision.failure, planOnlyDecision.status || 'plan_only_output');
+        }
+        const repairedFullText = repairDoubleEscapedAssistantText(fullText);
+        if (repairedFullText !== fullText) {
+          fullText = repairedFullText;
+          // Streaming deltas have already displayed the malformed escapes.
+          // Replace the transient bubble once with the repaired terminal text.
+          onUpdate('text', { content: fullText, replace: true });
         }
         if (costStopMessage) {
           onUpdate('text_delta', { content: `\n\n${costStopMessage}` });

--- a/src/firefox/src/agent/text-sanitize.js
+++ b/src/firefox/src/agent/text-sanitize.js
@@ -15,3 +15,70 @@ export function sanitizeText(value, max = 500, { collapseWhitespace = false } = 
   }
   return out.trim().slice(0, max);
 }
+
+function escapedLineBreakRuns(value) {
+  const runs = [];
+  const pattern = /(^|[^\\])((?:\\r\\n|\\n|\\r)+)/g;
+  let match;
+  while ((match = pattern.exec(value)) !== null) {
+    const start = match.index + match[1].length;
+    const end = start + match[2].length;
+    runs.push({
+      raw: match[2],
+      previous: start > 0 ? value[start - 1] : '',
+      next: end < value.length ? value[end] : '',
+    });
+  }
+  return runs;
+}
+
+/**
+ * Repair one extra JSON-string escaping layer in user-visible assistant text.
+ *
+ * Some OpenAI-compatible model backends occasionally return Markdown as an
+ * encoded string fragment, leaving literal `\n` and `\"` sequences after the
+ * API response itself has already been parsed. Decoding every response would
+ * corrupt legitimate code, paths, and escape-sequence explanations, so repair
+ * only high-confidence cases: no real layout characters, multiple escaped
+ * line breaks, a valid one-level JSON decode, and Markdown-like structure in
+ * the decoded result.
+ */
+export function repairDoubleEscapedAssistantText(value) {
+  if (typeof value !== 'string' || !value) return value;
+  if (/[\r\n\t]/.test(value)) return value;
+
+  const lineBreakRuns = escapedLineBreakRuns(value);
+  const escapedLineBreakCount = lineBreakRuns.reduce(
+    (count, run) => count + (run.raw.match(/\\r\\n|\\n|\\r/g) || []).length,
+    0,
+  );
+  if (escapedLineBreakCount < 2) return value;
+
+  // A run surrounded by whitespace or code delimiters is much more likely to
+  // be an escape-sequence example (for example `/\n\n/` or "write \n here")
+  // than encoded document layout. Fail closed instead of rewriting it.
+  if (lineBreakRuns.some((run) => (
+    (/\s/.test(run.previous) && /\s/.test(run.next))
+    || run.previous === '/'
+    || run.next === '/'
+    || (run.previous === '`' && run.next === '`')
+  ))) return value;
+
+  let decoded;
+  try {
+    decoded = JSON.parse(`"${value}"`);
+  } catch {
+    return value;
+  }
+  if (typeof decoded !== 'string' || decoded === value) return value;
+
+  const decodedLineBreaks = decoded.match(/\r\n|\r|\n/g) || [];
+  if (decodedLineBreaks.length < escapedLineBreakCount) return value;
+
+  const hasMarkdownBlock = /(?:^|[\r\n])[ \t]*(?:#{1,6}[ \t]+|[-*+][ \t]+\S|\d+[.)][ \t]+\S|>{1,3}[ \t]+\S|```|~~~|---[ \t]*(?:$|[\r\n]))/m.test(decoded);
+  const hasInlineMarkdownAcrossParagraphs = /(?:\*\*[^*\r\n]+\*\*|__[^_\r\n]+__|`[^`\r\n]+`|\[[^\]\r\n]+\]\([^)]+\))/.test(decoded)
+    && /\r?\n[ \t]*\r?\n/.test(decoded);
+  if (!hasMarkdownBlock && !hasInlineMarkdownAcrossParagraphs) return value;
+
+  return decoded;
+}

--- a/test/run.js
+++ b/test/run.js
@@ -568,6 +568,12 @@ const { Agent: AgentCh } = await import(
 const { Agent: AgentFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/agent/agent.js').replace(/\\/g, '/')
 );
+const { repairDoubleEscapedAssistantText: repairDoubleEscapedAssistantTextCh } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/agent/text-sanitize.js').replace(/\\/g, '/')
+);
+const { repairDoubleEscapedAssistantText: repairDoubleEscapedAssistantTextFx } = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/agent/text-sanitize.js').replace(/\\/g, '/')
+);
 const userMemoryCh = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/agent/user-memory.js').replace(/\\/g, '/')
 );
@@ -19329,6 +19335,161 @@ test('_defaultConfigs: new cloud providers present and disabled by default', () 
     );
     assert.equal(streamBody.temperature, undefined);
     assert.deepEqual(streamBody.stream_options, { include_usage: true });
+  }
+});
+
+test('assistant response repair decodes issue #409 double-escaped Markdown', () => {
+  const expected = '**Registro en vivo**\n\n---\n\n*Nota: El texto parece estar truncado ("Live Lo").*';
+  const malformed = JSON.stringify(expected).slice(1, -1);
+
+  assert.match(malformed, /\\n\\n/);
+  assert.match(malformed, /\\"Live Lo\\"/);
+  for (const [label, repair] of [
+    ['chrome', repairDoubleEscapedAssistantTextCh],
+    ['firefox', repairDoubleEscapedAssistantTextFx],
+  ]) {
+    assert.equal(repair(malformed), expected, `${label}: malformed Markdown should decode exactly one level`);
+  }
+});
+
+test('assistant response repair preserves legitimate escapes and formatted text', () => {
+  const unchanged = [
+    String.raw`Use the literal sequences \n\n when documenting JSON escapes.`,
+    String.raw`Path C:\new\temp and regex /\n\n/.`,
+    String.raw`**Regex:**\n\nUse /\n\n/ to match a blank line.`,
+    String.raw`**Literal:**\n\nWrite \n\n between paragraphs.`,
+    String.raw`### Escapes\n\nThe token \n starts a new line.`,
+    '```json\n{"line":"one\\ntwo"}\n```',
+    'Already\n\n**formatted**',
+    String.raw`First\nSecond`,
+    String.raw`### Title\n\nBad \q escape`,
+  ];
+
+  for (const [label, repair] of [
+    ['chrome', repairDoubleEscapedAssistantTextCh],
+    ['firefox', repairDoubleEscapedAssistantTextFx],
+  ]) {
+    for (const value of unchanged) {
+      assert.equal(repair(value), value, `${label}: should preserve ${JSON.stringify(value)}`);
+    }
+  }
+});
+
+test('assistant response repair preserves escapes inside double-escaped fenced code', () => {
+  const expected = '```json\n{"line":"one\\ntwo"}\n```';
+  const malformed = JSON.stringify(expected).slice(1, -1);
+
+  for (const [label, repair] of [
+    ['chrome', repairDoubleEscapedAssistantTextCh],
+    ['firefox', repairDoubleEscapedAssistantTextFx],
+  ]) {
+    assert.equal(repair(malformed), expected, `${label}: fenced JSON should retain its inner escape`);
+  }
+});
+
+test('provider response path preserves raw assistant content and metadata', async () => {
+  const expected = '**Result**\n\n- First\n- Second';
+  const malformed = JSON.stringify(expected).slice(1, -1);
+  const reasoningContent = String.raw`Keep \n reasoning unchanged`;
+
+  for (const [label, AgentClass] of [
+    ['chrome', AgentCh],
+    ['firefox', AgentFx],
+  ]) {
+    const raw = { choices: [{ message: { content: malformed } }] };
+    const agent = new AgentClass({});
+    agent._checkCostAllowance = async () => null;
+    agent._recordCostUsage = async () => null;
+    const result = await agent._chatWithCostAllowance({
+      chat: async () => ({
+        content: malformed,
+        reasoningContent,
+        raw,
+        usage: null,
+      }),
+    }, [], {}, {});
+
+    assert.equal(result.content, malformed, `${label}: raw content should remain available to semantic gates`);
+    assert.equal(result.reasoningContent, reasoningContent, `${label}: hidden reasoning should not be decoded`);
+    assert.equal(raw.choices[0].message.content, malformed, `${label}: raw provider payload should remain untouched`);
+  }
+});
+
+test('terminal display repair cannot turn escaped text into executable tool calls', async () => {
+  const expected = '### Continuing\n\n<tool_call>{"name":"read_page","arguments":{}}</tool_call>';
+  const malformed = JSON.stringify(expected).slice(1, -1);
+
+  for (const [index, AgentClass] of [AgentCh, AgentFx].entries()) {
+    const provider = {
+      supportsTools: true,
+      supportsVision: false,
+      promptTier: 'full',
+      contextWindow: 128000,
+      model: 'test-model',
+      name: 'test-provider',
+      chat: async () => ({ content: malformed, toolCalls: [] }),
+    };
+    const agent = new AgentClass({
+      getActive: () => provider,
+      getVisionProvider: async () => null,
+    });
+    const tabId = 4090 + index;
+    configurePlanOnlyGuardAgent(agent, tabId);
+    let executed = false;
+    agent.executeTool = async () => {
+      executed = true;
+      throw new Error('display-only text must not execute');
+    };
+
+    const final = await agent.processMessage(tabId, 'Show the response.', () => {}, 'ask');
+
+    assert.equal(final, expected, `${AgentClass.name}: terminal display text should be repaired`);
+    assert.equal(executed, false, `${AgentClass.name}: decoded display text became a tool call`);
+  }
+});
+
+test('agent repairs only terminal content after raw tool-call and plan gates', () => {
+  for (const [label, prefix] of [
+    ['chrome', 'src/chrome'],
+    ['firefox', 'src/firefox'],
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, prefix, 'src/agent/agent.js'), 'utf8');
+    const rawFallback = source.indexOf(
+      'const fallback = this._tryParseToolCallsFromText(result.content, allowedToolNames);',
+    );
+    const planGate = source.indexOf(
+      'const planOnlyDecision = this._planOnlyTerminalDecision(tabId, result.content);',
+      rawFallback,
+    );
+    const terminalRepair = source.indexOf(
+      'const repairedFinalContent = repairDoubleEscapedAssistantText(result.content);',
+      planGate,
+    );
+    assert.ok(
+      rawFallback >= 0 && rawFallback < planGate && planGate < terminalRepair,
+      `${label}: non-streaming repair must run after raw semantic gates`,
+    );
+
+    const rawStreamFallback = source.indexOf(
+      'const fallback = this._tryParseToolCallsFromText(fullText, allowedToolNames);',
+    );
+    const streamPlanGate = source.indexOf(
+      'const planOnlyDecision = this._planOnlyTerminalDecision(tabId, fullText);',
+      rawStreamFallback,
+    );
+    const streamTerminalRepair = source.indexOf(
+      'const repairedFullText = repairDoubleEscapedAssistantText(fullText);',
+      streamPlanGate,
+    );
+    assert.ok(
+      rawStreamFallback >= 0 && rawStreamFallback < streamPlanGate && streamPlanGate < streamTerminalRepair,
+      `${label}: streaming repair must run after raw semantic gates`,
+    );
+    assert.match(
+      source,
+      /if \(repairedFullText !== fullText\) \{[\s\S]{0,400}onUpdate\('text', \{ content: fullText, replace: true \}\);/,
+      `${label}: malformed streamed deltas should be replaced once at completion`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

- repair one extra JSON-string escaping layer in high-confidence assistant Markdown responses
- apply repair only at the terminal display boundary, after raw tool-call parsing and plan gates
- preserve legitimate escape-sequence examples and escaped content inside fenced code
- mirror the behavior across Chrome and Firefox

## Root cause

Some OpenAI-compatible backends can return assistant content with one JSON escaping layer still present after response parsing. The extension then displays literal `\n` and `\"` sequences instead of formatted Markdown. Repairing the content earlier in the agent pipeline would also risk changing how raw tool-call text is interpreted, so this keeps semantic processing on the original provider text and normalizes only genuine terminal output.

## Impact

Affected assistant responses render normally while literal escape documentation, regex examples, paths, and fenced-code escapes remain unchanged. Double-escaped display text cannot become an executable tool call.

Addresses webbrain-one/webbrain#409.

## Validation

- `npm test`
  - 961/961 repository tests passed
  - 60/60 security corpus checks passed
- `git diff --check`