### PR TITLE
Reject stale accessibility actions and misverified field values

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -13189,18 +13189,21 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   }
 
   /**
-   * If a successful set_field touched a credential/secret field, append a
-   * note to the tool result so the model is reminded not to echo the value
-   * in subsequent text/summaries. Detection lives in credential-fields.js
-   * (pure ESM, node-testable). Content scripts ship `fieldMeta`; we apply
-   * the policy here so the regex stays in one place.
+   * If set_field touched a credential/secret field, redact any failed
+   * verification readback and annotate the result. Detection lives in
+   * credential-fields.js (pure ESM, node-testable). Content scripts ship
+   * `fieldMeta`; we apply the policy here so the regex stays in one place.
    */
   _annotateCredentialField(toolName, response) {
     if (toolName !== 'set_field') return;
-    if (!response || !response.success || !response.fieldMeta) return;
+    if (!response || !response.fieldMeta) return;
     try {
       const det = isCredentialField(response.fieldMeta);
       if (!det.sensitive) return;
+      if (Object.prototype.hasOwnProperty.call(response, 'actual')) {
+        delete response.actual;
+        response.actualRedacted = true;
+      }
       // Always set the flag — useful for trace review and downstream tooling
       // — but only emit a model-facing `note` in STRICT mode. Rationale:
       //  (1) webbrain runs small local models (qwen 3-30B class). They handle

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -828,7 +828,7 @@
     const weak = window.__wbElementMap[refId];
     if (!weak) return null;
     const el = weak.deref();
-    if (!el) {
+    if (!el || !el.isConnected) {
       delete window.__wbElementMap[refId];
       return null;
     }

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -2971,8 +2971,15 @@
 
   const SET_FIELD_VERIFY_DELAY_MS = 80;
 
-  function _setFieldValueMatches(actual, previous, text, clear) {
-    return actual === (clear ? text : previous + text);
+  function _setFieldValueMatches(actual, previous, text, clear, normalizeNewlines = false) {
+    const expected = clear ? text : previous + text;
+    if (!normalizeNewlines) return actual === expected;
+    const normalize = value => String(value).replace(/\r\n?/g, '\n');
+    return normalize(actual) === normalize(expected);
+  }
+
+  function _editableTextValue(el) {
+    return typeof el.innerText === 'string' ? el.innerText : (el.textContent || '');
   }
 
   // --- Message handler ---
@@ -3483,7 +3490,7 @@
           let prevValue = '';
           dispatched = true;
           if (el.isContentEditable) {
-            prevValue = el.textContent || '';
+            prevValue = _editableTextValue(el);
             if (clear) {
               try {
                 const sel = window.getSelection();
@@ -3520,8 +3527,8 @@
               { ref_id },
             );
           }
-          const actual = el.isContentEditable ? (el.textContent || '') : (el.value || '');
-          const verified = _setFieldValueMatches(actual, prevValue, text, clear);
+          const actual = el.isContentEditable ? _editableTextValue(el) : (el.value || '');
+          const verified = _setFieldValueMatches(actual, prevValue, text, clear, el.isContentEditable);
 
           // Collect field attributes for credential-field detection. The
           // detector itself lives in src/agent/credential-fields.js (pure

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -2969,6 +2969,12 @@
     };
   }
 
+  const SET_FIELD_VERIFY_DELAY_MS = 80;
+
+  function _setFieldValueMatches(actual, previous, text, clear) {
+    return actual === (clear ? text : previous + text);
+  }
+
   // --- Message handler ---
   chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     if (msg.target !== 'content') return;
@@ -3063,6 +3069,16 @@
           }
           try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
           try { el.focus({ preventScroll: true }); } catch {}
+          const rect = el.getBoundingClientRect();
+          if (!el.isConnected || rect.width < 1 || rect.height < 1) {
+            return failure(
+              `ref_id ${ref_id} is stale or not visibly rendered. Re-read the accessibility tree and retry with the current target ref_id.`,
+              {
+                ref_id,
+                rect: { x: Math.round(rect.x), y: Math.round(rect.y), w: Math.round(rect.width), h: Math.round(rect.height) },
+              },
+            );
+          }
           // Identity only (tag:role:label) — must match agent-side
           // _clickAxActiveIdentity / _clickProgressSnapshot.active so layout
           // shift cannot turn preparatory focus into false "focus" proof.
@@ -3080,7 +3096,6 @@
             }
           })();
           const fallbackStateBefore = _axFallbackState(el);
-          const rect = el.getBoundingClientRect();
           const tag = el.tagName ? el.tagName.toLowerCase() : '';
           const targetContext = (() => {
             try {
@@ -3445,6 +3460,15 @@
               return { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) };
             } catch { return null; }
           })();
+          if (!el.isConnected || !rect || rect.w < 1 || rect.h < 1) {
+            return failure(
+              `ref_id ${ref_id} is stale or not visibly rendered. Re-read the accessibility tree and retry with the current field ref_id.`,
+              {
+                ref_id,
+                rect,
+              },
+            );
+          }
           // Guard: refuse non-typeable elements up-front so the caller gets a
           // clear error instead of a silent no-op.
           if (el.tagName === 'INPUT') {
@@ -3486,9 +3510,18 @@
             el.dispatchEvent(new Event('input', { bubbles: true }));
             el.dispatchEvent(new Event('change', { bubbles: true }));
           }
-          // Verify: read back the value and confirm it contains what we typed.
+          // Controlled inputs can reconcile on the next task and overwrite or
+          // append to the value after their input/change handlers return.
+          // Let that reconciliation settle before verifying the exact result.
+          await new Promise(resolve => setTimeout(resolve, SET_FIELD_VERIFY_DELAY_MS));
+          if (!el.isConnected) {
+            return failure(
+              `ref_id ${ref_id} was replaced while the value was being set. Re-read the accessibility tree and retry with the current field ref_id.`,
+              { ref_id },
+            );
+          }
           const actual = el.isContentEditable ? (el.textContent || '') : (el.value || '');
-          const verified = actual.includes(text);
+          const verified = _setFieldValueMatches(actual, prevValue, text, clear);
 
           // Collect field attributes for credential-field detection. The
           // detector itself lives in src/agent/credential-fields.js (pure
@@ -3522,7 +3555,7 @@
               };
             } catch { return null; }
           })();
-          if (submit) {
+          if (submit && verified) {
             try {
               // Detect combobox/searchbox pattern: if the element is a searchbox,
               // has role=combobox, has aria-controls pointing to a listbox, or a
@@ -3571,13 +3604,25 @@
               }
             } catch {}
           }
+          if (!verified) {
+            return failure(
+              'The field value did not exactly match the requested text after the page settled. Re-read the field and retry with a fresh ref_id.',
+              {
+                method: 'set_field',
+                ref_id,
+                rect,
+                verified: false,
+                actual: actual.slice(0, 200),
+                fieldMeta,
+              },
+            );
+          }
           return {
             success: true,
             method: 'set_field',
             ref_id,
             rect,
-            verified,
-            actual: verified ? undefined : actual.slice(0, 200),
+            verified: true,
             fieldMeta,
           };
         } catch (e) {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -10093,18 +10093,21 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   }
 
   /**
-   * If a successful set_field touched a credential/secret field, append a
-   * note to the tool result so the model is reminded not to echo the value
-   * in subsequent text/summaries. Detection lives in credential-fields.js
-   * (pure ESM, node-testable). Content scripts ship `fieldMeta`; we apply
-   * the policy here so the regex stays in one place.
+   * If set_field touched a credential/secret field, redact any failed
+   * verification readback and annotate the result. Detection lives in
+   * credential-fields.js (pure ESM, node-testable). Content scripts ship
+   * `fieldMeta`; we apply the policy here so the regex stays in one place.
    */
   _annotateCredentialField(toolName, response) {
     if (toolName !== 'set_field') return;
-    if (!response || !response.success || !response.fieldMeta) return;
+    if (!response || !response.fieldMeta) return;
     try {
       const det = isCredentialField(response.fieldMeta);
       if (!det.sensitive) return;
+      if (Object.prototype.hasOwnProperty.call(response, 'actual')) {
+        delete response.actual;
+        response.actualRedacted = true;
+      }
       // Always set the flag — useful for trace review and downstream tooling
       // — but only emit a model-facing `note` in STRICT mode. See chrome/
       // agent.js for rationale: mid-run nuanced hints confuse small models;

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -828,7 +828,7 @@
     const weak = window.__wbElementMap[refId];
     if (!weak) return null;
     const el = weak.deref();
-    if (!el) {
+    if (!el || !el.isConnected) {
       delete window.__wbElementMap[refId];
       return null;
     }

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -2408,8 +2408,15 @@
 
   const SET_FIELD_VERIFY_DELAY_MS = 80;
 
-  function _setFieldValueMatches(actual, previous, text, clear) {
-    return actual === (clear ? text : previous + text);
+  function _setFieldValueMatches(actual, previous, text, clear, normalizeNewlines = false) {
+    const expected = clear ? text : previous + text;
+    if (!normalizeNewlines) return actual === expected;
+    const normalize = value => String(value).replace(/\r\n?/g, '\n');
+    return normalize(actual) === normalize(expected);
+  }
+
+  function _editableTextValue(el) {
+    return typeof el.innerText === 'string' ? el.innerText : (el.textContent || '');
   }
 
   // --- Message handler ---
@@ -2876,7 +2883,7 @@
           let prevValue = '';
           dispatched = true;
           if (el.isContentEditable) {
-            prevValue = el.textContent || '';
+            prevValue = _editableTextValue(el);
             if (clear) {
               try {
                 const sel = window.getSelection();
@@ -2913,8 +2920,8 @@
               { ref_id },
             );
           }
-          const actual = el.isContentEditable ? (el.textContent || '') : (el.value || '');
-          const verified = _setFieldValueMatches(actual, prevValue, text, clear);
+          const actual = el.isContentEditable ? _editableTextValue(el) : (el.value || '');
+          const verified = _setFieldValueMatches(actual, prevValue, text, clear, el.isContentEditable);
 
           // Collect field attributes for credential-field detection. The
           // detector itself lives in src/agent/credential-fields.js (pure

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -2406,6 +2406,12 @@
     };
   }
 
+  const SET_FIELD_VERIFY_DELAY_MS = 80;
+
+  function _setFieldValueMatches(actual, previous, text, clear) {
+    return actual === (clear ? text : previous + text);
+  }
+
   // --- Message handler ---
   browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     if (msg.target !== 'content') return;
@@ -2536,6 +2542,15 @@
           try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
           try { el.focus({ preventScroll: true }); } catch {}
           const rect = el.getBoundingClientRect();
+          if (!el.isConnected || rect.width < 1 || rect.height < 1) {
+            return failure(
+              `ref_id ${ref_id} is stale or not visibly rendered. Re-read the accessibility tree and retry with the current target ref_id.`,
+              {
+                ref_id,
+                rect: { x: Math.round(rect.x), y: Math.round(rect.y), w: Math.round(rect.width), h: Math.round(rect.height) },
+              },
+            );
+          }
           const targetContext = (() => {
             try {
               const ownText = String(_axAccessibleName(el) || el.innerText || '')
@@ -2840,6 +2855,15 @@
               return { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) };
             } catch { return null; }
           })();
+          if (!el.isConnected || !rect || rect.w < 1 || rect.h < 1) {
+            return failure(
+              `ref_id ${ref_id} is stale or not visibly rendered. Re-read the accessibility tree and retry with the current field ref_id.`,
+              {
+                ref_id,
+                rect,
+              },
+            );
+          }
           if (el.tagName === 'INPUT') {
             const inputType = (el.type || 'text').toLowerCase();
             const nonTypeable = new Set(['checkbox', 'radio', 'file', 'submit', 'button', 'reset', 'image', 'color', 'range', 'hidden']);
@@ -2879,8 +2903,18 @@
             el.dispatchEvent(new Event('input', { bubbles: true }));
             el.dispatchEvent(new Event('change', { bubbles: true }));
           }
+          // Controlled inputs may reconcile after their event handlers return.
+          // Verify only after that turn, and require the complete expected
+          // value rather than accepting a matching substring.
+          await new Promise(resolve => setTimeout(resolve, SET_FIELD_VERIFY_DELAY_MS));
+          if (!el.isConnected) {
+            return failure(
+              `ref_id ${ref_id} was replaced while the value was being set. Re-read the accessibility tree and retry with the current field ref_id.`,
+              { ref_id },
+            );
+          }
           const actual = el.isContentEditable ? (el.textContent || '') : (el.value || '');
-          const verified = actual.includes(text);
+          const verified = _setFieldValueMatches(actual, prevValue, text, clear);
 
           // Collect field attributes for credential-field detection. The
           // detector itself lives in src/agent/credential-fields.js (pure
@@ -2915,7 +2949,7 @@
             } catch { return null; }
           })();
 
-          if (submit) {
+          if (submit && verified) {
             try {
               const roleAttr = (el.getAttribute && el.getAttribute('role') || '').toLowerCase();
               const controls = el.getAttribute && el.getAttribute('aria-controls');
@@ -2952,13 +2986,25 @@
               }
             } catch {}
           }
+          if (!verified) {
+            return failure(
+              'The field value did not exactly match the requested text after the page settled. Re-read the field and retry with a fresh ref_id.',
+              {
+                method: 'set_field',
+                ref_id,
+                rect,
+                verified: false,
+                actual: actual.slice(0, 200),
+                fieldMeta,
+              },
+            );
+          }
           return {
             success: true,
             method: 'set_field',
             ref_id,
             rect,
-            verified,
-            actual: verified ? undefined : actual.slice(0, 200),
+            verified: true,
             fieldMeta,
           };
         } catch (e) {

--- a/test/run.js
+++ b/test/run.js
@@ -18597,6 +18597,50 @@ test('reason is informative', () => {
   assert.match(isCredentialField({ type: 'text', name: 'api_key' }).reason, /name matches credential pattern/);
 });
 
+test('failed sensitive set_field readbacks are annotated and redacted', () => {
+  for (const [label, rel, detector, strictNote] of [
+    ['chrome', 'src/chrome/src/agent/agent.js', isCredentialField, CREDENTIAL_NOTE_STRICT],
+    ['firefox', 'src/firefox/src/agent/agent.js', isCredentialFieldFx, CREDENTIAL_NOTE_STRICT_FX],
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+    const start = source.indexOf('_annotateCredentialField(toolName, response) {');
+    const end = source.indexOf('\n  }\n\n', start);
+    assert.ok(start >= 0 && end > start, `${label}: credential result annotator should remain independently testable`);
+    const method = vm.runInNewContext(`({${source.slice(start, end + 4)}})._annotateCredentialField`, {
+      isCredentialField: detector,
+      CREDENTIAL_NOTE_STRICT: strictNote,
+    });
+
+    const failedSensitive = {
+      success: false,
+      actual: 'settled-secret-value',
+      fieldMeta: { type: 'password' },
+    };
+    method.call({ strictSecretMode: false }, 'set_field', failedSensitive);
+    assert.equal(Object.hasOwn(failedSensitive, 'actual'), false, `${label}: sensitive readback must not reach the model`);
+    assert.equal(failedSensitive.actualRedacted, true, `${label}: redaction should remain observable without the value`);
+    assert.equal(failedSensitive.sensitiveField, true, `${label}: failed post-dispatch results should retain sensitive-field policy`);
+
+    const failedOrdinary = {
+      success: false,
+      actual: 'Magnetic Locksg',
+      fieldMeta: { type: 'text', name: 'product_name' },
+    };
+    method.call({ strictSecretMode: false }, 'set_field', failedOrdinary);
+    assert.equal(failedOrdinary.actual, 'Magnetic Locksg', `${label}: ordinary mismatch diagnostics should remain available`);
+    assert.equal(failedOrdinary.actualRedacted, undefined, `${label}: ordinary fields should not be marked redacted`);
+
+    const strictFailure = {
+      success: false,
+      actual: '123456',
+      fieldMeta: { type: 'text', autocomplete: 'one-time-code' },
+    };
+    method.call({ strictSecretMode: true }, 'set_field', strictFailure);
+    assert.equal(Object.hasOwn(strictFailure, 'actual'), false, `${label}: strict mode must also redact failed readbacks`);
+    assert.equal(strictFailure.note, strictNote, `${label}: strict secret reminder should apply to failed sensitive results`);
+  }
+});
+
 // ────────────────────────────────────────────────────────────────────────
 // Provider categorization (filter UI)
 // ────────────────────────────────────────────────────────────────────────

--- a/test/run.js
+++ b/test/run.js
@@ -23923,7 +23923,7 @@ test('set_field waits for reconciliation and verifies the complete value', () =>
   ]) {
     const source = fs.readFileSync(path.join(ROOT, rel), 'utf8');
     const helperStart = source.indexOf('function _setFieldValueMatches(');
-    const helperEnd = source.indexOf('\n\n  // --- Message handler', helperStart);
+    const helperEnd = source.indexOf('\n\n  function _editableTextValue', helperStart);
     assert.ok(helperStart >= 0 && helperEnd > helperStart, `${label}: exact-value helper should remain independently testable`);
     const matches = vm.runInNewContext(`(${source.slice(helperStart, helperEnd)})`);
 
@@ -23932,6 +23932,9 @@ test('set_field waits for reconciliation and verifies the complete value', () =>
     assert.equal(matches('xMagnetic Locks', '', 'Magnetic Locks', true), false, `${label}: leading corruption must not verify`);
     assert.equal(matches('old-new', 'old-', 'new', false), true, `${label}: exact append should verify`);
     assert.equal(matches('new', 'old-', 'new', false), false, `${label}: append verification must preserve prior content`);
+    assert.equal(matches('first\nsecond', '', 'first\r\nsecond', true, true), true, `${label}: rich-editor CRLF should match rendered newlines`);
+    assert.equal(matches('firstsecond', '', 'first\nsecond', true, true), false, `${label}: missing rich-editor newlines must still fail`);
+    assert.equal(matches('first\nsecond!', '', 'first\nsecond', true, true), false, `${label}: rich-editor normalization must not accept other corruption`);
 
     const branchStart = source.indexOf("'set_field': async () => {");
     const branchEnd = source.indexOf(label === 'chrome' ? "'ax_resolve_rect':" : "'hover':", branchStart);
@@ -23940,6 +23943,8 @@ test('set_field waits for reconciliation and verifies the complete value', () =>
     const settleIndex = branch.indexOf('await new Promise(resolve => setTimeout(resolve, SET_FIELD_VERIFY_DELAY_MS))');
     const readbackIndex = branch.indexOf("const actual = el.isContentEditable");
     assert.ok(settleIndex >= 0 && readbackIndex > settleIndex, `${label}: verification must happen after controlled-input reconciliation`);
+    assert.match(branch, /const actual = el\.isContentEditable \? _editableTextValue\(el\)/, `${label}: rich-editor verification must use rendered text`);
+    assert.match(branch, /_setFieldValueMatches\(actual, prevValue, text, clear, el\.isContentEditable\)/, `${label}: newline normalization must remain contenteditable-only`);
     assert.match(branch, /!el\.isConnected \|\| !rect \|\| rect\.w < 1 \|\| rect\.h < 1/, `${label}: stale or zero-sized targets must fail before typing`);
     assert.match(branch, /if \(submit && verified\)/, `${label}: mismatched field values must not be submitted`);
     assert.match(branch, /if \(!verified\) \{[\s\S]*return failure\(/, `${label}: mismatched field values must be explicit failed actions`);

--- a/test/run.js
+++ b/test/run.js
@@ -23844,6 +23844,84 @@ test('submit controls bypass native select guards in click paths', () => {
   }
 });
 
+test('accessibility ref lookup rejects disconnected elements', () => {
+  for (const [label, rel] of [
+    ['chrome', 'src/chrome/src/content/accessibility-tree.js'],
+    ['firefox', 'src/firefox/src/content/accessibility-tree.js'],
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+    const start = source.indexOf('function lookup(refId) {');
+    const end = source.indexOf('\n\n  // ── Public: suggest nearby refs', start);
+    assert.ok(start >= 0 && end > start, `${label}: lookup helper should remain independently testable`);
+
+    const connected = { isConnected: true };
+    const elementMap = {
+      ref_live: { deref: () => connected },
+      ref_stale: { deref: () => ({ isConnected: false }) },
+      ref_collected: { deref: () => null },
+    };
+    const lookup = vm.runInNewContext(`(${source.slice(start, end)})`, {
+      window: { __wbElementMap: elementMap },
+    });
+
+    assert.equal(lookup('ref_live'), connected, `${label}: connected refs should remain usable`);
+    assert.equal(lookup('ref_stale'), null, `${label}: disconnected refs must be rejected`);
+    assert.equal(elementMap.ref_stale, undefined, `${label}: disconnected refs should be evicted`);
+    assert.equal(lookup('ref_collected'), null, `${label}: collected refs must be rejected`);
+    assert.equal(elementMap.ref_collected, undefined, `${label}: collected refs should be evicted`);
+  }
+});
+
+test('set_field waits for reconciliation and verifies the complete value', () => {
+  for (const [label, rel] of [
+    ['chrome', 'src/chrome/src/content/content.js'],
+    ['firefox', 'src/firefox/src/content/content.js'],
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+    const helperStart = source.indexOf('function _setFieldValueMatches(');
+    const helperEnd = source.indexOf('\n\n  // --- Message handler', helperStart);
+    assert.ok(helperStart >= 0 && helperEnd > helperStart, `${label}: exact-value helper should remain independently testable`);
+    const matches = vm.runInNewContext(`(${source.slice(helperStart, helperEnd)})`);
+
+    assert.equal(matches('Magnetic Locks', '', 'Magnetic Locks', true), true, `${label}: exact replacement should verify`);
+    assert.equal(matches('Magnetic Locksg', '', 'Magnetic Locks', true), false, `${label}: trailing corruption must not verify`);
+    assert.equal(matches('xMagnetic Locks', '', 'Magnetic Locks', true), false, `${label}: leading corruption must not verify`);
+    assert.equal(matches('old-new', 'old-', 'new', false), true, `${label}: exact append should verify`);
+    assert.equal(matches('new', 'old-', 'new', false), false, `${label}: append verification must preserve prior content`);
+
+    const branchStart = source.indexOf("'set_field': async () => {");
+    const branchEnd = source.indexOf(label === 'chrome' ? "'ax_resolve_rect':" : "'hover':", branchStart);
+    assert.ok(branchStart >= 0 && branchEnd > branchStart, `${label}: set_field handler should be bounded for regression checks`);
+    const branch = source.slice(branchStart, branchEnd);
+    const settleIndex = branch.indexOf('await new Promise(resolve => setTimeout(resolve, SET_FIELD_VERIFY_DELAY_MS))');
+    const readbackIndex = branch.indexOf("const actual = el.isContentEditable");
+    assert.ok(settleIndex >= 0 && readbackIndex > settleIndex, `${label}: verification must happen after controlled-input reconciliation`);
+    assert.match(branch, /!el\.isConnected \|\| !rect \|\| rect\.w < 1 \|\| rect\.h < 1/, `${label}: stale or zero-sized targets must fail before typing`);
+    assert.match(branch, /if \(submit && verified\)/, `${label}: mismatched field values must not be submitted`);
+    assert.match(branch, /if \(!verified\) \{[\s\S]*return failure\(/, `${label}: mismatched field values must be explicit failed actions`);
+    assert.match(branch, /dispatched\s*\?\s*\{ dispatched: true \}/, `${label}: post-dispatch verification failures must preserve action evidence`);
+    assert.doesNotMatch(branch, /actual\.includes\(text\)/, `${label}: substring matches must not count as verified field values`);
+  }
+});
+
+test('click_ax rejects stale zero-sized targets before activation', () => {
+  for (const [label, rel] of [
+    ['chrome', 'src/chrome/src/content/content.js'],
+    ['firefox', 'src/firefox/src/content/content.js'],
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+    const branchStart = source.indexOf("'click_ax': () => {");
+    const branchEnd = source.indexOf("'type_ax':", branchStart);
+    assert.ok(branchStart >= 0 && branchEnd > branchStart, `${label}: click_ax handler should be bounded for regression checks`);
+    const branch = source.slice(branchStart, branchEnd);
+    const staleGuard = branch.indexOf('!el.isConnected || rect.width < 1 || rect.height < 1');
+    const activation = branch.indexOf('el.click()');
+    assert.ok(staleGuard >= 0 && activation > staleGuard, `${label}: zero-sized AX targets must be rejected before click activation`);
+    assert.match(branch, /return failure\([\s\S]*stale or not visibly rendered[\s\S]*Re-read the accessibility tree/, `${label}: stale click errors should direct the agent to refresh refs`);
+    assert.match(branch, /dispatched: false, noDispatch: true, fallbackAttempted: false/, `${label}: pre-click stale failures must remain safe for agent fallback`);
+  }
+});
+
 test('submit detector source covers submit controls, Enter, set_field, iframes, and execute_js', () => {
   for (const [label, rel] of [
     ['chrome', 'src/chrome/src/agent/agent.js'],


### PR DESCRIPTION
## Summary

- evict disconnected accessibility refs before reuse
- reject disconnected or zero-sized `click_ax` / `set_field` targets before activation
- wait for controlled-input reconciliation and require exact settled `set_field` values
- verify rich-editor multiline values from rendered text with newline normalization
- preserve the new completion-invariant dispatch semantics for pre-action and post-action failures
- redact failed sensitive-field readbacks before they reach the model
- mirror the behavior in Chrome and Firefox

## Dump evidence

A fresh WebBrain Cloud audit covered 1,210 checkpoints grouped into 91 sessions (80 meaningful after filtering trivial probes). The selected non-duplicate issue was observed independently of the already-merged planner/completion work:

- 37 `set_field` results across 3 sessions claimed `success: true`, `verified: true` on zero-sized targets
- one affected session had 6 visible suffix-corruption mismatches accepted by substring verification
- 6 zero-sized `click_ax` calls across 5 sessions were reported successful; one stale ref navigated to the wrong supplier
- all affected traces used `minimax/minimax-m3`, but the root cause is deterministic in the content-script verifier

## Review follow-up

- `e3f77b73` applies credential annotation to failed post-dispatch results and removes sensitive readbacks while preserving ordinary mismatch diagnostics.
- `56d411d7` reads rendered rich-editor text and normalizes newline encodings only for contenteditable exact verification, preventing duplicate retries on successful multiline fills.

## Verification

- `git diff --check`
- `node test/run.js` — 983 passed
- `npm test` — 983 functional + 60 security checks passed
- `npm run test:security` — 60/60 passed