### PR TITLE
Fix false agent stops and stale accessibility clicks

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -189,6 +189,7 @@ export class Agent {
     this._lastCdpClickIdent = new Map(); // tabId -> string
     this._lastClickProgress = new Map(); // tabId -> { ident, snapshot }
     this._clickAxCdpFallbacks = new Map(); // tabId -> Set(documentToken|ref_id), one trusted fallback per document target
+    this._lastAxScopes = new Map(); // tabId -> { documentToken, pageUrl }, captured by the latest AX read
     // Loop detection: per-tab ring buffer of recent tool calls + nudge count.
     this.recentCalls = new Map(); // tabId -> [{ key, name, ts }]
     this.loopNudges = new Map();  // tabId -> consecutive-nudge counter
@@ -2677,11 +2678,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         onUpdate('tool_result', { name: fnName, result: toolResult });
       }
       const _runIdForTool = this.currentRunId.get(tabId);
-      if (_runIdForTool) {
-        trace.recordToolCall(_runIdForTool, step, {
-          name: fnName, args: fnArgs, result: toolResult, latencyMs: _toolLatency,
-        });
-      }
+      const recordFinalToolTrace = result => {
+        if (_runIdForTool) {
+          trace.recordToolCall(_runIdForTool, step, {
+            name: fnName, args: fnArgs, result, latencyMs: _toolLatency,
+          });
+        }
+      };
+      if (!toolResult?.done) recordFinalToolTrace(toolResult);
 
       // done() short-circuit — push result, persist, and bail out.
       if (toolResult && toolResult.done) {
@@ -2705,6 +2709,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             tool_call_id: tc.id,
             content: this._wrapUntrusted(fnName, this._limitToolResult(blockedResult)),
           });
+          recordFinalToolTrace(blockedResult);
           onUpdate('warning', { message: 'Progress ledger has unresolved rows; continuing.' });
           this._persist(tabId);
           continue;
@@ -2727,6 +2732,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             tool_call_id: tc.id,
             content: JSON.stringify(blockedResult),
           });
+          recordFinalToolTrace(blockedResult);
           // The remaining calls were generated alongside the invalid done,
           // before the model saw the recovery instruction. Never execute that
           // stale batch; close every tool_call and start a fresh model turn.
@@ -2756,6 +2762,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             tool_call_id: tc.id,
             content: JSON.stringify(failedResult),
           });
+          recordFinalToolTrace(failedResult);
           this._appendSyntheticToolResults(
             tabId, toolCalls, toolIndex + 1, messages, onUpdate, step,
             () => ({ success: false, skipped: true, error: 'skipped: plan-only completion failed' })
@@ -2772,6 +2779,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           // are page-derived and get persisted as history for the next turn.
           content: this._wrapUntrusted(fnName, this._limitToolResult(toolResult)),
         });
+        recordFinalToolTrace(toolResult);
         // If `done` wasn't the last call in the batch, the remaining tool_calls
         // in this assistant message still need matching tool results — otherwise
         // the persisted conversation has orphaned tool_calls and the provider
@@ -6379,6 +6387,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this._lastInteractionRect.delete(tabId);
     this._doneBlockCount.delete(tabId);
     this._recentSubmitClicks.delete(tabId);
+    this._lastAxScopes.delete(tabId);
     this.completionInvariants.delete(tabId);
     if (!preserveRunGuard) {
       this._runningTabs.delete(tabId);
@@ -7912,6 +7921,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   _isExecutionMutationEvidence(name, args = {}, capabilities = []) {
     const mutationCapabilities = new Set([
+      Capability.NAVIGATE,
       Capability.CLICK,
       Capability.TYPE,
       Capability.EXECUTE_JS,
@@ -13132,6 +13142,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       );
     };
 
+    const axScope = this._lastAxScopes.get(tabId);
+    const contentArgs = name === 'click_ax' && axScope?.documentToken
+      ? {
+          ...args,
+          expectedDocumentToken: axScope.documentToken,
+          ...(axScope.pageUrl ? { expectedPageUrl: axScope.pageUrl } : {}),
+        }
+      : args;
+
     try {
       let response;
       try {
@@ -13139,7 +13158,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         response = await chrome.tabs.sendMessage(tabId, {
           target: 'content',
           action,
-          params: args,
+          params: contentArgs,
         });
       } catch (e) {
         // Content script might not be injected — try injecting it.
@@ -13161,11 +13180,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           response = await chrome.tabs.sendMessage(tabId, {
             target: 'content',
             action,
-            params: args,
+            params: contentArgs,
           });
         } catch (e2) {
           return { error: `Failed to communicate with page: ${e2.message}` };
         }
+      }
+      if (name === 'get_accessibility_tree' && response?.documentToken) {
+        this._lastAxScopes.set(tabId, {
+          documentToken: response.documentToken,
+          pageUrl: response.refScopeUrl || '',
+        });
+        delete response.documentToken;
+        delete response.refScopeUrl;
       }
       if (name === 'click_ax') {
         response = await this._maybeFallbackClickAxWithCdp(tabId, args, response, clickAxBaseline);

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -52,6 +52,41 @@
   if (!window.__wbElementMap) window.__wbElementMap = Object.create(null);
   if (typeof window.__wbRefCounter !== 'number') window.__wbRefCounter = 0;
 
+  function mintRefScopeId() {
+    try {
+      const words = new Uint32Array(2);
+      globalThis.crypto.getRandomValues(words);
+      const value = (BigInt(words[0]) << 32n) | BigInt(words[1]);
+      return (value % 1000000000000n).toString().padStart(12, '0');
+    } catch {
+      const fallback = `${Date.now()}${Math.random().toString().slice(2)}`.replace(/\D/g, '');
+      return fallback.slice(-12).padStart(12, '0');
+    }
+  }
+
+  function ensureRefScope() {
+    const pageUrl = String(location.href || '');
+    const scope = window.__wbAxRefScope;
+    if (!scope || scope.pageUrl !== pageUrl || !/^\d{12}$/.test(scope.id)) {
+      // A full navigation gets a fresh isolated world automatically. Reset on
+      // SPA route changes too so an old ref can never resolve to a new route's
+      // element with the same local traversal number.
+      window.__wbElementMap = Object.create(null);
+      window.__wbRefCounter = 0;
+      window.__wbAxRefScope = { pageUrl, id: mintRefScopeId() };
+    }
+    return window.__wbAxRefScope;
+  }
+
+  function refOrdinal(refId) {
+    const scope = ensureRefScope();
+    const prefix = `ref_${scope.id}`;
+    const value = String(refId || '');
+    if (!value.startsWith(prefix)) return null;
+    const suffix = value.slice(prefix.length);
+    return /^\d+$/.test(suffix) ? Number(suffix) : null;
+  }
+
   const MAX_NAME_LEN = 100;
 
   // ── Role inference (matches Claude's mapping) ───────────────────────────
@@ -397,13 +432,15 @@
 
   // ── Ref_id management ───────────────────────────────────────────────────
   //
-  // Elements keep the same ref_id across calls: if we already have a WeakRef
-  // pointing at `el`, reuse its key; otherwise mint a new ref_N.
+  // Elements keep the same ref_id across calls on one document route. The
+  // numeric scope prefix changes across documents and SPA routes, so a local
+  // ref counter restart can never alias a target from an older page.
   function getOrMintRef(el) {
+    const prefix = `ref_${ensureRefScope().id}`;
     for (const key in window.__wbElementMap) {
       if (window.__wbElementMap[key].deref() === el) return key;
     }
-    const key = 'ref_' + (++window.__wbRefCounter);
+    const key = prefix + (++window.__wbRefCounter);
     window.__wbElementMap[key] = new WeakRef(el);
     return key;
   }
@@ -664,6 +701,7 @@
 
   function generateAccessibilityTree(filter, maxDepth, maxChars, refId, page) {
     try {
+      ensureRefScope();
       const effFilter = filter || 'all';
       // Tighter defaults for the 'visible' / 'interactive' modes so small
       // models don't drown in 18K-token Stripe trees. Callers can still
@@ -825,6 +863,7 @@
 
   // ── Public: lookup by ref_id (used by click_ax / type_ax) ──────────────
   function lookup(refId) {
+    if (refOrdinal(refId) == null) return null;
     const weak = window.__wbElementMap[refId];
     if (!weak) return null;
     const el = weak.deref();
@@ -848,8 +887,7 @@
   //    interactive text-entry refs to the top of the suggestions.
   function suggestNearRefs(requestedRefId, limit) {
     const cap = typeof limit === 'number' ? limit : 6;
-    const m = /^ref_(\d+)$/.exec(String(requestedRefId || ''));
-    const targetNum = m ? parseInt(m[1], 10) : null;
+    const targetNum = refOrdinal(requestedRefId);
     const live = [];
     for (const key in window.__wbElementMap) {
       const weak = window.__wbElementMap[key];
@@ -859,8 +897,7 @@
         if (!el.isConnected) continue;
         if (!isVisible(el)) continue;
       } catch { continue; }
-      const km = /^ref_(\d+)$/.exec(key);
-      const n = km ? parseInt(km[1], 10) : 0;
+      const n = refOrdinal(key) || 0;
       const role = getRole(el);
       const name = getAccessibleName(el) || '';
       const interactive = isInteractive(el);

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -509,7 +509,7 @@
     return false;
   }
 
-  function _axAccessibleName(el) {
+  function _axCanonicalName(el) {
     try {
       if (typeof window.__wb_ax_name === 'function') {
         const name = window.__wb_ax_name(el);
@@ -517,15 +517,27 @@
       }
     } catch {}
     try {
+      const labelledBy = String(el?.getAttribute?.('aria-labelledby') || '').trim();
+      const labelledText = labelledBy
+        .split(/\s+/)
+        .filter(Boolean)
+        .map(id => document.getElementById(id)?.innerText || document.getElementById(id)?.textContent || '')
+        .join(' ')
+        .trim();
       return String(
         el?.getAttribute?.('aria-label')
+        || labelledText
         || el?.getAttribute?.('title')
-        || el?.innerText
         || ''
       ).trim().slice(0, 160);
     } catch {
       return '';
     }
+  }
+
+  function _axAccessibleName(el) {
+    return _axCanonicalName(el)
+      || String(el?.innerText || '').trim().slice(0, 160);
   }
 
   function _axDocumentToken() {
@@ -3113,7 +3125,8 @@
           const rect = el.getBoundingClientRect();
           const tag = el.tagName ? el.tagName.toLowerCase() : '';
           const targetRole = String(el.getAttribute?.('role') || '').toLowerCase();
-          const targetName = _axAccessibleName(el);
+          const canonicalTargetName = _axCanonicalName(el);
+          const targetName = canonicalTargetName || _axAccessibleName(el);
           const targetContext = (() => {
             try {
               const ownText = String(targetName || el.innerText || '')
@@ -3153,7 +3166,7 @@
           })();
           const genericTags = new Set(['body', 'div', 'span', 'section', 'main', 'article', 'nav', 'ul', 'ol', 'li']);
           const genericRoles = new Set(['', 'generic', 'group', 'list', 'listitem', 'region', 'none', 'presentation']);
-          if (!targetName && genericTags.has(tag) && genericRoles.has(targetRole) && targetContext?.truncated) {
+          if (!canonicalTargetName && genericTags.has(tag) && genericRoles.has(targetRole) && targetContext?.truncated) {
             return failure(
               `ref_id ${ref_id} resolves to an unnamed generic element inside a broad container. Re-read the accessibility tree and choose a named row or control instead of clicking this ambiguous target.`,
               { ambiguousTarget: true, targetContext, documentToken, refScopeUrl: location.href },

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -528,6 +528,13 @@
     }
   }
 
+  function _axDocumentToken() {
+    if (!window.__wbAxDocumentToken) {
+      window.__wbAxDocumentToken = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+    }
+    return window.__wbAxDocumentToken;
+  }
+
   function _axFallbackState(el) {
     const empty = { full: '', strong: '', weak: '' };
     if (!el) return empty;
@@ -3005,6 +3012,8 @@
           if (typeof window.__generateAccessibilityTree !== 'function') {
             return { error: 'accessibility-tree.js not injected' };
           }
+          const documentToken = _axDocumentToken();
+          const refScopeUrl = location.href;
           const { filter, maxDepth, maxChars, ref_id, page } = msg.params || {};
           const gate = detectPageGate();
           if (gate) {
@@ -3017,18 +3026,24 @@
                 const gateMaxDepth = Math.min(Number.isFinite(requestedDepth) ? Math.max(1, Math.trunc(requestedDepth)) : 8, 8);
                 const gateMaxChars = Math.min(Number.isFinite(requestedChars) ? Math.max(256, Math.trunc(requestedChars)) : 3000, 5000);
                 const tree = window.__generateAccessibilitySubtree(gate.element, gateFilter, gateMaxDepth, gateMaxChars, page);
-                return { pageGate, ...tree, textSource: 'page-gate' };
+                return { pageGate, ...tree, textSource: 'page-gate', documentToken, refScopeUrl };
               }
-              return { pageGate, pageContent: gate.label, textSource: 'page-gate' };
+              return { pageGate, pageContent: gate.label, textSource: 'page-gate', documentToken, refScopeUrl };
             }
             const articleRoot = gate.element.closest('article, [role="article"], main, [role="main"]');
             return {
               pageGate,
               pageContent: renderedArticleTextBeforeGate(articleRoot, gate.element),
               textSource: 'article (pre-gate)',
+              documentToken,
+              refScopeUrl,
             };
           }
-          return window.__generateAccessibilityTree(filter, maxDepth, maxChars, ref_id, page);
+          return {
+            ...window.__generateAccessibilityTree(filter, maxDepth, maxChars, ref_id, page),
+            documentToken,
+            refScopeUrl,
+          };
         } catch (e) {
           return { error: 'Failed to build accessibility tree: ' + (e && e.message || String(e)) };
         }
@@ -3044,9 +3059,24 @@
             : { dispatched: false, noDispatch: true, fallbackAttempted: false }),
         });
         try {
-          const { ref_id } = msg.params || {};
+          const { ref_id, expectedDocumentToken, expectedPageUrl } = msg.params || {};
           if (typeof ref_id !== 'string') return failure('ref_id (string, e.g. "ref_42") is required');
           if (typeof window.__wb_ax_lookup !== 'function') return failure('accessibility-tree.js not injected');
+          const documentToken = _axDocumentToken();
+          const documentChanged = !!expectedDocumentToken && expectedDocumentToken !== documentToken;
+          const routeChanged = !!expectedPageUrl && expectedPageUrl !== location.href;
+          if (documentChanged || routeChanged) {
+            return failure(
+              `ref_id ${ref_id} belongs to a previous page or route. Re-read the accessibility tree and choose a fresh ref_id before clicking.`,
+              {
+                staleRef: true,
+                documentChanged,
+                routeChanged,
+                documentToken,
+                refScopeUrl: location.href,
+              },
+            );
+          }
           const el = window.__wb_ax_lookup(ref_id);
           if (!el) {
             let suggestions = [];
@@ -3082,9 +3112,11 @@
           const fallbackStateBefore = _axFallbackState(el);
           const rect = el.getBoundingClientRect();
           const tag = el.tagName ? el.tagName.toLowerCase() : '';
+          const targetRole = String(el.getAttribute?.('role') || '').toLowerCase();
+          const targetName = _axAccessibleName(el);
           const targetContext = (() => {
             try {
-              const ownText = String(_axAccessibleName(el) || el.innerText || '')
+              const ownText = String(targetName || el.innerText || '')
                 .replace(/\s+/g, ' ').trim();
               let fallback = null;
               let node = el.parentElement;
@@ -3104,7 +3136,8 @@
                   '[class*="tile" i]',
                 ].join(','));
                 const context = {
-                  text: text.slice(0, 600),
+                  text: text.slice(0, 240),
+                  ...(text.length > 240 ? { truncated: true } : {}),
                   ...(headingEl ? { heading: String(headingEl.innerText || headingEl.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 160) } : {}),
                   ...(linkEl ? { href: String(linkEl.href || linkEl.getAttribute('href') || '').slice(0, 500) } : {}),
                 };
@@ -3118,6 +3151,14 @@
               return null;
             }
           })();
+          const genericTags = new Set(['body', 'div', 'span', 'section', 'main', 'article', 'nav', 'ul', 'ol', 'li']);
+          const genericRoles = new Set(['', 'generic', 'group', 'list', 'listitem', 'region', 'none', 'presentation']);
+          if (!targetName && genericTags.has(tag) && genericRoles.has(targetRole) && targetContext?.truncated) {
+            return failure(
+              `ref_id ${ref_id} resolves to an unnamed generic element inside a broad container. Re-read the accessibility tree and choose a named row or control instead of clicking this ambiguous target.`,
+              { ambiguousTarget: true, targetContext, documentToken, refScopeUrl: location.href },
+            );
+          }
           const fallbackStatic = _axFallbackStaticAssessment(el);
           let popupRole = '';
           let popupHasPopup = null;
@@ -3203,8 +3244,7 @@
             // the wrong thing — e.g. a sidebar nav link that navigates away
             // from an open modal, silently destroying in-progress form state.
             try {
-              const accName = _axAccessibleName(el);
-              if (accName) resp.name = accName;
+              if (targetName) resp.name = targetName;
             } catch {}
             if (tag === 'a') {
               try {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -159,6 +159,7 @@ export class Agent {
     this.recentCalls = new Map();
     this.loopNudges = new Map();
     this.healthyCallsSinceLoop = new Map();
+    this._lastAxScopes = new Map(); // tabId -> { documentToken, pageUrl }, captured by the latest AX read
     // A model can walk ref_1, ref_2, … forever while every call looks unique
     // to the exact-argument loop detector. Track that semantic read pattern.
     this.axReadStates = new Map();
@@ -2289,15 +2290,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (!toolResult?.done) {
         onUpdate('tool_result', { name: fnName, result: toolResult });
       }
-      try {
-        const runId = this.currentRunId.get(tabId);
-        if (runId) {
-          await trace.recordToolCall(runId, step, {
-            name: fnName, args: fnArgs, result: toolResult,
-            latencyMs: _toolLatency,
-          });
-        }
-      } catch {}
+      const runIdForTool = this.currentRunId.get(tabId);
+      const recordFinalToolTrace = async result => {
+        try {
+          if (runIdForTool) {
+            await trace.recordToolCall(runIdForTool, step, {
+              name: fnName, args: fnArgs, result,
+              latencyMs: _toolLatency,
+            });
+          }
+        } catch {}
+      };
+      if (!toolResult?.done) await recordFinalToolTrace(toolResult);
 
       if (toolResult && toolResult.done) {
         const progressBlock = this._shouldBlockDoneForProgress(tabId)
@@ -2320,6 +2324,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             tool_call_id: tc.id,
             content: this._wrapUntrusted(fnName, this._limitToolResult(blockedResult)),
           });
+          await recordFinalToolTrace(blockedResult);
           onUpdate('warning', { message: 'Progress ledger has unresolved rows; continuing.' });
           this._persist(tabId);
           continue;
@@ -2342,6 +2347,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             tool_call_id: tc.id,
             content: JSON.stringify(blockedResult),
           });
+          await recordFinalToolTrace(blockedResult);
           // The remaining calls were generated alongside the invalid done,
           // before the model saw the recovery instruction. Never execute that
           // stale batch; close every tool_call and start a fresh model turn.
@@ -2371,6 +2377,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             tool_call_id: tc.id,
             content: JSON.stringify(failedResult),
           });
+          await recordFinalToolTrace(failedResult);
           this._appendSyntheticToolResults(
             tabId, toolCalls, toolIndex + 1, messages, onUpdate, step,
             () => ({ success: false, skipped: true, error: 'skipped: plan-only completion failed' })
@@ -2387,6 +2394,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           // are page-derived and get persisted as history for the next turn.
           content: this._wrapUntrusted(fnName, this._limitToolResult(toolResult)),
         });
+        await recordFinalToolTrace(toolResult);
         // If `done` wasn't the last call in the batch, the remaining tool_calls
         // in this assistant message still need matching tool results — otherwise
         // the persisted conversation has orphaned tool_calls and the provider
@@ -5528,6 +5536,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this._nytimesPageGateNotified.delete(tabId);
     this._doneBlockCount.delete(tabId);
     this._recentSubmitClicks.delete(tabId);
+    this._lastAxScopes.delete(tabId);
     this.completionInvariants.delete(tabId);
     if (!preserveRunGuard) {
       this._runningTabs.delete(tabId);
@@ -7040,6 +7049,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   _isExecutionMutationEvidence(name, args = {}, capabilities = []) {
     const mutationCapabilities = new Set([
+      Capability.NAVIGATE,
       Capability.CLICK,
       Capability.TYPE,
       Capability.EXECUTE_JS,
@@ -10061,12 +10071,29 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
     } catch { /* tab lookup failures are non-fatal — fall through */ }
 
+    const axScope = this._lastAxScopes.get(tabId);
+    const contentArgs = name === 'click_ax' && axScope?.documentToken
+      ? {
+          ...args,
+          expectedDocumentToken: axScope.documentToken,
+          ...(axScope.pageUrl ? { expectedPageUrl: axScope.pageUrl } : {}),
+        }
+      : args;
+
     try {
       const response = await browser.tabs.sendMessage(tabId, {
         target: 'content',
         action,
-        params: args,
+        params: contentArgs,
       });
+      if (name === 'get_accessibility_tree' && response?.documentToken) {
+        this._lastAxScopes.set(tabId, {
+          documentToken: response.documentToken,
+          pageUrl: response.refScopeUrl || '',
+        });
+        delete response.documentToken;
+        delete response.refScopeUrl;
+      }
       this._annotateCredentialField(name, response);
       return response;
     } catch (e) {
@@ -10078,8 +10105,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         const response = await browser.tabs.sendMessage(tabId, {
           target: 'content',
           action,
-          params: args,
+          params: contentArgs,
         });
+        if (name === 'get_accessibility_tree' && response?.documentToken) {
+          this._lastAxScopes.set(tabId, {
+            documentToken: response.documentToken,
+            pageUrl: response.refScopeUrl || '',
+          });
+          delete response.documentToken;
+          delete response.refScopeUrl;
+        }
         this._annotateCredentialField(name, response);
         return response;
       } catch (e2) {

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -52,6 +52,41 @@
   if (!window.__wbElementMap) window.__wbElementMap = Object.create(null);
   if (typeof window.__wbRefCounter !== 'number') window.__wbRefCounter = 0;
 
+  function mintRefScopeId() {
+    try {
+      const words = new Uint32Array(2);
+      globalThis.crypto.getRandomValues(words);
+      const value = (BigInt(words[0]) << 32n) | BigInt(words[1]);
+      return (value % 1000000000000n).toString().padStart(12, '0');
+    } catch {
+      const fallback = `${Date.now()}${Math.random().toString().slice(2)}`.replace(/\D/g, '');
+      return fallback.slice(-12).padStart(12, '0');
+    }
+  }
+
+  function ensureRefScope() {
+    const pageUrl = String(location.href || '');
+    const scope = window.__wbAxRefScope;
+    if (!scope || scope.pageUrl !== pageUrl || !/^\d{12}$/.test(scope.id)) {
+      // A full navigation gets a fresh isolated world automatically. Reset on
+      // SPA route changes too so an old ref can never resolve to a new route's
+      // element with the same local traversal number.
+      window.__wbElementMap = Object.create(null);
+      window.__wbRefCounter = 0;
+      window.__wbAxRefScope = { pageUrl, id: mintRefScopeId() };
+    }
+    return window.__wbAxRefScope;
+  }
+
+  function refOrdinal(refId) {
+    const scope = ensureRefScope();
+    const prefix = `ref_${scope.id}`;
+    const value = String(refId || '');
+    if (!value.startsWith(prefix)) return null;
+    const suffix = value.slice(prefix.length);
+    return /^\d+$/.test(suffix) ? Number(suffix) : null;
+  }
+
   const MAX_NAME_LEN = 100;
 
   // ── Role inference (matches Claude's mapping) ───────────────────────────
@@ -397,13 +432,15 @@
 
   // ── Ref_id management ───────────────────────────────────────────────────
   //
-  // Elements keep the same ref_id across calls: if we already have a WeakRef
-  // pointing at `el`, reuse its key; otherwise mint a new ref_N.
+  // Elements keep the same ref_id across calls on one document route. The
+  // numeric scope prefix changes across documents and SPA routes, so a local
+  // ref counter restart can never alias a target from an older page.
   function getOrMintRef(el) {
+    const prefix = `ref_${ensureRefScope().id}`;
     for (const key in window.__wbElementMap) {
       if (window.__wbElementMap[key].deref() === el) return key;
     }
-    const key = 'ref_' + (++window.__wbRefCounter);
+    const key = prefix + (++window.__wbRefCounter);
     window.__wbElementMap[key] = new WeakRef(el);
     return key;
   }
@@ -664,6 +701,7 @@
 
   function generateAccessibilityTree(filter, maxDepth, maxChars, refId, page) {
     try {
+      ensureRefScope();
       const effFilter = filter || 'all';
       // Tighter defaults for the 'visible' / 'interactive' modes so small
       // models don't drown in 18K-token Stripe trees. Callers can still
@@ -825,6 +863,7 @@
 
   // ── Public: lookup by ref_id (used by click_ax / type_ax) ──────────────
   function lookup(refId) {
+    if (refOrdinal(refId) == null) return null;
     const weak = window.__wbElementMap[refId];
     if (!weak) return null;
     const el = weak.deref();
@@ -848,8 +887,7 @@
   //    interactive text-entry refs to the top of the suggestions.
   function suggestNearRefs(requestedRefId, limit) {
     const cap = typeof limit === 'number' ? limit : 6;
-    const m = /^ref_(\d+)$/.exec(String(requestedRefId || ''));
-    const targetNum = m ? parseInt(m[1], 10) : null;
+    const targetNum = refOrdinal(requestedRefId);
     const live = [];
     for (const key in window.__wbElementMap) {
       const weak = window.__wbElementMap[key];
@@ -859,8 +897,7 @@
         if (!el.isConnected) continue;
         if (!isVisible(el)) continue;
       } catch { continue; }
-      const km = /^ref_(\d+)$/.exec(key);
-      const n = km ? parseInt(km[1], 10) : 0;
+      const n = refOrdinal(key) || 0;
       const role = getRole(el);
       const name = getAccessibleName(el) || '';
       const interactive = isInteractive(el);

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -894,7 +894,7 @@
     return false;
   }
 
-  function _axAccessibleName(el) {
+  function _axCanonicalName(el) {
     try {
       if (typeof window.__wb_ax_name === 'function') {
         const name = window.__wb_ax_name(el);
@@ -913,12 +913,16 @@
         el?.getAttribute?.('aria-label')
         || labelledText
         || el?.getAttribute?.('title')
-        || el?.innerText
         || ''
       ).trim().slice(0, 160);
     } catch {
       return '';
     }
+  }
+
+  function _axAccessibleName(el) {
+    return _axCanonicalName(el)
+      || String(el?.innerText || '').trim().slice(0, 160);
   }
 
   function _axDocumentToken() {
@@ -2564,7 +2568,8 @@
           }
           const tag = el.tagName ? el.tagName.toLowerCase() : '';
           const targetRole = String(el.getAttribute?.('role') || '').toLowerCase();
-          const targetName = _axAccessibleName(el);
+          const canonicalTargetName = _axCanonicalName(el);
+          const targetName = canonicalTargetName || _axAccessibleName(el);
           try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
           try { el.focus({ preventScroll: true }); } catch {}
           const rect = el.getBoundingClientRect();
@@ -2607,7 +2612,7 @@
           })();
           const genericTags = new Set(['body', 'div', 'span', 'section', 'main', 'article', 'nav', 'ul', 'ol', 'li']);
           const genericRoles = new Set(['', 'generic', 'group', 'list', 'listitem', 'region', 'none', 'presentation']);
-          if (!targetName && genericTags.has(tag) && genericRoles.has(targetRole) && targetContext?.truncated) {
+          if (!canonicalTargetName && genericTags.has(tag) && genericRoles.has(targetRole) && targetContext?.truncated) {
             return failure(
               `ref_id ${ref_id} resolves to an unnamed generic element inside a broad container. Re-read the accessibility tree and choose a named row or control instead of clicking this ambiguous target.`,
               { ambiguousTarget: true, targetContext, documentToken, refScopeUrl: location.href },

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -921,6 +921,13 @@
     }
   }
 
+  function _axDocumentToken() {
+    if (!window.__wbAxDocumentToken) {
+      window.__wbAxDocumentToken = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+    }
+    return window.__wbAxDocumentToken;
+  }
+
   /** Walk up from a passive child to find its interactive ancestor (up to 5 levels). */
   function _resolveInteractiveAncestor(el) {
     if (!_PASSIVE_TAGS.has(el.tagName) || _isInteractive(el)) return el;
@@ -2476,6 +2483,8 @@
           if (typeof window.__generateAccessibilityTree !== 'function') {
             return { error: 'accessibility-tree.js not injected' };
           }
+          const documentToken = _axDocumentToken();
+          const refScopeUrl = location.href;
           const { filter, maxDepth, maxChars, ref_id, page } = msg.params || {};
           const gate = detectPageGate();
           if (gate) {
@@ -2488,18 +2497,24 @@
                 const gateMaxDepth = Math.min(Number.isFinite(requestedDepth) ? Math.max(1, Math.trunc(requestedDepth)) : 8, 8);
                 const gateMaxChars = Math.min(Number.isFinite(requestedChars) ? Math.max(256, Math.trunc(requestedChars)) : 3000, 5000);
                 const tree = window.__generateAccessibilitySubtree(gate.element, gateFilter, gateMaxDepth, gateMaxChars, page);
-                return { pageGate, ...tree, textSource: 'page-gate' };
+                return { pageGate, ...tree, textSource: 'page-gate', documentToken, refScopeUrl };
               }
-              return { pageGate, pageContent: gate.label, textSource: 'page-gate' };
+              return { pageGate, pageContent: gate.label, textSource: 'page-gate', documentToken, refScopeUrl };
             }
             const articleRoot = gate.element.closest('article, [role="article"], main, [role="main"]');
             return {
               pageGate,
               pageContent: renderedArticleTextBeforeGate(articleRoot, gate.element),
               textSource: 'article (pre-gate)',
+              documentToken,
+              refScopeUrl,
             };
           }
-          return window.__generateAccessibilityTree(filter, maxDepth, maxChars, ref_id, page);
+          return {
+            ...window.__generateAccessibilityTree(filter, maxDepth, maxChars, ref_id, page),
+            documentToken,
+            refScopeUrl,
+          };
         } catch (e) {
           return { error: 'Failed to build accessibility tree: ' + (e && e.message || String(e)) };
         }
@@ -2515,9 +2530,24 @@
             : { dispatched: false, noDispatch: true, fallbackAttempted: false }),
         });
         try {
-          const { ref_id } = msg.params || {};
+          const { ref_id, expectedDocumentToken, expectedPageUrl } = msg.params || {};
           if (typeof ref_id !== 'string') return failure('ref_id (string, e.g. "ref_42") is required');
           if (typeof window.__wb_ax_lookup !== 'function') return failure('accessibility-tree.js not injected');
+          const documentToken = _axDocumentToken();
+          const documentChanged = !!expectedDocumentToken && expectedDocumentToken !== documentToken;
+          const routeChanged = !!expectedPageUrl && expectedPageUrl !== location.href;
+          if (documentChanged || routeChanged) {
+            return failure(
+              `ref_id ${ref_id} belongs to a previous page or route. Re-read the accessibility tree and choose a fresh ref_id before clicking.`,
+              {
+                staleRef: true,
+                documentChanged,
+                routeChanged,
+                documentToken,
+                refScopeUrl: location.href,
+              },
+            );
+          }
           const el = window.__wb_ax_lookup(ref_id);
           if (!el) {
             let suggestions = [];
@@ -2533,12 +2563,14 @@
             return failure(`ref_id ${ref_id} not found.${formatNote} The element may have been removed or the page replaced.${hint} Re-read the accessibility tree to get fresh ids — do NOT guess ref numbers or invent placeholders.`, { suggestions });
           }
           const tag = el.tagName ? el.tagName.toLowerCase() : '';
+          const targetRole = String(el.getAttribute?.('role') || '').toLowerCase();
+          const targetName = _axAccessibleName(el);
           try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
           try { el.focus({ preventScroll: true }); } catch {}
           const rect = el.getBoundingClientRect();
           const targetContext = (() => {
             try {
-              const ownText = String(_axAccessibleName(el) || el.innerText || '')
+              const ownText = String(targetName || el.innerText || '')
                 .replace(/\s+/g, ' ').trim();
               let fallback = null;
               let node = el.parentElement;
@@ -2558,7 +2590,8 @@
                   '[class*="tile" i]',
                 ].join(','));
                 const context = {
-                  text: text.slice(0, 600),
+                  text: text.slice(0, 240),
+                  ...(text.length > 240 ? { truncated: true } : {}),
                   ...(headingEl ? { heading: String(headingEl.innerText || headingEl.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 160) } : {}),
                   ...(linkEl ? { href: String(linkEl.href || linkEl.getAttribute('href') || '').slice(0, 500) } : {}),
                 };
@@ -2572,6 +2605,14 @@
               return null;
             }
           })();
+          const genericTags = new Set(['body', 'div', 'span', 'section', 'main', 'article', 'nav', 'ul', 'ol', 'li']);
+          const genericRoles = new Set(['', 'generic', 'group', 'list', 'listitem', 'region', 'none', 'presentation']);
+          if (!targetName && genericTags.has(tag) && genericRoles.has(targetRole) && targetContext?.truncated) {
+            return failure(
+              `ref_id ${ref_id} resolves to an unnamed generic element inside a broad container. Re-read the accessibility tree and choose a named row or control instead of clicking this ambiguous target.`,
+              { ambiguousTarget: true, targetContext, documentToken, refScopeUrl: location.href },
+            );
+          }
           let popupRole = '';
           let popupHasPopup = null;
           let isPopupOpener = false;
@@ -2637,8 +2678,7 @@
               ...(targetContext ? { targetContext } : {}),
             };
             try {
-              const accName = _axAccessibleName(el);
-              if (accName) resp.name = accName;
+              if (targetName) resp.name = targetName;
             } catch {}
             if (tag === 'a') {
               try {

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -695,6 +695,45 @@ for (const browserKind of ['chrome', 'firefox']) {
     }
   });
 
+  test(`click_ax (${browserKind}): refs are rejected after a same-document route change`, async (page) => {
+    await setupContentFixture(page, 'trusted-click-fallback.html', browserKind);
+    const tree = await call(page, 'get_accessibility_tree', { filter: 'all', maxDepth: 10, maxChars: 20000 });
+    const match = String(tree?.pageContent || '').match(/listitem "Normal synthetic row" \[(ref_\d+)\]/);
+    if (!match || !tree?.documentToken || !tree?.refScopeUrl) {
+      throw new Error(`expected scoped AX ref, got: ${JSON.stringify(tree)}`);
+    }
+    await page.evaluate(() => history.pushState({}, '', '#different-route'));
+    const result = await call(page, 'click_ax', {
+      ref_id: match[1],
+      expectedDocumentToken: tree.documentToken,
+      expectedPageUrl: tree.refScopeUrl,
+    });
+    if (
+      result?.success !== false
+      || result?.staleRef !== true
+      || result?.routeChanged !== true
+      || result?.dispatched !== false
+    ) {
+      throw new Error(`expected route-scoped stale-ref failure, got: ${JSON.stringify(result)}`);
+    }
+  });
+
+  test(`click_ax (${browserKind}): unnamed broad generic targets are rejected`, async (page) => {
+    await setupContentFixture(page, 'trusted-click-fallback.html', browserKind);
+    const tree = await call(page, 'get_accessibility_tree', { filter: 'all', maxDepth: 10, maxChars: 20000 });
+    const match = String(tree?.pageContent || '').match(/group \[(ref_\d+)\]/);
+    if (!match) throw new Error(`could not find unnamed broad group in AX tree: ${tree?.pageContent}`);
+    const result = await call(page, 'click_ax', { ref_id: match[1] });
+    if (
+      result?.success !== false
+      || result?.ambiguousTarget !== true
+      || result?.dispatched !== false
+      || result?.targetContext?.truncated !== true
+    ) {
+      throw new Error(`expected ambiguous generic target failure, got: ${JSON.stringify(result)}`);
+    }
+  });
+
   test(`input tools (${browserKind}): invalid targets and keys are explicit pre-dispatch failures`, async (page) => {
     await setupContentFixture(page, 'trusted-click-fallback.html', browserKind);
     const calls = [
@@ -734,7 +773,7 @@ for (const browserKind of ['chrome', 'firefox']) {
       throw new Error(`nearest product context missing or wrong: ${JSON.stringify(result)}`);
     }
     if (
-      String(result.targetContext.text).length > 600
+      String(result.targetContext.text).length > 240
       || String(result.targetContext.heading).length > 160
       || String(result.targetContext.href).length > 500
     ) {

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -583,6 +583,14 @@ const gmailComposeRecipientFixture = `<!doctype html>
 
 let chromeGmailComposeTree = '';
 
+function normalizeTreeRefs(content) {
+  const refs = new Map();
+  return String(content || '').replace(/ref_\d+/g, ref => {
+    if (!refs.has(ref)) refs.set(ref, `ref_${refs.size + 1}`);
+    return refs.get(ref);
+  });
+}
+
 function assertGmailComposeRecipientTree(tree, label) {
   const content = String(tree?.pageContent || '');
   if (!/generic "Alex Russell \(gmail\.com\)" \[ref_\d+\]/.test(content)) {
@@ -597,7 +605,7 @@ function assertGmailComposeRecipientTree(tree, label) {
   for (const forbidden of ['To recipients', 'Hidden stale recipient', 'Opacity hidden override', 'Offscreen hidden override', 'ARIA hidden override', 'Hidden wrapper text', 'generic "Composite controls', 'x'.repeat(101)]) {
     if (content.includes(forbidden)) throw new Error(`${label}: tree promoted forbidden generic text: ${forbidden}`);
   }
-  return content;
+  return normalizeTreeRefs(content);
 }
 
 test('accessibility tree (Chrome): existing Gmail compose exposes the selected recipient chip', async (page) => {
@@ -715,6 +723,49 @@ for (const browserKind of ['chrome', 'firefox']) {
       || result?.dispatched !== false
     ) {
       throw new Error(`expected route-scoped stale-ref failure, got: ${JSON.stringify(result)}`);
+    }
+  });
+
+  test(`click_ax (${browserKind}): an old ref cannot alias after the new route tree is read`, async (page) => {
+    await setupContentFixture(page, 'trusted-click-fallback.html', browserKind);
+    const firstTree = await call(page, 'get_accessibility_tree', { filter: 'all', maxDepth: 10, maxChars: 20000 });
+    const firstMatch = String(firstTree?.pageContent || '').match(/listitem "Normal synthetic row" \[(ref_\d+)\]/);
+    if (!firstMatch) throw new Error(`expected first-route ref, got: ${JSON.stringify(firstTree)}`);
+
+    await page.evaluate(() => history.pushState({}, '', '#new-tree-route'));
+    const secondTree = await call(page, 'get_accessibility_tree', { filter: 'all', maxDepth: 10, maxChars: 20000 });
+    const secondMatch = String(secondTree?.pageContent || '').match(/listitem "Normal synthetic row" \[(ref_\d+)\]/);
+    if (!secondMatch || !secondTree?.documentToken || !secondTree?.refScopeUrl) {
+      throw new Error(`expected second-route scoped AX ref, got: ${JSON.stringify(secondTree)}`);
+    }
+    if (firstMatch[1] === secondMatch[1]) {
+      throw new Error(`route-scoped refs must not reuse the same identifier: ${firstMatch[1]}`);
+    }
+
+    // Simulate the reviewed failure exactly: the agent has already cached the
+    // latest route scope but the model reuses a ref string from the old tree.
+    const stale = await call(page, 'click_ax', {
+      ref_id: firstMatch[1],
+      expectedDocumentToken: secondTree.documentToken,
+      expectedPageUrl: secondTree.refScopeUrl,
+    });
+    if (
+      stale?.success !== false
+      || stale?.dispatched !== false
+      || stale?.noDispatch !== true
+      || stale?.fallbackAttempted !== false
+      || !/not found/i.test(stale?.error || '')
+    ) {
+      throw new Error(`expected old ref to fail before dispatch, got: ${JSON.stringify(stale)}`);
+    }
+
+    const fresh = await call(page, 'click_ax', {
+      ref_id: secondMatch[1],
+      expectedDocumentToken: secondTree.documentToken,
+      expectedPageUrl: secondTree.refScopeUrl,
+    });
+    if (!fresh?.success) {
+      throw new Error(`expected current-route ref to remain usable, got: ${JSON.stringify(fresh)}`);
     }
   });
 

--- a/test/fixtures/trusted-click-fallback.html
+++ b/test/fixtures/trusted-click-fallback.html
@@ -97,14 +97,13 @@
     </div>
   </article>
   <section id="ambiguous-context">
-    <div id="ambiguous-target" class="row" role="group" tabindex="0"></div>
-    <p>
-      Archived conversations and navigation items from many unrelated contacts appear in this broad container.
-      This deliberately long surrounding context repeats enough descriptive page copy to make an unnamed generic
-      child unsafe to click without a fresh, named accessibility target. Archived conversations and navigation
-      items from many unrelated contacts appear in this broad container, alongside settings, shortcuts, status
-      notices, filters, and other controls that are not the requested destination.
-    </p>
+    <div id="ambiguous-target" class="row" role="group" tabindex="0">
+      <span>Archived conversations and navigation items from many unrelated contacts appear in this broad container.</span>
+      <span>This deliberately long surrounding context repeats enough descriptive page copy to make an unnamed generic
+        target unsafe to click without a fresh, named accessibility target. Archived conversations and navigation
+        items from many unrelated contacts appear in this broad container, alongside settings, shortcuts, status
+        notices, filters, and other controls that are not the requested destination.</span>
+    </div>
   </section>
   <div id="trusted-row" class="row" role="listitem" tabindex="0">Defne Sokullu Yesterday Photo</div>
   <div id="synthetic-row" class="row" role="listitem" tabindex="0">Normal synthetic row</div>

--- a/test/fixtures/trusted-click-fallback.html
+++ b/test/fixtures/trusted-click-fallback.html
@@ -96,6 +96,16 @@
       </button>
     </div>
   </article>
+  <section id="ambiguous-context">
+    <div id="ambiguous-target" class="row" role="group" tabindex="0"></div>
+    <p>
+      Archived conversations and navigation items from many unrelated contacts appear in this broad container.
+      This deliberately long surrounding context repeats enough descriptive page copy to make an unnamed generic
+      child unsafe to click without a fresh, named accessibility target. Archived conversations and navigation
+      items from many unrelated contacts appear in this broad container, alongside settings, shortcuts, status
+      notices, filters, and other controls that are not the requested destination.
+    </p>
+  </section>
   <div id="trusted-row" class="row" role="listitem" tabindex="0">Defne Sokullu Yesterday Photo</div>
   <div id="synthetic-row" class="row" role="listitem" tabindex="0">Normal synthetic row</div>
   <div id="tabindex-negative-row" class="row focus-wrapper-row" role="listitem">

--- a/test/run.js
+++ b/test/run.js
@@ -31428,7 +31428,8 @@ test('click_ax captures bounded nearest product/card context in both content scr
     const source = fs.readFileSync(path.join(ROOT, rel), 'utf8');
     const axSource = fs.readFileSync(path.join(ROOT, axRel), 'utf8');
     assert.match(source, /const targetContext = \(\(\) => \{/, `${label}: targetContext capture missing`);
-    assert.match(source, /const targetName = _axAccessibleName\(el\)/, `${label}: click target does not cache the canonical AX accessible name`);
+    assert.match(source, /const canonicalTargetName = _axCanonicalName\(el\)/, `${label}: broad-target guard does not cache the canonical AX accessible name`);
+    assert.match(source, /const targetName = canonicalTargetName \|\| _axAccessibleName\(el\)/, `${label}: click result loses its bounded display-name fallback`);
     assert.match(source, /const ownText = String\(targetName \|\| el\.innerText \|\| ''\)/, `${label}: targetContext does not use the AX accessible name`);
     assert.match(axSource, /window\.__wb_ax_name = getAccessibleName;/, `${label}: accessibility tree does not expose its canonical name helper`);
     assert.match(source, /depth < 6/, `${label}: ancestor search is not bounded`);
@@ -31438,6 +31439,7 @@ test('click_ax captures bounded nearest product/card context in both content scr
     assert.match(source, /\.slice\(0,\s*500\)/, `${label}: href is not bounded`);
     assert.match(source, /const productCard = .*node\.matches/s, `${label}: product/card ancestor detection missing`);
     assert.match(source, /ambiguousTarget: true/, `${label}: unnamed broad generic click guard missing`);
+    assert.match(source, /if \(!canonicalTargetName && genericTags\.has\(tag\)/, `${label}: broad-target guard still trusts innerText fallback names`);
     assert.match(source, /expectedDocumentToken/, `${label}: document-scoped AX ref guard missing`);
     assert.match(source, /expectedPageUrl/, `${label}: route-scoped AX ref guard missing`);
     assert.match(source, /\.\.\.\(targetContext \? \{ targetContext \} : \{\}\)/, `${label}: click_ax result does not expose targetContext`);

--- a/test/run.js
+++ b/test/run.js
@@ -31440,6 +31440,11 @@ test('click_ax captures bounded nearest product/card context in both content scr
     assert.match(source, /const productCard = .*node\.matches/s, `${label}: product/card ancestor detection missing`);
     assert.match(source, /ambiguousTarget: true/, `${label}: unnamed broad generic click guard missing`);
     assert.match(source, /if \(!canonicalTargetName && genericTags\.has\(tag\)/, `${label}: broad-target guard still trusts innerText fallback names`);
+    assert.match(axSource, /function ensureRefScope\(\)/, `${label}: route-scoped AX ref registry missing`);
+    assert.match(axSource, /scope\.pageUrl !== pageUrl/, `${label}: AX refs are not invalidated across SPA routes`);
+    assert.match(axSource, /window\.__wbElementMap = Object\.create\(null\)/, `${label}: stale AX refs survive a scope change`);
+    assert.match(axSource, /const key = prefix \+ \(\+\+window\.__wbRefCounter\)/, `${label}: AX refs do not carry their document-route scope`);
+    assert.match(axSource, /if \(refOrdinal\(refId\) == null\) return null/, `${label}: stale scoped refs can still reach element lookup`);
     assert.match(source, /expectedDocumentToken/, `${label}: document-scoped AX ref guard missing`);
     assert.match(source, /expectedPageUrl/, `${label}: route-scoped AX ref guard missing`);
     assert.match(source, /\.\.\.\(targetContext \? \{ targetContext \} : \{\}\)/, `${label}: click_ax result does not expose targetContext`);

--- a/test/run.js
+++ b/test/run.js
@@ -27311,8 +27311,8 @@ test('execution evidence ignores failed, denied, skipped, blocked, and unknown o
     const tabId = 8614 + index;
     assert.equal(
       agent._isExecutionMutationEvidence('navigate', { url: 'https://example.com/next' }, [Capability.NAVIGATE]),
-      false,
-      `${AgentClass.name}: navigation counted as mutation evidence`,
+      true,
+      `${AgentClass.name}: navigation was not counted as mutation evidence`,
     );
     assert.equal(
       agent._isExecutionMutationEvidence('scroll', { direction: 'down' }, []),
@@ -27351,7 +27351,6 @@ test('execution evidence ignores failed, denied, skipped, blocked, and unknown o
       agent._markPlanExecutionToolCall(tabId, 'click_ax', result, { consequential: true });
     }
     for (const [name, args, toolCapabilities] of [
-      ['navigate', { url: 'https://example.com/next' }, [Capability.NAVIGATE]],
       ['scroll', { direction: 'down' }, []],
       ['fetch_url', { method: 'GET' }, [Capability.NETWORK]],
     ]) {
@@ -27362,8 +27361,83 @@ test('execution evidence ignores failed, denied, skipped, blocked, and unknown o
     agent._markPlanExecutionToolCall(tabId, 'read_page', { success: true }, { consequential: false });
     assert.equal(agent._executionEvidenceSatisfied(state), false, `${AgentClass.name}: invalid mutation evidence was counted`);
 
-    agent._markPlanExecutionToolCall(tabId, 'click_ax', { success: true }, { consequential: true });
-    assert.equal(agent._executionEvidenceSatisfied(state), true, `${AgentClass.name}: successful mutation evidence was not counted`);
+    agent._markPlanExecutionToolCall(tabId, 'navigate', { success: true }, { consequential: true });
+    assert.equal(agent._executionEvidenceSatisfied(state), true, `${AgentClass.name}: successful navigation evidence was not counted`);
+  }
+});
+
+test('Act accepts a verified navigation as execution for a state-change plan', async () => {
+  for (const [index, AgentClass] of [AgentCh, AgentFx].entries()) {
+    const responses = [
+      {
+        content: null,
+        toolCalls: [{
+          id: `navigate_${index}`,
+          function: { name: 'navigate', arguments: JSON.stringify({ url: 'https://yahoo.com/' }) },
+        }],
+      },
+      {
+        content: null,
+        toolCalls: [{
+          id: `verify_${index}`,
+          function: { name: 'get_accessibility_tree', arguments: JSON.stringify({ filter: 'visible' }) },
+        }],
+      },
+      {
+        content: null,
+        toolCalls: [{
+          id: `done_${index}`,
+          function: {
+            name: 'done',
+            arguments: JSON.stringify({ summary: 'Yahoo opened and verified.', outcome: 'success' }),
+          },
+        }],
+      },
+    ];
+    const provider = {
+      supportsTools: true,
+      supportsVision: false,
+      promptTier: 'full',
+      contextWindow: 128000,
+      model: 'test-model',
+      name: 'test-provider',
+      chat: async () => {
+        const next = responses.shift();
+        assert.ok(next, `${AgentClass.name}: navigation flow requested an unexpected recovery turn`);
+        return next;
+      },
+    };
+    const agent = new AgentClass({ getActive: () => provider, getVisionProvider: async () => null });
+    const tabId = 8640 + index;
+    configurePlanOnlyGuardAgent(agent, tabId);
+    agent._maybeRunPlannerGate = async () => ({
+      proceed: true,
+      requestKind: 'execute',
+      requiresStateChange: true,
+    });
+    let currentUrl = 'https://example.com/';
+    agent._currentUrl = async () => currentUrl;
+    agent.executeTool = async (_toolTabId, name, args) => {
+      if (name === 'navigate') {
+        currentUrl = args.url;
+        return { success: true, url: currentUrl };
+      }
+      if (name === 'get_accessibility_tree') {
+        return { success: true, pageContent: 'Yahoo homepage', url: currentUrl };
+      }
+      if (name === 'done') return { done: true, summary: args.summary, outcome: args.outcome };
+      throw new Error(`unexpected tool ${name}`);
+    };
+
+    const final = await agent.processMessage(tabId, 'Go to yahoo.com.', () => {}, 'act');
+
+    assert.equal(final, 'Yahoo opened and verified.', `${AgentClass.name}: verified navigation ended as plan-only output`);
+    assert.equal(responses.length, 0, `${AgentClass.name}: navigation flow did not finish in one done call`);
+    assert.equal(
+      agent.conversations.get(tabId).some(message => /"planOnlyTerminal":true/.test(String(message.content || ''))),
+      false,
+      `${AgentClass.name}: successful navigation was incorrectly rejected as plan-only`,
+    );
   }
 });
 
@@ -31354,14 +31428,35 @@ test('click_ax captures bounded nearest product/card context in both content scr
     const source = fs.readFileSync(path.join(ROOT, rel), 'utf8');
     const axSource = fs.readFileSync(path.join(ROOT, axRel), 'utf8');
     assert.match(source, /const targetContext = \(\(\) => \{/, `${label}: targetContext capture missing`);
-    assert.match(source, /const ownText = String\(_axAccessibleName\(el\) \|\| el\.innerText \|\| ''\)/, `${label}: targetContext does not use the AX accessible name`);
+    assert.match(source, /const targetName = _axAccessibleName\(el\)/, `${label}: click target does not cache the canonical AX accessible name`);
+    assert.match(source, /const ownText = String\(targetName \|\| el\.innerText \|\| ''\)/, `${label}: targetContext does not use the AX accessible name`);
     assert.match(axSource, /window\.__wb_ax_name = getAccessibleName;/, `${label}: accessibility tree does not expose its canonical name helper`);
     assert.match(source, /depth < 6/, `${label}: ancestor search is not bounded`);
-    assert.match(source, /text:\s*text\.slice\(0,\s*600\)/, `${label}: context text is not bounded`);
+    assert.match(source, /text:\s*text\.slice\(0,\s*240\)/, `${label}: context text is not tightly bounded`);
+    assert.match(source, /text\.length > 240 \? \{ truncated: true \}/, `${label}: broad target context is not marked as truncated`);
     assert.match(source, /\.slice\(0,\s*160\)/, `${label}: heading is not bounded`);
     assert.match(source, /\.slice\(0,\s*500\)/, `${label}: href is not bounded`);
     assert.match(source, /const productCard = .*node\.matches/s, `${label}: product/card ancestor detection missing`);
+    assert.match(source, /ambiguousTarget: true/, `${label}: unnamed broad generic click guard missing`);
+    assert.match(source, /expectedDocumentToken/, `${label}: document-scoped AX ref guard missing`);
+    assert.match(source, /expectedPageUrl/, `${label}: route-scoped AX ref guard missing`);
     assert.match(source, /\.\.\.\(targetContext \? \{ targetContext \} : \{\}\)/, `${label}: click_ax result does not expose targetContext`);
+  }
+});
+
+test('agent forwards private AX scope and records only the final done verdict', () => {
+  for (const [label, rel] of [
+    ['chrome', 'src/chrome/src/agent/agent.js'],
+    ['firefox', 'src/firefox/src/agent/agent.js'],
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+    assert.match(source, /this\._lastAxScopes = new Map\(\)/, `${label}: per-tab AX ref scope cache missing`);
+    assert.match(source, /expectedDocumentToken: axScope\.documentToken/, `${label}: click_ax does not receive the private document scope`);
+    assert.match(source, /expectedPageUrl: axScope\.pageUrl/, `${label}: click_ax does not receive the private route scope`);
+    assert.match(source, /delete response\.documentToken/, `${label}: private AX document token leaks into model context`);
+    assert.match(source, /if \(!toolResult\?\.done\) (?:await )?recordFinalToolTrace\(toolResult\)/, `${label}: raw done is still recorded before terminal guards`);
+    assert.match(source, /recordFinalToolTrace\(blockedResult\)/, `${label}: blocked done verdict is not recorded`);
+    assert.match(source, /recordFinalToolTrace\(failedResult\)/, `${label}: failed done verdict is not recorded`);
   }
 });
 


### PR DESCRIPTION
## What changed

- Count successful navigation and history tools as consequential execution evidence for state-changing plans.
- Record the final accepted, blocked, or failed `done` verdict in traces instead of the pre-guard raw result.
- Scope accessibility refs to the document and current SPA route before `click_ax` dispatch.
- Reject unnamed generic click targets with broad surrounding context and reduce target-context payloads from 600 to 240 characters.
- Mirror the behavior in Chrome and Firefox and add unit plus browser-fixture regressions.

## Why

Simple requests such as opening X or Yahoo navigated successfully and verified the destination, but the plan-only guard still reported `Agent stopped` because `Capability.NAVIGATE` was omitted from mutation evidence. The exported trace was misleading because it recorded the raw successful `done` result before the terminal guards replaced it.

Separately, accessibility refs could be reused after a navigation or SPA route change, and unnamed broad containers could be clicked as if they were precise rows. Both paths increased the chance of early wrong clicks.

## Impact

Verified navigation tasks now terminate successfully without a false stop. Stale or ambiguous accessibility targets fail before click dispatch and ask the agent to refresh the tree, while precise named targets and measured coordinate flows remain supported.

## Validation

- `git diff --check`
- `node test/run.js` — 981 passed
- `npm run test:fixtures` — 63 passed
- `npm test` — 981 functional tests and 60 security checks passed
- `npm run test:security` — 60/60 passed