### PR TITLE
Add permanent WebBrain tweet suggested action

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1857,7 +1857,7 @@ export class Agent {
   static EXECUTION_APP_STATE_WRITE_TOOLS = new Set(['scratchpad_write', 'progress_update']);
   static DELIVERY_OBSERVATION_TOOLS = new Set(['read_page', 'get_accessibility_tree', 'get_interactive_elements', 'extract_data', 'get_selection', 'scroll', 'wait_for_stable', 'wait_for_element', 'read_pdf', 'fetch_url', 'research_url', 'read_downloaded_file', 'iframe_read', 'get_window_info', 'list_downloads', 'progress_read', 'screenshot', 'get_frames', 'get_shadow_dom', 'shadow_dom_query', 'read_youtube_transcript']);
   static NAV_PRONE_TOOLS = new Set(['click', 'click_ax', 'navigate', 'go_back', 'go_forward', 'execute_js', 'iframe_click']);
-  static RECOMMENDED_ACTION_FAST_PATH_IDS = new Set(['download-media']);
+  static RECOMMENDED_ACTION_FAST_PATH_IDS = new Set(['download-media', 'tweet-webbrain']);
   static RECOMMENDED_ACTION_FIRST_TOOLS = Object.freeze({
     'download-media': new Set(['screenshot']),
     'summarize-page': new Set(['read_page']),
@@ -4794,6 +4794,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (tool !== 'download_public_media') return null;
       if (!this._skillToolForName(tool)) return null;
     }
+    if (id === 'tweet-webbrain' && tool !== 'navigate') return null;
     const summary = sanitizePlannerText(action.summary || 'Run the selected recommended action.', 500, { collapseWhitespace: true });
     const steps = Array.isArray(action.steps)
       ? action.steps.map(step => sanitizePlannerText(step, 300, { collapseWhitespace: true })).filter(Boolean).slice(0, 5)

--- a/src/chrome/src/ui/recommended-actions.js
+++ b/src/chrome/src/ui/recommended-actions.js
@@ -136,6 +136,22 @@ function visibleTreeArgs(maxDepth = 10) {
   return { filter: 'visible', maxDepth };
 }
 
+function webbrainTweetRunOptions() {
+  return {
+    id: 'tweet-webbrain',
+    skipPlanner: true,
+    tool: 'navigate',
+    summary: 'Publish a concise promotional tweet about WebBrain.',
+    steps: [
+      'Open https://x.com/compose/post in the current tab through the visible browser UI.',
+      'Draft a concise, engaging tweet that describes WebBrain as an open-source AI browser agent for chatting with pages, automating tasks, and running multi-step workflows with the user’s choice of LLM.',
+      'Include https://webbrain.one, keep the post within X’s character limit, and avoid claims that cannot be verified from the supplied WebBrain description.',
+      'Enter the tweet in the visible X composer and publish it.',
+      'Verify the new tweet appears, then report its URL when available.',
+    ],
+  };
+}
+
 function hasCartOrPriceSignal(pageInfo = {}) {
   const haystack = [
     pageInfo.title,
@@ -225,6 +241,14 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
   const host = hostFromUrl(pageInfo.url || '');
   const path = pathFromUrl(pageInfo.url || '');
   const actions = [];
+
+  addUnique(actions, {
+    id: 'tweet-webbrain',
+    label: 'Tweet about WebBrain',
+    prompt: 'Publish a concise, engaging tweet about WebBrain through the visible X interface. Describe it as an open-source AI browser agent for chatting with pages, automating tasks, and running multi-step workflows with the user’s choice of LLM. Include https://webbrain.one, verify the tweet was posted, and report its URL when available.',
+    mode: 'act',
+    runOptions: webbrainTweetRunOptions(),
+  });
 
   if (MEETING_HOST_RE.test(host)) {
     addUnique(actions, {
@@ -393,7 +417,7 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     });
   }
 
-  if (!actions.length && pageInfo.title) {
+  if (!actions.some((action) => action.id !== 'tweet-webbrain') && pageInfo.title) {
     const explainUsesArticleRead = isLongArticle(pageInfo);
     addUnique(actions, {
       id: 'explain-page',

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1630,7 +1630,7 @@ export class Agent {
   static EXECUTION_APP_STATE_WRITE_TOOLS = new Set(['scratchpad_write', 'progress_update']);
   static DELIVERY_OBSERVATION_TOOLS = new Set(['read_page', 'get_accessibility_tree', 'get_interactive_elements', 'extract_data', 'get_selection', 'scroll', 'wait_for_stable', 'wait_for_element', 'read_pdf', 'fetch_url', 'research_url', 'read_downloaded_file', 'iframe_read', 'get_window_info', 'list_downloads', 'progress_read', 'screenshot', 'get_frames', 'get_shadow_dom', 'shadow_dom_query', 'read_youtube_transcript']);
   static NAV_PRONE_TOOLS = new Set(['click', 'click_ax', 'navigate', 'go_back', 'go_forward', 'execute_js', 'iframe_click']);
-  static RECOMMENDED_ACTION_FAST_PATH_IDS = new Set(['download-media']);
+  static RECOMMENDED_ACTION_FAST_PATH_IDS = new Set(['download-media', 'tweet-webbrain']);
   static RECOMMENDED_ACTION_FIRST_TOOLS = Object.freeze({
     'download-media': new Set(['screenshot']),
     'summarize-page': new Set(['read_page']),
@@ -4075,6 +4075,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (tool !== 'download_public_media') return null;
       if (!this._skillToolForName(tool)) return null;
     }
+    if (id === 'tweet-webbrain' && tool !== 'navigate') return null;
     const summary = sanitizePlannerText(action.summary || 'Run the selected recommended action.', 500, { collapseWhitespace: true });
     const steps = Array.isArray(action.steps)
       ? action.steps.map(step => sanitizePlannerText(step, 300, { collapseWhitespace: true })).filter(Boolean).slice(0, 5)

--- a/src/firefox/src/ui/recommended-actions.js
+++ b/src/firefox/src/ui/recommended-actions.js
@@ -135,6 +135,22 @@ function visibleTreeArgs(maxDepth = 10) {
   return { filter: 'visible', maxDepth };
 }
 
+function webbrainTweetRunOptions() {
+  return {
+    id: 'tweet-webbrain',
+    skipPlanner: true,
+    tool: 'navigate',
+    summary: 'Publish a concise promotional tweet about WebBrain.',
+    steps: [
+      'Open https://x.com/compose/post in the current tab through the visible browser UI.',
+      'Draft a concise, engaging tweet that describes WebBrain as an open-source AI browser agent for chatting with pages, automating tasks, and running multi-step workflows with the user’s choice of LLM.',
+      'Include https://webbrain.one, keep the post within X’s character limit, and avoid claims that cannot be verified from the supplied WebBrain description.',
+      'Enter the tweet in the visible X composer and publish it.',
+      'Verify the new tweet appears, then report its URL when available.',
+    ],
+  };
+}
+
 function hasCartOrPriceSignal(pageInfo = {}) {
   const haystack = [
     pageInfo.title,
@@ -224,6 +240,14 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
   const host = hostFromUrl(pageInfo.url || '');
   const path = pathFromUrl(pageInfo.url || '');
   const actions = [];
+
+  addUnique(actions, {
+    id: 'tweet-webbrain',
+    label: 'Tweet about WebBrain',
+    prompt: 'Publish a concise, engaging tweet about WebBrain through the visible X interface. Describe it as an open-source AI browser agent for chatting with pages, automating tasks, and running multi-step workflows with the user’s choice of LLM. Include https://webbrain.one, verify the tweet was posted, and report its URL when available.',
+    mode: 'act',
+    runOptions: webbrainTweetRunOptions(),
+  });
 
   if (host === 'github.com' && RELEASES_PATH_RE.test(path)) {
     addUnique(actions, {
@@ -383,7 +407,7 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     });
   }
 
-  if (!actions.length && pageInfo.title) {
+  if (!actions.some((action) => action.id !== 'tweet-webbrain') && pageInfo.title) {
     const explainUsesArticleRead = isLongArticle(pageInfo);
     addUnique(actions, {
       id: 'explain-page',

--- a/test/run.js
+++ b/test/run.js
@@ -4856,6 +4856,33 @@ test('recommended actions match issue scenarios', () => {
   }
 });
 
+test('Tweet about WebBrain is permanent and carries a ready-to-go plan', () => {
+  const pages = [
+    {},
+    { url: 'https://example.com/', title: 'Example page' },
+    { url: 'https://mail.google.com/mail/u/0/#inbox/FMfc123', title: 'Gmail - Project update', text: 'From Ada Subject Project update Reply' },
+  ];
+
+  for (const buildRecommendedActions of [buildRecommendedActionsCh, buildRecommendedActionsFx]) {
+    for (const pageInfo of pages) {
+      const actions = buildRecommendedActions(pageInfo, { max: 1 });
+      const tweet = actions.find((action) => action.id === 'tweet-webbrain');
+      assert.equal(tweet?.label, 'Tweet about WebBrain');
+      assert.equal(tweet?.mode, 'act');
+      assert.match(tweet?.prompt || '', /visible X interface/);
+      assert.equal(tweet?.runOptions?.skipPlanner, true);
+      assert.equal(tweet?.runOptions?.tool, 'navigate');
+      assert.match(tweet?.runOptions?.summary || '', /Publish a concise promotional tweet about WebBrain/);
+      assert.ok(tweet?.runOptions?.steps?.some((step) => step.includes('https://x.com/compose/post')));
+      assert.ok(tweet?.runOptions?.steps?.some((step) => step.includes('https://webbrain.one')));
+      assert.ok(tweet?.runOptions?.steps?.some((step) => /Verify the new tweet appears/.test(step)));
+    }
+
+    const fallbackActions = buildRecommendedActions({ url: 'https://example.com/', title: 'Example page' });
+    assert.equal(fallbackActions.some((action) => action.id === 'explain-page'), true, 'permanent action should not suppress the generic page action');
+  }
+});
+
 test('actionable recommendations opt into Act mode', () => {
   const actionablePages = [
     { url: 'https://github.com/esokullu/webbrain/releases', title: 'Releases · esokullu/webbrain' },
@@ -32572,6 +32599,65 @@ test('planner gate: trusted recommended media action skips planner and pins read
       );
       assert.equal(noSkillOutcome.proceed, true, `${label} missing skill should still proceed through normal planner`);
       assert.equal(noSkillPlannerCalls, 1, `${label} missing skill should run planner`);
+    }
+  });
+});
+
+test('planner gate: trusted WebBrain tweet action skips planner and pins ready plan', async () => {
+  await withPlannerBrowserGlobals(async () => {
+    for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+      const tabId = label === 'chrome' ? 9211 : 9212;
+      const agent = new AgentClass({ getActive: () => ({}) });
+      agent.setPlanBeforeActMode('strict');
+      agent.setPlanReviewSettings({ mode: 'always' });
+      agent.conversations.set(tabId, [{ role: 'system', content: 'system' }]);
+      let plannerCalls = 0;
+      agent._runPlannerGate = async () => {
+        plannerCalls += 1;
+        throw new Error('recommended action fast path should not call planner');
+      };
+
+      const readyPlan = {
+        id: 'tweet-webbrain',
+        skipPlanner: true,
+        tool: 'navigate',
+        summary: 'Publish a concise promotional tweet about WebBrain.',
+        steps: [
+          'Open https://x.com/compose/post in the current tab through the visible browser UI.',
+          'Include https://webbrain.one and publish through the visible X composer.',
+          'Verify the new tweet appears and report its URL.',
+        ],
+      };
+      const outcome = await agent._maybeRunPlannerGate(
+        tabId,
+        agent.conversations.get(tabId),
+        { role: 'user', content: 'Publish a concise tweet about WebBrain.' },
+        () => {},
+        'act',
+        null,
+        null,
+        null,
+        { recommendedAction: readyPlan },
+      );
+
+      assert.equal(outcome.proceed, true, `${label} should proceed`);
+      assert.equal(plannerCalls, 0, `${label} should skip the planner call`);
+      const messages = agent.conversations.get(tabId);
+      const idx = agent._findScratchpadIndex(messages);
+      assert.ok(idx >= 0, `${label} should pin the ready tweet plan`);
+      const body = agent._extractScratchpadBody(messages[idx].content);
+      assert.match(body, /\[Approved plan — pinned by recommended action\]/);
+      assert.match(body, /https:\/\/x\.com\/compose\/post/);
+      assert.match(body, /https:\/\/webbrain\.one/);
+      assert.match(body, /Immediate tool[\s\S]*navigate/);
+
+      assert.equal(
+        agent._recommendedActionFastPathPlan({
+          recommendedAction: { ...readyPlan, tool: 'click_ax' },
+        }),
+        null,
+        `${label} should reject a forged immediate tool for the tweet fast path`,
+      );
     }
   });
 });

--- a/test/run.js
+++ b/test/run.js
@@ -4857,6 +4857,13 @@ test('recommended actions match issue scenarios', () => {
 });
 
 test('Tweet about WebBrain is permanent and carries a ready-to-go plan', () => {
+  const expectedPlanSteps = [
+    'Open https://x.com/compose/post in the current tab through the visible browser UI.',
+    'Draft a concise, engaging tweet that describes WebBrain as an open-source AI browser agent for chatting with pages, automating tasks, and running multi-step workflows with the user’s choice of LLM.',
+    'Include https://webbrain.one, keep the post within X’s character limit, and avoid claims that cannot be verified from the supplied WebBrain description.',
+    'Enter the tweet in the visible X composer and publish it.',
+    'Verify the new tweet appears, then report its URL when available.',
+  ];
   const pages = [
     {},
     { url: 'https://example.com/', title: 'Example page' },
@@ -4873,9 +4880,7 @@ test('Tweet about WebBrain is permanent and carries a ready-to-go plan', () => {
       assert.equal(tweet?.runOptions?.skipPlanner, true);
       assert.equal(tweet?.runOptions?.tool, 'navigate');
       assert.match(tweet?.runOptions?.summary || '', /Publish a concise promotional tweet about WebBrain/);
-      assert.ok(tweet?.runOptions?.steps?.some((step) => step.includes('https://x.com/compose/post')));
-      assert.ok(tweet?.runOptions?.steps?.some((step) => step.includes('https://webbrain.one')));
-      assert.ok(tweet?.runOptions?.steps?.some((step) => /Verify the new tweet appears/.test(step)));
+      assert.deepEqual(tweet?.runOptions?.steps, expectedPlanSteps);
     }
 
     const fallbackActions = buildRecommendedActions({ url: 'https://example.com/', title: 'Example page' });


### PR DESCRIPTION
## Summary

- add a permanent **Tweet about WebBrain** pill to suggested actions in Chrome and Firefox
- launch it in Act mode with a trusted ready-to-run plan that opens X, drafts a concise WebBrain post, includes `https://webbrain.one`, publishes through the visible UI, verifies the result, and reports the post URL
- preserve the generic page fallback and validate the trusted fast-path tool
- add mirrored regression coverage for action availability and pinned-plan execution

## Why

Suggested actions were entirely page-dependent. This gives users an always-available, one-click way to share WebBrain without spending another model call generating an execution plan.

## User impact

The action appears first in the fresh-conversation suggested-action list on any page. Selecting it switches to Act mode and begins the approved publishing workflow through the visible X interface.

## Validation

- `npm test` — 981 passed, 0 failed
- injection corpus — 60/60 checks passed
- `git diff --check`