### PR TITLE
Repair JSON-quoted page titles in assistant output

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2771,7 +2771,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           return { action: 'return', value: planOnlyDecision.failure, status: 'plan_only_output' };
         }
         onUpdate('tool_result', { name: fnName, result: toolResult });
-        const finalResponse = this._appendProgressLedgerToFinal(tabId, toolResult.summary || partialAssistantText || 'Task completed.');
+        const repairedDoneSummary = repairAssistantDisplayText(
+          toolResult.summary || partialAssistantText || 'Task completed.',
+        );
+        const finalResponse = this._appendProgressLedgerToFinal(tabId, repairedDoneSummary);
         messages.push({
           role: 'tool',
           tool_call_id: tc.id,

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2771,10 +2771,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           return { action: 'return', value: planOnlyDecision.failure, status: 'plan_only_output' };
         }
         onUpdate('tool_result', { name: fnName, result: toolResult });
-        const repairedDoneSummary = repairAssistantDisplayText(
-          toolResult.summary || partialAssistantText || 'Task completed.',
-        );
+        const rawDoneSummary = toolResult.summary || partialAssistantText || 'Task completed.';
+        const repairedDoneSummary = repairAssistantDisplayText(rawDoneSummary);
         const finalResponse = this._appendProgressLedgerToFinal(tabId, repairedDoneSummary);
+        if (repairedDoneSummary !== rawDoneSummary) {
+          // Streaming providers may already have rendered the malformed summary
+          // before the done call. Replace it so the visible bubble matches the
+          // repaired terminal value returned by this batch.
+          onUpdate('text', { content: finalResponse, replace: true });
+        }
         messages.push({
           role: 'tool',
           tool_call_id: tc.id,

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -42,7 +42,7 @@ import {
   messageContentToText,
 } from './planner.js';
 import { extractFirstJsonObject } from './json-extract.js';
-import { repairDoubleEscapedAssistantText, sanitizeText as sanitizePlannerText } from './text-sanitize.js';
+import { repairAssistantDisplayText, sanitizeText as sanitizePlannerText } from './text-sanitize.js';
 import { buildCustomSkillsPrompt, buildSkillLoaderDefinition, buildSkillToolDefinitions, buildSkillToolRegistry, getEligibleCustomSkills, getEligibleSkillCatalog, normalizeCustomSkills } from './skills.js';
 import { publicMediaUrlNeedsExplicitTarget } from './public-media-url.js';
 import { USER_MEMORY_DEFAULT_MAX_PROMPT_CHARS, formatUserMemoryPrompt, normalizeUserMemoryMaxPromptChars, normalizeUserMemoryStore } from './user-memory.js';
@@ -14802,7 +14802,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         onUpdate('warning', { message: finalResponse });
         break;
       }
-      const repairedFinalContent = repairDoubleEscapedAssistantText(result.content);
+      const repairedFinalContent = repairAssistantDisplayText(result.content);
       finalResponse = result.costAllowanceMessage
         ? `${repairedFinalContent}\n\n${result.costAllowanceMessage}`
         : repairedFinalContent;
@@ -15200,7 +15200,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           this._persist(tabId);
           return finish(planOnlyDecision.failure, planOnlyDecision.status || 'plan_only_output');
         }
-        const repairedFullText = repairDoubleEscapedAssistantText(fullText);
+        const repairedFullText = repairAssistantDisplayText(fullText);
         if (repairedFullText !== fullText) {
           fullText = repairedFullText;
           // Streaming deltas have already displayed the malformed escapes.

--- a/src/chrome/src/agent/text-sanitize.js
+++ b/src/chrome/src/agent/text-sanitize.js
@@ -84,7 +84,7 @@ export function repairDoubleEscapedAssistantText(value) {
 }
 
 function repairJsonQuotedPageTitleLines(value) {
-  if (typeof value !== 'string' || !value || !value.includes('\\"')) return value;
+  if (typeof value !== 'string' || !value) return value;
 
   const parts = value.split(/(\r\n|\n|\r)/);
   let fence = null;
@@ -106,7 +106,7 @@ function repairJsonQuotedPageTitleLines(value) {
     const titleMatch = line.match(
       /^([ \t]*(?:(?:[-*+]|\d+[.)])[ \t]+)?Page title:[ \t]*)("(?:[^"\\]|\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4}))*")([ \t]*)$/i,
     );
-    if (!titleMatch || !titleMatch[2].includes('\\"')) continue;
+    if (!titleMatch) continue;
 
     try {
       const decodedTitle = JSON.parse(titleMatch[2]);

--- a/src/chrome/src/agent/text-sanitize.js
+++ b/src/chrome/src/agent/text-sanitize.js
@@ -109,6 +109,9 @@ function repairJsonQuotedPageTitleLines(value) {
       continue;
     }
     if (fence) continue;
+    // Four columns of leading indentation form a Markdown code block. Keep
+    // exact examples verbatim just as we do for fenced code.
+    if (/^(?: {4}| {0,3}\t)/.test(line)) continue;
 
     const titleMatch = line.match(
       /^([ \t]*(?:(?:[-*+]|\d+[.)])[ \t]+)?Page title:[ \t]*)("(?:[^"\\]|\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4}))*")([ \t]*)$/i,

--- a/src/chrome/src/agent/text-sanitize.js
+++ b/src/chrome/src/agent/text-sanitize.js
@@ -91,7 +91,9 @@ function repairJsonQuotedPageTitleLines(value) {
 
   for (let i = 0; i < parts.length; i += 2) {
     const line = parts[i];
-    const fenceMatch = line.match(/^[ \t]*(`{3,}|~{3,})/);
+    const fenceMatch = line.match(
+      /^[ \t]*(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+))*(`{3,}|~{3,})/,
+    );
     if (fenceMatch) {
       const marker = fenceMatch[1];
       if (!fence) {

--- a/src/chrome/src/agent/text-sanitize.js
+++ b/src/chrome/src/agent/text-sanitize.js
@@ -92,13 +92,18 @@ function repairJsonQuotedPageTitleLines(value) {
   for (let i = 0; i < parts.length; i += 2) {
     const line = parts[i];
     const fenceMatch = line.match(
-      /^[ \t]*(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+))*(`{3,}|~{3,})/,
+      /^[ \t]*(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+))*(`{3,}|~{3,})([\s\S]*)$/,
     );
     if (fenceMatch) {
       const marker = fenceMatch[1];
+      const suffix = fenceMatch[2];
       if (!fence) {
         fence = { character: marker[0], length: marker.length };
-      } else if (marker[0] === fence.character && marker.length >= fence.length) {
+      } else if (
+        marker[0] === fence.character
+        && marker.length >= fence.length
+        && /^[ \t]*$/.test(suffix)
+      ) {
         fence = null;
       }
       continue;

--- a/src/chrome/src/agent/text-sanitize.js
+++ b/src/chrome/src/agent/text-sanitize.js
@@ -82,3 +82,50 @@ export function repairDoubleEscapedAssistantText(value) {
 
   return decoded;
 }
+
+function repairJsonQuotedPageTitleLines(value) {
+  if (typeof value !== 'string' || !value || !value.includes('\\"')) return value;
+
+  const parts = value.split(/(\r\n|\n|\r)/);
+  let fence = null;
+
+  for (let i = 0; i < parts.length; i += 2) {
+    const line = parts[i];
+    const fenceMatch = line.match(/^[ \t]*(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1];
+      if (!fence) {
+        fence = { character: marker[0], length: marker.length };
+      } else if (marker[0] === fence.character && marker.length >= fence.length) {
+        fence = null;
+      }
+      continue;
+    }
+    if (fence) continue;
+
+    const titleMatch = line.match(
+      /^([ \t]*(?:(?:[-*+]|\d+[.)])[ \t]+)?Page title:[ \t]*)("(?:[^"\\]|\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4}))*")([ \t]*)$/i,
+    );
+    if (!titleMatch || !titleMatch[2].includes('\\"')) continue;
+
+    try {
+      const decodedTitle = JSON.parse(titleMatch[2]);
+      if (typeof decodedTitle === 'string') {
+        parts[i] = `${titleMatch[1]}${decodedTitle}${titleMatch[3]}`;
+      }
+    } catch {
+      // Preserve malformed or incomplete JSON-looking text verbatim.
+    }
+  }
+
+  return parts.join('');
+}
+
+/**
+ * Normalize only high-confidence serialization artifacts in terminal assistant
+ * text. Semantic gates and tool-call parsing must always inspect the original
+ * provider content before this display-only repair runs.
+ */
+export function repairAssistantDisplayText(value) {
+  return repairJsonQuotedPageTitleLines(repairDoubleEscapedAssistantText(value));
+}

--- a/src/chrome/src/agent/text-sanitize.js
+++ b/src/chrome/src/agent/text-sanitize.js
@@ -112,7 +112,10 @@ function repairJsonQuotedPageTitleLines(value) {
 
     try {
       const decodedTitle = JSON.parse(titleMatch[2]);
-      if (typeof decodedTitle === 'string') {
+      if (
+        typeof decodedTitle === 'string'
+        && !/[\x00-\x1f\x7f\u2028\u2029]/.test(decodedTitle)
+      ) {
         parts[i] = `${titleMatch[1]}${decodedTitle}${titleMatch[3]}`;
       }
     } catch {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2386,7 +2386,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           return { action: 'return', value: planOnlyDecision.failure, status: 'plan_only_output' };
         }
         onUpdate('tool_result', { name: fnName, result: toolResult });
-        const finalResponse = this._appendProgressLedgerToFinal(tabId, toolResult.summary || partialAssistantText || 'Task completed.');
+        const repairedDoneSummary = repairAssistantDisplayText(
+          toolResult.summary || partialAssistantText || 'Task completed.',
+        );
+        const finalResponse = this._appendProgressLedgerToFinal(tabId, repairedDoneSummary);
         messages.push({
           role: 'tool',
           tool_call_id: tc.id,

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2386,10 +2386,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           return { action: 'return', value: planOnlyDecision.failure, status: 'plan_only_output' };
         }
         onUpdate('tool_result', { name: fnName, result: toolResult });
-        const repairedDoneSummary = repairAssistantDisplayText(
-          toolResult.summary || partialAssistantText || 'Task completed.',
-        );
+        const rawDoneSummary = toolResult.summary || partialAssistantText || 'Task completed.';
+        const repairedDoneSummary = repairAssistantDisplayText(rawDoneSummary);
         const finalResponse = this._appendProgressLedgerToFinal(tabId, repairedDoneSummary);
+        if (repairedDoneSummary !== rawDoneSummary) {
+          // Streaming providers may already have rendered the malformed summary
+          // before the done call. Replace it so the visible bubble matches the
+          // repaired terminal value returned by this batch.
+          onUpdate('text', { content: finalResponse, replace: true });
+        }
         messages.push({
           role: 'tool',
           tool_call_id: tc.id,

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -43,7 +43,7 @@ import {
   messageContentToText,
 } from './planner.js';
 import { extractFirstJsonObject } from './json-extract.js';
-import { repairDoubleEscapedAssistantText, sanitizeText as sanitizePlannerText } from './text-sanitize.js';
+import { repairAssistantDisplayText, sanitizeText as sanitizePlannerText } from './text-sanitize.js';
 import { buildCustomSkillsPrompt, buildSkillLoaderDefinition, buildSkillToolDefinitions, buildSkillToolRegistry, getEligibleCustomSkills, getEligibleSkillCatalog, normalizeCustomSkills } from './skills.js';
 import { publicMediaUrlNeedsExplicitTarget } from './public-media-url.js';
 import { USER_MEMORY_DEFAULT_MAX_PROMPT_CHARS, formatUserMemoryPrompt, normalizeUserMemoryMaxPromptChars, normalizeUserMemoryStore } from './user-memory.js';
@@ -10813,7 +10813,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         onUpdate('warning', { message: finalResponse });
         break;
       }
-      const repairedFinalContent = repairDoubleEscapedAssistantText(result.content);
+      const repairedFinalContent = repairAssistantDisplayText(result.content);
       finalResponse = result.costAllowanceMessage
         ? `${repairedFinalContent}\n\n${result.costAllowanceMessage}`
         : repairedFinalContent;
@@ -11199,7 +11199,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           this._persist(tabId);
           return finish(planOnlyDecision.failure, planOnlyDecision.status || 'plan_only_output');
         }
-        const repairedFullText = repairDoubleEscapedAssistantText(fullText);
+        const repairedFullText = repairAssistantDisplayText(fullText);
         if (repairedFullText !== fullText) {
           fullText = repairedFullText;
           // Streaming deltas have already displayed the malformed escapes.

--- a/src/firefox/src/agent/text-sanitize.js
+++ b/src/firefox/src/agent/text-sanitize.js
@@ -84,7 +84,7 @@ export function repairDoubleEscapedAssistantText(value) {
 }
 
 function repairJsonQuotedPageTitleLines(value) {
-  if (typeof value !== 'string' || !value || !value.includes('\\"')) return value;
+  if (typeof value !== 'string' || !value) return value;
 
   const parts = value.split(/(\r\n|\n|\r)/);
   let fence = null;
@@ -106,7 +106,7 @@ function repairJsonQuotedPageTitleLines(value) {
     const titleMatch = line.match(
       /^([ \t]*(?:(?:[-*+]|\d+[.)])[ \t]+)?Page title:[ \t]*)("(?:[^"\\]|\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4}))*")([ \t]*)$/i,
     );
-    if (!titleMatch || !titleMatch[2].includes('\\"')) continue;
+    if (!titleMatch) continue;
 
     try {
       const decodedTitle = JSON.parse(titleMatch[2]);

--- a/src/firefox/src/agent/text-sanitize.js
+++ b/src/firefox/src/agent/text-sanitize.js
@@ -109,6 +109,9 @@ function repairJsonQuotedPageTitleLines(value) {
       continue;
     }
     if (fence) continue;
+    // Four columns of leading indentation form a Markdown code block. Keep
+    // exact examples verbatim just as we do for fenced code.
+    if (/^(?: {4}| {0,3}\t)/.test(line)) continue;
 
     const titleMatch = line.match(
       /^([ \t]*(?:(?:[-*+]|\d+[.)])[ \t]+)?Page title:[ \t]*)("(?:[^"\\]|\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4}))*")([ \t]*)$/i,

--- a/src/firefox/src/agent/text-sanitize.js
+++ b/src/firefox/src/agent/text-sanitize.js
@@ -91,7 +91,9 @@ function repairJsonQuotedPageTitleLines(value) {
 
   for (let i = 0; i < parts.length; i += 2) {
     const line = parts[i];
-    const fenceMatch = line.match(/^[ \t]*(`{3,}|~{3,})/);
+    const fenceMatch = line.match(
+      /^[ \t]*(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+))*(`{3,}|~{3,})/,
+    );
     if (fenceMatch) {
       const marker = fenceMatch[1];
       if (!fence) {

--- a/src/firefox/src/agent/text-sanitize.js
+++ b/src/firefox/src/agent/text-sanitize.js
@@ -92,13 +92,18 @@ function repairJsonQuotedPageTitleLines(value) {
   for (let i = 0; i < parts.length; i += 2) {
     const line = parts[i];
     const fenceMatch = line.match(
-      /^[ \t]*(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+))*(`{3,}|~{3,})/,
+      /^[ \t]*(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+))*(`{3,}|~{3,})([\s\S]*)$/,
     );
     if (fenceMatch) {
       const marker = fenceMatch[1];
+      const suffix = fenceMatch[2];
       if (!fence) {
         fence = { character: marker[0], length: marker.length };
-      } else if (marker[0] === fence.character && marker.length >= fence.length) {
+      } else if (
+        marker[0] === fence.character
+        && marker.length >= fence.length
+        && /^[ \t]*$/.test(suffix)
+      ) {
         fence = null;
       }
       continue;

--- a/src/firefox/src/agent/text-sanitize.js
+++ b/src/firefox/src/agent/text-sanitize.js
@@ -82,3 +82,50 @@ export function repairDoubleEscapedAssistantText(value) {
 
   return decoded;
 }
+
+function repairJsonQuotedPageTitleLines(value) {
+  if (typeof value !== 'string' || !value || !value.includes('\\"')) return value;
+
+  const parts = value.split(/(\r\n|\n|\r)/);
+  let fence = null;
+
+  for (let i = 0; i < parts.length; i += 2) {
+    const line = parts[i];
+    const fenceMatch = line.match(/^[ \t]*(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1];
+      if (!fence) {
+        fence = { character: marker[0], length: marker.length };
+      } else if (marker[0] === fence.character && marker.length >= fence.length) {
+        fence = null;
+      }
+      continue;
+    }
+    if (fence) continue;
+
+    const titleMatch = line.match(
+      /^([ \t]*(?:(?:[-*+]|\d+[.)])[ \t]+)?Page title:[ \t]*)("(?:[^"\\]|\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4}))*")([ \t]*)$/i,
+    );
+    if (!titleMatch || !titleMatch[2].includes('\\"')) continue;
+
+    try {
+      const decodedTitle = JSON.parse(titleMatch[2]);
+      if (typeof decodedTitle === 'string') {
+        parts[i] = `${titleMatch[1]}${decodedTitle}${titleMatch[3]}`;
+      }
+    } catch {
+      // Preserve malformed or incomplete JSON-looking text verbatim.
+    }
+  }
+
+  return parts.join('');
+}
+
+/**
+ * Normalize only high-confidence serialization artifacts in terminal assistant
+ * text. Semantic gates and tool-call parsing must always inspect the original
+ * provider content before this display-only repair runs.
+ */
+export function repairAssistantDisplayText(value) {
+  return repairJsonQuotedPageTitleLines(repairDoubleEscapedAssistantText(value));
+}

--- a/src/firefox/src/agent/text-sanitize.js
+++ b/src/firefox/src/agent/text-sanitize.js
@@ -112,7 +112,10 @@ function repairJsonQuotedPageTitleLines(value) {
 
     try {
       const decodedTitle = JSON.parse(titleMatch[2]);
-      if (typeof decodedTitle === 'string') {
+      if (
+        typeof decodedTitle === 'string'
+        && !/[\x00-\x1f\x7f\u2028\u2029]/.test(decodedTitle)
+      ) {
         parts[i] = `${titleMatch[1]}${decodedTitle}${titleMatch[3]}`;
       }
     } catch {

--- a/test/run.js
+++ b/test/run.js
@@ -20187,23 +20187,27 @@ test('assistant response repair preserves escapes inside double-escaped fenced c
 });
 
 test('assistant display repair decodes JSON-quoted page title verification lines', () => {
-  const title = 'Emre Sokullu on X: "Introducing WebBrain — an open-source AI browser agent…"';
-  const malformed = [
-    'Verification:',
-    `- Page title: ${JSON.stringify(title)}`,
-    '- Timestamp: 3:39 PM · Jul 19, 2026',
-  ].join('\r\n');
-  const expected = [
-    'Verification:',
-    `- Page title: ${title}`,
-    '- Timestamp: 3:39 PM · Jul 19, 2026',
-  ].join('\r\n');
-
-  for (const [label, repair] of [
-    ['chrome', repairAssistantDisplayTextCh],
-    ['firefox', repairAssistantDisplayTextFx],
+  for (const title of [
+    'Example Domain',
+    'Emre Sokullu on X: "Introducing WebBrain — an open-source AI browser agent…"',
   ]) {
-    assert.equal(repair(malformed), expected, `${label}: page title JSON scalar should decode`);
+    const malformed = [
+      'Verification:',
+      `- Page title: ${JSON.stringify(title)}`,
+      '- Timestamp: 3:39 PM · Jul 19, 2026',
+    ].join('\r\n');
+    const expected = [
+      'Verification:',
+      `- Page title: ${title}`,
+      '- Timestamp: 3:39 PM · Jul 19, 2026',
+    ].join('\r\n');
+
+    for (const [label, repair] of [
+      ['chrome', repairAssistantDisplayTextCh],
+      ['firefox', repairAssistantDisplayTextFx],
+    ]) {
+      assert.equal(repair(malformed), expected, `${label}: page title JSON scalar should decode`);
+    }
   }
 });
 
@@ -20212,8 +20216,10 @@ test('assistant display repair preserves unrelated, fenced, and malformed escape
   const jsonTitle = JSON.stringify(title);
   const unchanged = [
     `Other field: ${jsonTitle}`,
+    'Other field: "Example Domain"',
     `Use this example: Page title: ${jsonTitle}`,
     `Page title: ${jsonTitle} trailing text`,
+    'Page title: "Example Domain" trailing text',
     String.raw`Page title: "Emre Sokullu on X: \q"`,
     `\`\`\`text\nPage title: ${jsonTitle}\n\`\`\``,
     `~~~text\n- Page title: ${jsonTitle}\n~~~`,
@@ -20258,7 +20264,7 @@ test('provider response path preserves raw assistant content and metadata', asyn
 });
 
 test('terminal display repair normalizes JSON-quoted page title lines', async () => {
-  const title = 'Emre Sokullu on X: "Introducing WebBrain"';
+  const title = 'Example Domain';
   const malformed = `Verification:\n- Page title: ${JSON.stringify(title)}\n- Timestamp: 3:39 PM`;
   const expected = `Verification:\n- Page title: ${title}\n- Timestamp: 3:39 PM`;
 

--- a/test/run.js
+++ b/test/run.js
@@ -20258,6 +20258,26 @@ test('assistant display repair preserves list-prefixed fenced page-title example
   }
 });
 
+test('assistant display repair rejects page-title layout and control characters', () => {
+  const unsafeTitles = [
+    'Example Domain\n- Timestamp: fake',
+    'Example Domain\r\n- Page title: fake',
+    'Example Domain\tforged field',
+    'Example Domain\u2028- Timestamp: fake',
+    'Example Domain\u2029- Timestamp: fake',
+  ];
+
+  for (const title of unsafeTitles) {
+    const malformed = `Verification:\n- Page title: ${JSON.stringify(title)}\n- Timestamp: real`;
+    for (const [label, repair] of [
+      ['chrome', repairAssistantDisplayTextCh],
+      ['firefox', repairAssistantDisplayTextFx],
+    ]) {
+      assert.equal(repair(malformed), malformed, `${label}: unsafe title layout should remain escaped`);
+    }
+  }
+});
+
 test('provider response path preserves raw assistant content and metadata', async () => {
   const expected = '**Result**\n\n- First\n- Second';
   const malformed = JSON.stringify(expected).slice(1, -1);
@@ -20311,6 +20331,34 @@ test('terminal display repair normalizes JSON-quoted page title lines', async ()
     const final = await agent.processMessage(tabId, 'Show the verification.', () => {}, 'ask');
 
     assert.equal(final, expected, `${AgentClass.name}: terminal page title should be normalized`);
+  }
+});
+
+test('terminal display repair cannot forge lines from page-title escapes', async () => {
+  const title = 'Example Domain\n- Timestamp: fake';
+  const malformed = `Verification:\n- Page title: ${JSON.stringify(title)}\n- Timestamp: real`;
+
+  for (const [index, AgentClass] of [AgentCh, AgentFx].entries()) {
+    const provider = {
+      supportsTools: true,
+      supportsVision: false,
+      promptTier: 'full',
+      contextWindow: 128000,
+      model: 'test-model',
+      name: 'test-provider',
+      chat: async () => ({ content: malformed, toolCalls: [] }),
+    };
+    const agent = new AgentClass({
+      getActive: () => provider,
+      getVisionProvider: async () => null,
+    });
+    const tabId = 4070 + index;
+    configurePlanOnlyGuardAgent(agent, tabId);
+
+    const final = await agent.processMessage(tabId, 'Show the verification.', () => {}, 'ask');
+
+    assert.equal(final, malformed, `${AgentClass.name}: escaped title layout should remain inert`);
+    assert.equal(final.includes('\n- Timestamp: fake'), false, `${AgentClass.name}: title forged a verification line`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -20448,6 +20448,18 @@ test('agent repairs only terminal content after raw tool-call and plan gates', (
       `${label}: non-streaming repair must run after raw semantic gates`,
     );
 
+    const rawDoneGate = source.indexOf(
+      "toolResult.summary || partialAssistantText || '',",
+    );
+    const doneTerminalRepair = source.indexOf(
+      'const repairedDoneSummary = repairAssistantDisplayText(',
+      rawDoneGate,
+    );
+    assert.ok(
+      rawDoneGate >= 0 && rawDoneGate < doneTerminalRepair,
+      `${label}: done summary repair must run after the raw plan-only gate`,
+    );
+
     const rawStreamFallback = source.indexOf(
       'const fallback = this._tryParseToolCallsFromText(fullText, allowedToolNames);',
     );
@@ -26166,6 +26178,47 @@ test('accepted done emits successful result update after progress gate', async (
       1,
       `${AgentClass.name}: accepted done should emit one successful done update`,
     );
+  }
+});
+
+test('accepted done repairs only the terminal display summary', async () => {
+  const title = 'Emre Sokullu on X: "Introducing WebBrain"';
+  const malformed = `Verification:\n- Page title: ${JSON.stringify(title)}`;
+  const expected = `Verification:\n- Page title: ${title}`;
+
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getActive: () => ({ contextWindow: 128000, supportsVision: false }) });
+    const tabId = 795;
+    const messages = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'Finish this task.' },
+    ];
+    agent.conversations.set(tabId, messages);
+    agent.conversationModes.set(tabId, 'act');
+    agent.executeTool = async () => ({ done: true, summary: malformed, outcome: 'success' });
+    agent._persist = () => {};
+    agent.providerManager = { ...(agent.providerManager || {}), getVisionProvider: async () => null };
+
+    const updates = [];
+    const toolCalls = [{
+      id: 'done_repair_call',
+      function: { name: 'done', arguments: JSON.stringify({ summary: malformed, outcome: 'success' }) },
+    }];
+    const result = await agent._executeToolBatch(
+      tabId,
+      toolCalls,
+      messages,
+      (type, data) => updates.push({ type, data }),
+      { supportsVision: false },
+      null,
+      new Set(['done']),
+      1,
+    );
+
+    assert.equal(result.action, 'return', `${AgentClass.name}: accepted done should finish`);
+    assert.equal(result.value, expected, `${AgentClass.name}: done summary display was not repaired`);
+    const rawUpdate = updates.find(update => update.type === 'tool_result' && update.data?.name === 'done');
+    assert.equal(rawUpdate?.data?.result?.summary, malformed, `${AgentClass.name}: raw done summary was mutated before display repair`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -580,6 +580,12 @@ const { repairDoubleEscapedAssistantText: repairDoubleEscapedAssistantTextCh } =
 const { repairDoubleEscapedAssistantText: repairDoubleEscapedAssistantTextFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/agent/text-sanitize.js').replace(/\\/g, '/')
 );
+const { repairAssistantDisplayText: repairAssistantDisplayTextCh } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/agent/text-sanitize.js').replace(/\\/g, '/')
+);
+const { repairAssistantDisplayText: repairAssistantDisplayTextFx } = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/agent/text-sanitize.js').replace(/\\/g, '/')
+);
 const userMemoryCh = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/agent/user-memory.js').replace(/\\/g, '/')
 );
@@ -20180,6 +20186,49 @@ test('assistant response repair preserves escapes inside double-escaped fenced c
   }
 });
 
+test('assistant display repair decodes JSON-quoted page title verification lines', () => {
+  const title = 'Emre Sokullu on X: "Introducing WebBrain — an open-source AI browser agent…"';
+  const malformed = [
+    'Verification:',
+    `- Page title: ${JSON.stringify(title)}`,
+    '- Timestamp: 3:39 PM · Jul 19, 2026',
+  ].join('\r\n');
+  const expected = [
+    'Verification:',
+    `- Page title: ${title}`,
+    '- Timestamp: 3:39 PM · Jul 19, 2026',
+  ].join('\r\n');
+
+  for (const [label, repair] of [
+    ['chrome', repairAssistantDisplayTextCh],
+    ['firefox', repairAssistantDisplayTextFx],
+  ]) {
+    assert.equal(repair(malformed), expected, `${label}: page title JSON scalar should decode`);
+  }
+});
+
+test('assistant display repair preserves unrelated, fenced, and malformed escapes', () => {
+  const title = 'Emre Sokullu on X: "Introducing WebBrain"';
+  const jsonTitle = JSON.stringify(title);
+  const unchanged = [
+    `Other field: ${jsonTitle}`,
+    `Use this example: Page title: ${jsonTitle}`,
+    `Page title: ${jsonTitle} trailing text`,
+    String.raw`Page title: "Emre Sokullu on X: \q"`,
+    `\`\`\`text\nPage title: ${jsonTitle}\n\`\`\``,
+    `~~~text\n- Page title: ${jsonTitle}\n~~~`,
+  ];
+
+  for (const [label, repair] of [
+    ['chrome', repairAssistantDisplayTextCh],
+    ['firefox', repairAssistantDisplayTextFx],
+  ]) {
+    for (const value of unchanged) {
+      assert.equal(repair(value), value, `${label}: should preserve ${JSON.stringify(value)}`);
+    }
+  }
+});
+
 test('provider response path preserves raw assistant content and metadata', async () => {
   const expected = '**Result**\n\n- First\n- Second';
   const malformed = JSON.stringify(expected).slice(1, -1);
@@ -20205,6 +20254,34 @@ test('provider response path preserves raw assistant content and metadata', asyn
     assert.equal(result.content, malformed, `${label}: raw content should remain available to semantic gates`);
     assert.equal(result.reasoningContent, reasoningContent, `${label}: hidden reasoning should not be decoded`);
     assert.equal(raw.choices[0].message.content, malformed, `${label}: raw provider payload should remain untouched`);
+  }
+});
+
+test('terminal display repair normalizes JSON-quoted page title lines', async () => {
+  const title = 'Emre Sokullu on X: "Introducing WebBrain"';
+  const malformed = `Verification:\n- Page title: ${JSON.stringify(title)}\n- Timestamp: 3:39 PM`;
+  const expected = `Verification:\n- Page title: ${title}\n- Timestamp: 3:39 PM`;
+
+  for (const [index, AgentClass] of [AgentCh, AgentFx].entries()) {
+    const provider = {
+      supportsTools: true,
+      supportsVision: false,
+      promptTier: 'full',
+      contextWindow: 128000,
+      model: 'test-model',
+      name: 'test-provider',
+      chat: async () => ({ content: malformed, toolCalls: [] }),
+    };
+    const agent = new AgentClass({
+      getActive: () => provider,
+      getVisionProvider: async () => null,
+    });
+    const tabId = 4080 + index;
+    configurePlanOnlyGuardAgent(agent, tabId);
+
+    const final = await agent.processMessage(tabId, 'Show the verification.', () => {}, 'ask');
+
+    assert.equal(final, expected, `${AgentClass.name}: terminal page title should be normalized`);
   }
 });
 
@@ -20255,7 +20332,7 @@ test('agent repairs only terminal content after raw tool-call and plan gates', (
       rawFallback,
     );
     const terminalRepair = source.indexOf(
-      'const repairedFinalContent = repairDoubleEscapedAssistantText(result.content);',
+      'const repairedFinalContent = repairAssistantDisplayText(result.content);',
       planGate,
     );
     assert.ok(
@@ -20271,7 +20348,7 @@ test('agent repairs only terminal content after raw tool-call and plan gates', (
       rawStreamFallback,
     );
     const streamTerminalRepair = source.indexOf(
-      'const repairedFullText = repairDoubleEscapedAssistantText(fullText);',
+      'const repairedFullText = repairAssistantDisplayText(fullText);',
       streamPlanGate,
     );
     assert.ok(

--- a/test/run.js
+++ b/test/run.js
@@ -20258,6 +20258,37 @@ test('assistant display repair preserves list-prefixed fenced page-title example
   }
 });
 
+test('assistant display repair ignores fence-like content with trailing text', () => {
+  const jsonTitle = JSON.stringify('Example Domain');
+
+  for (const [opening, fenceLikeContent, closing] of [
+    ['```text', '````js', '```'],
+    ['~~~text', '~~~~yaml', '~~~'],
+  ]) {
+    const malformed = [
+      opening,
+      fenceLikeContent,
+      `Page title: ${jsonTitle}`,
+      closing,
+      `Page title: ${jsonTitle}`,
+    ].join('\n');
+    const expected = [
+      opening,
+      fenceLikeContent,
+      `Page title: ${jsonTitle}`,
+      closing,
+      'Page title: Example Domain',
+    ].join('\n');
+
+    for (const [label, repair] of [
+      ['chrome', repairAssistantDisplayTextCh],
+      ['firefox', repairAssistantDisplayTextFx],
+    ]) {
+      assert.equal(repair(malformed), expected, `${label}: trailing fence text must not close the block`);
+    }
+  }
+});
+
 test('assistant display repair rejects page-title layout and control characters', () => {
   const unsafeTitles = [
     'Example Domain\n- Timestamp: fake',

--- a/test/run.js
+++ b/test/run.js
@@ -20235,6 +20235,29 @@ test('assistant display repair preserves unrelated, fenced, and malformed escape
   }
 });
 
+test('assistant display repair preserves list-prefixed fenced page-title examples', () => {
+  const jsonTitle = JSON.stringify('Example Domain');
+  const malformed = [
+    '- ```text',
+    `  Page title: ${jsonTitle}`,
+    '  ```',
+    `Page title: ${jsonTitle}`,
+  ].join('\n');
+  const expected = [
+    '- ```text',
+    `  Page title: ${jsonTitle}`,
+    '  ```',
+    'Page title: Example Domain',
+  ].join('\n');
+
+  for (const [label, repair] of [
+    ['chrome', repairAssistantDisplayTextCh],
+    ['firefox', repairAssistantDisplayTextFx],
+  ]) {
+    assert.equal(repair(malformed), expected, `${label}: list-prefixed fenced title should remain verbatim`);
+  }
+});
+
 test('provider response path preserves raw assistant content and metadata', async () => {
   const expected = '**Result**\n\n- First\n- Second';
   const malformed = JSON.stringify(expected).slice(1, -1);

--- a/test/run.js
+++ b/test/run.js
@@ -20289,6 +20289,29 @@ test('assistant display repair ignores fence-like content with trailing text', (
   }
 });
 
+test('assistant display repair preserves indented code blocks', () => {
+  const jsonTitle = JSON.stringify('Example Domain');
+  const malformed = [
+    `    Page title: ${jsonTitle}`,
+    `\tPage title: ${jsonTitle}`,
+    `  \tPage title: ${jsonTitle}`,
+    `  - Page title: ${jsonTitle}`,
+  ].join('\n');
+  const expected = [
+    `    Page title: ${jsonTitle}`,
+    `\tPage title: ${jsonTitle}`,
+    `  \tPage title: ${jsonTitle}`,
+    '  - Page title: Example Domain',
+  ].join('\n');
+
+  for (const [label, repair] of [
+    ['chrome', repairAssistantDisplayTextCh],
+    ['firefox', repairAssistantDisplayTextFx],
+  ]) {
+    assert.equal(repair(malformed), expected, `${label}: indented code examples must remain verbatim`);
+  }
+});
+
 test('assistant display repair rejects page-title layout and control characters', () => {
   const unsafeTitles = [
     'Example Domain\n- Timestamp: fake',

--- a/test/run.js
+++ b/test/run.js
@@ -20452,12 +20452,17 @@ test('agent repairs only terminal content after raw tool-call and plan gates', (
       "toolResult.summary || partialAssistantText || '',",
     );
     const doneTerminalRepair = source.indexOf(
-      'const repairedDoneSummary = repairAssistantDisplayText(',
+      'const repairedDoneSummary = repairAssistantDisplayText(rawDoneSummary);',
       rawDoneGate,
     );
     assert.ok(
       rawDoneGate >= 0 && rawDoneGate < doneTerminalRepair,
       `${label}: done summary repair must run after the raw plan-only gate`,
+    );
+    assert.match(
+      source.slice(doneTerminalRepair, doneTerminalRepair + 900),
+      /if \(repairedDoneSummary !== rawDoneSummary\) \{[\s\S]*?onUpdate\('text', \{ content: finalResponse, replace: true \}\);/,
+      `${label}: repaired done summaries should replace already-streamed terminal text`,
     );
 
     const rawStreamFallback = source.indexOf(
@@ -26178,6 +26183,11 @@ test('accepted done emits successful result update after progress gate', async (
       1,
       `${AgentClass.name}: accepted done should emit one successful done update`,
     );
+    assert.equal(
+      updates.some(update => update.type === 'text'),
+      false,
+      `${AgentClass.name}: an unchanged done summary should not replace visible text`,
+    );
   }
 });
 
@@ -26186,7 +26196,7 @@ test('accepted done repairs only the terminal display summary', async () => {
   const malformed = `Verification:\n- Page title: ${JSON.stringify(title)}`;
   const expected = `Verification:\n- Page title: ${title}`;
 
-  for (const AgentClass of [AgentCh, AgentFx]) {
+  for (const [index, AgentClass] of [AgentCh, AgentFx].entries()) {
     const agent = new AgentClass({ getActive: () => ({ contextWindow: 128000, supportsVision: false }) });
     const tabId = 795;
     const messages = [
@@ -26195,7 +26205,11 @@ test('accepted done repairs only the terminal display summary', async () => {
     ];
     agent.conversations.set(tabId, messages);
     agent.conversationModes.set(tabId, 'act');
-    agent.executeTool = async () => ({ done: true, summary: malformed, outcome: 'success' });
+    agent.executeTool = async () => ({
+      done: true,
+      summary: index === 0 ? malformed : '',
+      outcome: 'success',
+    });
     agent._persist = () => {};
     agent.providerManager = { ...(agent.providerManager || {}), getVisionProvider: async () => null };
 
@@ -26210,7 +26224,7 @@ test('accepted done repairs only the terminal display summary', async () => {
       messages,
       (type, data) => updates.push({ type, data }),
       { supportsVision: false },
-      null,
+      index === 0 ? null : malformed,
       new Set(['done']),
       1,
     );
@@ -26218,7 +26232,16 @@ test('accepted done repairs only the terminal display summary', async () => {
     assert.equal(result.action, 'return', `${AgentClass.name}: accepted done should finish`);
     assert.equal(result.value, expected, `${AgentClass.name}: done summary display was not repaired`);
     const rawUpdate = updates.find(update => update.type === 'tool_result' && update.data?.name === 'done');
-    assert.equal(rawUpdate?.data?.result?.summary, malformed, `${AgentClass.name}: raw done summary was mutated before display repair`);
+    assert.equal(
+      rawUpdate?.data?.result?.summary,
+      index === 0 ? malformed : '',
+      `${AgentClass.name}: raw done summary was mutated before display repair`,
+    );
+    assert.deepEqual(
+      updates.find(update => update.type === 'text'),
+      { type: 'text', data: { content: expected, replace: true } },
+      `${AgentClass.name}: repaired done summary did not replace streamed terminal text`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

- decode complete JSON string literals only on user-visible `Page title:` lines
- run the repair only at the terminal display boundary, after raw tool-call and plan gates
- preserve unrelated escapes, malformed JSON-looking text, and fenced code
- mirror the behavior across Chrome and Firefox

## Root cause

Page-reading tool results are JSON-serialized before the model sees them. When a title itself contains quotes, a model can copy the serialized scalar verbatim into an otherwise normally formatted response, exposing the outer JSON quotes and inner `\"` escapes.

PR #154 repairs responses where the entire Markdown document still has an extra JSON-escaping layer. It intentionally leaves normally formatted multiline responses unchanged, so it did not cover this single-field serialization artifact.

## Impact

Verification output now renders quoted page titles as normal text without globally rewriting backslashes or changing tool-result serialization. Raw provider content still reaches semantic and tool-call gates unchanged.

## Validation

- `node test/run.js`
  - all new response-repair, display-repair, terminal-integration, and ordering tests pass
  - repository result: 989 passed, 1 pre-existing failure in `accessibility ref lookup rejects disconnected elements` (`refOrdinal is not defined` on `origin/main`)
- `npm run test:security` — 60/60 checks passed
- `node --check` on changed JavaScript files
- Chrome/Firefox sanitizer parity check
- `git diff --check`