### PR TITLE
Fix stale Stop WebBrain indicators

### DIFF
--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -1299,6 +1299,9 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   const tabId = sender?.tab?.id;
   if (tabId != null) {
     try { agent.abort(tabId); } catch { /* ignore */ }
+    // Always clear the sender tab's page-owned indicator, even when the run
+    // already ended or this service worker lost its in-memory run state.
+    sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
   }
   sendResponse({ ok: true });
   // Synchronous response — return undefined.

--- a/src/chrome/src/content/agent-visual-indicator.js
+++ b/src/chrome/src/content/agent-visual-indicator.js
@@ -172,6 +172,10 @@
       if (indicatorsActive) button.style.background = '#ffffff';
     });
     button.addEventListener('click', async () => {
+      // Clear the page-owned UI immediately. The service worker may have
+      // restarted (or the run may already be gone), leaving this indicator
+      // with no live background state to clean it up.
+      hide();
       try {
         await chrome.runtime.sendMessage({ type: 'WB_STOP_AGENT' });
       } catch { /* extension context invalidated, ignore */ }

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -1409,6 +1409,9 @@ browser.runtime.onMessage.addListener((msg, sender) => {
   const tabId = sender?.tab?.id;
   if (tabId != null) {
     try { agent.abort(tabId); } catch { /* ignore */ }
+    // Always clear the sender tab's page-owned indicator, even when the run
+    // already ended or this background lost its in-memory run state.
+    sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
   }
   return Promise.resolve({ ok: true });
 });

--- a/src/firefox/src/content/agent-visual-indicator.js
+++ b/src/firefox/src/content/agent-visual-indicator.js
@@ -172,6 +172,10 @@
       if (indicatorsActive) button.style.background = '#ffffff';
     });
     button.addEventListener('click', async () => {
+      // Clear the page-owned UI immediately. The background may have
+      // restarted (or the run may already be gone), leaving this indicator
+      // with no live background state to clean it up.
+      hide();
       try {
         await browser.runtime.sendMessage({ type: 'WB_STOP_AGENT' });
       } catch { /* extension context invalidated, ignore */ }

--- a/test/run.js
+++ b/test/run.js
@@ -32912,6 +32912,49 @@ test('background reasserts active viewport glow after tab reload', () => {
   }
 });
 
+test('page Stop WebBrain clears stale indicators without stopping recordings', () => {
+  for (const [label, prefix, runtimeApi] of [
+    ['chrome', 'src/chrome', 'chrome'],
+    ['firefox', 'src/firefox', 'browser'],
+  ]) {
+    const indicator = fs.readFileSync(path.join(ROOT, prefix, 'src/content/agent-visual-indicator.js'), 'utf8');
+    const background = fs.readFileSync(path.join(ROOT, prefix, 'src/background.js'), 'utf8');
+
+    const clickStart = indicator.indexOf("button.addEventListener('click', async () => {");
+    const clickEnd = indicator.indexOf('\n    });', clickStart);
+    assert.notEqual(clickStart, -1, `${label}: page Stop handler missing`);
+    assert.notEqual(clickEnd, -1, `${label}: page Stop handler boundary missing`);
+    const clickBody = indicator.slice(clickStart, clickEnd);
+    const localHideIdx = clickBody.indexOf('hide();');
+    const abortMessageIdx = clickBody.indexOf(`${runtimeApi}.runtime.sendMessage({ type: 'WB_STOP_AGENT' })`);
+    assert.notEqual(localHideIdx, -1, `${label}: page Stop should immediately hide its local indicator`);
+    assert.notEqual(abortMessageIdx, -1, `${label}: page Stop should still request agent abort`);
+    assert.equal(localHideIdx < abortMessageIdx, true, `${label}: stale indicator should hide before background abort dispatch`);
+
+    const handlerStart = background.indexOf("if (msg?.type !== 'WB_STOP_AGENT') return;");
+    const handlerEnd = background.indexOf('\n});', handlerStart);
+    assert.notEqual(handlerStart, -1, `${label}: background Stop handler missing`);
+    assert.notEqual(handlerEnd, -1, `${label}: background Stop handler boundary missing`);
+    const handlerBody = background.slice(handlerStart, handlerEnd);
+    assert.match(handlerBody, /agent\.abort\(tabId\)/, `${label}: active agent runs should still be aborted`);
+    assert.match(
+      handlerBody,
+      /sendIndicatorMessage\(tabId, 'WB_HIDE_AGENT_INDICATORS'\)/,
+      `${label}: background should clear stale sender-tab indicators even without an active run`,
+    );
+    assert.doesNotMatch(
+      handlerBody,
+      /agent\.(?:isRunning|activeRunState)\(tabId\)/,
+      `${label}: stale indicator cleanup must not depend on an active agent run`,
+    );
+    assert.doesNotMatch(
+      handlerBody,
+      /stopTabRecording|stop_tab_recording|recording_capture_ended/,
+      `${label}: page Stop must not stop or alter recordings`,
+    );
+  }
+});
+
 test('planner gate: abort during planner call stops before review card', async () => {
   await withPlannerBrowserGlobals(async () => {
     for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {


### PR DESCRIPTION
## Summary

- dismiss the page-owned Stop WebBrain indicator immediately when the user clicks it
- clear the sender tab's indicator state from the background even when no active run remains
- mirror the fix across Chrome and Firefox without changing recording or side-panel behavior
- add regression coverage for active and stale agent states and recording isolation

## Root cause

The page button only dispatched `WB_STOP_AGENT`. If the agent run had already ended or the extension background had restarted, there was no live run completion path left to emit `WB_HIDE_AGENT_INDICATORS`, so the purple border and Stop WebBrain button could remain orphaned on the tab.

## Validation

- `node test/run.js` — new regression passes; 997 passed, 1 existing repository baseline failure because `package.json` is `25.0.1` while the newest changelog entry is `25.0.0`
- `node test/security/injection-corpus.mjs` — 60/60 checks passed
- `node --check` passed for both Chrome/Firefox indicator and background files
- `git diff --check` passed