### PR TITLE
Prevent stale file upload dialogs

### DIFF
--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -39,6 +39,12 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
+      "js": ["src/content/file-picker-guard-page.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
+      "matches": ["<all_urls>"],
       "js": [
         "src/content/accessibility-tree.js",
         "src/content/content.js",

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -9757,7 +9757,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const originalResponse = { ...response };
     delete originalResponse._filePickerGuardId;
 
-    await new Promise(resolve => setTimeout(resolve, 120));
+    await new Promise(resolve => setTimeout(resolve, 275));
     try {
       let settled = await chrome.tabs.sendMessage(tabId, {
         target: 'content',

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -13865,6 +13865,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let pressedDelivered = false;
     try {
       await cdpClient.attach(tabId);
+      dispatchStage = 'filePickerGuardArm';
+      await cdpClient.armFileInputClickGuard(tabId);
       dispatchStage = 'mouseMoved';
       await cdpClient.dispatchMouseEvent(tabId, 'mouseMoved', target.x, target.y);
       dispatchedEvents++;
@@ -13883,6 +13885,22 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       dispatchStage = 'mouseReleased';
       await cdpClient.dispatchMouseEvent(tabId, 'mouseReleased', target.x, target.y);
       dispatchedEvents++;
+      dispatchStage = 'filePickerGuardConsume';
+      const blockedFileInput = await cdpClient.consumeFileInputClickGuard(tabId);
+      if (blockedFileInput?.blocked) {
+        return withSnapshot({
+          ...cdpClient.fileInputClickBlockedResult(
+            blockedFileInput,
+            `Do not click ${args?.ref_id || 'this upload control'} before uploading.`,
+          ),
+          ref_id: args?.ref_id,
+          fallback: 'cdp_after_synthetic_no_progress',
+          fallbackAttempted: true,
+          trusted: true,
+          verified: true,
+          rect: target.rect || response.rect,
+        }, settledObservation);
+      }
       dispatchStage = 'complete';
     } catch (error) {
       const fallbackAttempted = dispatchedEvents > 0;

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -11448,6 +11448,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (!nodeIds || nodeIds.length === 0) {
           return { success: false, error: `File input not found for selector "${args.selector}". Re-inspect the page with get_interactive_elements or get_accessibility_tree to find the real <input type=file> (some upload widgets hide it until you click their "add files" button first).` };
         }
+        if (nodeIds.length > 1) {
+          return {
+            success: false,
+            error: `Selector "${args.selector}" matched ${nodeIds.length} elements across the document and open shadow roots. Use an exact, unique selector for the intended <input type=file>; do not use a generic input[type=file] selector when multiple inputs exist.`,
+          };
+        }
 
         // Pre-validate the local path BEFORE handing it to the page's input.
         // CDP's setFileInputFiles silently attaches a phantom 0-byte entry for

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -9425,19 +9425,28 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       return await chrome.tabs.sendMessage(tabId, { target: 'content', action, params });
     } catch (e) {
       try {
-        await chrome.scripting.executeScript({
-          target: { tabId },
-          files: [
-            'src/content/accessibility-tree.js',
-            'src/content/content.js',
-            'src/content/agent-visual-indicator.js',
-          ],
-        });
+        await this._injectCoreContentScripts(tabId);
         return await chrome.tabs.sendMessage(tabId, { target: 'content', action, params });
       } catch (e2) {
         return { success: false, error: `Failed to communicate with page: ${e2.message || e2}` };
       }
     }
+  }
+
+  async _injectCoreContentScripts(tabId) {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      world: 'MAIN',
+      files: ['src/content/file-picker-guard-page.js'],
+    });
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: [
+        'src/content/accessibility-tree.js',
+        'src/content/content.js',
+        'src/content/agent-visual-indicator.js',
+      ],
+    });
   }
 
   _devCssPatchStorageKey(patchId) {
@@ -13236,14 +13245,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         // get_accessibility_tree / click_ax / type_ax handlers can reach
         // window.__generateAccessibilityTree and window.__wb_ax_lookup.
         try {
-          await chrome.scripting.executeScript({
-            target: { tabId },
-            files: [
-              'src/content/accessibility-tree.js',
-              'src/content/content.js',
-              'src/content/agent-visual-indicator.js',
-            ],
-          });
+          await this._injectCoreContentScripts(tabId);
           // Re-stamp after inject so the safety window does not include the
           // injection gap (which can exceed 400ms on cold tabs).
           await captureClickAxBaseline();

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -12319,9 +12319,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             w: Math.round(Number(info.width) || 1),
             h: Math.round(Number(info.height) || 1),
           }, 'click_text');
+          await cdpClient.armFileInputClickGuard(tabId);
           await cdpClient.dispatchMouseEvent(tabId, 'mouseMoved', info.x, info.y);
           await cdpClient.dispatchMouseEvent(tabId, 'mousePressed', info.x, info.y);
           await cdpClient.dispatchMouseEvent(tabId, 'mouseReleased', info.x, info.y);
+          const blockedFileInput = await cdpClient.consumeFileInputClickGuard(tabId);
+          if (blockedFileInput?.blocked) {
+            return cdpClient.fileInputClickBlockedResult(
+              blockedFileInput,
+              `Do not click "${args.text}" before uploading.`,
+            );
+          }
           // Kicked off in parallel with the SELECT post-click check below;
           // awaited before we return so we can fold the redirect into the
           // tool result.
@@ -12588,9 +12596,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           const progressBeforeCoord = await this._clickProgressSnapshot(tabId);
           const beforeTabIdsCoord = new Set((await chrome.tabs.query({})).map(t => t.id));
           this._showAgentTarget(tabId, { x: Math.round(clickX), y: Math.round(clickY), w: 1, h: 1 }, 'click_coordinates');
+          await cdpClient.armFileInputClickGuard(tabId);
           await cdpClient.dispatchMouseEvent(tabId, 'mouseMoved', clickX, clickY);
           await cdpClient.dispatchMouseEvent(tabId, 'mousePressed', clickX, clickY);
           await cdpClient.dispatchMouseEvent(tabId, 'mouseReleased', clickX, clickY);
+          const blockedFileInput = await cdpClient.consumeFileInputClickGuard(tabId);
+          if (blockedFileInput?.blocked) {
+            return cdpClient.fileInputClickBlockedResult(
+              blockedFileInput,
+              `The attempted control was at (${args.x}, ${args.y}).`,
+            );
+          }
           const newTabPromiseCoord = this._redirectTargetBlankClick(tabId, beforeTabIdsCoord);
 
           // Post-click SELECT detection (same as text-based path above).

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -9757,7 +9757,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const originalResponse = { ...response };
     delete originalResponse._filePickerGuardId;
 
-    await new Promise(resolve => setTimeout(resolve, 275));
+    await new Promise(resolve => setTimeout(resolve, 525));
     try {
       let settled = await chrome.tabs.sendMessage(tabId, {
         target: 'content',

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -9742,6 +9742,44 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
   }
 
+  async _settleContentFilePickerGuard(tabId, response) {
+    const guardId = response?._filePickerGuardId;
+    if (!guardId) return response;
+    const originalResponse = { ...response };
+    delete originalResponse._filePickerGuardId;
+
+    await new Promise(resolve => setTimeout(resolve, 120));
+    try {
+      let settled = await chrome.tabs.sendMessage(tabId, {
+        target: 'content',
+        action: 'consume_file_picker_guard',
+        params: { guardId },
+      });
+      if (settled?.settled === false) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        settled = await chrome.tabs.sendMessage(tabId, {
+          target: 'content',
+          action: 'consume_file_picker_guard',
+          params: { guardId },
+        });
+      }
+      if (settled?.filePickerBlocked) {
+        const blockedResponse = { ...settled };
+        delete blockedResponse.settled;
+        return {
+          ...blockedResponse,
+          ...(originalResponse.rect ? { rect: originalResponse.rect } : {}),
+          ...(originalResponse.ref_id ? { ref_id: originalResponse.ref_id } : {}),
+        };
+      }
+    } catch {
+      // The delivered click may have navigated or submitted the old document.
+      // Keep its original response and never re-inject/replay the action just
+      // because the best-effort deferred-picker probe lost that document.
+    }
+    return originalResponse;
+  }
+
   async executeTool(tabId, name, args, onUpdate = null, executionContext = null) {
     if (name === 'load_skill') {
       return this._loadSkillForRun(tabId, args || {});
@@ -13211,6 +13249,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         } catch (e2) {
           return { error: `Failed to communicate with page: ${e2.message}` };
         }
+      }
+      if (name === 'click' || name === 'click_ax') {
+        response = await this._settleContentFilePickerGuard(tabId, response);
       }
       if (name === 'get_accessibility_tree' && response?.documentToken) {
         this._lastAxScopes.set(tabId, {

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -849,7 +849,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'upload_file',
-      description: 'Upload a file to a file input element. Provide EITHER downloadId (preferred — the id from download_files/list_downloads; you do not need to recall the path) OR filePath (absolute local path). The file must exist on the local filesystem.',
+      description: 'Upload a file directly to an existing file input without opening the page or OS file-picker dialog. Do NOT click "Choose file", "Select a file", an upload drop zone, or the input first when the input already exists. Provide EITHER downloadId (preferred — the id from download_files/list_downloads; you do not need to recall the path) OR filePath (absolute local path). If no file input exists because the widget creates it lazily, one guarded click on its add-files control may initialize the widget; then retry upload_file with the exact selector returned or discovered. The file must exist on the local filesystem.',
       parameters: {
         type: 'object',
         properties: {
@@ -1500,6 +1500,7 @@ CLICKING — read this:
 - For buttons and links you can SEE, click by visible text: \`click({text: "Publish release"})\`. Default matching is EXACT (case-insensitive). If exact fails (no match), the system automatically tries prefix then substring matching — but if multiple elements match at any level, it returns an ambiguity error instead of guessing.
 - If you get an ambiguity error, use a more specific text string, switch to \`click({index: N})\` from \`get_interactive_elements\`, or use a selector.
 - You can explicitly control matching with \`textMatch\`: \`"exact"\` (default), \`"prefix"\`, or \`"contains"\`.
+- FILE UPLOADS: when the page already has an \`<input type="file">\`, do not click "Choose file", "Select a file", "Browse", the upload drop zone, or the input first. Find the exact selector and call \`upload_file({selector, downloadId})\` directly; it attaches the file without opening a native dialog. Exception: if \`upload_file\` reports that no input exists because the widget creates it lazily, make one guarded click on the widget's add-files control to initialize it. A blocked-picker result may return the new exact selector; retry \`upload_file\` with that selector. Never substitute a generic \`input[type="file"]\` selector when multiple file inputs exist.
 - Order of preference:
   1. \`click_ax({ref_id: "ref_N"})\` — ref_id from get_accessibility_tree. Most reliable; carries role+name so you always know what you're clicking, and ref_ids are stable across calls.
   2. \`click({text: "..."})\` — visible button/link text. Good fallback if the tree didn't surface the element cleanly.

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -2308,14 +2308,7 @@ async function handleMessage(msg, sender) {
       } catch {
         // Try injecting content script. accessibility-tree.js must load
         // first so content.js's a11y-tree handlers can reach the builder.
-        await chrome.scripting.executeScript({
-          target: { tabId },
-          files: [
-            'src/content/accessibility-tree.js',
-            'src/content/content.js',
-            'src/content/agent-visual-indicator.js',
-          ],
-        });
+        await agent._injectCoreContentScripts(tabId);
         return await chrome.tabs.sendMessage(tabId, {
           target: 'content',
           action: 'get_page_info',

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -1191,7 +1191,11 @@ export class CDPClient {
     }
     const protocolBlocked = this.fileChooserGuards.get(tabId)?.blocked || null;
     const blocked = rendererBlocked || protocolBlocked;
-    if (blocked) await this._disarmProtocolFileChooserGuard(tabId);
+    // Protocol interception cancels every chooser in the tab, including a
+    // user's later trusted click, so it must never outlive this observation
+    // window. The narrower page-world wrapper can remain on its TTL to cover
+    // delayed programmatic click()/showPicker() callbacks.
+    await this._disarmProtocolFileChooserGuard(tabId);
     return blocked;
   }
 

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -997,8 +997,58 @@ export class CDPClient {
           };
           document.addEventListener('click', window.__wb_file_input_click_guard, true);
         }
+        if (typeof window.__wb_file_input_show_picker_guard_restore === 'function') {
+          window.__wb_file_input_show_picker_guard_restore();
+        }
+        if (window.__wb_file_input_show_picker_guard_timer) {
+          clearTimeout(window.__wb_file_input_show_picker_guard_timer);
+          window.__wb_file_input_show_picker_guard_timer = null;
+        }
+        const showPickerProto = window.HTMLInputElement?.prototype;
+        const showPickerDescriptor = showPickerProto
+          && Object.getOwnPropertyDescriptor(showPickerProto, 'showPicker');
+        const originalShowPicker = showPickerDescriptor?.value;
+        if (typeof originalShowPicker === 'function') {
+          const guardedShowPicker = function(...args) {
+            const isFileInput = this?.tagName === 'INPUT'
+              && String(this.getAttribute?.('type') || this.type || '').toLowerCase() === 'file';
+            if (
+              isFileInput
+              && Date.now() <= Number(window.__wb_file_input_click_guard_until || 0)
+            ) {
+              window.__wb_file_input_click_guard_last = {
+                blocked: true,
+                selector: uniqueFileInputSelector(this),
+                ts: Date.now(),
+              };
+              return undefined;
+            }
+            return Reflect.apply(originalShowPicker, this, args);
+          };
+          try {
+            Object.defineProperty(showPickerProto, 'showPicker', {
+              ...showPickerDescriptor,
+              value: guardedShowPicker,
+            });
+            window.__wb_file_input_show_picker_guard_restore = () => {
+              try {
+                if (showPickerProto.showPicker === guardedShowPicker) {
+                  Object.defineProperty(showPickerProto, 'showPicker', showPickerDescriptor);
+                }
+              } catch {}
+              window.__wb_file_input_show_picker_guard_restore = null;
+            };
+          } catch {
+            window.__wb_file_input_show_picker_guard_restore = null;
+          }
+        }
         window.__wb_file_input_click_guard_last = null;
         window.__wb_file_input_click_guard_until = Date.now() + ${ttl};
+        window.__wb_file_input_show_picker_guard_timer = setTimeout(() => {
+          if (Date.now() <= Number(window.__wb_file_input_click_guard_until || 0)) return;
+          window.__wb_file_input_show_picker_guard_timer = null;
+          window.__wb_file_input_show_picker_guard_restore?.();
+        }, ${ttl} + 25);
         return true;
       })()
     `);
@@ -1019,6 +1069,11 @@ export class CDPClient {
           const blocked = window.__wb_file_input_click_guard_last || null;
           window.__wb_file_input_click_guard_until = 0;
           window.__wb_file_input_click_guard_last = null;
+          if (window.__wb_file_input_show_picker_guard_timer) {
+            clearTimeout(window.__wb_file_input_show_picker_guard_timer);
+            window.__wb_file_input_show_picker_guard_timer = null;
+          }
+          window.__wb_file_input_show_picker_guard_restore?.();
           return blocked;
         })()
       `);

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -553,20 +553,57 @@ export class CDPClient {
   }
 
   /**
-   * Query a selector in the main frame or any iframe/shadow DOM (pierce).
+   * Query a selector in the main document and all open shadow roots.
+   * DOM.querySelectorAll only searches the supplied root node; its protocol
+   * schema has no shadow-piercing option. Resolve matches in page JS, then
+   * convert the returned DOM objects back to nodeIds for DOM.setFileInputFiles.
    */
   async querySelectorPierce(tabId, selector) {
     await this.sendCommand(tabId, 'DOM.enable');
-    const doc = await this.sendCommand(tabId, 'DOM.getDocument', { depth: 0, pierce: false });
-    const rootNodeId = doc.root?.nodeId;
-    if (!rootNodeId) throw new Error('No document root');
-
-    const result = await this.sendCommand(tabId, 'DOM.querySelectorAll', {
-      nodeId: rootNodeId,
-      selector,
-      piercesShadowDom: true,
-    });
-    return result.nodeIds || [];
+    await this.sendCommand(tabId, 'Runtime.enable');
+    const objectGroup = `webbrain-query-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    try {
+      const evaluated = await this.sendCommand(tabId, 'Runtime.evaluate', {
+        expression: `
+          (() => {
+            const selector = ${JSON.stringify(selector)};
+            const matches = [];
+            const visit = (root) => {
+              matches.push(...root.querySelectorAll(selector));
+              for (const element of root.querySelectorAll('*')) {
+                if (element.shadowRoot) visit(element.shadowRoot);
+              }
+            };
+            visit(document);
+            return matches;
+          })()
+        `,
+        objectGroup,
+        returnByValue: false,
+      });
+      if (evaluated?.exceptionDetails) {
+        throw new Error(evaluated.exceptionDetails.text || 'Selector evaluation failed');
+      }
+      const arrayObjectId = evaluated?.result?.objectId;
+      if (!arrayObjectId) return [];
+      const properties = await this.sendCommand(tabId, 'Runtime.getProperties', {
+        objectId: arrayObjectId,
+        ownProperties: true,
+      });
+      const nodeIds = [];
+      for (const property of properties?.result || []) {
+        if (!/^\d+$/.test(property?.name || '')) continue;
+        const objectId = property?.value?.objectId;
+        if (!objectId) continue;
+        const requested = await this.sendCommand(tabId, 'DOM.requestNode', { objectId });
+        if (requested?.nodeId) nodeIds.push(requested.nodeId);
+      }
+      return nodeIds;
+    } finally {
+      try {
+        await this.sendCommand(tabId, 'Runtime.releaseObjectGroup', { objectGroup });
+      } catch {}
+    }
   }
 
   /**

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -971,8 +971,12 @@ export class CDPClient {
    * Disarm the temporary file-input click guard and return any intercepted
    * chooser activation from the current agent click.
    */
-  async consumeFileInputClickGuard(tabId) {
+  async consumeFileInputClickGuard(tabId, settleMs = 100) {
     try {
+      const delayMs = Math.max(0, Number(settleMs) || 0);
+      if (delayMs > 0) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
       const result = await this.evaluate(tabId, `
         (() => {
           const blocked = window.__wb_file_input_click_guard_last || null;

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -1058,7 +1058,7 @@ export class CDPClient {
    * Disarm the temporary file-input click guard and return any intercepted
    * chooser activation from the current agent click.
    */
-  async consumeFileInputClickGuard(tabId, settleMs = 100) {
+  async consumeFileInputClickGuard(tabId, settleMs = 250) {
     try {
       const delayMs = Math.max(0, Number(settleMs) || 0);
       if (delayMs > 0) {

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -1008,37 +1008,81 @@ export class CDPClient {
         const showPickerDescriptor = showPickerProto
           && Object.getOwnPropertyDescriptor(showPickerProto, 'showPicker');
         const originalShowPicker = showPickerDescriptor?.value;
-        if (typeof originalShowPicker === 'function') {
+        const ownClickDescriptor = showPickerProto
+          && Object.getOwnPropertyDescriptor(showPickerProto, 'click');
+        const originalClick = showPickerProto?.click;
+        if (typeof originalShowPicker === 'function' || typeof originalClick === 'function') {
+          const isFileInput = (input) =>
+            input?.tagName === 'INPUT'
+            && String(input.getAttribute?.('type') || input.type || '').toLowerCase() === 'file';
+          const blockInput = (input) => {
+            window.__wb_file_input_click_guard_last = {
+              blocked: true,
+              selector: uniqueFileInputSelector(input),
+              ts: Date.now(),
+            };
+          };
           const guardedShowPicker = function(...args) {
-            const isFileInput = this?.tagName === 'INPUT'
-              && String(this.getAttribute?.('type') || this.type || '').toLowerCase() === 'file';
             if (
-              isFileInput
+              isFileInput(this)
               && Date.now() <= Number(window.__wb_file_input_click_guard_until || 0)
             ) {
-              window.__wb_file_input_click_guard_last = {
-                blocked: true,
-                selector: uniqueFileInputSelector(this),
-                ts: Date.now(),
-              };
+              blockInput(this);
               return undefined;
             }
             return Reflect.apply(originalShowPicker, this, args);
           };
-          try {
-            Object.defineProperty(showPickerProto, 'showPicker', {
-              ...showPickerDescriptor,
-              value: guardedShowPicker,
-            });
+          const guardedClick = function(...args) {
+            if (
+              isFileInput(this)
+              && Date.now() <= Number(window.__wb_file_input_click_guard_until || 0)
+            ) {
+              blockInput(this);
+              return undefined;
+            }
+            return Reflect.apply(originalClick, this, args);
+          };
+          let showPickerInstalled = false;
+          let clickInstalled = false;
+          if (typeof originalShowPicker === 'function') {
+            try {
+              Object.defineProperty(showPickerProto, 'showPicker', {
+                ...showPickerDescriptor,
+                value: guardedShowPicker,
+              });
+              showPickerInstalled = true;
+            } catch {}
+          }
+          if (typeof originalClick === 'function') {
+            try {
+              Object.defineProperty(showPickerProto, 'click', {
+                configurable: true,
+                enumerable: ownClickDescriptor?.enumerable ?? false,
+                writable: true,
+                value: guardedClick,
+              });
+              clickInstalled = true;
+            } catch {}
+          }
+          if (showPickerInstalled || clickInstalled) {
             window.__wb_file_input_show_picker_guard_restore = () => {
               try {
-                if (showPickerProto.showPicker === guardedShowPicker) {
+                if (showPickerInstalled && showPickerProto.showPicker === guardedShowPicker) {
                   Object.defineProperty(showPickerProto, 'showPicker', showPickerDescriptor);
+                }
+              } catch {}
+              try {
+                if (clickInstalled && showPickerProto.click === guardedClick) {
+                  if (ownClickDescriptor) {
+                    Object.defineProperty(showPickerProto, 'click', ownClickDescriptor);
+                  } else {
+                    delete showPickerProto.click;
+                  }
                 }
               } catch {}
               window.__wb_file_input_show_picker_guard_restore = null;
             };
-          } catch {
+          } else {
             window.__wb_file_input_show_picker_guard_restore = null;
           }
         }
@@ -1058,7 +1102,7 @@ export class CDPClient {
    * Disarm the temporary file-input click guard and return any intercepted
    * chooser activation from the current agent click.
    */
-  async consumeFileInputClickGuard(tabId, settleMs = 250) {
+  async consumeFileInputClickGuard(tabId, settleMs = 500) {
     try {
       const delayMs = Math.max(0, Number(settleMs) || 0);
       if (delayMs > 0) {
@@ -1067,13 +1111,15 @@ export class CDPClient {
       const result = await this.evaluate(tabId, `
         (() => {
           const blocked = window.__wb_file_input_click_guard_last || null;
-          window.__wb_file_input_click_guard_until = 0;
           window.__wb_file_input_click_guard_last = null;
-          if (window.__wb_file_input_show_picker_guard_timer) {
-            clearTimeout(window.__wb_file_input_show_picker_guard_timer);
-            window.__wb_file_input_show_picker_guard_timer = null;
+          if (blocked) {
+            window.__wb_file_input_click_guard_until = 0;
+            if (window.__wb_file_input_show_picker_guard_timer) {
+              clearTimeout(window.__wb_file_input_show_picker_guard_timer);
+              window.__wb_file_input_show_picker_guard_timer = null;
+            }
+            window.__wb_file_input_show_picker_guard_restore?.();
           }
-          window.__wb_file_input_show_picker_guard_restore?.();
           return blocked;
         })()
       `);

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -17,6 +17,7 @@ export class CDPClient {
     this.sessions = new Map(); // tabId -> debugger session
     this.eventHandlers = new Map(); // tabId -> { eventName -> [handlers] }
     this.devDiagnostics = new Map(); // tabId -> bounded console/network buffers
+    this.fileChooserGuards = new Map(); // tabId -> temporary protocol interception
   }
 
   /**
@@ -50,6 +51,9 @@ export class CDPClient {
             this.sessions.delete(tabId);
             this.eventHandlers.delete(tabId);
             this.devDiagnostics.delete(tabId);
+            const fileChooserGuard = this.fileChooserGuards.get(tabId);
+            if (fileChooserGuard?.timer) clearTimeout(fileChooserGuard.timer);
+            this.fileChooserGuards.delete(tabId);
           }
         });
 
@@ -63,12 +67,14 @@ export class CDPClient {
    */
   async detach(tabId) {
     if (!this.sessions.has(tabId)) return;
+    await this._disarmProtocolFileChooserGuard(tabId);
 
     return new Promise((resolve) => {
       chrome.debugger.detach({ tabId }, () => {
         this.sessions.delete(tabId);
         this.eventHandlers.delete(tabId);
         this.devDiagnostics.delete(tabId);
+        this.fileChooserGuards.delete(tabId);
         resolve();
       });
     });
@@ -916,6 +922,52 @@ export class CDPClient {
     return { success: true };
   }
 
+  async _disarmProtocolFileChooserGuard(tabId) {
+    const state = this.fileChooserGuards.get(tabId);
+    if (!state) return;
+    this.fileChooserGuards.delete(tabId);
+    if (state.timer) clearTimeout(state.timer);
+    this.off(tabId, 'Page.fileChooserOpened', state.handler);
+    try {
+      await this.sendCommand(tabId, 'Page.setInterceptFileChooserDialog', {
+        enabled: false,
+      });
+    } catch {}
+  }
+
+  async _armProtocolFileChooserGuard(tabId, ttlMs) {
+    await this._disarmProtocolFileChooserGuard(tabId);
+    const state = {
+      blocked: null,
+      handler: null,
+      timer: null,
+    };
+    state.handler = (params = {}) => {
+      state.blocked = {
+        blocked: true,
+        selector: null,
+        ts: Date.now(),
+        ...(params.backendNodeId ? { backendNodeId: params.backendNodeId } : {}),
+      };
+    };
+    this.on(tabId, 'Page.fileChooserOpened', state.handler);
+    this.fileChooserGuards.set(tabId, state);
+    try {
+      await this.sendCommand(tabId, 'Page.enable');
+      await this.sendCommand(tabId, 'Page.setInterceptFileChooserDialog', {
+        enabled: true,
+        cancel: true,
+      });
+    } catch {
+      this.off(tabId, 'Page.fileChooserOpened', state.handler);
+      this.fileChooserGuards.delete(tabId);
+      return;
+    }
+    state.timer = setTimeout(() => {
+      this._disarmProtocolFileChooserGuard(tabId).catch(() => {});
+    }, ttlMs);
+  }
+
   /**
    * Temporarily suppress renderer-driven <input type=file> activation while an
    * agent click is being dispatched. The upload_file tool sets files directly
@@ -929,6 +981,7 @@ export class CDPClient {
    */
   async armFileInputClickGuard(tabId, ttlMs = 2500) {
     const ttl = Math.max(250, Math.min(Number(ttlMs) || 2500, 5000));
+    await this._armProtocolFileChooserGuard(tabId, ttl);
     await this.evaluate(tabId, `
       (() => {
         const uniqueFileInputSelector = (input) => {
@@ -1103,11 +1156,12 @@ export class CDPClient {
    * chooser activation from the current agent click.
    */
   async consumeFileInputClickGuard(tabId, settleMs = 500) {
+    const delayMs = Math.max(0, Number(settleMs) || 0);
+    if (delayMs > 0) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+    let rendererBlocked = null;
     try {
-      const delayMs = Math.max(0, Number(settleMs) || 0);
-      if (delayMs > 0) {
-        await new Promise(resolve => setTimeout(resolve, delayMs));
-      }
       const result = await this.evaluate(tabId, `
         (() => {
           const blocked = window.__wb_file_input_click_guard_last || null;
@@ -1123,14 +1177,17 @@ export class CDPClient {
           return blocked;
         })()
       `);
-      return result?.result?.value || null;
+      rendererBlocked = result?.result?.value || null;
     } catch {
       // A delivered click may navigate or reload before this best-effort probe
       // runs, destroying its execution context. Never turn that observation
       // race into a failed click (or let clickElement retry the action); the
       // short guard TTL disarms the abandoned document automatically.
-      return null;
     }
+    const protocolBlocked = this.fileChooserGuards.get(tabId)?.blocked || null;
+    const blocked = rendererBlocked || protocolBlocked;
+    if (blocked) await this._disarmProtocolFileChooserGuard(tabId);
+    return blocked;
   }
 
   fileInputClickBlockedResult(blocked, context = '') {

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -984,6 +984,11 @@ export class CDPClient {
     await this._armProtocolFileChooserGuard(tabId, ttl);
     await this.evaluate(tabId, `
       (() => {
+        // A prior content-script click may intentionally leave its MAIN-world
+        // programmatic guard alive through a short TTL. Restore that wrapper
+        // before CDP snapshots the native methods, otherwise the two restore
+        // lifecycles can re-install each other's stale wrapper.
+        document.dispatchEvent(new Event('webbrain:file-picker-guard-reset'));
         const uniqueFileInputSelector = (input) => {
           const allPiercedMatches = (selector) => {
             const matches = [];

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -880,6 +880,134 @@ export class CDPClient {
   }
 
   /**
+   * Temporarily suppress renderer-driven <input type=file> activation while an
+   * agent click is being dispatched. The upload_file tool sets files directly
+   * with DOM.setFileInputFiles; clicking a page's "Choose file" affordance
+   * first only opens an OS dialog that CDP cannot operate and leaves it stale
+   * after the direct upload succeeds.
+   *
+   * The capture listener is installed once per document, but it is inert
+   * unless armed. A short expiry is a safety net for early-return/error paths,
+   * so normal user clicks are never permanently affected.
+   */
+  async armFileInputClickGuard(tabId, ttlMs = 2500) {
+    const ttl = Math.max(250, Math.min(Number(ttlMs) || 2500, 5000));
+    await this.evaluate(tabId, `
+      (() => {
+        const uniqueFileInputSelector = (input) => {
+          const allPiercedMatches = (selector) => {
+            const matches = [];
+            const visit = (root) => {
+              try { matches.push(...root.querySelectorAll(selector)); } catch { return; }
+              let elements = [];
+              try { elements = root.querySelectorAll('*'); } catch {}
+              for (const element of elements) {
+                if (element.shadowRoot) visit(element.shadowRoot);
+              }
+            };
+            visit(document);
+            return matches;
+          };
+          const unique = (selector) => {
+            if (!selector) return null;
+            const matches = allPiercedMatches(selector);
+            return matches.length === 1 && matches[0] === input ? selector : null;
+          };
+          try {
+            if (input.id && window.CSS?.escape) {
+              const byId = unique('#' + CSS.escape(input.id));
+              if (byId) return byId;
+            }
+            if (input.name && window.CSS?.escape) {
+              const byName = unique('input[type="file"][name=' + CSS.escape(String(input.name)) + ']');
+              if (byName) return byName;
+            }
+            const parts = [];
+            let node = input;
+            while (node?.nodeType === Node.ELEMENT_NODE) {
+              let part = node.tagName.toLowerCase();
+              const parent = node.parentElement;
+              if (parent) {
+                const siblings = Array.from(parent.children).filter(child => child.tagName === node.tagName);
+                if (siblings.length > 1) part += ':nth-of-type(' + (siblings.indexOf(node) + 1) + ')';
+              }
+              parts.unshift(part);
+              const byPath = unique(parts.join(' > '));
+              if (byPath) return byPath;
+              node = parent;
+            }
+          } catch {}
+          return null;
+        };
+        if (!window.__wb_file_input_click_guard) {
+          window.__wb_file_input_click_guard = (event) => {
+            if (Date.now() > Number(window.__wb_file_input_click_guard_until || 0)) return;
+            const path = typeof event.composedPath === 'function'
+              ? event.composedPath()
+              : [event.target];
+            const input = path.find(node =>
+              node?.tagName === 'INPUT'
+              && String(node.getAttribute?.('type') || node.type || '').toLowerCase() === 'file'
+            );
+            if (!input) return;
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            window.__wb_file_input_click_guard_last = {
+              blocked: true,
+              selector: uniqueFileInputSelector(input),
+              ts: Date.now(),
+            };
+          };
+          document.addEventListener('click', window.__wb_file_input_click_guard, true);
+        }
+        window.__wb_file_input_click_guard_last = null;
+        window.__wb_file_input_click_guard_until = Date.now() + ${ttl};
+        return true;
+      })()
+    `);
+  }
+
+  /**
+   * Disarm the temporary file-input click guard and return any intercepted
+   * chooser activation from the current agent click.
+   */
+  async consumeFileInputClickGuard(tabId) {
+    try {
+      const result = await this.evaluate(tabId, `
+        (() => {
+          const blocked = window.__wb_file_input_click_guard_last || null;
+          window.__wb_file_input_click_guard_until = 0;
+          window.__wb_file_input_click_guard_last = null;
+          return blocked;
+        })()
+      `);
+      return result?.result?.value || null;
+    } catch {
+      // A delivered click may navigate or reload before this best-effort probe
+      // runs, destroying its execution context. Never turn that observation
+      // race into a failed click (or let clickElement retry the action); the
+      // short guard TTL disarms the abandoned document automatically.
+      return null;
+    }
+  }
+
+  fileInputClickBlockedResult(blocked, context = '') {
+    const selector = typeof blocked?.selector === 'string' && blocked.selector
+      ? blocked.selector
+      : null;
+    const guidance = selector
+      ? `Call upload_file with selector ${JSON.stringify(selector)} and the existing downloadId or absolute filePath; it attaches the file without opening an OS dialog.`
+      : 'Re-inspect the page to find an exact, unique <input type=file> selector, then call upload_file directly. Do not use a generic input[type="file"] selector when the page has multiple file inputs.';
+    return {
+      success: false,
+      dispatched: true,
+      filePickerBlocked: true,
+      ...(selector ? { selector } : {}),
+      error: ['Blocked a native file chooser.', context, guidance].filter(Boolean).join(' '),
+    };
+  }
+
+  /**
    * Read back the FileList attached to an <input type=file> so callers can
    * confirm a setFileInputFiles actually took effect. CDP's
    * DOM.setFileInputFiles does NOT throw on a non-existent path — it silently
@@ -1759,6 +1887,7 @@ export class CDPClient {
     let dispatchAttempted = false;
     if (info.inViewport && info.hitOk) {
       try {
+        await this.armFileInputClickGuard(tabId);
         const rect = {
           x: Math.round(info.x - (info.width || 1) / 2),
           y: Math.round(info.y - (info.height || 1) / 2),
@@ -1775,6 +1904,13 @@ export class CDPClient {
         await this.sendCommand(tabId, 'Input.dispatchMouseEvent', {
           type: 'mouseReleased', x: info.x, y: info.y, button: 'left', buttons: 0, clickCount: 1,
         });
+        const blockedFileInput = await this.consumeFileInputClickGuard(tabId);
+        if (blockedFileInput?.blocked) {
+          return this.fileInputClickBlockedResult(
+            blockedFileInput,
+            'Do not click file-upload controls before uploading.',
+          );
+        }
         return {
           success: true,
           method: info.viaCDP ? 'cdp-mouse-closed-shadow' : 'cdp-mouse',
@@ -1793,6 +1929,7 @@ export class CDPClient {
     // and Runtime.callFunctionOn to invoke .click() on the resolved object.
     if (info.nodeId) {
       try {
+        await this.armFileInputClickGuard(tabId);
         await this.sendCommand(tabId, 'DOM.focus', { nodeId: info.nodeId }).catch(() => {});
         const { object } = await this.sendCommand(tabId, 'DOM.resolveNode', { nodeId: info.nodeId });
         if (object?.objectId) {
@@ -1801,6 +1938,13 @@ export class CDPClient {
             functionDeclaration: 'function() { this.click(); }',
             awaitPromise: false,
           });
+          const blockedFileInput = await this.consumeFileInputClickGuard(tabId);
+          if (blockedFileInput?.blocked) {
+            return this.fileInputClickBlockedResult(
+              blockedFileInput,
+              'Do not click file-upload controls before uploading.',
+            );
+          }
           return {
             success: true,
             method: 'cdp-node-click',
@@ -1819,6 +1963,7 @@ export class CDPClient {
 
     // Step 3: JS fallback for open shadow roots.
     const selectorJSON = JSON.stringify(selector);
+    await this.armFileInputClickGuard(tabId);
     const fb = await this.evaluate(tabId, `
       (() => {
         const sel = ${selectorJSON};
@@ -1843,6 +1988,13 @@ export class CDPClient {
         };
       })()
     `);
+    const blockedFileInput = await this.consumeFileInputClickGuard(tabId);
+    if (blockedFileInput?.blocked) {
+      return this.fileInputClickBlockedResult(
+        blockedFileInput,
+        'Do not click file-upload controls before uploading.',
+      );
+    }
     const fallbackResult = fb?.result?.value || { success: false, error: 'Click failed' };
     if (fallbackResult.success === false && fallbackResult.dispatched == null) {
       fallbackResult.dispatched = dispatchAttempted;

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -912,39 +912,76 @@
       blocked: null,
       settled: false,
       guard: null,
+      restoreShowPicker: null,
       settleTimer: null,
       cleanupTimer: null,
+    };
+    const isFileInput = (input) =>
+      input?.tagName === 'INPUT'
+      && String(input.getAttribute?.('type') || input.type || '').toLowerCase() === 'file';
+    const blockFileInput = (input) => {
+      state.blocked = { selector: uniqueFileInputSelector(input) };
     };
     const guard = (event) => {
       const path = typeof event.composedPath === 'function'
         ? event.composedPath()
         : [event.target];
-      const input = path.find(node =>
-        node?.tagName === 'INPUT'
-        && String(node.getAttribute?.('type') || node.type || '').toLowerCase() === 'file'
-      );
+      const input = path.find(isFileInput);
       if (!input) return;
       event.preventDefault();
       event.stopImmediatePropagation();
-      state.blocked = { selector: uniqueFileInputSelector(input) };
+      blockFileInput(input);
+    };
+    const installShowPickerGuard = () => {
+      const proto = window.HTMLInputElement?.prototype;
+      const descriptor = proto && Object.getOwnPropertyDescriptor(proto, 'showPicker');
+      const originalShowPicker = descriptor?.value;
+      if (typeof originalShowPicker !== 'function') return () => {};
+      const guardedShowPicker = function(...args) {
+        if (isFileInput(this)) {
+          blockFileInput(this);
+          return undefined;
+        }
+        return Reflect.apply(originalShowPicker, this, args);
+      };
+      try {
+        Object.defineProperty(proto, 'showPicker', { ...descriptor, value: guardedShowPicker });
+      } catch {
+        return () => {};
+      }
+      let restored = false;
+      return () => {
+        if (restored) return;
+        restored = true;
+        try {
+          if (proto.showPicker === guardedShowPicker) {
+            Object.defineProperty(proto, 'showPicker', descriptor);
+          }
+        } catch {}
+      };
+    };
+    const cleanupGuard = () => {
+      document.removeEventListener('click', guard, true);
+      state.restoreShowPicker?.();
     };
     state.guard = guard;
     _filePickerGuardStates.set(guardId, state);
     document.addEventListener('click', guard, true);
+    state.restoreShowPicker = installShowPickerGuard();
     try {
       runClick();
     } catch (error) {
-      document.removeEventListener('click', guard, true);
+      cleanupGuard();
       _filePickerGuardStates.delete(guardId);
       throw error;
     }
     if (state.blocked) {
-      document.removeEventListener('click', guard, true);
+      cleanupGuard();
       _filePickerGuardStates.delete(guardId);
       return { blocked: state.blocked, guardId: null };
     }
     state.settleTimer = setTimeout(() => {
-      document.removeEventListener('click', guard, true);
+      cleanupGuard();
       state.settled = true;
       state.cleanupTimer = setTimeout(() => {
         if (_filePickerGuardStates.get(guardId) === state) {

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -912,7 +912,7 @@
       blocked: null,
       settled: false,
       guard: null,
-      restoreShowPicker: null,
+      cleanupPageShowPickerGuard: null,
       settleTimer: null,
       cleanupTimer: null,
     };
@@ -932,42 +932,43 @@
       event.stopImmediatePropagation();
       blockFileInput(input);
     };
-    const installShowPickerGuard = () => {
-      const proto = window.HTMLInputElement?.prototype;
-      const descriptor = proto && Object.getOwnPropertyDescriptor(proto, 'showPicker');
-      const originalShowPicker = descriptor?.value;
-      if (typeof originalShowPicker !== 'function') return () => {};
-      const guardedShowPicker = function(...args) {
-        if (isFileInput(this)) {
-          blockFileInput(this);
-          return undefined;
-        }
-        return Reflect.apply(originalShowPicker, this, args);
+    const installPageShowPickerGuard = () => {
+      const root = document.documentElement;
+      if (!root) return () => {};
+      const guardAttr = 'data-webbrain-file-picker-guard';
+      const blockedAttr = 'data-webbrain-file-picker-blocked';
+      const blockedEvent = 'webbrain:file-picker-guard-blocked';
+      const signal = (eventName) => {
+        root.setAttribute(guardAttr, guardId);
+        document.dispatchEvent(new Event(eventName));
+        root.removeAttribute(guardAttr);
       };
-      try {
-        Object.defineProperty(proto, 'showPicker', { ...descriptor, value: guardedShowPicker });
-      } catch {
-        return () => {};
-      }
-      let restored = false;
-      return () => {
-        if (restored) return;
-        restored = true;
+      const onBlocked = () => {
         try {
-          if (proto.showPicker === guardedShowPicker) {
-            Object.defineProperty(proto, 'showPicker', descriptor);
-          }
+          const payload = JSON.parse(root.getAttribute(blockedAttr) || 'null');
+          if (payload?.guardId !== guardId) return;
+          state.blocked = {
+            selector: typeof payload.selector === 'string' && payload.selector
+              ? payload.selector
+              : null,
+          };
         } catch {}
+      };
+      document.addEventListener(blockedEvent, onBlocked, true);
+      signal('webbrain:file-picker-guard-arm');
+      return () => {
+        signal('webbrain:file-picker-guard-disarm');
+        document.removeEventListener(blockedEvent, onBlocked, true);
       };
     };
     const cleanupGuard = () => {
       document.removeEventListener('click', guard, true);
-      state.restoreShowPicker?.();
+      state.cleanupPageShowPickerGuard?.();
     };
     state.guard = guard;
     _filePickerGuardStates.set(guardId, state);
     document.addEventListener('click', guard, true);
-    state.restoreShowPicker = installShowPickerGuard();
+    state.cleanupPageShowPickerGuard = installPageShowPickerGuard();
     try {
       runClick();
     } catch (error) {

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -901,7 +901,7 @@
     return null;
   }
 
-  const FILE_PICKER_GUARD_SETTLE_MS = 100;
+  const FILE_PICKER_GUARD_SETTLE_MS = 250;
   const FILE_PICKER_GUARD_RETENTION_MS = 5000;
   const _filePickerGuardStates = new Map();
   let _filePickerGuardSequence = 0;
@@ -982,10 +982,10 @@
       return { blocked: state.blocked, guardId: null };
     }
     state.settleTimer = setTimeout(() => {
-      cleanupGuard();
       state.settled = true;
       state.cleanupTimer = setTimeout(() => {
         if (_filePickerGuardStates.get(guardId) === state) {
+          cleanupGuard();
           _filePickerGuardStates.delete(guardId);
         }
       }, FILE_PICKER_GUARD_RETENTION_MS);
@@ -998,6 +998,8 @@
     if (!state) return { success: true, settled: true, filePickerBlocked: false };
     if (!state.settled) return { success: true, settled: false, filePickerBlocked: false };
     if (state.cleanupTimer) clearTimeout(state.cleanupTimer);
+    document.removeEventListener('click', state.guard, true);
+    state.cleanupPageShowPickerGuard?.();
     _filePickerGuardStates.delete(guardId);
     if (state.blocked) {
       return { ...filePickerBlockedResponse(state.blocked), settled: true };

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -850,7 +850,7 @@
   }
 
   /**
-   * Run one synthetic agent click while suppressing any synchronous
+   * Run one synthetic agent click while suppressing any immediate or deferred
    * <input type=file>.click() it triggers. Uploads should go through
    * upload_file, which attaches the bytes directly; allowing the page click
    * first opens an OS picker that remains orphaned after the direct upload.
@@ -901,7 +901,9 @@
     return null;
   }
 
-  function clickWithoutNativeFilePicker(runClick) {
+  const FILE_PICKER_GUARD_SETTLE_MS = 100;
+
+  function clickWithoutNativeFilePicker(runClick, settleMs = FILE_PICKER_GUARD_SETTLE_MS) {
     let blocked = null;
     const guard = (event) => {
       const path = typeof event.composedPath === 'function'
@@ -919,10 +921,16 @@
     document.addEventListener('click', guard, true);
     try {
       runClick();
-    } finally {
+    } catch (error) {
       document.removeEventListener('click', guard, true);
+      throw error;
     }
-    return blocked;
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        document.removeEventListener('click', guard, true);
+        resolve(blocked);
+      }, Math.max(0, Number(settleMs) || 0));
+    });
   }
 
   function filePickerBlockedResponse(blocked, label = '') {
@@ -946,7 +954,7 @@
   /**
    * Click an element by selector or coordinates.
    */
-  function clickElement(params) {
+  async function clickElement(params) {
     let el;
     if (params.selector && /:contains\(|:has-text\(/.test(params.selector)) {
       return {
@@ -1263,7 +1271,7 @@
     }
 
     const clickedRect = rememberInteractionPoint(el, 'click');
-    const blockedFileInput = clickWithoutNativeFilePicker(() => el.click());
+    const blockedFileInput = await clickWithoutNativeFilePicker(() => el.click());
     if (blockedFileInput) {
       return {
         ...filePickerBlockedResponse(blockedFileInput, params.text || el.innerText?.trim() || ''),
@@ -3171,7 +3179,7 @@
           return { error: 'Failed to build accessibility tree: ' + (e && e.message || String(e)) };
         }
       },
-      'click_ax': () => {
+      'click_ax': async () => {
         let dispatched = false;
         const failure = (error, extra = {}) => ({
           success: false,
@@ -3341,7 +3349,9 @@
           rememberInteractionPoint(el, 'click_ax');
           const syntheticClickStartedAt = Date.now();
           dispatched = true;
-          const blockedFileInput = clickWithoutNativeFilePicker(() => el.click());
+          const blockedFileInputPromise = clickWithoutNativeFilePicker(() => el.click());
+          const fallbackStateAfterImmediate = _axFallbackState(el);
+          const blockedFileInput = await blockedFileInputPromise;
           if (blockedFileInput) {
             return failure(
               filePickerBlockedResponse(blockedFileInput, targetName || '').error,
@@ -3352,7 +3362,6 @@
               },
             );
           }
-          const fallbackStateAfterImmediate = _axFallbackState(el);
           // If the model just clicked a text-entry element, its next call must
           // be type_ax on the same ref_id. Putting the directive in the tool
           // payload (rather than only in the system prompt) keeps it in the

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -938,10 +938,9 @@
       const guardAttr = 'data-webbrain-file-picker-guard';
       const blockedAttr = 'data-webbrain-file-picker-blocked';
       const blockedEvent = 'webbrain:file-picker-guard-blocked';
-      const signal = (eventName) => {
+      const armPageGuard = () => {
         root.setAttribute(guardAttr, guardId);
-        document.dispatchEvent(new Event(eventName));
-        root.removeAttribute(guardAttr);
+        document.dispatchEvent(new Event('webbrain:file-picker-guard-arm'));
       };
       const onBlocked = () => {
         try {
@@ -955,9 +954,10 @@
         } catch {}
       };
       document.addEventListener(blockedEvent, onBlocked, true);
-      signal('webbrain:file-picker-guard-arm');
+      armPageGuard();
       return () => {
-        signal('webbrain:file-picker-guard-disarm');
+        document.dispatchEvent(new Event('webbrain:file-picker-guard-disarm'));
+        if (root.getAttribute(guardAttr) === guardId) root.removeAttribute(guardAttr);
         document.removeEventListener(blockedEvent, onBlocked, true);
       };
     };

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -849,6 +849,98 @@
     return null;
   }
 
+  /**
+   * Run one synthetic agent click while suppressing any synchronous
+   * <input type=file>.click() it triggers. Uploads should go through
+   * upload_file, which attaches the bytes directly; allowing the page click
+   * first opens an OS picker that remains orphaned after the direct upload.
+   */
+  function uniqueFileInputSelector(input) {
+    const allPiercedMatches = (selector) => {
+      const matches = [];
+      const visit = (root) => {
+        try { matches.push(...root.querySelectorAll(selector)); } catch { return; }
+        let elements = [];
+        try { elements = root.querySelectorAll('*'); } catch {}
+        for (const element of elements) {
+          if (element.shadowRoot) visit(element.shadowRoot);
+        }
+      };
+      visit(document);
+      return matches;
+    };
+    const unique = (selector) => {
+      if (!selector) return null;
+      const matches = allPiercedMatches(selector);
+      return matches.length === 1 && matches[0] === input ? selector : null;
+    };
+    try {
+      if (input.id && window.CSS?.escape) {
+        const byId = unique('#' + CSS.escape(input.id));
+        if (byId) return byId;
+      }
+      if (input.name && window.CSS?.escape) {
+        const byName = unique('input[type="file"][name=' + CSS.escape(String(input.name)) + ']');
+        if (byName) return byName;
+      }
+      const parts = [];
+      let node = input;
+      while (node?.nodeType === Node.ELEMENT_NODE) {
+        let part = node.tagName.toLowerCase();
+        const parent = node.parentElement;
+        if (parent) {
+          const siblings = Array.from(parent.children).filter(child => child.tagName === node.tagName);
+          if (siblings.length > 1) part += ':nth-of-type(' + (siblings.indexOf(node) + 1) + ')';
+        }
+        parts.unshift(part);
+        const byPath = unique(parts.join(' > '));
+        if (byPath) return byPath;
+        node = parent;
+      }
+    } catch {}
+    return null;
+  }
+
+  function clickWithoutNativeFilePicker(runClick) {
+    let blocked = null;
+    const guard = (event) => {
+      const path = typeof event.composedPath === 'function'
+        ? event.composedPath()
+        : [event.target];
+      const input = path.find(node =>
+        node?.tagName === 'INPUT'
+        && String(node.getAttribute?.('type') || node.type || '').toLowerCase() === 'file'
+      );
+      if (!input) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      blocked = { selector: uniqueFileInputSelector(input) };
+    };
+    document.addEventListener('click', guard, true);
+    try {
+      runClick();
+    } finally {
+      document.removeEventListener('click', guard, true);
+    }
+    return blocked;
+  }
+
+  function filePickerBlockedResponse(blocked, label = '') {
+    const selector = typeof blocked?.selector === 'string' && blocked.selector
+      ? blocked.selector
+      : null;
+    const guidance = selector
+      ? `Call upload_file with selector ${JSON.stringify(selector)} and the existing downloadId or absolute filePath; it attaches the file without opening an OS dialog.`
+      : 'Re-inspect the page to find an exact, unique <input type=file> selector, then call upload_file directly. Do not use a generic input[type="file"] selector when the page has multiple file inputs.';
+    return {
+      success: false,
+      dispatched: true,
+      filePickerBlocked: true,
+      ...(selector ? { selector } : {}),
+      error: `Blocked a native file chooser${label ? ` opened by "${label}"` : ''}. ${guidance}`,
+    };
+  }
+
   let _lastClickIdent = null;
 
   /**
@@ -1171,7 +1263,13 @@
     }
 
     const clickedRect = rememberInteractionPoint(el, 'click');
-    el.click();
+    const blockedFileInput = clickWithoutNativeFilePicker(() => el.click());
+    if (blockedFileInput) {
+      return {
+        ...filePickerBlockedResponse(blockedFileInput, params.text || el.innerText?.trim() || ''),
+        ...(clickedRect ? { rect: clickedRect } : {}),
+      };
+    }
 
     // Post-click SELECT detection: the click may have activated a <select>
     // via a label, wrapper, or overlapping element. Return error, not success.
@@ -3243,7 +3341,17 @@
           rememberInteractionPoint(el, 'click_ax');
           const syntheticClickStartedAt = Date.now();
           dispatched = true;
-          el.click();
+          const blockedFileInput = clickWithoutNativeFilePicker(() => el.click());
+          if (blockedFileInput) {
+            return failure(
+              filePickerBlockedResponse(blockedFileInput, targetName || '').error,
+              {
+                filePickerBlocked: true,
+                ...(blockedFileInput.selector ? { selector: blockedFileInput.selector } : {}),
+                ref_id,
+              },
+            );
+          }
           const fallbackStateAfterImmediate = _axFallbackState(el);
           // If the model just clicked a text-entry element, its next call must
           // be type_ax on the same ref_id. Putting the directive in the tool

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -901,7 +901,7 @@
     return null;
   }
 
-  const FILE_PICKER_GUARD_SETTLE_MS = 250;
+  const FILE_PICKER_GUARD_SETTLE_MS = 500;
   const FILE_PICKER_GUARD_RETENTION_MS = 5000;
   const _filePickerGuardStates = new Map();
   let _filePickerGuardSequence = 0;
@@ -955,8 +955,10 @@
       };
       document.addEventListener(blockedEvent, onBlocked, true);
       armPageGuard();
-      return () => {
-        document.dispatchEvent(new Event('webbrain:file-picker-guard-disarm'));
+      return (disarmPageGuard = true) => {
+        if (disarmPageGuard) {
+          document.dispatchEvent(new Event('webbrain:file-picker-guard-disarm'));
+        }
         if (root.getAttribute(guardAttr) === guardId) root.removeAttribute(guardAttr);
         document.removeEventListener(blockedEvent, onBlocked, true);
       };
@@ -999,7 +1001,11 @@
     if (!state.settled) return { success: true, settled: false, filePickerBlocked: false };
     if (state.cleanupTimer) clearTimeout(state.cleanupTimer);
     document.removeEventListener('click', state.guard, true);
-    state.cleanupPageShowPickerGuard?.();
+    // If nothing was observed, stop content-side observation but leave the
+    // page-world programmatic click/showPicker guard active until its own
+    // short TTL. This suppresses longer debounces without blocking the tool
+    // response or intercepting a user's direct native input click.
+    state.cleanupPageShowPickerGuard?.(!!state.blocked);
     _filePickerGuardStates.delete(guardId);
     if (state.blocked) {
       return { ...filePickerBlockedResponse(state.blocked), settled: true };

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -902,9 +902,19 @@
   }
 
   const FILE_PICKER_GUARD_SETTLE_MS = 100;
+  const FILE_PICKER_GUARD_RETENTION_MS = 5000;
+  const _filePickerGuardStates = new Map();
+  let _filePickerGuardSequence = 0;
 
   function clickWithoutNativeFilePicker(runClick, settleMs = FILE_PICKER_GUARD_SETTLE_MS) {
-    let blocked = null;
+    const guardId = `fpg_${Date.now().toString(36)}_${++_filePickerGuardSequence}`;
+    const state = {
+      blocked: null,
+      settled: false,
+      guard: null,
+      settleTimer: null,
+      cleanupTimer: null,
+    };
     const guard = (event) => {
       const path = typeof event.composedPath === 'function'
         ? event.composedPath()
@@ -916,21 +926,45 @@
       if (!input) return;
       event.preventDefault();
       event.stopImmediatePropagation();
-      blocked = { selector: uniqueFileInputSelector(input) };
+      state.blocked = { selector: uniqueFileInputSelector(input) };
     };
+    state.guard = guard;
+    _filePickerGuardStates.set(guardId, state);
     document.addEventListener('click', guard, true);
     try {
       runClick();
     } catch (error) {
       document.removeEventListener('click', guard, true);
+      _filePickerGuardStates.delete(guardId);
       throw error;
     }
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        document.removeEventListener('click', guard, true);
-        resolve(blocked);
-      }, Math.max(0, Number(settleMs) || 0));
-    });
+    if (state.blocked) {
+      document.removeEventListener('click', guard, true);
+      _filePickerGuardStates.delete(guardId);
+      return { blocked: state.blocked, guardId: null };
+    }
+    state.settleTimer = setTimeout(() => {
+      document.removeEventListener('click', guard, true);
+      state.settled = true;
+      state.cleanupTimer = setTimeout(() => {
+        if (_filePickerGuardStates.get(guardId) === state) {
+          _filePickerGuardStates.delete(guardId);
+        }
+      }, FILE_PICKER_GUARD_RETENTION_MS);
+    }, Math.max(0, Number(settleMs) || 0));
+    return { blocked: null, guardId };
+  }
+
+  function consumeFilePickerGuard(guardId) {
+    const state = typeof guardId === 'string' ? _filePickerGuardStates.get(guardId) : null;
+    if (!state) return { success: true, settled: true, filePickerBlocked: false };
+    if (!state.settled) return { success: true, settled: false, filePickerBlocked: false };
+    if (state.cleanupTimer) clearTimeout(state.cleanupTimer);
+    _filePickerGuardStates.delete(guardId);
+    if (state.blocked) {
+      return { ...filePickerBlockedResponse(state.blocked), settled: true };
+    }
+    return { success: true, settled: true, filePickerBlocked: false };
   }
 
   function filePickerBlockedResponse(blocked, label = '') {
@@ -954,7 +988,7 @@
   /**
    * Click an element by selector or coordinates.
    */
-  async function clickElement(params) {
+  function clickElement(params) {
     let el;
     if (params.selector && /:contains\(|:has-text\(/.test(params.selector)) {
       return {
@@ -1271,13 +1305,16 @@
     }
 
     const clickedRect = rememberInteractionPoint(el, 'click');
-    const blockedFileInput = await clickWithoutNativeFilePicker(() => el.click());
-    if (blockedFileInput) {
+    const filePickerGuard = clickWithoutNativeFilePicker(() => el.click());
+    if (filePickerGuard.blocked) {
       return {
-        ...filePickerBlockedResponse(blockedFileInput, params.text || el.innerText?.trim() || ''),
+        ...filePickerBlockedResponse(filePickerGuard.blocked, params.text || el.innerText?.trim() || ''),
         ...(clickedRect ? { rect: clickedRect } : {}),
       };
     }
+    const filePickerGuardMeta = filePickerGuard.guardId
+      ? { _filePickerGuardId: filePickerGuard.guardId }
+      : {};
 
     // Post-click SELECT detection: the click may have activated a <select>
     // via a label, wrapper, or overlapping element. Return error, not success.
@@ -1292,6 +1329,7 @@
         tag: 'SELECT',
         text: postActive.options[postActive.selectedIndex]?.text?.trim() || '',
         error: `CANNOT CLICK — a <select> dropdown was activated by this click (current: "${postActive.options[postActive.selectedIndex]?.text?.trim() || ''}"). The dropdown is now focused. Use type_text({text: "option name"}) to change the value. Available options: ${postOpts.join(', ')}`,
+        ...filePickerGuardMeta,
       };
     }
 
@@ -1312,6 +1350,7 @@
       text: el.innerText?.slice(0, 50),
       ...(clickedRect ? { rect: clickedRect } : {}),
       ...(warning ? { warning } : {}),
+      ...filePickerGuardMeta,
     };
   }
 
@@ -3117,6 +3156,7 @@
       'get_interactive_elements': () => getInteractiveElements(),
       'get_interactive_elements_cdp': () => getInteractiveElementsFull(),
       'click': () => clickElement(msg.params || {}),
+      'consume_file_picker_guard': () => consumeFilePickerGuard(msg.params?.guardId),
       'type': () => typeText(msg.params || {}),
       'press_keys': () => pressKeys(msg.params || {}),
       'scroll': () => scrollPage(msg.params || {}),
@@ -3179,7 +3219,7 @@
           return { error: 'Failed to build accessibility tree: ' + (e && e.message || String(e)) };
         }
       },
-      'click_ax': async () => {
+      'click_ax': () => {
         let dispatched = false;
         const failure = (error, extra = {}) => ({
           success: false,
@@ -3349,15 +3389,14 @@
           rememberInteractionPoint(el, 'click_ax');
           const syntheticClickStartedAt = Date.now();
           dispatched = true;
-          const blockedFileInputPromise = clickWithoutNativeFilePicker(() => el.click());
+          const filePickerGuard = clickWithoutNativeFilePicker(() => el.click());
           const fallbackStateAfterImmediate = _axFallbackState(el);
-          const blockedFileInput = await blockedFileInputPromise;
-          if (blockedFileInput) {
+          if (filePickerGuard.blocked) {
             return failure(
-              filePickerBlockedResponse(blockedFileInput, targetName || '').error,
+              filePickerBlockedResponse(filePickerGuard.blocked, targetName || '').error,
               {
                 filePickerBlocked: true,
-                ...(blockedFileInput.selector ? { selector: blockedFileInput.selector } : {}),
+                ...(filePickerGuard.blocked.selector ? { selector: filePickerGuard.blocked.selector } : {}),
                 ref_id,
               },
             );
@@ -3390,6 +3429,7 @@
               _fallbackStaticBlockedReason: fallbackStatic.blockedReason,
               rect: { x: Math.round(rect.x), y: Math.round(rect.y), w: Math.round(rect.width), h: Math.round(rect.height) },
               ...(targetContext ? { targetContext } : {}),
+              ...(filePickerGuard.guardId ? { _filePickerGuardId: filePickerGuard.guardId } : {}),
             };
             // Echo accessible name + href so the model can see exactly what
             // element it hit. This is critical when a stale ref_id points at

--- a/src/chrome/src/content/file-picker-guard-page.js
+++ b/src/chrome/src/content/file-picker-guard-page.js
@@ -1,0 +1,139 @@
+/*
+ * Main-world bridge for suppressing input.showPicker() during agent clicks.
+ *
+ * Extension content scripts run in an isolated JavaScript world, so replacing
+ * HTMLInputElement.prototype.showPicker there does not affect page handlers.
+ * This script runs in the page's MAIN world and uses short-lived DOM events
+ * and attributes to coordinate with content.js.
+ */
+(() => {
+  if (window.__webbrainFilePickerGuardBridge) return;
+  window.__webbrainFilePickerGuardBridge = true;
+
+  const ARM_EVENT = 'webbrain:file-picker-guard-arm';
+  const DISARM_EVENT = 'webbrain:file-picker-guard-disarm';
+  const BLOCKED_EVENT = 'webbrain:file-picker-guard-blocked';
+  const GUARD_ATTR = 'data-webbrain-file-picker-guard';
+  const BLOCKED_ATTR = 'data-webbrain-file-picker-blocked';
+  const MAX_GUARD_MS = 5000;
+
+  let activeGuardId = null;
+  let restoreShowPicker = null;
+  let expiryTimer = null;
+
+  function allPiercedMatches(selector) {
+    const matches = [];
+    const visit = (root) => {
+      try { matches.push(...root.querySelectorAll(selector)); } catch { return; }
+      let elements = [];
+      try { elements = root.querySelectorAll('*'); } catch {}
+      for (const element of elements) {
+        if (element.shadowRoot) visit(element.shadowRoot);
+      }
+    };
+    visit(document);
+    return matches;
+  }
+
+  function uniqueFileInputSelector(input) {
+    const unique = (selector) => {
+      if (!selector) return null;
+      const matches = allPiercedMatches(selector);
+      return matches.length === 1 && matches[0] === input ? selector : null;
+    };
+    try {
+      if (input.id && window.CSS?.escape) {
+        const byId = unique('#' + CSS.escape(input.id));
+        if (byId) return byId;
+      }
+      if (input.name && window.CSS?.escape) {
+        const byName = unique('input[type="file"][name=' + CSS.escape(String(input.name)) + ']');
+        if (byName) return byName;
+      }
+      const parts = [];
+      let node = input;
+      while (node?.nodeType === Node.ELEMENT_NODE) {
+        let part = node.tagName.toLowerCase();
+        const parent = node.parentElement;
+        if (parent) {
+          const siblings = Array.from(parent.children).filter(child => child.tagName === node.tagName);
+          if (siblings.length > 1) part += ':nth-of-type(' + (siblings.indexOf(node) + 1) + ')';
+        }
+        parts.unshift(part);
+        const byPath = unique(parts.join(' > '));
+        if (byPath) return byPath;
+        node = parent;
+      }
+    } catch {}
+    return null;
+  }
+
+  function isFileInput(input) {
+    return input?.tagName === 'INPUT'
+      && String(input.getAttribute?.('type') || input.type || '').toLowerCase() === 'file';
+  }
+
+  function clearGuard() {
+    activeGuardId = null;
+    if (expiryTimer) {
+      clearTimeout(expiryTimer);
+      expiryTimer = null;
+    }
+    restoreShowPicker?.();
+    restoreShowPicker = null;
+  }
+
+  function reportBlocked(input) {
+    const root = document.documentElement;
+    if (!root || !activeGuardId) return;
+    root.setAttribute(BLOCKED_ATTR, JSON.stringify({
+      guardId: activeGuardId,
+      selector: uniqueFileInputSelector(input),
+    }));
+    document.dispatchEvent(new Event(BLOCKED_EVENT));
+    root.removeAttribute(BLOCKED_ATTR);
+  }
+
+  function armGuard() {
+    const root = document.documentElement;
+    const guardId = root?.getAttribute(GUARD_ATTR);
+    if (!guardId) return;
+    clearGuard();
+
+    const proto = window.HTMLInputElement?.prototype;
+    const descriptor = proto && Object.getOwnPropertyDescriptor(proto, 'showPicker');
+    const originalShowPicker = descriptor?.value;
+    if (typeof originalShowPicker !== 'function') return;
+
+    const guardedShowPicker = function(...args) {
+      if (activeGuardId && isFileInput(this)) {
+        reportBlocked(this);
+        return undefined;
+      }
+      return Reflect.apply(originalShowPicker, this, args);
+    };
+    try {
+      Object.defineProperty(proto, 'showPicker', { ...descriptor, value: guardedShowPicker });
+    } catch {
+      return;
+    }
+
+    activeGuardId = guardId;
+    restoreShowPicker = () => {
+      try {
+        if (proto.showPicker === guardedShowPicker) {
+          Object.defineProperty(proto, 'showPicker', descriptor);
+        }
+      } catch {}
+    };
+    expiryTimer = setTimeout(clearGuard, MAX_GUARD_MS);
+  }
+
+  function disarmGuard() {
+    const guardId = document.documentElement?.getAttribute(GUARD_ATTR);
+    if (guardId && guardId === activeGuardId) clearGuard();
+  }
+
+  document.addEventListener(ARM_EVENT, armGuard, true);
+  document.addEventListener(DISARM_EVENT, disarmGuard, true);
+})();

--- a/src/chrome/src/content/file-picker-guard-page.js
+++ b/src/chrome/src/content/file-picker-guard-page.js
@@ -7,15 +7,26 @@
  * and attributes to coordinate with content.js.
  */
 (() => {
-  if (window.__webbrainFilePickerGuardBridge) return;
-  window.__webbrainFilePickerGuardBridge = true;
-
+  const PROBE_EVENT = 'webbrain:file-picker-guard-probe';
+  const PROBE_ATTR = 'data-webbrain-file-picker-probe';
+  const PROBE_ACK_ATTR = 'data-webbrain-file-picker-probe-ack';
   const ARM_EVENT = 'webbrain:file-picker-guard-arm';
   const DISARM_EVENT = 'webbrain:file-picker-guard-disarm';
   const BLOCKED_EVENT = 'webbrain:file-picker-guard-blocked';
   const GUARD_ATTR = 'data-webbrain-file-picker-guard';
   const BLOCKED_ATTR = 'data-webbrain-file-picker-blocked';
   const MAX_GUARD_MS = 5000;
+
+  const probeRoot = document.documentElement;
+  if (probeRoot) {
+    const probeToken = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+    probeRoot.setAttribute(PROBE_ATTR, probeToken);
+    document.dispatchEvent(new Event(PROBE_EVENT));
+    const alreadyInstalled = probeRoot.getAttribute(PROBE_ACK_ATTR) === probeToken;
+    probeRoot.removeAttribute(PROBE_ATTR);
+    probeRoot.removeAttribute(PROBE_ACK_ATTR);
+    if (alreadyInstalled) return;
+  }
 
   let activeGuardId = null;
   let restoreShowPicker = null;
@@ -134,6 +145,14 @@
     if (guardId && guardId === activeGuardId) clearGuard();
   }
 
+  function acknowledgeProbe() {
+    const root = document.documentElement;
+    const probeToken = root?.getAttribute(PROBE_ATTR);
+    if (probeToken) root.setAttribute(PROBE_ACK_ATTR, probeToken);
+  }
+
+  document.addEventListener(PROBE_EVENT, acknowledgeProbe, true);
   document.addEventListener(ARM_EVENT, armGuard, true);
   document.addEventListener(DISARM_EVENT, disarmGuard, true);
+  armGuard();
 })();

--- a/src/chrome/src/content/file-picker-guard-page.js
+++ b/src/chrome/src/content/file-picker-guard-page.js
@@ -29,7 +29,7 @@
   }
 
   let activeGuardId = null;
-  let restoreShowPicker = null;
+  let restorePickerMethods = null;
   let expiryTimer = null;
 
   function allPiercedMatches(selector) {
@@ -90,8 +90,8 @@
       clearTimeout(expiryTimer);
       expiryTimer = null;
     }
-    restoreShowPicker?.();
-    restoreShowPicker = null;
+    restorePickerMethods?.();
+    restorePickerMethods = null;
   }
 
   function reportBlocked(input) {
@@ -112,9 +112,12 @@
     clearGuard();
 
     const proto = window.HTMLInputElement?.prototype;
-    const descriptor = proto && Object.getOwnPropertyDescriptor(proto, 'showPicker');
-    const originalShowPicker = descriptor?.value;
-    if (typeof originalShowPicker !== 'function') return;
+    if (!proto) return;
+    const showPickerDescriptor = Object.getOwnPropertyDescriptor(proto, 'showPicker');
+    const originalShowPicker = showPickerDescriptor?.value;
+    const ownClickDescriptor = Object.getOwnPropertyDescriptor(proto, 'click');
+    const originalClick = proto.click;
+    if (typeof originalShowPicker !== 'function' && typeof originalClick !== 'function') return;
 
     const guardedShowPicker = function(...args) {
       if (activeGuardId && isFileInput(this)) {
@@ -123,17 +126,48 @@
       }
       return Reflect.apply(originalShowPicker, this, args);
     };
-    try {
-      Object.defineProperty(proto, 'showPicker', { ...descriptor, value: guardedShowPicker });
-    } catch {
-      return;
+    const guardedClick = function(...args) {
+      if (activeGuardId && isFileInput(this)) {
+        reportBlocked(this);
+        return undefined;
+      }
+      return Reflect.apply(originalClick, this, args);
+    };
+    let showPickerInstalled = false;
+    let clickInstalled = false;
+    if (typeof originalShowPicker === 'function') {
+      try {
+        Object.defineProperty(proto, 'showPicker', {
+          ...showPickerDescriptor,
+          value: guardedShowPicker,
+        });
+        showPickerInstalled = true;
+      } catch {}
     }
+    if (typeof originalClick === 'function') {
+      try {
+        Object.defineProperty(proto, 'click', {
+          configurable: true,
+          enumerable: ownClickDescriptor?.enumerable ?? false,
+          writable: true,
+          value: guardedClick,
+        });
+        clickInstalled = true;
+      } catch {}
+    }
+    if (!showPickerInstalled && !clickInstalled) return;
 
     activeGuardId = guardId;
-    restoreShowPicker = () => {
+    restorePickerMethods = () => {
       try {
-        if (proto.showPicker === guardedShowPicker) {
-          Object.defineProperty(proto, 'showPicker', descriptor);
+        if (showPickerInstalled && proto.showPicker === guardedShowPicker) {
+          Object.defineProperty(proto, 'showPicker', showPickerDescriptor);
+        }
+      } catch {}
+      try {
+        if (clickInstalled && proto.click === guardedClick) {
+          if (ownClickDescriptor) Object.defineProperty(proto, 'click', ownClickDescriptor);
+          else delete proto.click;
         }
       } catch {}
     };

--- a/src/chrome/src/content/file-picker-guard-page.js
+++ b/src/chrome/src/content/file-picker-guard-page.js
@@ -12,6 +12,7 @@
   const PROBE_ACK_ATTR = 'data-webbrain-file-picker-probe-ack';
   const ARM_EVENT = 'webbrain:file-picker-guard-arm';
   const DISARM_EVENT = 'webbrain:file-picker-guard-disarm';
+  const RESET_EVENT = 'webbrain:file-picker-guard-reset';
   const BLOCKED_EVENT = 'webbrain:file-picker-guard-blocked';
   const GUARD_ATTR = 'data-webbrain-file-picker-guard';
   const BLOCKED_ATTR = 'data-webbrain-file-picker-blocked';
@@ -188,5 +189,6 @@
   document.addEventListener(PROBE_EVENT, acknowledgeProbe, true);
   document.addEventListener(ARM_EVENT, armGuard, true);
   document.addEventListener(DISARM_EVENT, disarmGuard, true);
+  document.addEventListener(RESET_EVENT, clearGuard, true);
   armGuard();
 })();

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -34,6 +34,11 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
+      "js": ["src/content/file-picker-guard-loader.js"],
+      "run_at": "document_start"
+    },
+    {
+      "matches": ["<all_urls>"],
       "js": [
         "src/content/accessibility-tree.js",
         "src/content/content.js",
@@ -90,6 +95,7 @@
     "vendor/pdfjs/pdf.mjs",
     "vendor/pdfjs/pdf.worker.mjs",
     "src/agent/social-media-downloader.js",
+    "src/content/file-picker-guard-page.js",
     "vendor/turkish-deasciifier-patterns.json",
     "skills/*"
   ],

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -8587,7 +8587,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const originalResponse = { ...response };
     delete originalResponse._filePickerGuardId;
 
-    await new Promise(resolve => setTimeout(resolve, 120));
+    await new Promise(resolve => setTimeout(resolve, 275));
     try {
       let settled = await browser.tabs.sendMessage(tabId, {
         target: 'content',

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -10182,9 +10182,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     } catch (e) {
       // Content script might not be injected — try injecting it
       try {
-        await browser.tabs.executeScript(tabId, {
-          file: 'src/content/content.js',
-        });
+        await this._injectCoreContentScripts(tabId);
         let response = await browser.tabs.sendMessage(tabId, {
           target: 'content',
           action,
@@ -10211,6 +10209,27 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         return { error: `Failed to communicate with page: ${e2.message}` };
       }
     }
+  }
+
+  async _injectCoreContentScripts(tabId) {
+    await browser.tabs.executeScript(tabId, {
+      file: 'src/content/file-picker-guard-loader.js',
+    });
+    // The loader fetches a web-accessible extension script into the page's
+    // main world. Give that local load a brief head start before content.js
+    // can dispatch an action; content.js also leaves its arm token in the
+    // shared DOM for the bridge to pick up if the load completes slightly
+    // later.
+    await new Promise(resolve => setTimeout(resolve, 50));
+    await browser.tabs.executeScript(tabId, {
+      file: 'src/content/accessibility-tree.js',
+    });
+    await browser.tabs.executeScript(tabId, {
+      file: 'src/content/content.js',
+    });
+    await browser.tabs.executeScript(tabId, {
+      file: 'src/content/agent-visual-indicator.js',
+    });
   }
 
   /**

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -9294,10 +9294,38 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
         const injectCode = `
           (function() {
-            const el = document.querySelector(${JSON.stringify(args.selector)});
-            if (!el) return { success: false, dispatched: false, error: 'Element not found matching selector: ' + ${JSON.stringify(args.selector)} };
+            const selector = ${JSON.stringify(args.selector)};
+            const matches = [];
+            const collectDeepMatches = (root) => {
+              matches.push(...root.querySelectorAll(selector));
+              for (const element of root.querySelectorAll('*')) {
+                if (element.shadowRoot) collectDeepMatches(element.shadowRoot);
+              }
+            };
+            try {
+              collectDeepMatches(document);
+            } catch (e) {
+              return {
+                success: false,
+                dispatched: false,
+                error: 'Invalid file input selector: ' + selector + ' (' + (e.message || String(e)) + ')',
+              };
+            }
+            if (matches.length === 0) {
+              return { success: false, dispatched: false, error: 'Element not found matching selector: ' + selector };
+            }
+            if (matches.length > 1) {
+              return {
+                success: false,
+                dispatched: false,
+                ambiguous: true,
+                matchCount: matches.length,
+                error: 'Selector matched ' + matches.length + ' elements across the document and open shadow roots. Use an exact, unique selector for the intended <input type="file">.',
+              };
+            }
+            const el = matches[0];
             if (!(el instanceof HTMLInputElement) || el.type !== 'file') {
-              return { success: false, dispatched: false, error: 'Selector does not match an <input type="file"> element: ' + ${JSON.stringify(args.selector)} };
+              return { success: false, dispatched: false, error: 'Selector does not match an <input type="file"> element: ' + selector };
             }
             let dispatched = false;
             try {
@@ -9334,6 +9362,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           return {
             success: false,
             dispatched: res?.dispatched === true,
+            ...(res?.ambiguous ? {
+              ambiguous: true,
+              matchCount: Number(res.matchCount) || 0,
+            } : {}),
             error: res ? res.error : 'Failed to attach file to input element',
           };
         }

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -8581,6 +8581,44 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     };
   }
 
+  async _settleContentFilePickerGuard(tabId, response) {
+    const guardId = response?._filePickerGuardId;
+    if (!guardId) return response;
+    const originalResponse = { ...response };
+    delete originalResponse._filePickerGuardId;
+
+    await new Promise(resolve => setTimeout(resolve, 120));
+    try {
+      let settled = await browser.tabs.sendMessage(tabId, {
+        target: 'content',
+        action: 'consume_file_picker_guard',
+        params: { guardId },
+      });
+      if (settled?.settled === false) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        settled = await browser.tabs.sendMessage(tabId, {
+          target: 'content',
+          action: 'consume_file_picker_guard',
+          params: { guardId },
+        });
+      }
+      if (settled?.filePickerBlocked) {
+        const blockedResponse = { ...settled };
+        delete blockedResponse.settled;
+        return {
+          ...blockedResponse,
+          ...(originalResponse.rect ? { rect: originalResponse.rect } : {}),
+          ...(originalResponse.ref_id ? { ref_id: originalResponse.ref_id } : {}),
+        };
+      }
+    } catch {
+      // The delivered click may have navigated or submitted the old document.
+      // Keep its original response and never re-inject/replay the action just
+      // because the best-effort deferred-picker probe lost that document.
+    }
+    return originalResponse;
+  }
+
   async executeTool(tabId, name, args, onUpdate = null, executionContext = null) {
     if (name === 'load_skill') {
       return this._loadSkillForRun(tabId, args || {});
@@ -10123,11 +10161,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       : args;
 
     try {
-      const response = await browser.tabs.sendMessage(tabId, {
+      let response = await browser.tabs.sendMessage(tabId, {
         target: 'content',
         action,
         params: contentArgs,
       });
+      if (name === 'click' || name === 'click_ax') {
+        response = await this._settleContentFilePickerGuard(tabId, response);
+      }
       if (name === 'get_accessibility_tree' && response?.documentToken) {
         this._lastAxScopes.set(tabId, {
           documentToken: response.documentToken,
@@ -10144,11 +10185,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         await browser.tabs.executeScript(tabId, {
           file: 'src/content/content.js',
         });
-        const response = await browser.tabs.sendMessage(tabId, {
+        let response = await browser.tabs.sendMessage(tabId, {
           target: 'content',
           action,
           params: contentArgs,
         });
+        if (name === 'click' || name === 'click_ax') {
+          response = await this._settleContentFilePickerGuard(tabId, response);
+        }
         if (name === 'get_accessibility_tree' && response?.documentToken) {
           this._lastAxScopes.set(tabId, {
             documentToken: response.documentToken,

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -8587,7 +8587,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const originalResponse = { ...response };
     delete originalResponse._filePickerGuardId;
 
-    await new Promise(resolve => setTimeout(resolve, 275));
+    await new Promise(resolve => setTimeout(resolve, 525));
     try {
       let settled = await browser.tabs.sendMessage(tabId, {
         target: 'content',

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -695,7 +695,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'upload_file',
-      description: 'Attach a file to a <input type="file"> element on the page. Provide EITHER downloadId (preferred — re-fetches the file from its original URL) OR omit it to let the user pick a file manually via a file-picker dialog. NOTE: Firefox cannot set arbitrary local file paths (no CDP); only downloadId and user-picker flows are supported.',
+      description: 'Attach a file directly to an existing <input type="file"> without clicking the page upload control. Do NOT click "Choose file", "Select a file", an upload drop zone, or the input first when the input already exists. Provide downloadId (preferred — re-fetches the file from its original URL without an OS dialog), or omit it only when the user must pick a local file through WebBrain\'s own picker. If no file input exists because the widget creates it lazily, one guarded click on its add-files control may initialize the widget; then retry upload_file with the exact selector returned or discovered. NOTE: Firefox cannot set arbitrary local file paths (no CDP); only downloadId and user-picker flows are supported.',
       parameters: {
         type: 'object',
         properties: {
@@ -1331,6 +1331,7 @@ CLICKING — read this:
 - For buttons and links you can SEE, click by visible text: \`click({text: "Publish release"})\`. Default matching is EXACT (case-insensitive). If exact fails (no match), the system automatically tries prefix then substring matching — but if multiple elements match at any level, it returns an ambiguity error instead of guessing.
 - If you get an ambiguity error, use a more specific text string, switch to \`click({index: N})\` from \`get_interactive_elements\`, or use a selector.
 - You can explicitly control matching with \`textMatch\`: \`"exact"\` (default), \`"prefix"\`, or \`"contains"\`.
+- FILE UPLOADS: when the page already has an \`<input type="file">\`, do not click "Choose file", "Select a file", "Browse", the upload drop zone, or the input first. If the file is already downloaded, find the exact selector and call \`upload_file({selector, downloadId})\` directly; omit downloadId only when the user must choose a local file through WebBrain's own picker. Exception: if \`upload_file\` reports that no input exists because the widget creates it lazily, make one guarded click on the widget's add-files control to initialize it. A blocked-picker result may return the new exact selector; retry \`upload_file\` with that selector. Never substitute a generic \`input[type="file"]\` selector when multiple file inputs exist.
 - Order of preference:
   1. \`click({text: "..."})\` — visible text. Most reliable.
   2. \`click({index: N})\` — index from get_interactive_elements MADE THIS SAME TURN.

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -2024,15 +2024,7 @@ async function handleMessage(msg, sender) {
           action: 'get_page_info',
         });
       } catch {
-        await browser.tabs.executeScript(tabId, {
-          file: 'src/content/accessibility-tree.js',
-        });
-        await browser.tabs.executeScript(tabId, {
-          file: 'src/content/content.js',
-        });
-        await browser.tabs.executeScript(tabId, {
-          file: 'src/content/agent-visual-indicator.js',
-        });
+        await agent._injectCoreContentScripts(tabId);
         return await browser.tabs.sendMessage(tabId, {
           target: 'content',
           action: 'get_page_info',

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1117,7 +1117,7 @@
     return null;
   }
 
-  const FILE_PICKER_GUARD_SETTLE_MS = 100;
+  const FILE_PICKER_GUARD_SETTLE_MS = 250;
   const FILE_PICKER_GUARD_RETENTION_MS = 5000;
   const _filePickerGuardStates = new Map();
   let _filePickerGuardSequence = 0;
@@ -1198,10 +1198,10 @@
       return { blocked: state.blocked, guardId: null };
     }
     state.settleTimer = setTimeout(() => {
-      cleanupGuard();
       state.settled = true;
       state.cleanupTimer = setTimeout(() => {
         if (_filePickerGuardStates.get(guardId) === state) {
+          cleanupGuard();
           _filePickerGuardStates.delete(guardId);
         }
       }, FILE_PICKER_GUARD_RETENTION_MS);
@@ -1214,6 +1214,8 @@
     if (!state) return { success: true, settled: true, filePickerBlocked: false };
     if (!state.settled) return { success: true, settled: false, filePickerBlocked: false };
     if (state.cleanupTimer) clearTimeout(state.cleanupTimer);
+    document.removeEventListener('click', state.guard, true);
+    state.cleanupPageShowPickerGuard?.();
     _filePickerGuardStates.delete(guardId);
     if (state.blocked) {
       return { ...filePickerBlockedResponse(state.blocked), settled: true };

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1128,39 +1128,76 @@
       blocked: null,
       settled: false,
       guard: null,
+      restoreShowPicker: null,
       settleTimer: null,
       cleanupTimer: null,
+    };
+    const isFileInput = (input) =>
+      input?.tagName === 'INPUT'
+      && String(input.getAttribute?.('type') || input.type || '').toLowerCase() === 'file';
+    const blockFileInput = (input) => {
+      state.blocked = { selector: uniqueFileInputSelector(input) };
     };
     const guard = (event) => {
       const path = typeof event.composedPath === 'function'
         ? event.composedPath()
         : [event.target];
-      const input = path.find(node =>
-        node?.tagName === 'INPUT'
-        && String(node.getAttribute?.('type') || node.type || '').toLowerCase() === 'file'
-      );
+      const input = path.find(isFileInput);
       if (!input) return;
       event.preventDefault();
       event.stopImmediatePropagation();
-      state.blocked = { selector: uniqueFileInputSelector(input) };
+      blockFileInput(input);
+    };
+    const installShowPickerGuard = () => {
+      const proto = window.HTMLInputElement?.prototype;
+      const descriptor = proto && Object.getOwnPropertyDescriptor(proto, 'showPicker');
+      const originalShowPicker = descriptor?.value;
+      if (typeof originalShowPicker !== 'function') return () => {};
+      const guardedShowPicker = function(...args) {
+        if (isFileInput(this)) {
+          blockFileInput(this);
+          return undefined;
+        }
+        return Reflect.apply(originalShowPicker, this, args);
+      };
+      try {
+        Object.defineProperty(proto, 'showPicker', { ...descriptor, value: guardedShowPicker });
+      } catch {
+        return () => {};
+      }
+      let restored = false;
+      return () => {
+        if (restored) return;
+        restored = true;
+        try {
+          if (proto.showPicker === guardedShowPicker) {
+            Object.defineProperty(proto, 'showPicker', descriptor);
+          }
+        } catch {}
+      };
+    };
+    const cleanupGuard = () => {
+      document.removeEventListener('click', guard, true);
+      state.restoreShowPicker?.();
     };
     state.guard = guard;
     _filePickerGuardStates.set(guardId, state);
     document.addEventListener('click', guard, true);
+    state.restoreShowPicker = installShowPickerGuard();
     try {
       runClick();
     } catch (error) {
-      document.removeEventListener('click', guard, true);
+      cleanupGuard();
       _filePickerGuardStates.delete(guardId);
       throw error;
     }
     if (state.blocked) {
-      document.removeEventListener('click', guard, true);
+      cleanupGuard();
       _filePickerGuardStates.delete(guardId);
       return { blocked: state.blocked, guardId: null };
     }
     state.settleTimer = setTimeout(() => {
-      document.removeEventListener('click', guard, true);
+      cleanupGuard();
       state.settled = true;
       state.cleanupTimer = setTimeout(() => {
         if (_filePickerGuardStates.get(guardId) === state) {

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1154,10 +1154,9 @@
       const guardAttr = 'data-webbrain-file-picker-guard';
       const blockedAttr = 'data-webbrain-file-picker-blocked';
       const blockedEvent = 'webbrain:file-picker-guard-blocked';
-      const signal = (eventName) => {
+      const armPageGuard = () => {
         root.setAttribute(guardAttr, guardId);
-        document.dispatchEvent(new Event(eventName));
-        root.removeAttribute(guardAttr);
+        document.dispatchEvent(new Event('webbrain:file-picker-guard-arm'));
       };
       const onBlocked = () => {
         try {
@@ -1171,9 +1170,10 @@
         } catch {}
       };
       document.addEventListener(blockedEvent, onBlocked, true);
-      signal('webbrain:file-picker-guard-arm');
+      armPageGuard();
       return () => {
-        signal('webbrain:file-picker-guard-disarm');
+        document.dispatchEvent(new Event('webbrain:file-picker-guard-disarm'));
+        if (root.getAttribute(guardAttr) === guardId) root.removeAttribute(guardAttr);
         document.removeEventListener(blockedEvent, onBlocked, true);
       };
     };

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1066,7 +1066,7 @@
   }
 
   /**
-   * Run one synthetic agent click while suppressing any synchronous
+   * Run one synthetic agent click while suppressing any immediate or deferred
    * <input type=file>.click() it triggers. upload_file attaches a downloaded
    * file directly (or presents WebBrain's own picker when no downloadId is
    * available); clicking the page control first only opens a stale OS dialog.
@@ -1117,7 +1117,9 @@
     return null;
   }
 
-  function clickWithoutNativeFilePicker(runClick) {
+  const FILE_PICKER_GUARD_SETTLE_MS = 100;
+
+  function clickWithoutNativeFilePicker(runClick, settleMs = FILE_PICKER_GUARD_SETTLE_MS) {
     let blocked = null;
     const guard = (event) => {
       const path = typeof event.composedPath === 'function'
@@ -1135,10 +1137,16 @@
     document.addEventListener('click', guard, true);
     try {
       runClick();
-    } finally {
+    } catch (error) {
       document.removeEventListener('click', guard, true);
+      throw error;
     }
-    return blocked;
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        document.removeEventListener('click', guard, true);
+        resolve(blocked);
+      }, Math.max(0, Number(settleMs) || 0));
+    });
   }
 
   function filePickerBlockedResponse(blocked, label = '') {
@@ -1160,7 +1168,7 @@
   /**
    * Click an element by selector or coordinates.
    */
-  function clickElement(params) {
+  async function clickElement(params) {
     let el;
     // Reject jQuery/Playwright selectors with a clear error.
     if (params.selector && /:contains\(|:has-text\(/.test(params.selector)) {
@@ -1541,7 +1549,7 @@
     }
 
     const clickedRect = rememberInteractionPoint(el, 'click');
-    const blockedFileInput = clickWithoutNativeFilePicker(() => el.click());
+    const blockedFileInput = await clickWithoutNativeFilePicker(() => el.click());
     if (blockedFileInput) {
       return {
         ...filePickerBlockedResponse(blockedFileInput, params.text || el.innerText?.trim() || ''),
@@ -2634,7 +2642,7 @@
           return { error: 'Failed to build accessibility tree: ' + (e && e.message || String(e)) };
         }
       },
-      'click_ax': () => {
+      'click_ax': async () => {
         let dispatched = false;
         const failure = (error, extra = {}) => ({
           success: false,
@@ -2785,7 +2793,7 @@
           }
           rememberInteractionPoint(el, 'click_ax');
           dispatched = true;
-          const blockedFileInput = clickWithoutNativeFilePicker(() => el.click());
+          const blockedFileInput = await clickWithoutNativeFilePicker(() => el.click());
           if (blockedFileInput) {
             return failure(
               filePickerBlockedResponse(blockedFileInput, targetName || '').error,

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1128,7 +1128,7 @@
       blocked: null,
       settled: false,
       guard: null,
-      restoreShowPicker: null,
+      cleanupPageShowPickerGuard: null,
       settleTimer: null,
       cleanupTimer: null,
     };
@@ -1148,42 +1148,43 @@
       event.stopImmediatePropagation();
       blockFileInput(input);
     };
-    const installShowPickerGuard = () => {
-      const proto = window.HTMLInputElement?.prototype;
-      const descriptor = proto && Object.getOwnPropertyDescriptor(proto, 'showPicker');
-      const originalShowPicker = descriptor?.value;
-      if (typeof originalShowPicker !== 'function') return () => {};
-      const guardedShowPicker = function(...args) {
-        if (isFileInput(this)) {
-          blockFileInput(this);
-          return undefined;
-        }
-        return Reflect.apply(originalShowPicker, this, args);
+    const installPageShowPickerGuard = () => {
+      const root = document.documentElement;
+      if (!root) return () => {};
+      const guardAttr = 'data-webbrain-file-picker-guard';
+      const blockedAttr = 'data-webbrain-file-picker-blocked';
+      const blockedEvent = 'webbrain:file-picker-guard-blocked';
+      const signal = (eventName) => {
+        root.setAttribute(guardAttr, guardId);
+        document.dispatchEvent(new Event(eventName));
+        root.removeAttribute(guardAttr);
       };
-      try {
-        Object.defineProperty(proto, 'showPicker', { ...descriptor, value: guardedShowPicker });
-      } catch {
-        return () => {};
-      }
-      let restored = false;
-      return () => {
-        if (restored) return;
-        restored = true;
+      const onBlocked = () => {
         try {
-          if (proto.showPicker === guardedShowPicker) {
-            Object.defineProperty(proto, 'showPicker', descriptor);
-          }
+          const payload = JSON.parse(root.getAttribute(blockedAttr) || 'null');
+          if (payload?.guardId !== guardId) return;
+          state.blocked = {
+            selector: typeof payload.selector === 'string' && payload.selector
+              ? payload.selector
+              : null,
+          };
         } catch {}
+      };
+      document.addEventListener(blockedEvent, onBlocked, true);
+      signal('webbrain:file-picker-guard-arm');
+      return () => {
+        signal('webbrain:file-picker-guard-disarm');
+        document.removeEventListener(blockedEvent, onBlocked, true);
       };
     };
     const cleanupGuard = () => {
       document.removeEventListener('click', guard, true);
-      state.restoreShowPicker?.();
+      state.cleanupPageShowPickerGuard?.();
     };
     state.guard = guard;
     _filePickerGuardStates.set(guardId, state);
     document.addEventListener('click', guard, true);
-    state.restoreShowPicker = installShowPickerGuard();
+    state.cleanupPageShowPickerGuard = installPageShowPickerGuard();
     try {
       runClick();
     } catch (error) {

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1118,9 +1118,19 @@
   }
 
   const FILE_PICKER_GUARD_SETTLE_MS = 100;
+  const FILE_PICKER_GUARD_RETENTION_MS = 5000;
+  const _filePickerGuardStates = new Map();
+  let _filePickerGuardSequence = 0;
 
   function clickWithoutNativeFilePicker(runClick, settleMs = FILE_PICKER_GUARD_SETTLE_MS) {
-    let blocked = null;
+    const guardId = `fpg_${Date.now().toString(36)}_${++_filePickerGuardSequence}`;
+    const state = {
+      blocked: null,
+      settled: false,
+      guard: null,
+      settleTimer: null,
+      cleanupTimer: null,
+    };
     const guard = (event) => {
       const path = typeof event.composedPath === 'function'
         ? event.composedPath()
@@ -1132,21 +1142,45 @@
       if (!input) return;
       event.preventDefault();
       event.stopImmediatePropagation();
-      blocked = { selector: uniqueFileInputSelector(input) };
+      state.blocked = { selector: uniqueFileInputSelector(input) };
     };
+    state.guard = guard;
+    _filePickerGuardStates.set(guardId, state);
     document.addEventListener('click', guard, true);
     try {
       runClick();
     } catch (error) {
       document.removeEventListener('click', guard, true);
+      _filePickerGuardStates.delete(guardId);
       throw error;
     }
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        document.removeEventListener('click', guard, true);
-        resolve(blocked);
-      }, Math.max(0, Number(settleMs) || 0));
-    });
+    if (state.blocked) {
+      document.removeEventListener('click', guard, true);
+      _filePickerGuardStates.delete(guardId);
+      return { blocked: state.blocked, guardId: null };
+    }
+    state.settleTimer = setTimeout(() => {
+      document.removeEventListener('click', guard, true);
+      state.settled = true;
+      state.cleanupTimer = setTimeout(() => {
+        if (_filePickerGuardStates.get(guardId) === state) {
+          _filePickerGuardStates.delete(guardId);
+        }
+      }, FILE_PICKER_GUARD_RETENTION_MS);
+    }, Math.max(0, Number(settleMs) || 0));
+    return { blocked: null, guardId };
+  }
+
+  function consumeFilePickerGuard(guardId) {
+    const state = typeof guardId === 'string' ? _filePickerGuardStates.get(guardId) : null;
+    if (!state) return { success: true, settled: true, filePickerBlocked: false };
+    if (!state.settled) return { success: true, settled: false, filePickerBlocked: false };
+    if (state.cleanupTimer) clearTimeout(state.cleanupTimer);
+    _filePickerGuardStates.delete(guardId);
+    if (state.blocked) {
+      return { ...filePickerBlockedResponse(state.blocked), settled: true };
+    }
+    return { success: true, settled: true, filePickerBlocked: false };
   }
 
   function filePickerBlockedResponse(blocked, label = '') {
@@ -1168,7 +1202,7 @@
   /**
    * Click an element by selector or coordinates.
    */
-  async function clickElement(params) {
+  function clickElement(params) {
     let el;
     // Reject jQuery/Playwright selectors with a clear error.
     if (params.selector && /:contains\(|:has-text\(/.test(params.selector)) {
@@ -1549,13 +1583,16 @@
     }
 
     const clickedRect = rememberInteractionPoint(el, 'click');
-    const blockedFileInput = await clickWithoutNativeFilePicker(() => el.click());
-    if (blockedFileInput) {
+    const filePickerGuard = clickWithoutNativeFilePicker(() => el.click());
+    if (filePickerGuard.blocked) {
       return {
-        ...filePickerBlockedResponse(blockedFileInput, params.text || el.innerText?.trim() || ''),
+        ...filePickerBlockedResponse(filePickerGuard.blocked, params.text || el.innerText?.trim() || ''),
         ...(clickedRect ? { rect: clickedRect } : {}),
       };
     }
+    const filePickerGuardMeta = filePickerGuard.guardId
+      ? { _filePickerGuardId: filePickerGuard.guardId }
+      : {};
 
     // Post-click SELECT detection: the click may have activated a <select>
     // via a label, wrapper, or overlapping element. Return error, not success.
@@ -1581,6 +1618,7 @@
         tag: 'SELECT',
         text: postActive.options[postActive.selectedIndex]?.text?.trim() || '',
         error: `CANNOT CLICK — a <select> dropdown was activated by this click (current: "${postActive.options[postActive.selectedIndex]?.text?.trim() || ''}"). The dropdown is now focused. Use type_text({text: "option name"}) to change the value. Available options: ${postOpts.join(', ')}`,
+        ...filePickerGuardMeta,
       };
     }
 
@@ -1601,6 +1639,7 @@
       text: el.innerText?.slice(0, 50),
       ...(clickedRect ? { rect: clickedRect } : {}),
       ...(warning ? { warning } : {}),
+      ...filePickerGuardMeta,
     };
   }
 
@@ -2546,6 +2585,7 @@
       'get_interactive_elements': () => getInteractiveElements(),
       'get_interactive_elements_cdp': () => getInteractiveElementsFull(),
       'click': () => clickElement(msg.params || {}),
+      'consume_file_picker_guard': () => consumeFilePickerGuard(msg.params?.guardId),
       'type': () => typeText(msg.params || {}),
       'press_keys': () => pressKeys(msg.params || {}),
       'scroll': () => scrollPage(msg.params || {}),
@@ -2642,7 +2682,7 @@
           return { error: 'Failed to build accessibility tree: ' + (e && e.message || String(e)) };
         }
       },
-      'click_ax': async () => {
+      'click_ax': () => {
         let dispatched = false;
         const failure = (error, extra = {}) => ({
           success: false,
@@ -2793,13 +2833,13 @@
           }
           rememberInteractionPoint(el, 'click_ax');
           dispatched = true;
-          const blockedFileInput = await clickWithoutNativeFilePicker(() => el.click());
-          if (blockedFileInput) {
+          const filePickerGuard = clickWithoutNativeFilePicker(() => el.click());
+          if (filePickerGuard.blocked) {
             return failure(
-              filePickerBlockedResponse(blockedFileInput, targetName || '').error,
+              filePickerBlockedResponse(filePickerGuard.blocked, targetName || '').error,
               {
                 filePickerBlocked: true,
-                ...(blockedFileInput.selector ? { selector: blockedFileInput.selector } : {}),
+                ...(filePickerGuard.blocked.selector ? { selector: filePickerGuard.blocked.selector } : {}),
                 ref_id,
               },
             );
@@ -2819,6 +2859,7 @@
               tag,
               rect: { x: Math.round(rect.x), y: Math.round(rect.y), w: Math.round(rect.width), h: Math.round(rect.height) },
               ...(targetContext ? { targetContext } : {}),
+              ...(filePickerGuard.guardId ? { _filePickerGuardId: filePickerGuard.guardId } : {}),
             };
             try {
               if (targetName) resp.name = targetName;

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1066,6 +1066,98 @@
   }
 
   /**
+   * Run one synthetic agent click while suppressing any synchronous
+   * <input type=file>.click() it triggers. upload_file attaches a downloaded
+   * file directly (or presents WebBrain's own picker when no downloadId is
+   * available); clicking the page control first only opens a stale OS dialog.
+   */
+  function uniqueFileInputSelector(input) {
+    const allPiercedMatches = (selector) => {
+      const matches = [];
+      const visit = (root) => {
+        try { matches.push(...root.querySelectorAll(selector)); } catch { return; }
+        let elements = [];
+        try { elements = root.querySelectorAll('*'); } catch {}
+        for (const element of elements) {
+          if (element.shadowRoot) visit(element.shadowRoot);
+        }
+      };
+      visit(document);
+      return matches;
+    };
+    const unique = (selector) => {
+      if (!selector) return null;
+      const matches = allPiercedMatches(selector);
+      return matches.length === 1 && matches[0] === input ? selector : null;
+    };
+    try {
+      if (input.id && window.CSS?.escape) {
+        const byId = unique('#' + CSS.escape(input.id));
+        if (byId) return byId;
+      }
+      if (input.name && window.CSS?.escape) {
+        const byName = unique('input[type="file"][name=' + CSS.escape(String(input.name)) + ']');
+        if (byName) return byName;
+      }
+      const parts = [];
+      let node = input;
+      while (node?.nodeType === Node.ELEMENT_NODE) {
+        let part = node.tagName.toLowerCase();
+        const parent = node.parentElement;
+        if (parent) {
+          const siblings = Array.from(parent.children).filter(child => child.tagName === node.tagName);
+          if (siblings.length > 1) part += ':nth-of-type(' + (siblings.indexOf(node) + 1) + ')';
+        }
+        parts.unshift(part);
+        const byPath = unique(parts.join(' > '));
+        if (byPath) return byPath;
+        node = parent;
+      }
+    } catch {}
+    return null;
+  }
+
+  function clickWithoutNativeFilePicker(runClick) {
+    let blocked = null;
+    const guard = (event) => {
+      const path = typeof event.composedPath === 'function'
+        ? event.composedPath()
+        : [event.target];
+      const input = path.find(node =>
+        node?.tagName === 'INPUT'
+        && String(node.getAttribute?.('type') || node.type || '').toLowerCase() === 'file'
+      );
+      if (!input) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      blocked = { selector: uniqueFileInputSelector(input) };
+    };
+    document.addEventListener('click', guard, true);
+    try {
+      runClick();
+    } finally {
+      document.removeEventListener('click', guard, true);
+    }
+    return blocked;
+  }
+
+  function filePickerBlockedResponse(blocked, label = '') {
+    const selector = typeof blocked?.selector === 'string' && blocked.selector
+      ? blocked.selector
+      : null;
+    const guidance = selector
+      ? `Call upload_file({selector: ${JSON.stringify(selector)}, downloadId: N}) directly; it attaches the downloaded file without opening an OS dialog. If there is no downloadId, call upload_file({selector: ${JSON.stringify(selector)}}) to use WebBrain's own picker.`
+      : 'Re-inspect the page to find an exact, unique <input type=file> selector, then call upload_file directly. Do not use a generic input[type="file"] selector when the page has multiple file inputs.';
+    return {
+      success: false,
+      dispatched: true,
+      filePickerBlocked: true,
+      ...(selector ? { selector } : {}),
+      error: `Blocked a native file chooser${label ? ` opened by "${label}"` : ''}. ${guidance}`,
+    };
+  }
+
+  /**
    * Click an element by selector or coordinates.
    */
   function clickElement(params) {
@@ -1449,7 +1541,13 @@
     }
 
     const clickedRect = rememberInteractionPoint(el, 'click');
-    el.click();
+    const blockedFileInput = clickWithoutNativeFilePicker(() => el.click());
+    if (blockedFileInput) {
+      return {
+        ...filePickerBlockedResponse(blockedFileInput, params.text || el.innerText?.trim() || ''),
+        ...(clickedRect ? { rect: clickedRect } : {}),
+      };
+    }
 
     // Post-click SELECT detection: the click may have activated a <select>
     // via a label, wrapper, or overlapping element. Return error, not success.
@@ -2687,7 +2785,17 @@
           }
           rememberInteractionPoint(el, 'click_ax');
           dispatched = true;
-          el.click();
+          const blockedFileInput = clickWithoutNativeFilePicker(() => el.click());
+          if (blockedFileInput) {
+            return failure(
+              filePickerBlockedResponse(blockedFileInput, targetName || '').error,
+              {
+                filePickerBlocked: true,
+                ...(blockedFileInput.selector ? { selector: blockedFileInput.selector } : {}),
+                ref_id,
+              },
+            );
+          }
           let isTextEntry = false;
           if (tag === 'textarea') isTextEntry = true;
           else if (tag === 'input') {

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1117,7 +1117,7 @@
     return null;
   }
 
-  const FILE_PICKER_GUARD_SETTLE_MS = 250;
+  const FILE_PICKER_GUARD_SETTLE_MS = 500;
   const FILE_PICKER_GUARD_RETENTION_MS = 5000;
   const _filePickerGuardStates = new Map();
   let _filePickerGuardSequence = 0;
@@ -1171,8 +1171,10 @@
       };
       document.addEventListener(blockedEvent, onBlocked, true);
       armPageGuard();
-      return () => {
-        document.dispatchEvent(new Event('webbrain:file-picker-guard-disarm'));
+      return (disarmPageGuard = true) => {
+        if (disarmPageGuard) {
+          document.dispatchEvent(new Event('webbrain:file-picker-guard-disarm'));
+        }
         if (root.getAttribute(guardAttr) === guardId) root.removeAttribute(guardAttr);
         document.removeEventListener(blockedEvent, onBlocked, true);
       };
@@ -1215,7 +1217,11 @@
     if (!state.settled) return { success: true, settled: false, filePickerBlocked: false };
     if (state.cleanupTimer) clearTimeout(state.cleanupTimer);
     document.removeEventListener('click', state.guard, true);
-    state.cleanupPageShowPickerGuard?.();
+    // If nothing was observed, stop content-side observation but leave the
+    // page-world programmatic click/showPicker guard active until its own
+    // short TTL. This suppresses longer debounces without blocking the tool
+    // response or intercepting a user's direct native input click.
+    state.cleanupPageShowPickerGuard?.(!!state.blocked);
     _filePickerGuardStates.delete(guardId);
     if (state.blocked) {
       return { ...filePickerBlockedResponse(state.blocked), settled: true };

--- a/src/firefox/src/content/file-picker-guard-loader.js
+++ b/src/firefox/src/content/file-picker-guard-loader.js
@@ -1,0 +1,15 @@
+/*
+ * Firefox MV2 content scripts run in an isolated world. Load the file-picker
+ * bridge through a web-accessible extension URL so it executes in the page's
+ * main world and can intercept page-owned input.showPicker() calls.
+ */
+(() => {
+  try {
+    const script = document.createElement('script');
+    script.src = browser.runtime.getURL('src/content/file-picker-guard-page.js');
+    script.async = false;
+    script.onload = () => { try { script.remove(); } catch {} };
+    script.onerror = () => { try { script.remove(); } catch {} };
+    (document.head || document.documentElement).appendChild(script);
+  } catch {}
+})();

--- a/src/firefox/src/content/file-picker-guard-page.js
+++ b/src/firefox/src/content/file-picker-guard-page.js
@@ -1,0 +1,139 @@
+/*
+ * Main-world bridge for suppressing input.showPicker() during agent clicks.
+ *
+ * Extension content scripts run in an isolated JavaScript world, so replacing
+ * HTMLInputElement.prototype.showPicker there does not affect page handlers.
+ * This script runs in the page's MAIN world and uses short-lived DOM events
+ * and attributes to coordinate with content.js.
+ */
+(() => {
+  if (window.__webbrainFilePickerGuardBridge) return;
+  window.__webbrainFilePickerGuardBridge = true;
+
+  const ARM_EVENT = 'webbrain:file-picker-guard-arm';
+  const DISARM_EVENT = 'webbrain:file-picker-guard-disarm';
+  const BLOCKED_EVENT = 'webbrain:file-picker-guard-blocked';
+  const GUARD_ATTR = 'data-webbrain-file-picker-guard';
+  const BLOCKED_ATTR = 'data-webbrain-file-picker-blocked';
+  const MAX_GUARD_MS = 5000;
+
+  let activeGuardId = null;
+  let restoreShowPicker = null;
+  let expiryTimer = null;
+
+  function allPiercedMatches(selector) {
+    const matches = [];
+    const visit = (root) => {
+      try { matches.push(...root.querySelectorAll(selector)); } catch { return; }
+      let elements = [];
+      try { elements = root.querySelectorAll('*'); } catch {}
+      for (const element of elements) {
+        if (element.shadowRoot) visit(element.shadowRoot);
+      }
+    };
+    visit(document);
+    return matches;
+  }
+
+  function uniqueFileInputSelector(input) {
+    const unique = (selector) => {
+      if (!selector) return null;
+      const matches = allPiercedMatches(selector);
+      return matches.length === 1 && matches[0] === input ? selector : null;
+    };
+    try {
+      if (input.id && window.CSS?.escape) {
+        const byId = unique('#' + CSS.escape(input.id));
+        if (byId) return byId;
+      }
+      if (input.name && window.CSS?.escape) {
+        const byName = unique('input[type="file"][name=' + CSS.escape(String(input.name)) + ']');
+        if (byName) return byName;
+      }
+      const parts = [];
+      let node = input;
+      while (node?.nodeType === Node.ELEMENT_NODE) {
+        let part = node.tagName.toLowerCase();
+        const parent = node.parentElement;
+        if (parent) {
+          const siblings = Array.from(parent.children).filter(child => child.tagName === node.tagName);
+          if (siblings.length > 1) part += ':nth-of-type(' + (siblings.indexOf(node) + 1) + ')';
+        }
+        parts.unshift(part);
+        const byPath = unique(parts.join(' > '));
+        if (byPath) return byPath;
+        node = parent;
+      }
+    } catch {}
+    return null;
+  }
+
+  function isFileInput(input) {
+    return input?.tagName === 'INPUT'
+      && String(input.getAttribute?.('type') || input.type || '').toLowerCase() === 'file';
+  }
+
+  function clearGuard() {
+    activeGuardId = null;
+    if (expiryTimer) {
+      clearTimeout(expiryTimer);
+      expiryTimer = null;
+    }
+    restoreShowPicker?.();
+    restoreShowPicker = null;
+  }
+
+  function reportBlocked(input) {
+    const root = document.documentElement;
+    if (!root || !activeGuardId) return;
+    root.setAttribute(BLOCKED_ATTR, JSON.stringify({
+      guardId: activeGuardId,
+      selector: uniqueFileInputSelector(input),
+    }));
+    document.dispatchEvent(new Event(BLOCKED_EVENT));
+    root.removeAttribute(BLOCKED_ATTR);
+  }
+
+  function armGuard() {
+    const root = document.documentElement;
+    const guardId = root?.getAttribute(GUARD_ATTR);
+    if (!guardId) return;
+    clearGuard();
+
+    const proto = window.HTMLInputElement?.prototype;
+    const descriptor = proto && Object.getOwnPropertyDescriptor(proto, 'showPicker');
+    const originalShowPicker = descriptor?.value;
+    if (typeof originalShowPicker !== 'function') return;
+
+    const guardedShowPicker = function(...args) {
+      if (activeGuardId && isFileInput(this)) {
+        reportBlocked(this);
+        return undefined;
+      }
+      return Reflect.apply(originalShowPicker, this, args);
+    };
+    try {
+      Object.defineProperty(proto, 'showPicker', { ...descriptor, value: guardedShowPicker });
+    } catch {
+      return;
+    }
+
+    activeGuardId = guardId;
+    restoreShowPicker = () => {
+      try {
+        if (proto.showPicker === guardedShowPicker) {
+          Object.defineProperty(proto, 'showPicker', descriptor);
+        }
+      } catch {}
+    };
+    expiryTimer = setTimeout(clearGuard, MAX_GUARD_MS);
+  }
+
+  function disarmGuard() {
+    const guardId = document.documentElement?.getAttribute(GUARD_ATTR);
+    if (guardId && guardId === activeGuardId) clearGuard();
+  }
+
+  document.addEventListener(ARM_EVENT, armGuard, true);
+  document.addEventListener(DISARM_EVENT, disarmGuard, true);
+})();

--- a/src/firefox/src/content/file-picker-guard-page.js
+++ b/src/firefox/src/content/file-picker-guard-page.js
@@ -7,15 +7,26 @@
  * and attributes to coordinate with content.js.
  */
 (() => {
-  if (window.__webbrainFilePickerGuardBridge) return;
-  window.__webbrainFilePickerGuardBridge = true;
-
+  const PROBE_EVENT = 'webbrain:file-picker-guard-probe';
+  const PROBE_ATTR = 'data-webbrain-file-picker-probe';
+  const PROBE_ACK_ATTR = 'data-webbrain-file-picker-probe-ack';
   const ARM_EVENT = 'webbrain:file-picker-guard-arm';
   const DISARM_EVENT = 'webbrain:file-picker-guard-disarm';
   const BLOCKED_EVENT = 'webbrain:file-picker-guard-blocked';
   const GUARD_ATTR = 'data-webbrain-file-picker-guard';
   const BLOCKED_ATTR = 'data-webbrain-file-picker-blocked';
   const MAX_GUARD_MS = 5000;
+
+  const probeRoot = document.documentElement;
+  if (probeRoot) {
+    const probeToken = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+    probeRoot.setAttribute(PROBE_ATTR, probeToken);
+    document.dispatchEvent(new Event(PROBE_EVENT));
+    const alreadyInstalled = probeRoot.getAttribute(PROBE_ACK_ATTR) === probeToken;
+    probeRoot.removeAttribute(PROBE_ATTR);
+    probeRoot.removeAttribute(PROBE_ACK_ATTR);
+    if (alreadyInstalled) return;
+  }
 
   let activeGuardId = null;
   let restoreShowPicker = null;
@@ -134,6 +145,14 @@
     if (guardId && guardId === activeGuardId) clearGuard();
   }
 
+  function acknowledgeProbe() {
+    const root = document.documentElement;
+    const probeToken = root?.getAttribute(PROBE_ATTR);
+    if (probeToken) root.setAttribute(PROBE_ACK_ATTR, probeToken);
+  }
+
+  document.addEventListener(PROBE_EVENT, acknowledgeProbe, true);
   document.addEventListener(ARM_EVENT, armGuard, true);
   document.addEventListener(DISARM_EVENT, disarmGuard, true);
+  armGuard();
 })();

--- a/src/firefox/src/content/file-picker-guard-page.js
+++ b/src/firefox/src/content/file-picker-guard-page.js
@@ -29,7 +29,7 @@
   }
 
   let activeGuardId = null;
-  let restoreShowPicker = null;
+  let restorePickerMethods = null;
   let expiryTimer = null;
 
   function allPiercedMatches(selector) {
@@ -90,8 +90,8 @@
       clearTimeout(expiryTimer);
       expiryTimer = null;
     }
-    restoreShowPicker?.();
-    restoreShowPicker = null;
+    restorePickerMethods?.();
+    restorePickerMethods = null;
   }
 
   function reportBlocked(input) {
@@ -112,9 +112,12 @@
     clearGuard();
 
     const proto = window.HTMLInputElement?.prototype;
-    const descriptor = proto && Object.getOwnPropertyDescriptor(proto, 'showPicker');
-    const originalShowPicker = descriptor?.value;
-    if (typeof originalShowPicker !== 'function') return;
+    if (!proto) return;
+    const showPickerDescriptor = Object.getOwnPropertyDescriptor(proto, 'showPicker');
+    const originalShowPicker = showPickerDescriptor?.value;
+    const ownClickDescriptor = Object.getOwnPropertyDescriptor(proto, 'click');
+    const originalClick = proto.click;
+    if (typeof originalShowPicker !== 'function' && typeof originalClick !== 'function') return;
 
     const guardedShowPicker = function(...args) {
       if (activeGuardId && isFileInput(this)) {
@@ -123,17 +126,48 @@
       }
       return Reflect.apply(originalShowPicker, this, args);
     };
-    try {
-      Object.defineProperty(proto, 'showPicker', { ...descriptor, value: guardedShowPicker });
-    } catch {
-      return;
+    const guardedClick = function(...args) {
+      if (activeGuardId && isFileInput(this)) {
+        reportBlocked(this);
+        return undefined;
+      }
+      return Reflect.apply(originalClick, this, args);
+    };
+    let showPickerInstalled = false;
+    let clickInstalled = false;
+    if (typeof originalShowPicker === 'function') {
+      try {
+        Object.defineProperty(proto, 'showPicker', {
+          ...showPickerDescriptor,
+          value: guardedShowPicker,
+        });
+        showPickerInstalled = true;
+      } catch {}
     }
+    if (typeof originalClick === 'function') {
+      try {
+        Object.defineProperty(proto, 'click', {
+          configurable: true,
+          enumerable: ownClickDescriptor?.enumerable ?? false,
+          writable: true,
+          value: guardedClick,
+        });
+        clickInstalled = true;
+      } catch {}
+    }
+    if (!showPickerInstalled && !clickInstalled) return;
 
     activeGuardId = guardId;
-    restoreShowPicker = () => {
+    restorePickerMethods = () => {
       try {
-        if (proto.showPicker === guardedShowPicker) {
-          Object.defineProperty(proto, 'showPicker', descriptor);
+        if (showPickerInstalled && proto.showPicker === guardedShowPicker) {
+          Object.defineProperty(proto, 'showPicker', showPickerDescriptor);
+        }
+      } catch {}
+      try {
+        if (clickInstalled && proto.click === guardedClick) {
+          if (ownClickDescriptor) Object.defineProperty(proto, 'click', ownClickDescriptor);
+          else delete proto.click;
         }
       } catch {}
     };

--- a/src/firefox/src/content/file-picker-guard-page.js
+++ b/src/firefox/src/content/file-picker-guard-page.js
@@ -12,6 +12,7 @@
   const PROBE_ACK_ATTR = 'data-webbrain-file-picker-probe-ack';
   const ARM_EVENT = 'webbrain:file-picker-guard-arm';
   const DISARM_EVENT = 'webbrain:file-picker-guard-disarm';
+  const RESET_EVENT = 'webbrain:file-picker-guard-reset';
   const BLOCKED_EVENT = 'webbrain:file-picker-guard-blocked';
   const GUARD_ATTR = 'data-webbrain-file-picker-guard';
   const BLOCKED_ATTR = 'data-webbrain-file-picker-blocked';
@@ -188,5 +189,6 @@
   document.addEventListener(PROBE_EVENT, acknowledgeProbe, true);
   document.addEventListener(ARM_EVENT, armGuard, true);
   document.addEventListener(DISARM_EVENT, disarmGuard, true);
+  document.addEventListener(RESET_EVENT, clearGuard, true);
   armGuard();
 })();

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -782,6 +782,10 @@ const deferredFilePickerOpeners = [
   ['timer', 'setTimeout(openPicker, 0)'],
   ['animation-frame', 'requestAnimationFrame(openPicker)'],
 ];
+const showPickerOpeners = [
+  ['immediate', 'openPicker()'],
+  ...deferredFilePickerOpeners,
+];
 
 for (const browserKind of ['chrome', 'firefox']) {
   for (const [deferral, scheduleOpen] of deferredFilePickerOpeners) {
@@ -818,7 +822,65 @@ for (const browserKind of ['chrome', 'firefox']) {
       }
     });
   }
+
+  for (const [deferral, scheduleOpen] of showPickerOpeners) {
+    test(`file picker guard (${browserKind}): blocks ${deferral} showPicker activation`, async (page) => {
+      const inputId = `show-picker-${browserKind}-${deferral}`;
+      await setupContentHtml(page, `<!doctype html>
+        <button id="choose">Show a file picker...</button>
+        <input id=${JSON.stringify(inputId)} type="file" hidden>
+        <script>
+          document.querySelector('#choose').addEventListener('click', () => {
+            const input = document.querySelector('#' + ${JSON.stringify(inputId)});
+            const openPicker = () => input.showPicker();
+            ${scheduleOpen};
+          });
+        </script>`, browserKind);
+
+      let chooserOpened = false;
+      page.once('filechooser', () => { chooserOpened = true; });
+      const result = await call(page, 'click', { text: 'Show a file picker...' });
+      await page.waitForTimeout(20);
+      if (chooserOpened) throw new Error(`${deferral} showPicker native chooser was not suppressed`);
+      if (!result?.filePickerBlocked || result.success !== false || result.selector !== `#${inputId}`) {
+        throw new Error(`expected blocked showPicker with #${inputId}, got ${JSON.stringify(result)}`);
+      }
+    });
+  }
 }
+
+test('Chrome CDP file picker guard blocks trusted showPicker activation and restores the prototype', async (page) => {
+  await page.setContent(`<!doctype html>
+    <button id="choose">Open trusted picker</button>
+    <input id="trusted-show-picker" type="file" hidden>
+    <script>
+      window.__originalShowPicker = HTMLInputElement.prototype.showPicker;
+      document.querySelector('#choose').addEventListener('click', () => {
+        document.querySelector('#trusted-show-picker').showPicker();
+      });
+    </script>`);
+
+  const client = new CDPClient();
+  client.evaluate = async (_tabId, expression) => ({
+    result: { value: await page.evaluate(expression) },
+  });
+
+  let chooserOpened = false;
+  page.once('filechooser', () => { chooserOpened = true; });
+  await client.armFileInputClickGuard(77, 500);
+  await page.click('#choose');
+  const blocked = await client.consumeFileInputClickGuard(77, 0);
+  await page.waitForTimeout(20);
+
+  if (chooserOpened) throw new Error('trusted showPicker native chooser was not suppressed');
+  if (!blocked?.blocked || blocked.selector !== '#trusted-show-picker') {
+    throw new Error(`expected trusted showPicker block, got ${JSON.stringify(blocked)}`);
+  }
+  const restored = await page.evaluate(
+    () => HTMLInputElement.prototype.showPicker === window.__originalShowPicker,
+  );
+  if (!restored) throw new Error('showPicker prototype was not restored after guard consumption');
+});
 
 test('Firefox upload_file resolves one open-shadow input and rejects ambiguous pierced selectors', async (page) => {
   await page.setContent(`<!doctype html>

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -17,6 +17,7 @@ import { fileURLToPath } from 'node:url';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { Agent } from '../../src/chrome/src/agent/agent.js';
+import { Agent as FirefoxAgent } from '../../src/firefox/src/agent/agent.js';
 import { CDPClient, cdpClient } from '../../src/chrome/src/cdp/cdp-client.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -751,6 +752,155 @@ for (const browserKind of ['chrome', 'firefox']) {
     }
   });
 }
+
+const deferredFilePickerOpeners = [
+  ['promise', 'Promise.resolve().then(openPicker)'],
+  ['timer', 'setTimeout(openPicker, 0)'],
+  ['animation-frame', 'requestAnimationFrame(openPicker)'],
+];
+
+for (const browserKind of ['chrome', 'firefox']) {
+  for (const [deferral, scheduleOpen] of deferredFilePickerOpeners) {
+    test(`file picker guard (${browserKind}): blocks lazy ${deferral} chooser activation`, async (page) => {
+      const inputId = `lazy-${browserKind}-${deferral}`;
+      await setupContentHtml(page, `<!doctype html>
+        <button id="choose">Add a deferred file...</button>
+        <script>
+          document.querySelector('#choose').addEventListener('click', () => {
+            const input = document.createElement('input');
+            input.type = 'file';
+            input.id = ${JSON.stringify(inputId)};
+            input.hidden = true;
+            document.body.appendChild(input);
+            const openPicker = () => input.click();
+            ${scheduleOpen};
+          });
+        </script>`, browserKind);
+
+      let chooserOpened = false;
+      page.once('filechooser', () => { chooserOpened = true; });
+      const result = await call(page, 'click', { text: 'Add a deferred file...' });
+      await page.waitForTimeout(20);
+      if (chooserOpened) throw new Error(`${deferral} native file chooser was not suppressed`);
+      if (!result?.filePickerBlocked || result.success !== false || result.selector !== `#${inputId}`) {
+        throw new Error(`expected blocked lazy picker with #${inputId}, got ${JSON.stringify(result)}`);
+      }
+      const selectorCheck = await page.evaluate((selector) => {
+        const matches = document.querySelectorAll(selector);
+        return { count: matches.length, id: matches[0]?.id || '' };
+      }, result.selector);
+      if (selectorCheck.count !== 1 || selectorCheck.id !== inputId) {
+        throw new Error(`lazy selector did not resolve uniquely: ${JSON.stringify({ result, selectorCheck })}`);
+      }
+    });
+  }
+}
+
+test('Firefox upload_file resolves one open-shadow input and rejects ambiguous pierced selectors', async (page) => {
+  await page.setContent(`<!doctype html>
+    <div id="host-a"></div>
+    <div id="host-b"></div>
+    <script>
+      const inputA = document.createElement('input');
+      inputA.type = 'file';
+      inputA.id = 'shadow-upload';
+      window.__uploadEvents = { input: 0, change: 0 };
+      inputA.addEventListener('input', () => window.__uploadEvents.input++);
+      inputA.addEventListener('change', () => window.__uploadEvents.change++);
+      document.querySelector('#host-a').attachShadow({ mode: 'open' }).appendChild(inputA);
+      const inputB = document.createElement('input');
+      inputB.type = 'file';
+      document.querySelector('#host-b').attachShadow({ mode: 'open' }).appendChild(inputB);
+    </script>`);
+
+  const originalBrowser = globalThis.browser;
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.browser = {
+      downloads: {
+        async search(query) {
+          if (query?.id !== 9001) throw new Error(`unexpected download query ${JSON.stringify(query)}`);
+          return [{
+            id: 9001,
+            state: 'complete',
+            url: 'https://example.com/shadow-upload.txt',
+            filename: '/home/user/Downloads/shadow-upload.txt',
+            mime: 'text/plain',
+          }];
+        },
+      },
+      tabs: {
+        async get(tabId) {
+          return { id: tabId, url: 'https://example.com/form' };
+        },
+        async executeScript(_tabId, details) {
+          return [await page.evaluate((source) => window.eval(source), details.code)];
+        },
+      },
+    };
+    globalThis.fetch = async () => ({
+      ok: true,
+      status: 200,
+      headers: {
+        get(name) {
+          const key = String(name).toLowerCase();
+          if (key === 'content-length') return '2';
+          if (key === 'content-type') return 'text/plain';
+          return null;
+        },
+      },
+      async arrayBuffer() {
+        return new Uint8Array([111, 107]).buffer;
+      },
+    });
+
+    const agent = new FirefoxAgent({});
+    const uploaded = await agent.executeTool(77, 'upload_file', {
+      selector: '#shadow-upload',
+      downloadId: 9001,
+    });
+    if (!uploaded?.success || uploaded.attached?.name !== 'shadow-upload.txt' || uploaded.attached?.size !== 2) {
+      throw new Error(`open-shadow upload failed: ${JSON.stringify(uploaded)}`);
+    }
+    const state = await page.evaluate(() => {
+      const input = document.querySelector('#host-a').shadowRoot.querySelector('#shadow-upload');
+      return {
+        count: input.files.length,
+        name: input.files[0]?.name || '',
+        size: input.files[0]?.size ?? -1,
+        events: window.__uploadEvents,
+      };
+    });
+    if (
+      state.count !== 1
+      || state.name !== 'shadow-upload.txt'
+      || state.size !== 2
+      || state.events.input !== 1
+      || state.events.change !== 1
+    ) {
+      throw new Error(`open-shadow upload state mismatch: ${JSON.stringify(state)}`);
+    }
+
+    const ambiguous = await agent.executeTool(77, 'upload_file', {
+      selector: 'input[type="file"]',
+      downloadId: 9001,
+    });
+    if (
+      ambiguous?.success !== false
+      || ambiguous.dispatched !== false
+      || ambiguous.ambiguous !== true
+      || ambiguous.matchCount !== 2
+      || !/exact, unique selector/.test(ambiguous.error || '')
+    ) {
+      throw new Error(`ambiguous pierced selector did not fail closed: ${JSON.stringify(ambiguous)}`);
+    }
+  } finally {
+    if (originalBrowser === undefined) delete globalThis.browser;
+    else globalThis.browser = originalBrowser;
+    if (originalFetch === undefined) delete globalThis.fetch;
+    else globalThis.fetch = originalFetch;
+  }
+});
 
 for (const browserKind of ['chrome', 'firefox']) {
   test(`click_ax (${browserKind}): stale refs are explicit pre-dispatch failures`, async (page) => {

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -147,7 +147,7 @@ async function setupIsolatedContentHtml(page, html, browserKind) {
 
     const originalResponse = { ...response };
     delete originalResponse._filePickerGuardId;
-    await page.waitForTimeout(120);
+    await page.waitForTimeout(275);
     let settled = await rawIsolatedCall('consume_file_picker_guard', { guardId });
     if (settled?.settled === false) {
       await page.waitForTimeout(50);
@@ -198,7 +198,7 @@ async function call(page, action, params) {
 
   const originalResponse = { ...response };
   delete originalResponse._filePickerGuardId;
-  await page.waitForTimeout(120);
+  await page.waitForTimeout(275);
   let settled = await rawContentCall(page, 'consume_file_picker_guard', { guardId });
   if (settled?.settled === false) {
     await page.waitForTimeout(50);
@@ -861,6 +861,7 @@ for (const browserKind of ['chrome', 'firefox']) {
 const deferredFilePickerOpeners = [
   ['promise', 'Promise.resolve().then(openPicker)'],
   ['timer', 'setTimeout(openPicker, 0)'],
+  ['debounce-150ms', 'setTimeout(openPicker, 150)'],
   ['animation-frame', 'requestAnimationFrame(openPicker)'],
 ];
 const showPickerOpeners = [

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -26,6 +26,8 @@ const accessibilityTreeJsPath = path.join(root, 'src', 'chrome', 'src', 'content
 const firefoxAccessibilityTreeJsPath = path.join(root, 'src', 'firefox', 'src', 'content', 'accessibility-tree.js');
 const contentJsPath = path.join(root, 'src', 'chrome', 'src', 'content', 'content.js');
 const firefoxContentJsPath = path.join(root, 'src', 'firefox', 'src', 'content', 'content.js');
+const filePickerGuardPageJsPath = path.join(root, 'src', 'chrome', 'src', 'content', 'file-picker-guard-page.js');
+const firefoxFilePickerGuardPageJsPath = path.join(root, 'src', 'firefox', 'src', 'content', 'file-picker-guard-page.js');
 const selectionShortcutJsPath = path.join(root, 'src', 'chrome', 'src', 'content', 'selection-shortcut.js');
 const firefoxSelectionShortcutJsPath = path.join(root, 'src', 'firefox', 'src', 'content', 'selection-shortcut.js');
 const smdJsPath = path.join(root, 'src', 'chrome', 'src', 'agent', 'social-media-downloader.js');
@@ -78,10 +80,85 @@ async function setupContentFixture(page, fixture, browserKind) {
 async function setupContentHtml(page, html, browserKind) {
   const firefox = browserKind === 'firefox';
   await page.setContent(html, { waitUntil: 'domcontentloaded' });
+  const pageGuardSrc = await readFile(
+    firefox ? firefoxFilePickerGuardPageJsPath : filePickerGuardPageJsPath,
+    'utf-8',
+  );
+  await page.addScriptTag({ content: pageGuardSrc });
   await page.addScriptTag({ content: firefox ? stubFirefoxBrowser : stubChrome });
   const src = await readFile(firefox ? firefoxContentJsPath : contentJsPath, 'utf-8');
   await page.addScriptTag({ content: src });
   await page.waitForFunction(() => typeof window.__wb_handler === 'function');
+}
+
+async function setupIsolatedContentHtml(page, html, browserKind) {
+  const firefox = browserKind === 'firefox';
+  await page.setContent(html, { waitUntil: 'domcontentloaded' });
+  const pageGuardSrc = await readFile(
+    firefox ? firefoxFilePickerGuardPageJsPath : filePickerGuardPageJsPath,
+    'utf-8',
+  );
+  await page.addScriptTag({ content: pageGuardSrc });
+
+  const session = await page.context().newCDPSession(page);
+  await session.send('Page.enable');
+  await session.send('Runtime.enable');
+  const frameTree = await session.send('Page.getFrameTree');
+  const isolatedWorld = await session.send('Page.createIsolatedWorld', {
+    frameId: frameTree.frameTree.frame.id,
+    worldName: `webbrain-${browserKind}-fixture`,
+  });
+  const contextId = isolatedWorld.executionContextId;
+  const contentSrc = await readFile(firefox ? firefoxContentJsPath : contentJsPath, 'utf-8');
+  const injected = await session.send('Runtime.evaluate', {
+    contextId,
+    expression: `${firefox ? stubFirefoxBrowser : stubChrome}\n${contentSrc}`,
+    awaitPromise: true,
+  });
+  if (injected.exceptionDetails) {
+    throw new Error(`isolated content injection failed: ${injected.exceptionDetails.text}`);
+  }
+
+  const rawIsolatedCall = async (action, params) => {
+    const message = JSON.stringify({ target: 'content', action, params });
+    const evaluated = await session.send('Runtime.evaluate', {
+      contextId,
+      expression: `new Promise((resolve) => {
+        const ret = window.__wb_handler(${message}, {}, (resp) => resolve(resp));
+        if (ret !== true && ret !== undefined) resolve(ret);
+      })`,
+      awaitPromise: true,
+      returnByValue: true,
+    });
+    if (evaluated.exceptionDetails) {
+      throw new Error(`isolated content call failed: ${evaluated.exceptionDetails.text}`);
+    }
+    return evaluated.result.value;
+  };
+
+  return async (action, params) => {
+    const response = await rawIsolatedCall(action, params);
+    const guardId = response?._filePickerGuardId;
+    if (!guardId) return response;
+
+    const originalResponse = { ...response };
+    delete originalResponse._filePickerGuardId;
+    await page.waitForTimeout(120);
+    let settled = await rawIsolatedCall('consume_file_picker_guard', { guardId });
+    if (settled?.settled === false) {
+      await page.waitForTimeout(50);
+      settled = await rawIsolatedCall('consume_file_picker_guard', { guardId });
+    }
+    if (!settled?.filePickerBlocked) return originalResponse;
+
+    const blockedResponse = { ...settled };
+    delete blockedResponse.settled;
+    return {
+      ...blockedResponse,
+      ...(originalResponse.rect ? { rect: originalResponse.rect } : {}),
+      ...(originalResponse.ref_id ? { ref_id: originalResponse.ref_id } : {}),
+    };
+  };
 }
 
 async function setupFirefoxHtml(page, html) {
@@ -826,7 +903,7 @@ for (const browserKind of ['chrome', 'firefox']) {
   for (const [deferral, scheduleOpen] of showPickerOpeners) {
     test(`file picker guard (${browserKind}): blocks ${deferral} showPicker activation`, async (page) => {
       const inputId = `show-picker-${browserKind}-${deferral}`;
-      await setupContentHtml(page, `<!doctype html>
+      const isolatedCall = await setupIsolatedContentHtml(page, `<!doctype html>
         <button id="choose">Show a file picker...</button>
         <input id=${JSON.stringify(inputId)} type="file" hidden>
         <script>
@@ -839,7 +916,7 @@ for (const browserKind of ['chrome', 'firefox']) {
 
       let chooserOpened = false;
       page.once('filechooser', () => { chooserOpened = true; });
-      const result = await call(page, 'click', { text: 'Show a file picker...' });
+      const result = await isolatedCall('click', { text: 'Show a file picker...' });
       await page.waitForTimeout(20);
       if (chooserOpened) throw new Error(`${deferral} showPicker native chooser was not suppressed`);
       if (!result?.filePickerBlocked || result.success !== false || result.selector !== `#${inputId}`) {

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -85,6 +85,8 @@ async function setupContentHtml(page, html, browserKind) {
     'utf-8',
   );
   await page.addScriptTag({ content: pageGuardSrc });
+  // Simulate manifest injection followed by extension-reload recovery.
+  await page.addScriptTag({ content: pageGuardSrc });
   await page.addScriptTag({ content: firefox ? stubFirefoxBrowser : stubChrome });
   const src = await readFile(firefox ? firefoxContentJsPath : contentJsPath, 'utf-8');
   await page.addScriptTag({ content: src });
@@ -98,6 +100,8 @@ async function setupIsolatedContentHtml(page, html, browserKind) {
     firefox ? firefoxFilePickerGuardPageJsPath : filePickerGuardPageJsPath,
     'utf-8',
   );
+  await page.addScriptTag({ content: pageGuardSrc });
+  // Simulate recovery reinjection while keeping the content world separate.
   await page.addScriptTag({ content: pageGuardSrc });
 
   const session = await page.context().newCDPSession(page);
@@ -921,6 +925,15 @@ for (const browserKind of ['chrome', 'firefox']) {
       if (chooserOpened) throw new Error(`${deferral} showPicker native chooser was not suppressed`);
       if (!result?.filePickerBlocked || result.success !== false || result.selector !== `#${inputId}`) {
         throw new Error(`expected blocked showPicker with #${inputId}, got ${JSON.stringify(result)}`);
+      }
+      const footprint = await page.evaluate(() => ({
+        stableGlobal: Object.hasOwn(window, '__webbrainFilePickerGuardBridge'),
+        attributes: Array.from(document.documentElement.attributes)
+          .map(attribute => attribute.name)
+          .filter(name => name.startsWith('data-webbrain-file-picker-')),
+      }));
+      if (footprint.stableGlobal || footprint.attributes.length) {
+        throw new Error(`page-world guard left a detectable marker: ${JSON.stringify(footprint)}`);
       }
     });
   }

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -147,7 +147,7 @@ async function setupIsolatedContentHtml(page, html, browserKind) {
 
     const originalResponse = { ...response };
     delete originalResponse._filePickerGuardId;
-    await page.waitForTimeout(275);
+    await page.waitForTimeout(525);
     let settled = await rawIsolatedCall('consume_file_picker_guard', { guardId });
     if (settled?.settled === false) {
       await page.waitForTimeout(50);
@@ -198,7 +198,7 @@ async function call(page, action, params) {
 
   const originalResponse = { ...response };
   delete originalResponse._filePickerGuardId;
-  await page.waitForTimeout(275);
+  await page.waitForTimeout(525);
   let settled = await rawContentCall(page, 'consume_file_picker_guard', { guardId });
   if (settled?.settled === false) {
     await page.waitForTimeout(50);
@@ -862,6 +862,7 @@ const deferredFilePickerOpeners = [
   ['promise', 'Promise.resolve().then(openPicker)'],
   ['timer', 'setTimeout(openPicker, 0)'],
   ['debounce-150ms', 'setTimeout(openPicker, 150)'],
+  ['debounce-300ms', 'setTimeout(openPicker, 300)'],
   ['animation-frame', 'requestAnimationFrame(openPicker)'],
 ];
 const showPickerOpeners = [
@@ -938,17 +939,75 @@ for (const browserKind of ['chrome', 'firefox']) {
       }
     });
   }
+
+  test(`file picker guard (${browserKind}): blocks programmatic clicks inside closed shadow roots`, async (page) => {
+    const isolatedCall = await setupIsolatedContentHtml(page, `<!doctype html>
+      <button id="choose">Open a closed-shadow picker...</button>
+      <div id="host"></div>
+      <script>
+        const input = document.querySelector('#host')
+          .attachShadow({ mode: 'closed' })
+          .appendChild(document.createElement('input'));
+        input.type = 'file';
+        document.querySelector('#choose').addEventListener('click', () => input.click());
+      </script>`, browserKind);
+
+    let chooserOpened = false;
+    page.once('filechooser', () => { chooserOpened = true; });
+    const result = await isolatedCall('click', { text: 'Open a closed-shadow picker...' });
+    await page.waitForTimeout(20);
+    if (chooserOpened) throw new Error('closed-shadow native chooser was not suppressed');
+    if (!result?.filePickerBlocked || result.success !== false) {
+      throw new Error(`expected blocked closed-shadow picker, got ${JSON.stringify(result)}`);
+    }
+    if (Object.hasOwn(result, 'selector')) {
+      throw new Error(`closed-shadow picker must not expose an unusable selector: ${result.selector}`);
+    }
+  });
+
+  test(`file picker guard (${browserKind}): suppresses long programmatic debounce after result settlement`, async (page) => {
+    const isolatedCall = await setupIsolatedContentHtml(page, `<!doctype html>
+      <button id="choose">Schedule a late picker...</button>
+      <input id="late-picker" type="file" hidden>
+      <script>
+        document.querySelector('#choose').addEventListener('click', () => {
+          setTimeout(() => {
+            window.__latePickerAttempted = true;
+            document.querySelector('#late-picker').click();
+          }, 800);
+        });
+      </script>`, browserKind);
+
+    let chooserOpened = false;
+    page.once('filechooser', () => { chooserOpened = true; });
+    const result = await isolatedCall('click', { text: 'Schedule a late picker...' });
+    if (!result?.success || result.filePickerBlocked) {
+      throw new Error(`late picker should settle before its callback, got ${JSON.stringify(result)}`);
+    }
+    await page.waitForTimeout(350);
+    const attempted = await page.evaluate(() => window.__latePickerAttempted === true);
+    if (!attempted) throw new Error('late picker callback did not execute');
+    if (chooserOpened) throw new Error('post-settlement native chooser was not suppressed');
+  });
 }
 
 test('Chrome CDP file picker guard blocks trusted showPicker activation and restores the prototype', async (page) => {
   await page.setContent(`<!doctype html>
     <button id="choose">Open trusted picker</button>
+    <button id="choose-closed">Open trusted closed picker</button>
     <input id="trusted-show-picker" type="file" hidden>
+    <div id="closed-host"></div>
     <script>
       window.__originalShowPicker = HTMLInputElement.prototype.showPicker;
+      window.__originalInputClick = HTMLInputElement.prototype.click;
+      const closedInput = document.querySelector('#closed-host')
+        .attachShadow({ mode: 'closed' })
+        .appendChild(document.createElement('input'));
+      closedInput.type = 'file';
       document.querySelector('#choose').addEventListener('click', () => {
         document.querySelector('#trusted-show-picker').showPicker();
       });
+      document.querySelector('#choose-closed').addEventListener('click', () => closedInput.click());
     </script>`);
 
   const client = new CDPClient();
@@ -968,9 +1027,25 @@ test('Chrome CDP file picker guard blocks trusted showPicker activation and rest
     throw new Error(`expected trusted showPicker block, got ${JSON.stringify(blocked)}`);
   }
   const restored = await page.evaluate(
-    () => HTMLInputElement.prototype.showPicker === window.__originalShowPicker,
+    () => ({
+      showPicker: HTMLInputElement.prototype.showPicker === window.__originalShowPicker,
+      click: HTMLInputElement.prototype.click === window.__originalInputClick,
+    }),
   );
-  if (!restored) throw new Error('showPicker prototype was not restored after guard consumption');
+  if (!restored.showPicker || !restored.click) {
+    throw new Error(`input prototypes were not restored after guard consumption: ${JSON.stringify(restored)}`);
+  }
+
+  let closedChooserOpened = false;
+  page.once('filechooser', () => { closedChooserOpened = true; });
+  await client.armFileInputClickGuard(77, 500);
+  await page.click('#choose-closed');
+  const closedBlocked = await client.consumeFileInputClickGuard(77, 0);
+  await page.waitForTimeout(20);
+  if (closedChooserOpened) throw new Error('trusted closed-shadow native chooser was not suppressed');
+  if (!closedBlocked?.blocked || closedBlocked.selector !== null) {
+    throw new Error(`expected trusted closed-shadow block without selector, got ${JSON.stringify(closedBlocked)}`);
+  }
 });
 
 test('Firefox upload_file resolves one open-shadow input and rejects ambiguous pierced selectors', async (page) => {

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -74,6 +74,15 @@ async function setupContentFixture(page, fixture, browserKind) {
   await page.waitForFunction(() => typeof window.__wb_handler === 'function');
 }
 
+async function setupContentHtml(page, html, browserKind) {
+  const firefox = browserKind === 'firefox';
+  await page.setContent(html, { waitUntil: 'domcontentloaded' });
+  await page.addScriptTag({ content: firefox ? stubFirefoxBrowser : stubChrome });
+  const src = await readFile(firefox ? firefoxContentJsPath : contentJsPath, 'utf-8');
+  await page.addScriptTag({ content: src });
+  await page.waitForFunction(() => typeof window.__wb_handler === 'function');
+}
+
 async function setupFirefoxHtml(page, html) {
   await page.setContent(html, { waitUntil: 'domcontentloaded' });
   await page.addScriptTag({ content: stubFirefoxBrowser });
@@ -686,6 +695,63 @@ test('ambiguity: two Cancels return rich candidates with ancestor', async (page)
 });
 
 // ─── click_ax same-page anchors ─────────────────────────────────────────────
+for (const browserKind of ['chrome', 'firefox']) {
+  test(`file picker guard (${browserKind}): blocks the native chooser and returns the exact input`, async (page) => {
+    await setupContentHtml(page, `<!doctype html>
+      <button id="choose">Select a file...</button>
+      <input type="file" hidden>
+      <input type="file" hidden>
+      <script>
+        document.querySelector('#choose').addEventListener('click', () => {
+          document.querySelectorAll('input[type=file]')[1].click();
+        });
+      </script>`, browserKind);
+
+    let chooserOpened = false;
+    page.once('filechooser', () => { chooserOpened = true; });
+    const result = await call(page, 'click', { text: 'Select a file...' });
+    await page.waitForTimeout(20);
+    if (chooserOpened) throw new Error('native file chooser was not suppressed');
+    if (!result?.filePickerBlocked || result.success !== false || !result.selector) {
+      throw new Error(`expected blocked picker with exact selector, got ${JSON.stringify(result)}`);
+    }
+    const selectorCheck = await page.evaluate((selector) => {
+      const inputs = document.querySelectorAll('input[type=file]');
+      const matches = document.querySelectorAll(selector);
+      return { count: matches.length, correct: matches[0] === inputs[1] };
+    }, result.selector);
+    if (selectorCheck.count !== 1 || !selectorCheck.correct) {
+      throw new Error(`selector did not uniquely resolve the clicked input: ${JSON.stringify({ result, selectorCheck })}`);
+    }
+  });
+
+  test(`file picker guard (${browserKind}): withholds selectors that collide across shadow roots`, async (page) => {
+    await setupContentHtml(page, `<!doctype html>
+      <button id="choose">Select a shadow file...</button>
+      <div id="host-a"></div>
+      <div id="host-b"></div>
+      <script>
+        for (const id of ['host-a', 'host-b']) {
+          document.querySelector('#' + id).attachShadow({ mode: 'open' }).innerHTML = '<input type="file">';
+        }
+        document.querySelector('#choose').addEventListener('click', () => {
+          document.querySelector('#host-b').shadowRoot.querySelector('input').click();
+        });
+      </script>`, browserKind);
+
+    const result = await call(page, 'click', { text: 'Select a shadow file...' });
+    if (!result?.filePickerBlocked || result.success !== false) {
+      throw new Error(`expected blocked picker, got ${JSON.stringify(result)}`);
+    }
+    if (Object.hasOwn(result, 'selector')) {
+      throw new Error(`ambiguous shadow-root input must not return selector ${result.selector}`);
+    }
+    if (!/exact, unique/.test(result.error || '') || !/generic input\[type="file"\]/.test(result.error || '')) {
+      throw new Error(`missing unique-selector recovery guidance: ${JSON.stringify(result)}`);
+    }
+  });
+}
+
 for (const browserKind of ['chrome', 'firefox']) {
   test(`click_ax (${browserKind}): stale refs are explicit pre-dispatch failures`, async (page) => {
     await setupContentFixture(page, 'trusted-click-fallback.html', browserKind);

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -993,6 +993,9 @@ for (const browserKind of ['chrome', 'firefox']) {
 
 test('Chrome CDP file picker guard blocks trusted showPicker activation and restores the prototype', async (page) => {
   await page.setContent(`<!doctype html>
+    <style>
+      #closed-host { display: block; width: 220px; height: 40px; }
+    </style>
     <button id="choose">Open trusted picker</button>
     <button id="choose-closed">Open trusted closed picker</button>
     <input id="trusted-show-picker" type="file" hidden>
@@ -1004,6 +1007,7 @@ test('Chrome CDP file picker guard blocks trusted showPicker activation and rest
         .attachShadow({ mode: 'closed' })
         .appendChild(document.createElement('input'));
       closedInput.type = 'file';
+      closedInput.style.cssText = 'display:block;width:220px;height:40px';
       document.querySelector('#choose').addEventListener('click', () => {
         document.querySelector('#trusted-show-picker').showPicker();
       });
@@ -1011,6 +1015,12 @@ test('Chrome CDP file picker guard blocks trusted showPicker activation and rest
     </script>`);
 
   const client = new CDPClient();
+  const protocolSession = await page.context().newCDPSession(page);
+  client.sendCommand = async (_tabId, method, params = {}) => protocolSession.send(method, params);
+  protocolSession.on('Page.fileChooserOpened', (params) => {
+    const handlers = client.eventHandlers.get(77)?.['Page.fileChooserOpened'] || [];
+    for (const handler of handlers) handler(params);
+  });
   client.evaluate = async (_tabId, expression) => ({
     result: { value: await page.evaluate(expression) },
   });
@@ -1045,6 +1055,19 @@ test('Chrome CDP file picker guard blocks trusted showPicker activation and rest
   if (closedChooserOpened) throw new Error('trusted closed-shadow native chooser was not suppressed');
   if (!closedBlocked?.blocked || closedBlocked.selector !== null) {
     throw new Error(`expected trusted closed-shadow block without selector, got ${JSON.stringify(closedBlocked)}`);
+  }
+
+  let directChooserEventObserved = false;
+  page.once('filechooser', () => { directChooserEventObserved = true; });
+  await client.armFileInputClickGuard(77, 500);
+  await page.click('#closed-host');
+  const directBlocked = await client.consumeFileInputClickGuard(77, 0);
+  await page.waitForTimeout(20);
+  if (!directChooserEventObserved) {
+    throw new Error('direct trusted closed-shadow chooser did not emit the intercepted protocol event');
+  }
+  if (!directBlocked?.blocked || directBlocked.selector !== null) {
+    throw new Error(`expected protocol-level closed-shadow block, got ${JSON.stringify(directBlocked)}`);
   }
 });
 

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -99,7 +99,7 @@ async function setupAccessibilityTreeHtml(page, html, sourcePath) {
   await page.waitForFunction(() => typeof window.__generateAccessibilityTree === 'function');
 }
 
-async function call(page, action, params) {
+async function rawContentCall(page, action, params) {
   return page.evaluate(({ action, params }) => new Promise((resolve) => {
     const ret = window.__wb_handler(
       { target: 'content', action, params },
@@ -108,6 +108,30 @@ async function call(page, action, params) {
     );
     if (ret !== true && ret !== undefined) resolve(ret);
   }), { action, params });
+}
+
+async function call(page, action, params) {
+  const response = await rawContentCall(page, action, params);
+  const guardId = response?._filePickerGuardId;
+  if (!guardId) return response;
+
+  const originalResponse = { ...response };
+  delete originalResponse._filePickerGuardId;
+  await page.waitForTimeout(120);
+  let settled = await rawContentCall(page, 'consume_file_picker_guard', { guardId });
+  if (settled?.settled === false) {
+    await page.waitForTimeout(50);
+    settled = await rawContentCall(page, 'consume_file_picker_guard', { guardId });
+  }
+  if (!settled?.filePickerBlocked) return originalResponse;
+
+  const blockedResponse = { ...settled };
+  delete blockedResponse.settled;
+  return {
+    ...blockedResponse,
+    ...(originalResponse.rect ? { rect: originalResponse.rect } : {}),
+    ...(originalResponse.ref_id ? { ref_id: originalResponse.ref_id } : {}),
+  };
 }
 
 async function readThroughCdpMirror(page, opts = {}) {

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -1013,6 +1013,8 @@ test('Chrome CDP file picker guard blocks trusted showPicker activation and rest
       });
       document.querySelector('#choose-closed').addEventListener('click', () => closedInput.click());
     </script>`);
+  const pageGuardSrc = await readFile(filePickerGuardPageJsPath, 'utf-8');
+  await page.addScriptTag({ content: pageGuardSrc });
 
   const client = new CDPClient();
   const protocolSession = await page.context().newCDPSession(page);
@@ -1068,6 +1070,29 @@ test('Chrome CDP file picker guard blocks trusted showPicker activation and rest
   }
   if (!directBlocked?.blocked || directBlocked.selector !== null) {
     throw new Error(`expected protocol-level closed-shadow block, got ${JSON.stringify(directBlocked)}`);
+  }
+
+  await page.evaluate(() => {
+    const root = document.documentElement;
+    root.setAttribute('data-webbrain-file-picker-guard', 'residual-content-guard');
+    document.dispatchEvent(new Event('webbrain:file-picker-guard-arm'));
+    root.removeAttribute('data-webbrain-file-picker-guard');
+  });
+  const residualInstalled = await page.evaluate(
+    () => HTMLInputElement.prototype.click !== window.__originalInputClick,
+  );
+  if (!residualInstalled) throw new Error('residual page-world guard was not installed');
+
+  await client.armFileInputClickGuard(77, 250);
+  const noPickerBlocked = await client.consumeFileInputClickGuard(77, 0);
+  if (noPickerBlocked) throw new Error(`unexpected picker during restore-stack test: ${JSON.stringify(noPickerBlocked)}`);
+  await page.waitForTimeout(350);
+  const stackRestored = await page.evaluate(() => ({
+    showPicker: HTMLInputElement.prototype.showPicker === window.__originalShowPicker,
+    click: HTMLInputElement.prototype.click === window.__originalInputClick,
+  }));
+  if (!stackRestored.showPicker || !stackRestored.click) {
+    throw new Error(`stacked page/CDP guards did not restore native prototypes: ${JSON.stringify(stackRestored)}`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -31501,13 +31501,43 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
     assert.match(source, /const FILE_PICKER_GUARD_SETTLE_MS = 100/, `${relPath}: missing deferred picker settle window`);
     assert.match(source, /function clickWithoutNativeFilePicker\(runClick,\s*settleMs\s*=\s*FILE_PICKER_GUARD_SETTLE_MS\)/, `${relPath}: missing one-click file chooser guard`);
     assert.match(source, /setTimeout\(\(\) => \{\s*cleanupGuard\(\)/, `${relPath}: guard should survive deferred picker clicks`);
-    assert.match(source, /Object\.getOwnPropertyDescriptor\(proto,\s*'showPicker'\)/, `${relPath}: missing showPicker interception`);
-    assert.match(source, /if \(isFileInput\(this\)\)[\s\S]*blockFileInput\(this\)/, `${relPath}: showPicker should record file inputs`);
-    assert.match(source, /Object\.defineProperty\(proto,\s*'showPicker',\s*descriptor\)/, `${relPath}: showPicker interception should be restored`);
+    assert.match(source, /const installPageShowPickerGuard = \(\) =>/, `${relPath}: missing page-world showPicker bridge handshake`);
+    assert.match(source, /webbrain:file-picker-guard-arm/, `${relPath}: missing page-world showPicker arm event`);
+    assert.match(source, /webbrain:file-picker-guard-blocked/, `${relPath}: missing page-world blocked result event`);
     assert.match(source, /clickWithoutNativeFilePicker\(\(\) => el\.click\(\)\)/, `${relPath}: synthetic clicks should use the chooser guard`);
     assert.match(source, /_filePickerGuardId:\s*filePickerGuard\.guardId/, `${relPath}: click response should return without waiting on the unloading document`);
     assert.match(source, /'consume_file_picker_guard':\s*\(\) => consumeFilePickerGuard/, `${relPath}: missing deferred guard result handshake`);
     assert.match(source, /filePickerBlocked:\s*true/, `${relPath}: blocked chooser should be explicit to the model`);
+  }
+
+  const chromeManifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'src/chrome/manifest.json'), 'utf8'));
+  const chromeMainGuard = chromeManifest.content_scripts.find(entry =>
+    entry.world === 'MAIN'
+    && entry.js?.includes('src/content/file-picker-guard-page.js')
+  );
+  assert.ok(chromeMainGuard, 'chrome: showPicker guard must run in the page MAIN world');
+  assert.equal(chromeMainGuard.run_at, 'document_start');
+
+  const firefoxManifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'src/firefox/manifest.json'), 'utf8'));
+  const firefoxGuardLoader = firefoxManifest.content_scripts.find(entry =>
+    entry.js?.includes('src/content/file-picker-guard-loader.js')
+  );
+  assert.ok(firefoxGuardLoader, 'firefox: showPicker page-world loader is missing');
+  assert.equal(firefoxGuardLoader.run_at, 'document_start');
+  assert.ok(
+    firefoxManifest.web_accessible_resources.includes('src/content/file-picker-guard-page.js'),
+    'firefox: page-world showPicker guard must be web-accessible',
+  );
+
+  const pageGuardPaths = [
+    'src/chrome/src/content/file-picker-guard-page.js',
+    'src/firefox/src/content/file-picker-guard-page.js',
+  ];
+  for (const relPath of pageGuardPaths) {
+    const source = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
+    assert.match(source, /Object\.getOwnPropertyDescriptor\(proto,\s*'showPicker'\)/, `${relPath}: missing main-world showPicker interception`);
+    assert.match(source, /reportBlocked\(this\)/, `${relPath}: main-world showPicker should record the input`);
+    assert.match(source, /Object\.defineProperty\(proto,\s*'showPicker',\s*descriptor\)/, `${relPath}: showPicker interception should be restored`);
   }
 
   for (const relPath of [

--- a/test/run.js
+++ b/test/run.js
@@ -17160,7 +17160,7 @@ test('Chrome executeTool re-stamps the click_ax safety window after content-scri
 
   try {
     const result = await agent.executeTool(42, 'click_ax', { ref_id: 'ref_inject' });
-    assert.equal(injectCalls, 1);
+    assert.equal(injectCalls, 2, 'recovery should inject the MAIN-world guard before isolated content');
     assert.equal(sendAttempts, 2);
     assert.equal(captureTimes.length, 2, 'baseline must be re-captured after inject');
     assert.ok(
@@ -31535,9 +31535,64 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
   ];
   for (const relPath of pageGuardPaths) {
     const source = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
+    assert.doesNotMatch(source, /window\.__webbrainFilePickerGuardBridge/, `${relPath}: must not expose a stable page global`);
+    assert.match(source, /webbrain:file-picker-guard-probe/, `${relPath}: recovery reinjection should use an ephemeral idempotence probe`);
     assert.match(source, /Object\.getOwnPropertyDescriptor\(proto,\s*'showPicker'\)/, `${relPath}: missing main-world showPicker interception`);
     assert.match(source, /reportBlocked\(this\)/, `${relPath}: main-world showPicker should record the input`);
     assert.match(source, /Object\.defineProperty\(proto,\s*'showPicker',\s*descriptor\)/, `${relPath}: showPicker interception should be restored`);
+  }
+
+  const previousChrome = globalThis.chrome;
+  const chromeInjections = [];
+  globalThis.chrome = {
+    scripting: {
+      async executeScript(details) { chromeInjections.push(details); },
+    },
+  };
+  try {
+    const agent = Object.create(AgentCh.prototype);
+    await agent._injectCoreContentScripts(42);
+    assert.deepEqual(chromeInjections[0], {
+      target: { tabId: 42 },
+      world: 'MAIN',
+      files: ['src/content/file-picker-guard-page.js'],
+    });
+    assert.ok(
+      chromeInjections[1].files.includes('src/content/content.js'),
+      'chrome: recovery should inject isolated content after the MAIN-world guard',
+    );
+  } finally {
+    if (previousChrome === undefined) delete globalThis.chrome;
+    else globalThis.chrome = previousChrome;
+  }
+
+  const previousBrowser = globalThis.browser;
+  const firefoxInjections = [];
+  globalThis.browser = {
+    tabs: {
+      async executeScript(tabId, details) { firefoxInjections.push({ tabId, ...details }); },
+    },
+  };
+  try {
+    const agent = Object.create(AgentFx.prototype);
+    await agent._injectCoreContentScripts(43);
+    assert.deepEqual(firefoxInjections.map(injection => injection.file), [
+      'src/content/file-picker-guard-loader.js',
+      'src/content/accessibility-tree.js',
+      'src/content/content.js',
+      'src/content/agent-visual-indicator.js',
+    ]);
+  } finally {
+    if (previousBrowser === undefined) delete globalThis.browser;
+    else globalThis.browser = previousBrowser;
+  }
+
+  for (const relPath of [
+    'src/chrome/src/background.js',
+    'src/firefox/src/background.js',
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
+    assert.match(source, /agent\._injectCoreContentScripts\(tabId\)/, `${relPath}: background recovery should include the page guard`);
   }
 
   for (const relPath of [

--- a/test/run.js
+++ b/test/run.js
@@ -16168,6 +16168,17 @@ test('Chrome focused type_text marks missing focus as a pre-dispatch failure', a
   }
 });
 
+function stubChromeCdpFileInputClickGuard(blocked = null) {
+  const arm = cdpClientCh.armFileInputClickGuard;
+  const consume = cdpClientCh.consumeFileInputClickGuard;
+  cdpClientCh.armFileInputClickGuard = async () => {};
+  cdpClientCh.consumeFileInputClickGuard = async () => blocked;
+  return () => {
+    cdpClientCh.armFileInputClickGuard = arm;
+    cdpClientCh.consumeFileInputClickGuard = consume;
+  };
+}
+
 test('Chrome click_ax keeps successful synthetic clicks and skips trusted fallback', async () => {
   const agent = new AgentCh({});
   let resolved = false;
@@ -16208,6 +16219,7 @@ test('Chrome click_ax treats broad page churn as weak evidence and still uses on
     dispatch: cdpClientCh.dispatchMouseEvent,
   };
   const agent = new AgentCh({});
+  const restoreFileInputGuard = stubChromeCdpFileInputClickGuard();
   const weakObservation = {
     changed: true, proved: false, weakEvidence: true, safetyVeto: false, observable: true,
     reasons: ['page_text'], proofReasons: [], weakReasons: ['page_text'], safetyReasons: [],
@@ -16322,7 +16334,100 @@ test('Chrome click_ax treats broad page churn as weak evidence and still uses on
     assert.ok(result.observedHints?.includes('target_state_weak'));
     assert.ok(result.observedHints?.includes('page_controls'));
   } finally {
+    restoreFileInputGuard();
     cdpClientCh.attach = originals.attach;
+    cdpClientCh.dispatchMouseEvent = originals.dispatch;
+  }
+});
+
+test('Chrome click_ax guards the trusted CDP fallback against native file choosers', async () => {
+  const originals = {
+    attach: cdpClientCh.attach,
+    arm: cdpClientCh.armFileInputClickGuard,
+    consume: cdpClientCh.consumeFileInputClickGuard,
+    dispatch: cdpClientCh.dispatchMouseEvent,
+  };
+  const agent = new AgentCh({});
+  const dispatched = [];
+  let armed = 0;
+  let consumed = 0;
+  agent._clickAxFinalSettleMs = () => 0;
+  agent._observeClickAxSideEffect = async () => ({
+    changed: false,
+    proved: false,
+    weakEvidence: false,
+    safetyVeto: false,
+    observable: true,
+    reasons: [],
+    proofReasons: [],
+    weakReasons: [],
+    safetyReasons: [],
+    snapshot: '{"text":"same","active":""}',
+  });
+  agent._captureClickAxObservation = async (_tabId, snapshot, sideEffectWatch, startedAt) => ({
+    startedAt,
+    snapshot,
+    tabIds: '1,42',
+    sideEffectWatch,
+  });
+  agent._resolveClickAxFallbackTarget = async () => ({
+    success: true,
+    fallbackEligible: true,
+    documentToken: 'doc-upload',
+    fallbackState: '{"aria-current":"<absent>"}',
+    fallbackStrongState: '{"aria-current":"<absent>"}',
+    fallbackWeakState: '{"className":""}',
+    x: 120,
+    y: 80,
+    rect: { x: 70, y: 60, w: 100, h: 40 },
+  });
+
+  try {
+    cdpClientCh.attach = async () => ({ tabId: 42, attached: true });
+    cdpClientCh.armFileInputClickGuard = async () => { armed++; };
+    cdpClientCh.consumeFileInputClickGuard = async () => {
+      consumed++;
+      return { blocked: true, selector: '#trusted-upload' };
+    };
+    cdpClientCh.dispatchMouseEvent = async (_tabId, type) => {
+      dispatched.push(type);
+    };
+
+    const result = await agent._maybeFallbackClickAxWithCdp(
+      42,
+      { ref_id: 'ref_upload' },
+      {
+        success: true,
+        method: 'click_ax',
+        ref_id: 'ref_upload',
+        tag: 'div',
+        _fallbackStateBefore: '{"full":"same"}',
+        _fallbackStateAfterImmediate: '{"full":"same"}',
+        _fallbackStrongStateBefore: '{"aria-current":"<absent>"}',
+        _fallbackStrongStateAfterImmediate: '{"aria-current":"<absent>"}',
+        _fallbackWeakStateBefore: '{"className":""}',
+        _fallbackWeakStateAfterImmediate: '{"className":""}',
+      },
+      { snapshot: '{"text":"same"}', sideEffectWatch: { created: [], requests: [] } },
+    );
+
+    assert.equal(armed, 1);
+    assert.equal(consumed, 1);
+    assert.deepEqual(dispatched, ['mouseMoved', 'mousePressed', 'mouseReleased']);
+    assert.equal(result.success, false);
+    assert.equal(result.dispatched, true);
+    assert.equal(result.filePickerBlocked, true);
+    assert.equal(result.selector, '#trusted-upload');
+    assert.equal(result.ref_id, 'ref_upload');
+    assert.equal(result.fallback, 'cdp_after_synthetic_no_progress');
+    assert.equal(result.fallbackAttempted, true);
+    assert.equal(result.trusted, true);
+    assert.equal(result.verified, true);
+    assert.match(result.error, /upload_file/);
+  } finally {
+    cdpClientCh.attach = originals.attach;
+    cdpClientCh.armFileInputClickGuard = originals.arm;
+    cdpClientCh.consumeFileInputClickGuard = originals.consume;
     cdpClientCh.dispatchMouseEvent = originals.dispatch;
   }
 });
@@ -16333,6 +16438,7 @@ test('Chrome click_ax never trusts ineligible targets and never retries one trus
     dispatch: cdpClientCh.dispatchMouseEvent,
   };
   const agent = new AgentCh({});
+  const restoreFileInputGuard = stubChromeCdpFileInputClickGuard();
   let dispatched = 0;
   agent._clickAxFinalSettleMs = () => 0;
   agent._observeClickAxSideEffect = async () => ({
@@ -16414,6 +16520,7 @@ test('Chrome click_ax never trusts ineligible targets and never retries one trus
     assert.match(second.fallbackSkipped, /already attempted/);
     assert.equal(dispatched, 3, 'the same document/ref target must receive at most one trusted fallback');
   } finally {
+    restoreFileInputGuard();
     cdpClientCh.attach = originals.attach;
     cdpClientCh.dispatchMouseEvent = originals.dispatch;
   }
@@ -16425,6 +16532,7 @@ test('Chrome click_ax only consumes the one-shot slot after a CDP press is deliv
     dispatch: cdpClientCh.dispatchMouseEvent,
   };
   const agent = new AgentCh({});
+  const restoreFileInputGuard = stubChromeCdpFileInputClickGuard();
   const dispatched = [];
   let attachAttempts = 0;
   agent._clickAxFinalSettleMs = () => 0;
@@ -16519,6 +16627,7 @@ test('Chrome click_ax only consumes the one-shot slot after a CDP press is deliv
     assert.match(repeated.fallbackSkipped, /already attempted/);
     assert.deepEqual(dispatched, ['mouseMoved', 'mousePressed', 'mouseReleased']);
   } finally {
+    restoreFileInputGuard();
     cdpClientCh.attach = originals.attach;
     cdpClientCh.dispatchMouseEvent = originals.dispatch;
   }
@@ -16689,6 +16798,7 @@ test('Chrome click_ax trusted phase carries preparedActive so blur-only is not p
     dispatch: cdpClientCh.dispatchMouseEvent,
   };
   const agent = new AgentCh({});
+  const restoreFileInputGuard = stubChromeCdpFileInputClickGuard();
   let capturedPrepared = null;
   agent._clickAxFinalSettleMs = () => 0;
   agent._observeClickAxSideEffect = async (_tabId, baseline) => {
@@ -16785,6 +16895,7 @@ test('Chrome click_ax trusted phase carries preparedActive so blur-only is not p
     assert.equal(result.fallbackAttempted, true);
     assert.equal(result.verified, false);
   } finally {
+    restoreFileInputGuard();
     cdpClientCh.attach = originals.attach;
     cdpClientCh.dispatchMouseEvent = originals.dispatch;
   }
@@ -17204,6 +17315,7 @@ test('Chrome click_ax accepts a delayed semantic target-state change without sen
     dispatch: cdpClientCh.dispatchMouseEvent,
   };
   const agent = new AgentCh({});
+  const restoreFileInputGuard = stubChromeCdpFileInputClickGuard();
   let dispatched = 0;
   agent._observeClickAxSideEffect = async () => ({
     changed: false,
@@ -17250,6 +17362,7 @@ test('Chrome click_ax accepts a delayed semantic target-state change without sen
     assert.deepEqual(result.observedEffects, ['target_state']);
     assert.equal(dispatched, 0);
   } finally {
+    restoreFileInputGuard();
     cdpClientCh.attach = originals.attach;
     cdpClientCh.dispatchMouseEvent = originals.dispatch;
   }
@@ -17261,6 +17374,7 @@ test('Chrome click_ax accepts a target-state-only change after the trusted fallb
     dispatch: cdpClientCh.dispatchMouseEvent,
   };
   const agent = new AgentCh({});
+  const restoreFileInputGuard = stubChromeCdpFileInputClickGuard();
   let dispatched = 0;
   let resolves = 0;
   agent._clickAxFinalSettleMs = () => 0;
@@ -17333,6 +17447,7 @@ test('Chrome click_ax accepts a target-state-only change after the trusted fallb
     assert.equal(result.verified, true);
     assert.deepEqual(result.observedEffects, ['target_state']);
   } finally {
+    restoreFileInputGuard();
     cdpClientCh.attach = originals.attach;
     cdpClientCh.dispatchMouseEvent = originals.dispatch;
   }
@@ -17344,6 +17459,7 @@ test('Chrome click_ax accepts weak-only target state (class/data-status) after t
     dispatch: cdpClientCh.dispatchMouseEvent,
   };
   const agent = new AgentCh({});
+  const restoreFileInputGuard = stubChromeCdpFileInputClickGuard();
   let dispatched = 0;
   let resolves = 0;
   agent._clickAxFinalSettleMs = () => 0;
@@ -17421,6 +17537,7 @@ test('Chrome click_ax accepts weak-only target state (class/data-status) after t
     assert.equal(result.verified, true);
     assert.deepEqual(result.observedEffects, ['target_state_weak']);
   } finally {
+    restoreFileInputGuard();
     cdpClientCh.attach = originals.attach;
     cdpClientCh.dispatchMouseEvent = originals.dispatch;
   }
@@ -17432,6 +17549,7 @@ test('Chrome click_ax keeps an unobservable post-CDP navigation successful but u
     dispatch: cdpClientCh.dispatchMouseEvent,
   };
   const agent = new AgentCh({});
+  const restoreFileInputGuard = stubChromeCdpFileInputClickGuard();
   let dispatched = 0;
   let observeCalls = 0;
   let resolves = 0;
@@ -17531,6 +17649,7 @@ test('Chrome click_ax keeps an unobservable post-CDP navigation successful but u
     assert.equal(result.error, undefined);
     assert.match(result.warning, /navigation or reload/);
   } finally {
+    restoreFileInputGuard();
     cdpClientCh.attach = originals.attach;
     cdpClientCh.dispatchMouseEvent = originals.dispatch;
   }
@@ -17542,6 +17661,7 @@ test('Chrome executeTool runs automatic click_ax fallback and reuses its observe
     attach: cdpClientCh.attach,
     dispatch: cdpClientCh.dispatchMouseEvent,
   };
+  const restoreFileInputGuard = stubChromeCdpFileInputClickGuard();
   const actions = [];
   const dispatched = [];
   let snapshotCalls = 0;
@@ -17686,6 +17806,7 @@ test('Chrome executeTool runs automatic click_ax fallback and reuses its observe
     assert.equal(requestRemoves, 1);
     assert.deepEqual(requestFilter?.types, ['xmlhttprequest', 'ping']);
   } finally {
+    restoreFileInputGuard();
     cdpClientCh.attach = originals.attach;
     cdpClientCh.dispatchMouseEvent = originals.dispatch;
     if (originalChrome === undefined) delete globalThis.chrome;

--- a/test/run.js
+++ b/test/run.js
@@ -24307,7 +24307,7 @@ test('click_ax rejects stale zero-sized targets before activation', () => {
     ['firefox', 'src/firefox/src/content/content.js'],
   ]) {
     const source = fs.readFileSync(path.join(ROOT, rel), 'utf8');
-    const branchStart = source.indexOf("'click_ax': () => {");
+    const branchStart = source.search(/'click_ax': (?:async )?\(\) => \{/);
     const branchEnd = source.indexOf("'type_ax':", branchStart);
     assert.ok(branchStart >= 0 && branchEnd > branchStart, `${label}: click_ax handler should be bounded for regression checks`);
     const branch = source.slice(branchStart, branchEnd);
@@ -31265,7 +31265,7 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
   assert.match(expressions[0], /event\.stopImmediatePropagation\(\)/);
   assert.match(expressions[0], /tagName === 'INPUT'[\s\S]*=== 'file'/);
   assert.match(expressions[0], /matches\.length === 1 && matches\[0\] === input/);
-  const consumed = await cdp.consumeFileInputClickGuard(42);
+  const consumed = await cdp.consumeFileInputClickGuard(42, 0);
   assert.equal(consumed.blocked, true);
   assert.equal(consumed.selector, '#upload-addon');
   assert.equal(typeof consumed.ts, 'number');
@@ -31339,8 +31339,11 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
     const source = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
     assert.match(source, /function uniqueFileInputSelector\(input\)/, `${relPath}: missing unique selector builder`);
     assert.match(source, /matches\.length === 1 && matches\[0\] === input/, `${relPath}: selector should be proven unique`);
-    assert.match(source, /function clickWithoutNativeFilePicker\(runClick\)/, `${relPath}: missing one-click file chooser guard`);
+    assert.match(source, /const FILE_PICKER_GUARD_SETTLE_MS = 100/, `${relPath}: missing deferred picker settle window`);
+    assert.match(source, /function clickWithoutNativeFilePicker\(runClick,\s*settleMs\s*=\s*FILE_PICKER_GUARD_SETTLE_MS\)/, `${relPath}: missing one-click file chooser guard`);
+    assert.match(source, /setTimeout\(\(\) => \{[\s\S]*removeEventListener\('click', guard, true\)/, `${relPath}: guard should survive deferred picker clicks`);
     assert.match(source, /clickWithoutNativeFilePicker\(\(\) => el\.click\(\)\)/, `${relPath}: synthetic clicks should use the chooser guard`);
+    assert.match(source, /await (?:blockedFileInputPromise|clickWithoutNativeFilePicker)/, `${relPath}: click response should await the deferred guard`);
     assert.match(source, /filePickerBlocked:\s*true/, `${relPath}: blocked chooser should be explicit to the model`);
   }
 });
@@ -31528,6 +31531,9 @@ test('upload_file (firefox) re-fetches downloadId with manual redirect handling 
     assert.ok(executedScripts[0].includes('dt.items.add(file)'), 'Script should add file to DataTransfer');
     assert.ok(executedScripts[0].includes('el.files = dt.files'), 'Script should assign DataTransfer files to input');
     assert.ok(executedScripts[0].includes('el.type !== \'file\''), 'Script should require input[type=file]');
+    assert.ok(executedScripts[0].includes('collectDeepMatches(element.shadowRoot)'), 'Script should search open shadow roots');
+    assert.ok(executedScripts[0].includes('matches.length > 1'), 'Script should reject ambiguous selectors');
+    assert.ok(executedScripts[0].includes('exact, unique selector'), 'Script should return actionable ambiguity guidance');
   } finally {
     if (originalBrowser === undefined) delete globalThis.browser;
     else globalThis.browser = originalBrowser;

--- a/test/run.js
+++ b/test/run.js
@@ -16080,6 +16080,41 @@ test('CDP input dispatchers never call the nonexistent Input.enable command', as
   assert.doesNotMatch(source, /Input\.enable/, 'Chrome CDP client must not reintroduce the unsupported Input.enable command');
 });
 
+test('CDP querySelectorPierce resolves open-shadow matches to DOM nodeIds', async () => {
+  const client = new CDPClient();
+  const commands = [];
+  client.sendCommand = async (_tabId, method, params = {}) => {
+    commands.push({ method, params });
+    if (method === 'Runtime.evaluate') {
+      assert.match(params.expression, /element\.shadowRoot/);
+      assert.match(params.expression, /#shadow-upload/);
+      return { result: { objectId: 'matches-array' } };
+    }
+    if (method === 'Runtime.getProperties') {
+      return {
+        result: [
+          { name: '0', value: { objectId: 'input-a' } },
+          { name: '1', value: { objectId: 'input-b' } },
+          { name: 'length', value: { value: 2 } },
+        ],
+      };
+    }
+    if (method === 'DOM.requestNode') {
+      return { nodeId: params.objectId === 'input-a' ? 501 : 502 };
+    }
+    return {};
+  };
+
+  const nodeIds = await client.querySelectorPierce(42, '#shadow-upload');
+  assert.deepEqual(nodeIds, [501, 502]);
+  assert.equal(
+    commands.some(command => command.method === 'DOM.querySelectorAll'),
+    false,
+    'document-root DOM.querySelectorAll cannot pierce open shadow roots',
+  );
+  assert.equal(commands.at(-1).method, 'Runtime.releaseObjectGroup');
+});
+
 test('Chrome selector click distinguishes pre-dispatch failure from uncertain dispatch', async () => {
   const client = new CDPClient();
   client.resolveSelector = async () => null;
@@ -31527,6 +31562,7 @@ test('upload_file prefers downloadId over a supplied stale filePath (chrome)', a
   const realPath = '/Users/x/Downloads/real.zip';
   const stalePath = '/Users/Shared/made-up.zip';
   const uploaded = [];
+  let selectorMatches = [501];
 
   try {
     globalThis.chrome = {
@@ -31539,7 +31575,7 @@ test('upload_file prefers downloadId over a supplied stale filePath (chrome)', a
       },
     };
     cdpClientCh.attach = async (tabId) => ({ tabId, attached: true });
-    cdpClientCh.querySelectorPierce = async () => [501];
+    cdpClientCh.querySelectorPierce = async () => selectorMatches;
     cdpClientCh.probeLocalFile = async (_tabId, filePath) => {
       assert.equal(filePath, realPath, 'downloadId-resolved path should override stale filePath before probing');
       return { exists: true, readable: true, size: 123 };
@@ -31557,6 +31593,16 @@ test('upload_file prefers downloadId over a supplied stale filePath (chrome)', a
     assert.equal(result.file, realPath);
     assert.equal(args.filePath, realPath);
     assert.deepEqual(uploaded, [[realPath]]);
+
+    selectorMatches = [501, 502];
+    const ambiguous = await agent.executeTool(42, 'upload_file', {
+      selector: 'input[type=file]',
+      downloadId: 9123,
+    });
+    assert.equal(ambiguous.success, false);
+    assert.match(ambiguous.error, /matched 2 elements/);
+    assert.match(ambiguous.error, /exact, unique selector/);
+    assert.deepEqual(uploaded, [[realPath]], 'ambiguous selectors must fail before attaching the file');
   } finally {
     if (originalChrome === undefined) delete globalThis.chrome;
     else globalThis.chrome = originalChrome;

--- a/test/run.js
+++ b/test/run.js
@@ -31459,6 +31459,24 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
     && command.params.enabled === false
   ));
 
+  const quietProtocolGuard = new CDPClient();
+  const quietProtocolCommands = [];
+  quietProtocolGuard.sendCommand = async (_tabId, method, params) => {
+    quietProtocolCommands.push({ method, params });
+    return {};
+  };
+  quietProtocolGuard.evaluate = async (_tabId, expression) => ({
+    result: { value: expression.includes('__wb_file_input_click_guard_last || null') ? null : true },
+  });
+  await quietProtocolGuard.armFileInputClickGuard(44);
+  const quietBlocked = await quietProtocolGuard.consumeFileInputClickGuard(44, 0);
+  assert.equal(quietBlocked, null);
+  assert.equal(quietProtocolGuard.fileChooserGuards.has(44), false);
+  assert.ok(quietProtocolCommands.some(command =>
+    command.method === 'Page.setInterceptFileChooserDialog'
+    && command.params.enabled === false
+  ), 'empty consume must release tab-wide protocol interception');
+
   cdp.resolveSelector = async () => ({
     found: true,
     inViewport: true,

--- a/test/run.js
+++ b/test/run.js
@@ -31421,6 +31421,9 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
   assert.match(expressions[0], /event\.stopImmediatePropagation\(\)/);
   assert.match(expressions[0], /tagName === 'INPUT'[\s\S]*=== 'file'/);
   assert.match(expressions[0], /matches\.length === 1 && matches\[0\] === input/);
+  assert.match(expressions[0], /Object\.getOwnPropertyDescriptor\(showPickerProto,\s*'showPicker'\)/);
+  assert.match(expressions[0], /value:\s*guardedShowPicker/);
+  assert.match(expressions[0], /selector:\s*uniqueFileInputSelector\(this\)/);
   const consumed = await cdp.consumeFileInputClickGuard(42, 0);
   assert.equal(consumed.blocked, true);
   assert.equal(consumed.selector, '#upload-addon');
@@ -31497,7 +31500,10 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
     assert.match(source, /matches\.length === 1 && matches\[0\] === input/, `${relPath}: selector should be proven unique`);
     assert.match(source, /const FILE_PICKER_GUARD_SETTLE_MS = 100/, `${relPath}: missing deferred picker settle window`);
     assert.match(source, /function clickWithoutNativeFilePicker\(runClick,\s*settleMs\s*=\s*FILE_PICKER_GUARD_SETTLE_MS\)/, `${relPath}: missing one-click file chooser guard`);
-    assert.match(source, /setTimeout\(\(\) => \{[\s\S]*removeEventListener\('click', guard, true\)/, `${relPath}: guard should survive deferred picker clicks`);
+    assert.match(source, /setTimeout\(\(\) => \{\s*cleanupGuard\(\)/, `${relPath}: guard should survive deferred picker clicks`);
+    assert.match(source, /Object\.getOwnPropertyDescriptor\(proto,\s*'showPicker'\)/, `${relPath}: missing showPicker interception`);
+    assert.match(source, /if \(isFileInput\(this\)\)[\s\S]*blockFileInput\(this\)/, `${relPath}: showPicker should record file inputs`);
+    assert.match(source, /Object\.defineProperty\(proto,\s*'showPicker',\s*descriptor\)/, `${relPath}: showPicker interception should be restored`);
     assert.match(source, /clickWithoutNativeFilePicker\(\(\) => el\.click\(\)\)/, `${relPath}: synthetic clicks should use the chooser guard`);
     assert.match(source, /_filePickerGuardId:\s*filePickerGuard\.guardId/, `${relPath}: click response should return without waiting on the unloading document`);
     assert.match(source, /'consume_file_picker_guard':\s*\(\) => consumeFilePickerGuard/, `${relPath}: missing deferred guard result handshake`);

--- a/test/run.js
+++ b/test/run.js
@@ -31498,9 +31498,10 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
     const source = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
     assert.match(source, /function uniqueFileInputSelector\(input\)/, `${relPath}: missing unique selector builder`);
     assert.match(source, /matches\.length === 1 && matches\[0\] === input/, `${relPath}: selector should be proven unique`);
-    assert.match(source, /const FILE_PICKER_GUARD_SETTLE_MS = 100/, `${relPath}: missing deferred picker settle window`);
+    assert.match(source, /const FILE_PICKER_GUARD_SETTLE_MS = 250/, `${relPath}: missing deferred picker settle window`);
     assert.match(source, /function clickWithoutNativeFilePicker\(runClick,\s*settleMs\s*=\s*FILE_PICKER_GUARD_SETTLE_MS\)/, `${relPath}: missing one-click file chooser guard`);
-    assert.match(source, /setTimeout\(\(\) => \{\s*cleanupGuard\(\)/, `${relPath}: guard should survive deferred picker clicks`);
+    assert.match(source, /setTimeout\(\(\) => \{\s*state\.settled = true/, `${relPath}: guard should survive the settle window`);
+    assert.match(source, /state\.cleanupTimer = setTimeout\(\(\) => \{[\s\S]*cleanupGuard\(\)/, `${relPath}: abandoned guards should still expire`);
     assert.match(source, /const installPageShowPickerGuard = \(\) =>/, `${relPath}: missing page-world showPicker bridge handshake`);
     assert.match(source, /webbrain:file-picker-guard-arm/, `${relPath}: missing page-world showPicker arm event`);
     assert.match(source, /webbrain:file-picker-guard-blocked/, `${relPath}: missing page-world blocked result event`);

--- a/test/run.js
+++ b/test/run.js
@@ -31422,8 +31422,10 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
   assert.match(expressions[0], /tagName === 'INPUT'[\s\S]*=== 'file'/);
   assert.match(expressions[0], /matches\.length === 1 && matches\[0\] === input/);
   assert.match(expressions[0], /Object\.getOwnPropertyDescriptor\(showPickerProto,\s*'showPicker'\)/);
+  assert.match(expressions[0], /Object\.getOwnPropertyDescriptor\(showPickerProto,\s*'click'\)/);
   assert.match(expressions[0], /value:\s*guardedShowPicker/);
-  assert.match(expressions[0], /selector:\s*uniqueFileInputSelector\(this\)/);
+  assert.match(expressions[0], /value:\s*guardedClick/);
+  assert.match(expressions[0], /blockInput\(this\)/);
   const consumed = await cdp.consumeFileInputClickGuard(42, 0);
   assert.equal(consumed.blocked, true);
   assert.equal(consumed.selector, '#upload-addon');
@@ -31498,13 +31500,14 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
     const source = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
     assert.match(source, /function uniqueFileInputSelector\(input\)/, `${relPath}: missing unique selector builder`);
     assert.match(source, /matches\.length === 1 && matches\[0\] === input/, `${relPath}: selector should be proven unique`);
-    assert.match(source, /const FILE_PICKER_GUARD_SETTLE_MS = 250/, `${relPath}: missing deferred picker settle window`);
+    assert.match(source, /const FILE_PICKER_GUARD_SETTLE_MS = 500/, `${relPath}: missing deferred picker settle window`);
     assert.match(source, /function clickWithoutNativeFilePicker\(runClick,\s*settleMs\s*=\s*FILE_PICKER_GUARD_SETTLE_MS\)/, `${relPath}: missing one-click file chooser guard`);
     assert.match(source, /setTimeout\(\(\) => \{\s*state\.settled = true/, `${relPath}: guard should survive the settle window`);
     assert.match(source, /state\.cleanupTimer = setTimeout\(\(\) => \{[\s\S]*cleanupGuard\(\)/, `${relPath}: abandoned guards should still expire`);
     assert.match(source, /const installPageShowPickerGuard = \(\) =>/, `${relPath}: missing page-world showPicker bridge handshake`);
     assert.match(source, /webbrain:file-picker-guard-arm/, `${relPath}: missing page-world showPicker arm event`);
     assert.match(source, /webbrain:file-picker-guard-blocked/, `${relPath}: missing page-world blocked result event`);
+    assert.match(source, /cleanupPageShowPickerGuard\?\.\(!!state\.blocked\)/, `${relPath}: delayed programmatic guard should survive an empty consume`);
     assert.match(source, /clickWithoutNativeFilePicker\(\(\) => el\.click\(\)\)/, `${relPath}: synthetic clicks should use the chooser guard`);
     assert.match(source, /_filePickerGuardId:\s*filePickerGuard\.guardId/, `${relPath}: click response should return without waiting on the unloading document`);
     assert.match(source, /'consume_file_picker_guard':\s*\(\) => consumeFilePickerGuard/, `${relPath}: missing deferred guard result handshake`);
@@ -31539,8 +31542,10 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
     assert.doesNotMatch(source, /window\.__webbrainFilePickerGuardBridge/, `${relPath}: must not expose a stable page global`);
     assert.match(source, /webbrain:file-picker-guard-probe/, `${relPath}: recovery reinjection should use an ephemeral idempotence probe`);
     assert.match(source, /Object\.getOwnPropertyDescriptor\(proto,\s*'showPicker'\)/, `${relPath}: missing main-world showPicker interception`);
+    assert.match(source, /Object\.getOwnPropertyDescriptor\(proto,\s*'click'\)/, `${relPath}: missing closed-shadow click interception`);
     assert.match(source, /reportBlocked\(this\)/, `${relPath}: main-world showPicker should record the input`);
-    assert.match(source, /Object\.defineProperty\(proto,\s*'showPicker',\s*descriptor\)/, `${relPath}: showPicker interception should be restored`);
+    assert.match(source, /Object\.defineProperty\(proto,\s*'showPicker',\s*showPickerDescriptor\)/, `${relPath}: showPicker interception should be restored`);
+    assert.match(source, /delete proto\.click/, `${relPath}: inherited click interception should be restored`);
   }
 
   const previousChrome = globalThis.chrome;

--- a/test/run.js
+++ b/test/run.js
@@ -31417,6 +31417,7 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
 
   await cdp.armFileInputClickGuard(42);
   assert.match(expressions[0], /document\.addEventListener\('click'[\s\S]*true\)/);
+  assert.match(expressions[0], /webbrain:file-picker-guard-reset/);
   assert.match(expressions[0], /event\.preventDefault\(\)/);
   assert.match(expressions[0], /event\.stopImmediatePropagation\(\)/);
   assert.match(expressions[0], /tagName === 'INPUT'[\s\S]*=== 'file'/);
@@ -31568,6 +31569,7 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
     const source = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
     assert.doesNotMatch(source, /window\.__webbrainFilePickerGuardBridge/, `${relPath}: must not expose a stable page global`);
     assert.match(source, /webbrain:file-picker-guard-probe/, `${relPath}: recovery reinjection should use an ephemeral idempotence probe`);
+    assert.match(source, /webbrain:file-picker-guard-reset/, `${relPath}: CDP should be able to reset a residual page guard`);
     assert.match(source, /Object\.getOwnPropertyDescriptor\(proto,\s*'showPicker'\)/, `${relPath}: missing main-world showPicker interception`);
     assert.match(source, /Object\.getOwnPropertyDescriptor\(proto,\s*'click'\)/, `${relPath}: missing closed-shadow click interception`);
     assert.match(source, /reportBlocked\(this\)/, `${relPath}: main-world showPicker should record the input`);

--- a/test/run.js
+++ b/test/run.js
@@ -31244,6 +31244,105 @@ test('upload_file schema accepts downloadId and no longer hard-requires filePath
   assert.ok(up, 'upload_file not present in act tools');
   assert.ok(up.function.parameters.properties.downloadId, 'downloadId param missing from schema');
   assert.deepEqual(up.function.parameters.required, ['selector'], 'filePath should no longer be required');
+  assert.match(up.function.description, /without opening the page or OS file-picker dialog/i);
+  assert.match(up.function.description, /Do NOT click "Choose file", "Select a file"/);
+});
+
+test('Chrome click paths suppress native file choosers and redirect to upload_file', async () => {
+  const cdp = new CDPClient();
+  const expressions = [];
+  cdp.evaluate = async (_tabId, expression) => {
+    expressions.push(expression);
+    if (expression.includes('__wb_file_input_click_guard_last || null')) {
+      return { result: { value: { blocked: true, selector: '#upload-addon', ts: Date.now() } } };
+    }
+    return { result: { value: true } };
+  };
+
+  await cdp.armFileInputClickGuard(42);
+  assert.match(expressions[0], /document\.addEventListener\('click'[\s\S]*true\)/);
+  assert.match(expressions[0], /event\.preventDefault\(\)/);
+  assert.match(expressions[0], /event\.stopImmediatePropagation\(\)/);
+  assert.match(expressions[0], /tagName === 'INPUT'[\s\S]*=== 'file'/);
+  assert.match(expressions[0], /matches\.length === 1 && matches\[0\] === input/);
+  const consumed = await cdp.consumeFileInputClickGuard(42);
+  assert.equal(consumed.blocked, true);
+  assert.equal(consumed.selector, '#upload-addon');
+  assert.equal(typeof consumed.ts, 'number');
+
+  cdp.resolveSelector = async () => ({
+    found: true,
+    inViewport: true,
+    hitOk: true,
+    x: 120,
+    y: 80,
+    width: 100,
+    height: 30,
+    tag: 'A',
+    text: 'Select a file...',
+  });
+  cdp.armFileInputClickGuard = async () => {};
+  cdp.consumeFileInputClickGuard = async () => ({ blocked: true, selector: '#upload-addon' });
+  cdp.sendCommand = async () => ({});
+
+  const result = await cdp.clickElement(42, 'a.fileupload-button');
+  assert.equal(result.success, false);
+  assert.equal(result.dispatched, true);
+  assert.equal(result.filePickerBlocked, true);
+  assert.equal(result.selector, '#upload-addon');
+  assert.match(result.error, /upload_file/);
+  assert.match(result.error, /downloadId or absolute filePath/);
+
+  const ambiguousResult = cdp.fileInputClickBlockedResult({ blocked: true, selector: null });
+  assert.equal(ambiguousResult.success, false);
+  assert.equal(ambiguousResult.filePickerBlocked, true);
+  assert.equal(Object.hasOwn(ambiguousResult, 'selector'), false);
+  assert.match(ambiguousResult.error, /exact, unique/);
+  assert.match(ambiguousResult.error, /Do not use a generic input\[type="file"\]/);
+
+  const navigationRace = new CDPClient();
+  let mouseDispatches = 0;
+  let fallbackClicks = 0;
+  navigationRace.resolveSelector = async () => ({
+    found: true,
+    inViewport: true,
+    hitOk: true,
+    x: 120,
+    y: 80,
+    width: 100,
+    height: 30,
+    tag: 'A',
+    text: 'Continue',
+    nodeId: 777,
+  });
+  navigationRace.armFileInputClickGuard = async () => {};
+  navigationRace.evaluate = async () => {
+    throw new Error('Execution context was destroyed during navigation');
+  };
+  navigationRace.sendCommand = async (_tabId, method) => {
+    if (method === 'Input.dispatchMouseEvent') mouseDispatches++;
+    if (method === 'Runtime.callFunctionOn') fallbackClicks++;
+    if (method === 'DOM.resolveNode') return { object: { objectId: 'should-not-be-used' } };
+    return {};
+  };
+
+  const navigationResult = await navigationRace.clickElement(42, '#continue');
+  assert.equal(navigationResult.success, true);
+  assert.equal(navigationResult.method, 'cdp-mouse');
+  assert.equal(mouseDispatches, 3);
+  assert.equal(fallbackClicks, 0, 'post-click observation failure must not dispatch a fallback click');
+
+  for (const relPath of [
+    'src/chrome/src/content/content.js',
+    'src/firefox/src/content/content.js',
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
+    assert.match(source, /function uniqueFileInputSelector\(input\)/, `${relPath}: missing unique selector builder`);
+    assert.match(source, /matches\.length === 1 && matches\[0\] === input/, `${relPath}: selector should be proven unique`);
+    assert.match(source, /function clickWithoutNativeFilePicker\(runClick\)/, `${relPath}: missing one-click file chooser guard`);
+    assert.match(source, /clickWithoutNativeFilePicker\(\(\) => el\.click\(\)\)/, `${relPath}: synthetic clicks should use the chooser guard`);
+    assert.match(source, /filePickerBlocked:\s*true/, `${relPath}: blocked chooser should be explicit to the model`);
+  }
 });
 
 test('upload_file prefers downloadId over a supplied stale filePath (chrome)', async () => {
@@ -31301,6 +31400,8 @@ test('upload_file schema accepts downloadId and no longer hard-requires filePath
   assert.ok(up, 'upload_file not present in act tools');
   assert.ok(up.function.parameters.properties.downloadId, 'downloadId param missing from schema');
   assert.deepEqual(up.function.parameters.required, ['selector'], 'filePath should no longer be required');
+  assert.match(up.function.description, /without clicking the page upload control/i);
+  assert.match(up.function.description, /Do NOT click "Choose file", "Select a file"/);
 });
 
 test('upload_file (firefox) rejects non-complete downloads and missing picker base64', async () => {

--- a/test/run.js
+++ b/test/run.js
@@ -31343,8 +31343,54 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
     assert.match(source, /function clickWithoutNativeFilePicker\(runClick,\s*settleMs\s*=\s*FILE_PICKER_GUARD_SETTLE_MS\)/, `${relPath}: missing one-click file chooser guard`);
     assert.match(source, /setTimeout\(\(\) => \{[\s\S]*removeEventListener\('click', guard, true\)/, `${relPath}: guard should survive deferred picker clicks`);
     assert.match(source, /clickWithoutNativeFilePicker\(\(\) => el\.click\(\)\)/, `${relPath}: synthetic clicks should use the chooser guard`);
-    assert.match(source, /await (?:blockedFileInputPromise|clickWithoutNativeFilePicker)/, `${relPath}: click response should await the deferred guard`);
+    assert.match(source, /_filePickerGuardId:\s*filePickerGuard\.guardId/, `${relPath}: click response should return without waiting on the unloading document`);
+    assert.match(source, /'consume_file_picker_guard':\s*\(\) => consumeFilePickerGuard/, `${relPath}: missing deferred guard result handshake`);
     assert.match(source, /filePickerBlocked:\s*true/, `${relPath}: blocked chooser should be explicit to the model`);
+  }
+
+  for (const relPath of [
+    'src/chrome/src/agent/agent.js',
+    'src/firefox/src/agent/agent.js',
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
+    assert.match(source, /async _settleContentFilePickerGuard\(tabId, response\)/, `${relPath}: missing background-side settle window`);
+    assert.match(source, /action:\s*'consume_file_picker_guard'/, `${relPath}: missing deferred guard result request`);
+    assert.match(source, /never re-inject\/replay the action/, `${relPath}: guard probe failure must not replay a delivered click`);
+  }
+
+  for (const [label, AgentClass, apiName] of [
+    ['chrome', AgentCh, 'chrome'],
+    ['firefox', AgentFx, 'browser'],
+  ]) {
+    const previousApi = globalThis[apiName];
+    let probeCalls = 0;
+    globalThis[apiName] = {
+      tabs: {
+        async sendMessage() {
+          probeCalls++;
+          throw new Error('The message port closed during navigation');
+        },
+      },
+    };
+    try {
+      const agent = Object.create(AgentClass.prototype);
+      const delivered = {
+        success: true,
+        dispatched: true,
+        rect: { x: 1, y: 2, w: 3, h: 4 },
+        _filePickerGuardId: 'guard-from-old-document',
+      };
+      const result = await agent._settleContentFilePickerGuard(42, delivered);
+      assert.deepEqual(result, {
+        success: true,
+        dispatched: true,
+        rect: { x: 1, y: 2, w: 3, h: 4 },
+      }, `${label}: navigation must preserve the delivered click result`);
+      assert.equal(probeCalls, 1, `${label}: a lost old document must not trigger a replay`);
+    } finally {
+      if (previousApi === undefined) delete globalThis[apiName];
+      else globalThis[apiName] = previousApi;
+    }
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -31431,6 +31431,33 @@ test('Chrome click paths suppress native file choosers and redirect to upload_fi
   assert.equal(consumed.selector, '#upload-addon');
   assert.equal(typeof consumed.ts, 'number');
 
+  const protocolGuard = new CDPClient();
+  const protocolCommands = [];
+  protocolGuard.sendCommand = async (_tabId, method, params) => {
+    protocolCommands.push({ method, params });
+    return {};
+  };
+  protocolGuard.evaluate = async (_tabId, expression) => ({
+    result: { value: expression.includes('__wb_file_input_click_guard_last || null') ? null : true },
+  });
+  await protocolGuard.armFileInputClickGuard(43);
+  const chooserHandler = protocolGuard.eventHandlers.get(43)?.['Page.fileChooserOpened']?.[0];
+  assert.equal(typeof chooserHandler, 'function');
+  chooserHandler({ backendNodeId: 9001 });
+  const protocolBlocked = await protocolGuard.consumeFileInputClickGuard(43, 0);
+  assert.equal(protocolBlocked.blocked, true);
+  assert.equal(protocolBlocked.selector, null);
+  assert.equal(protocolBlocked.backendNodeId, 9001);
+  assert.ok(protocolCommands.some(command =>
+    command.method === 'Page.setInterceptFileChooserDialog'
+    && command.params.enabled === true
+    && command.params.cancel === true
+  ));
+  assert.ok(protocolCommands.some(command =>
+    command.method === 'Page.setInterceptFileChooserDialog'
+    && command.params.enabled === false
+  ));
+
   cdp.resolveSelector = async () => ({
     found: true,
     inViewport: true,


### PR DESCRIPTION
## Summary

- suppress native file chooser dialogs across Chrome click paths and mirrored Chrome/Firefox content-script clicks
- direct agents to attach files with `upload_file` when an input already exists, while preserving one guarded initializer click for lazy upload widgets
- intercept deferred `click()`/`showPicker()` activations in the page world, including closed-shadow inputs and extension-reload recovery
- return file-input selectors only when they are unique across the document and open shadow roots
- avoid replaying delivered clicks when navigation destroys the guard observation context
- add unit and real Chromium coverage for duplicate inputs, shadow roots, delayed activation, navigation races, and trusted CDP clicks

## Why

The agent could click a page upload control before calling `upload_file`. The direct upload would succeed, but the native OS chooser opened by the earlier click remained orphaned and stale. The click paths lacked a temporary file-input activation guard, and ambiguous fallback selectors could target the wrong input.

## Impact

Uploads now attach directly without leaving an OS dialog behind. Lazy widgets can still initialize safely, ambiguous file inputs fail closed with re-inspection guidance, and a post-click navigation race no longer causes the original action to be replayed.

## Validation

- `npm run test:fixtures` — 97 passed, 0 failed
- `npm run test:security` — 60/60 checks passed
- `node test/run.js` — 1000 passed, 1 unrelated pre-existing failure (`package.json` 25.0.2 vs newest `CHANGELOG.md` entry 25.0.0)
- `git diff --check` — clean