### PR TITLE
Add sparse provisioning config import

### DIFF
--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -2037,6 +2037,9 @@ async function handleMessage(msg, sender) {
       };
     }
 
+    // The cloud launcher calls import_config_patch directly from a privileged
+    // extension page. It must not be exposed through the offscreen WebSocket
+    // bridge, whose allowlist is limited to managed run operations.
     case 'import_config':
     case 'import_config_patch': {
       const imported = msg.action === 'import_config_patch'

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -59,7 +59,9 @@ import { PROFILE_SYNC_DATA_KEYS, PROFILE_SYNC_KEYS, ProfileSyncManager } from '.
 import {
   CONFIG_STORAGE_KEYS,
   createConfigExport,
+  mergeConfigPatchSettings,
   parseConfigImport,
+  parseConfigPatchImport,
 } from './config-transfer.js';
 import { installDownloadDirectoryRouting } from './download-directory.js';
 
@@ -2035,9 +2037,18 @@ async function handleMessage(msg, sender) {
       };
     }
 
-    case 'import_config': {
-      const imported = parseConfigImport(msg.json);
-      await chrome.storage.local.set(imported.settings);
+    case 'import_config':
+    case 'import_config_patch': {
+      const imported = msg.action === 'import_config_patch'
+        ? parseConfigPatchImport(msg.json)
+        : parseConfigImport(msg.json);
+      const settings = msg.action === 'import_config_patch'
+        ? mergeConfigPatchSettings(
+          await chrome.storage.local.get(['providers']),
+          imported.settings,
+        )
+        : imported.settings;
+      await chrome.storage.local.set(settings);
       await providerManager.load();
       await Promise.all([
         loadMaxSteps(),
@@ -2058,7 +2069,7 @@ async function handleMessage(msg, sender) {
       agent._refreshSystemPrompts();
       return {
         ok: true,
-        settingCount: CONFIG_STORAGE_KEYS.length,
+        settingCount: Object.keys(settings).length,
         ignoredKeys: imported.ignoredKeys,
       };
     }

--- a/src/chrome/src/config-transfer.js
+++ b/src/chrome/src/config-transfer.js
@@ -259,6 +259,11 @@ export function mergeConfigPatchSettings(current = {}, patch = {}) {
   const merged = clone(patch);
   if (!Object.hasOwn(merged, 'providers')) return merged;
   const currentProviders = isPlainObject(current.providers) ? clone(current.providers) : {};
-  merged.providers = { ...currentProviders, ...merged.providers };
+  const patchProviders = isPlainObject(merged.providers) ? merged.providers : {};
+  // Cloud provisioning owns this provider's credentials, endpoint and device
+  // identity. A portable export may contain a stale copy, so never let it
+  // replace the runtime's current WebBrain Cloud configuration.
+  delete patchProviders.webbrain_cloud;
+  merged.providers = { ...currentProviders, ...patchProviders };
   return merged;
 }

--- a/src/chrome/src/config-transfer.js
+++ b/src/chrome/src/config-transfer.js
@@ -213,3 +213,52 @@ export function parseConfigImport(json) {
     sourceVersion: typeof parsed.webbrainVersion === 'string' ? parsed.webbrainVersion : '',
   };
 }
+
+// Provisioning can apply an already-sanitized export as a sparse patch. Unlike
+// the user-facing restore command above, omitted settings remain untouched.
+export function parseConfigPatchImport(json) {
+  const text = String(json || '');
+  if (text.length > MAX_CONFIG_IMPORT_CHARS) throw new Error('Configuration JSON is too large.');
+  if (!text.trim()) throw new Error('Paste configuration JSON or use /import --file.');
+
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error('Configuration is not valid JSON.');
+  }
+  if (!isPlainObject(parsed) || parsed.schema !== CONFIG_SCHEMA) {
+    throw new Error(`Expected a ${CONFIG_SCHEMA} export.`);
+  }
+  if (!isPlainObject(parsed.settings)) {
+    throw new Error('Configuration settings must be a JSON object.');
+  }
+
+  const settings = {};
+  const ignoredKeys = [];
+  for (const [key, value] of Object.entries(parsed.settings)) {
+    if (!CONFIG_STORAGE_KEY_SET.has(key)) {
+      ignoredKeys.push(key);
+      continue;
+    }
+    if (!validSettingValue(key, value)) {
+      throw new Error(`Invalid value for configuration setting "${key}".`);
+    }
+    settings[key] = key === 'providers'
+      ? sanitizeProviders(value, { strict: true })
+      : clone(value);
+  }
+  return {
+    settings,
+    ignoredKeys,
+    sourceVersion: typeof parsed.webbrainVersion === 'string' ? parsed.webbrainVersion : '',
+  };
+}
+
+export function mergeConfigPatchSettings(current = {}, patch = {}) {
+  const merged = clone(patch);
+  if (!Object.hasOwn(merged, 'providers')) return merged;
+  const currentProviders = isPlainObject(current.providers) ? clone(current.providers) : {};
+  merged.providers = { ...currentProviders, ...merged.providers };
+  return merged;
+}

--- a/src/chrome/src/offscreen/cloud-bridge.js
+++ b/src/chrome/src/offscreen/cloud-bridge.js
@@ -7,6 +7,9 @@
  */
 
 (() => {
+  // Provisioning seeds Settings from a privileged extension page before this
+  // bridge starts. Keep configuration mutations out of the WebSocket command
+  // surface; the bridge is intentionally limited to managed run operations.
   const ALLOWED_BRIDGE_ACTIONS = new Set(['cloud_run', 'cloud_status', 'cloud_respond', 'cloud_abort']);
   let socket = null;
   let bridgeUrl = null;

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -48,7 +48,9 @@ import { PROFILE_SYNC_DATA_KEYS, PROFILE_SYNC_KEYS, ProfileSyncManager } from '.
 import {
   CONFIG_STORAGE_KEYS,
   createConfigExport,
+  mergeConfigPatchSettings,
   parseConfigImport,
+  parseConfigPatchImport,
 } from './config-transfer.js';
 import { RUN_CAPTURE_START_ERROR_PREFIX, createRunCaptureController } from './run-capture.js';
 
@@ -1754,9 +1756,18 @@ async function handleMessage(msg, sender) {
       };
     }
 
-    case 'import_config': {
-      const imported = parseConfigImport(msg.json);
-      await browser.storage.local.set(imported.settings);
+    case 'import_config':
+    case 'import_config_patch': {
+      const imported = msg.action === 'import_config_patch'
+        ? parseConfigPatchImport(msg.json)
+        : parseConfigImport(msg.json);
+      const settings = msg.action === 'import_config_patch'
+        ? mergeConfigPatchSettings(
+          await browser.storage.local.get(['providers']),
+          imported.settings,
+        )
+        : imported.settings;
+      await browser.storage.local.set(settings);
       await providerManager.load();
       await Promise.all([
         loadMaxSteps(),
@@ -1777,7 +1788,7 @@ async function handleMessage(msg, sender) {
       agent._refreshSystemPrompts();
       return {
         ok: true,
-        settingCount: CONFIG_STORAGE_KEYS.length,
+        settingCount: Object.keys(settings).length,
         ignoredKeys: imported.ignoredKeys,
       };
     }

--- a/src/firefox/src/config-transfer.js
+++ b/src/firefox/src/config-transfer.js
@@ -259,6 +259,11 @@ export function mergeConfigPatchSettings(current = {}, patch = {}) {
   const merged = clone(patch);
   if (!Object.hasOwn(merged, 'providers')) return merged;
   const currentProviders = isPlainObject(current.providers) ? clone(current.providers) : {};
-  merged.providers = { ...currentProviders, ...merged.providers };
+  const patchProviders = isPlainObject(merged.providers) ? merged.providers : {};
+  // Cloud provisioning owns this provider's credentials, endpoint and device
+  // identity. A portable export may contain a stale copy, so never let it
+  // replace the runtime's current WebBrain Cloud configuration.
+  delete patchProviders.webbrain_cloud;
+  merged.providers = { ...currentProviders, ...patchProviders };
   return merged;
 }

--- a/src/firefox/src/config-transfer.js
+++ b/src/firefox/src/config-transfer.js
@@ -213,3 +213,52 @@ export function parseConfigImport(json) {
     sourceVersion: typeof parsed.webbrainVersion === 'string' ? parsed.webbrainVersion : '',
   };
 }
+
+// Provisioning can apply an already-sanitized export as a sparse patch. Unlike
+// the user-facing restore command above, omitted settings remain untouched.
+export function parseConfigPatchImport(json) {
+  const text = String(json || '');
+  if (text.length > MAX_CONFIG_IMPORT_CHARS) throw new Error('Configuration JSON is too large.');
+  if (!text.trim()) throw new Error('Paste configuration JSON or use /import --file.');
+
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error('Configuration is not valid JSON.');
+  }
+  if (!isPlainObject(parsed) || parsed.schema !== CONFIG_SCHEMA) {
+    throw new Error(`Expected a ${CONFIG_SCHEMA} export.`);
+  }
+  if (!isPlainObject(parsed.settings)) {
+    throw new Error('Configuration settings must be a JSON object.');
+  }
+
+  const settings = {};
+  const ignoredKeys = [];
+  for (const [key, value] of Object.entries(parsed.settings)) {
+    if (!CONFIG_STORAGE_KEY_SET.has(key)) {
+      ignoredKeys.push(key);
+      continue;
+    }
+    if (!validSettingValue(key, value)) {
+      throw new Error(`Invalid value for configuration setting "${key}".`);
+    }
+    settings[key] = key === 'providers'
+      ? sanitizeProviders(value, { strict: true })
+      : clone(value);
+  }
+  return {
+    settings,
+    ignoredKeys,
+    sourceVersion: typeof parsed.webbrainVersion === 'string' ? parsed.webbrainVersion : '',
+  };
+}
+
+export function mergeConfigPatchSettings(current = {}, patch = {}) {
+  const merged = clone(patch);
+  if (!Object.hasOwn(merged, 'providers')) return merged;
+  const currentProviders = isPlainObject(current.providers) ? clone(current.providers) : {};
+  merged.providers = { ...currentProviders, ...merged.providers };
+  return merged;
+}

--- a/test/run.js
+++ b/test/run.js
@@ -2323,6 +2323,13 @@ test('config transfer exports and restores Settings values including provider ke
           configured: true,
           deviceGuid: 'must-not-import',
         },
+        webbrain_cloud: {
+          type: 'openai',
+          baseUrl: 'https://stale-export.example/v1',
+          apiKey: 'stale-export-secret',
+          configured: true,
+          deviceGuid: 'must-not-import',
+        },
       },
       futureSetting: 'ignored',
     },
@@ -2336,15 +2343,31 @@ test('config transfer exports and restores Settings values including provider ke
   assert.deepEqual(chromePatch.ignoredKeys, ['futureSetting']);
   const currentSettings = {
     providers: {
-      webbrain_cloud: { type: 'openai', deviceGuid: 'platform-device' },
+      webbrain_cloud: {
+        type: 'openai',
+        baseUrl: 'https://platform.example/v1',
+        apiKey: 'platform-secret',
+        deviceGuid: 'platform-device',
+      },
       anthropic: { type: 'anthropic', apiKey: 'existing-secret' },
     },
   };
   const mergedPatch = ConfigTransferCh.mergeConfigPatchSettings(currentSettings, chromePatch.settings);
-  assert.equal(mergedPatch.providers.webbrain_cloud.deviceGuid, 'platform-device');
+  const firefoxMergedPatch = ConfigTransferFx.mergeConfigPatchSettings(currentSettings, firefoxPatch.settings);
+  assert.deepEqual(firefoxMergedPatch, mergedPatch, 'Chrome and Firefox provider merge should remain identical');
+  assert.deepEqual(
+    mergedPatch.providers.webbrain_cloud,
+    currentSettings.providers.webbrain_cloud,
+    'sparse import must preserve the complete platform-managed WebBrain Cloud provider',
+  );
   assert.equal(mergedPatch.providers.anthropic.apiKey, 'existing-secret');
   assert.equal(mergedPatch.providers.openai.apiKey, 'provider-secret');
   assert.equal(currentSettings.providers.openai, undefined, 'provider merge must not mutate current storage');
+  assert.equal(
+    ConfigTransferCh.mergeConfigPatchSettings({}, chromePatch.settings).providers.webbrain_cloud,
+    undefined,
+    'a portable WebBrain Cloud provider must not be introduced without platform state',
+  );
 });
 
 test('config transfer validates schema, size, containers, and unknown keys', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -6143,14 +6143,23 @@ test('offscreen cloud bridge preserves failed run envelopes and rejects unauthor
   assert.equal(missing.error, 'Unknown cloud run.');
 
   const callCount = runtimeCalls.length;
-  socket.emit('message', {
-    data: JSON.stringify({ id: 'forbidden-1', action: 'get_providers', payload: {} }),
-  });
-  await new Promise(resolve => setImmediate(resolve));
-  const forbidden = socket.sent.find(message => message.id === 'forbidden-1');
-  assert.equal(forbidden.ok, false);
-  assert.match(forbidden.error, /unsupported cloud bridge action/i);
-  assert.equal(runtimeCalls.length, callCount, 'unauthorized bridge actions must not reach the background handler');
+  for (const [id, action] of [
+    ['forbidden-provider-read', 'get_providers'],
+    ['forbidden-config-write', 'import_config_patch'],
+  ]) {
+    socket.emit('message', {
+      data: JSON.stringify({ id, action, payload: {} }),
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    const forbidden = socket.sent.find(message => message.id === id);
+    assert.equal(forbidden.ok, false);
+    assert.match(forbidden.error, /unsupported cloud bridge action/i);
+  }
+  assert.equal(
+    runtimeCalls.length,
+    callCount,
+    'provider reads and provisioning config writes must not cross the run-only cloud bridge',
+  );
 });
 
 test('offscreen cloud bridge ignores asynchronous close events from replaced sockets', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -2310,6 +2310,41 @@ test('config transfer exports and restores Settings values including provider ke
   assert.equal(imported.settings.downloadDirectory, 'Work/WebBrain');
   assert.equal(imported.settings.themeMode, 'system', 'missing Settings values should restore their product defaults');
   assert.equal(Object.keys(imported.settings).length, ConfigTransferCh.CONFIG_STORAGE_KEYS.length);
+
+  const sparseJson = JSON.stringify({
+    schema: 'webbrain-config/1',
+    webbrainVersion: '24.0.2',
+    settings: {
+      verboseMode: true,
+      providers: {
+        openai: {
+          type: 'openai',
+          apiKey: 'provider-secret',
+          configured: true,
+          deviceGuid: 'must-not-import',
+        },
+      },
+      futureSetting: 'ignored',
+    },
+  });
+  const chromePatch = ConfigTransferCh.parseConfigPatchImport(sparseJson);
+  const firefoxPatch = ConfigTransferFx.parseConfigPatchImport(sparseJson);
+  assert.deepEqual(firefoxPatch, chromePatch, 'Chrome and Firefox sparse config imports should remain identical');
+  assert.deepEqual(Object.keys(chromePatch.settings), ['verboseMode', 'providers']);
+  assert.equal(chromePatch.settings.themeMode, undefined, 'sparse import must leave omitted settings untouched');
+  assert.equal(chromePatch.settings.providers.openai.deviceGuid, undefined);
+  assert.deepEqual(chromePatch.ignoredKeys, ['futureSetting']);
+  const currentSettings = {
+    providers: {
+      webbrain_cloud: { type: 'openai', deviceGuid: 'platform-device' },
+      anthropic: { type: 'anthropic', apiKey: 'existing-secret' },
+    },
+  };
+  const mergedPatch = ConfigTransferCh.mergeConfigPatchSettings(currentSettings, chromePatch.settings);
+  assert.equal(mergedPatch.providers.webbrain_cloud.deviceGuid, 'platform-device');
+  assert.equal(mergedPatch.providers.anthropic.apiKey, 'existing-secret');
+  assert.equal(mergedPatch.providers.openai.apiKey, 'provider-secret');
+  assert.equal(currentSettings.providers.openai, undefined, 'provider merge must not mutate current storage');
 });
 
 test('config transfer validates schema, size, containers, and unknown keys', () => {
@@ -2537,7 +2572,8 @@ test('/export --config and /import JSON or --file are wired in both browsers', (
     assert.match(panel, /command\.value === '\/import' && action === 'file'[\s\S]*?requestConfigurationFile\(tabId\)/, `${label}: file config import handler missing`);
     assert.match(panel, /input\.accept = '\.json,application\/json'[\s\S]*?file\.text\(\)/, `${label}: file picker should read JSON files`);
     assert.match(bg, /case 'export_config':[\s\S]*?createConfigExport\(stored/, `${label}: background config export missing`);
-    assert.match(bg, /case 'import_config':[\s\S]*?parseConfigImport\(msg\.json\)[\s\S]*?storage\.local\.set\(imported\.settings\)[\s\S]*?providerManager\.load\(\)/, `${label}: background config import and live provider reload missing`);
+    assert.match(bg, /case 'import_config':[\s\S]*?parseConfigImport\(msg\.json\)[\s\S]*?storage\.local\.set\(settings\)[\s\S]*?providerManager\.load\(\)/, `${label}: background config import and live provider reload missing`);
+    assert.match(bg, /case 'import_config_patch':[\s\S]*?parseConfigPatchImport\(msg\.json\)[\s\S]*?mergeConfigPatchSettings/, `${label}: background sparse config import and provider merge missing`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -2370,6 +2370,122 @@ test('config transfer exports and restores Settings values including provider ke
   );
 });
 
+// Runs the real import_config/import_config_patch case block against a mocked
+// storage.local, so the handler's own get(['providers']) -> merge -> set flow
+// is what preserves platform provider state, not a hand-built merge input.
+test('import_config_patch background handler merges against live provider storage', async () => {
+  const sparseJson = JSON.stringify({
+    schema: 'webbrain-config/1',
+    settings: {
+      verboseMode: true,
+      providers: {
+        openai: { type: 'openai', apiKey: 'provider-secret', configured: true },
+        webbrain_cloud: { type: 'openai', baseUrl: 'https://stale-export.example/v1', apiKey: 'stale-export-secret' },
+      },
+    },
+  });
+  const results = [];
+  for (const [label, prefix, configTransfer] of [
+    ['chrome', 'src/chrome', ConfigTransferCh],
+    ['firefox', 'src/firefox', ConfigTransferFx],
+  ]) {
+    const bg = fs.readFileSync(path.join(ROOT, prefix, 'src/background.js'), 'utf8');
+    const start = bg.indexOf("case 'import_config':");
+    const end = bg.indexOf("case 'get_progress':", start);
+    assert.ok(start > -1 && end > start, `${label}: import_config handler block not found`);
+    const handler = vm.runInNewContext(`(async (msg, api, helpers) => {
+      const chrome = api;
+      const browser = api;
+      const {
+        parseConfigImport, parseConfigPatchImport, mergeConfigPatchSettings,
+        providerManager, agent,
+        loadMaxSteps, loadClarifyTimeout, loadAutoScreenshot, loadSiteAdapters,
+        loadScreenshotRedaction, loadStrictSecretMode, loadProfile,
+        syncAgentUserMemoryFromStorage, loadCustomSkills, loadCaptchaSolver,
+        loadPlanBeforeAct, loadPlanReviewSettings, loadApiMutationObserverSetting,
+      } = helpers;
+      switch (msg.action) {
+        ${bg.slice(start, end)}
+      }
+    })`, {}, { filename: `${label}-import-config-handler.js` });
+
+    const stored = {
+      themeMode: 'dark',
+      providers: {
+        webbrain_cloud: {
+          type: 'openai',
+          baseUrl: 'https://platform.example/v1',
+          apiKey: 'platform-secret',
+          deviceGuid: 'platform-device',
+        },
+        anthropic: { type: 'anthropic', apiKey: 'existing-secret' },
+      },
+    };
+    const events = [];
+    const api = {
+      storage: {
+        local: {
+          get: async (keys) => {
+            events.push('get');
+            const list = keys == null ? Object.keys(stored) : Array.isArray(keys) ? keys : [keys];
+            return Object.fromEntries(list.filter(key => key in stored).map(key => [key, structuredClone(stored[key])]));
+          },
+          set: async (values) => {
+            events.push('set');
+            Object.assign(stored, structuredClone(values));
+          },
+        },
+      },
+    };
+    const noop = async () => {};
+    const helpers = {
+      parseConfigImport: configTransfer.parseConfigImport,
+      parseConfigPatchImport: configTransfer.parseConfigPatchImport,
+      mergeConfigPatchSettings: configTransfer.mergeConfigPatchSettings,
+      providerManager: { load: async () => { events.push('providerManager.load'); } },
+      agent: { _ensureGateSetting: noop, _refreshSystemPrompts: () => {} },
+      loadMaxSteps: noop,
+      loadClarifyTimeout: noop,
+      loadAutoScreenshot: noop,
+      loadSiteAdapters: noop,
+      loadScreenshotRedaction: noop,
+      loadStrictSecretMode: noop,
+      loadProfile: noop,
+      syncAgentUserMemoryFromStorage: noop,
+      loadCustomSkills: noop,
+      loadCaptchaSolver: noop,
+      loadPlanBeforeAct: noop,
+      loadPlanReviewSettings: noop,
+      loadApiMutationObserverSetting: noop,
+    };
+
+    const response = { ...(await handler({ action: 'import_config_patch', json: sparseJson }, api, helpers)) };
+    assert.equal(response.ok, true, `${label}: sparse import should succeed`);
+    assert.equal(response.settingCount, 2, `${label}: sparse import should report only the applied settings`);
+    assert.deepEqual(
+      stored.providers.webbrain_cloud,
+      { type: 'openai', baseUrl: 'https://platform.example/v1', apiKey: 'platform-secret', deviceGuid: 'platform-device' },
+      `${label}: the handler's storage read must preserve the platform-managed WebBrain Cloud provider`,
+    );
+    assert.equal(stored.providers.anthropic.apiKey, 'existing-secret', `${label}: existing providers must survive a sparse import`);
+    assert.equal(stored.providers.openai.apiKey, 'provider-secret', `${label}: imported providers must be added`);
+    assert.equal(stored.verboseMode, true, `${label}: patched settings must be written`);
+    assert.equal(stored.themeMode, 'dark', `${label}: omitted settings must stay untouched in storage`);
+    assert.deepEqual(events, ['get', 'set', 'providerManager.load'], `${label}: handler must read current providers before writing, then reload providers`);
+    results.push({ label, response, stored: structuredClone(stored) });
+
+    const fullResponse = await handler({ action: 'import_config', json: sparseJson }, api, helpers);
+    assert.equal(fullResponse.settingCount, configTransfer.CONFIG_STORAGE_KEYS.length, `${label}: full import should still write every setting`);
+    assert.equal(stored.themeMode, 'system', `${label}: full import should still restore omitted settings to defaults`);
+    assert.equal(stored.providers.webbrain_cloud.baseUrl, 'https://stale-export.example/v1', `${label}: full import intentionally keeps its replace-everything semantics`);
+  }
+  assert.deepEqual(
+    { response: results[1].response, stored: results[1].stored },
+    { response: results[0].response, stored: results[0].stored },
+    'Chrome and Firefox sparse import handlers should remain identical',
+  );
+});
+
 test('config transfer validates schema, size, containers, and unknown keys', () => {
   assert.throws(() => ConfigTransferCh.parseConfigImport('{nope'), /valid JSON/);
   assert.throws(() => ConfigTransferCh.parseConfigImport('{}'), /webbrain-config\/1/);


### PR DESCRIPTION
## What changed

- Add a provisioning-only sparse import path for `webbrain-config/1` exports in Chrome and Firefox.
- Preserve omitted settings instead of restoring defaults.
- Merge imported providers with existing provider storage while preserving device-local WebBrain Cloud configuration.
- Reload providers and live agent settings before cloud runtime readiness.
- Add Chrome/Firefox parity and provider-merge coverage.

## Why

WebBrain Cloud browser creation needs to apply an optional `/export --config` payload without changing the normal user-facing full restore behavior. Sparse imports must not overwrite omitted settings or replace platform-managed provider state.

## Validation

- Config transfer and browser wiring tests pass on current `main`.
- Prompt-injection security corpus: 60/60 passed.
- Full WebBrain suite: 997/998 passed; the sole failure is the pre-existing `package.json` 25.0.2 vs newest CHANGELOG 25.0.0 mismatch on `origin/main`, unrelated to this change.