### PR TITLE
Handle form validation failures reliably

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5794,9 +5794,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       return compact(parts.find(Boolean) || 'field', 120);
     };
     const describedMessage = (el) => {
-      const ids = compact(el.getAttribute?.('aria-describedby') || '', 240).split(/\s+/).filter(Boolean);
+      const ids = [...new Set(['aria-errormessage', 'aria-describedby'].flatMap(attr =>
+        compact(el.getAttribute?.(attr) || '', 240).split(/\s+/).filter(Boolean)
+      ))];
       const text = ids.map((id) => {
-        try { return document.getElementById(id)?.innerText || document.getElementById(id)?.textContent || ''; } catch { return ''; }
+        for (const root of roots) {
+          try {
+            const message = root.getElementById?.(id);
+            if (message) return message.innerText || message.textContent || '';
+          } catch {}
+        }
+        return '';
       }).filter(Boolean).join(' ');
       return compact(text || el.validationMessage || '', 300);
     };

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5528,8 +5528,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   }
 
   _formValidationActionLooksSubmit(toolName, args = {}, result = null, detectedSubmit = null) {
-    if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
     const name = String(toolName || '');
+    if (['click', 'click_ax', 'iframe_click'].includes(name)) {
+      const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
+      const type = String(target?.type || '').toLowerCase();
+      if (target?.isSubmitControl === false && type === 'button') return false;
+    }
+    if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
 
     const label = String(args?.text || result?.name || result?.matched || result?.text || '').trim();
@@ -5593,6 +5598,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       context.result,
       context.detectedSubmit,
     );
+    if (!looksLikeSubmit) return null;
     const includePersistentValidation = strongSubmitEvidence
       && context.priorValidationFailure === true;
     const beforeAlerts = new Set(before.flatMap(state =>

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -296,12 +296,6 @@ export class Agent {
     this._doneBlockCount = new Map(); // tabId -> consecutive done-blocks
     this._recentSubmitClicks = new Map(); // tabId -> recent submit click timestamps
     this._formValidationBlocks = new Map(); // tabId -> validation state that must change before another submit
-    const formValidationSaltBytes = new Uint32Array(4);
-    globalThis.crypto.getRandomValues(formValidationSaltBytes);
-    this._formValidationFingerprintSalt = Array.from(
-      formValidationSaltBytes,
-      value => value.toString(16).padStart(8, '0'),
-    ).join('');
     this._runningTabs = new Set(); // tabIds with an active processMessage/Stream in flight
     this.completionInvariants = new Map(); // tabId -> run-scoped post-action verification state
     this._completionRunCounter = 0;
@@ -5729,7 +5723,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         rawResults = await chrome.scripting.executeScript({
           target: { tabId, ...(allFrames ? { allFrames: true } : {}) },
           func: Agent._formValidationStateProbe,
-          args: [this._formValidationFingerprintSalt],
         });
         return (Array.isArray(rawResults) ? rawResults : [])
           .map(item => ({ frameId: item?.frameId ?? null, ...(item?.result || {}) }))
@@ -5738,8 +5731,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (globalThis.browser?.tabs?.executeScript) {
         let probeSource = Agent._formValidationStateProbe.toString();
         if (!/^\s*(?:async\s+)?function\b/.test(probeSource)) probeSource = `function ${probeSource}`;
-        const probeSalt = JSON.stringify(this._formValidationFingerprintSalt);
-        const code = `(() => { const __wbFormValidationProbe = (${probeSource}); return __wbFormValidationProbe(${probeSalt}); })()`;
+        const code = `(() => { const __wbFormValidationProbe = (${probeSource}); return __wbFormValidationProbe(); })()`;
         rawResults = await browser.tabs.executeScript(tabId, { code, allFrames });
         return (Array.isArray(rawResults) ? rawResults : [])
           .map((result, frameId) => ({ frameId, ...(result || {}) }))
@@ -5756,7 +5748,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * Page-side form validation snapshot. Keep self-contained: Firefox
    * serializes this function into tabs and neither browser may close over Agent.
    */
-  static _formValidationStateProbe = function _formValidationStateProbe(fingerprintSalt = '') {
+  static _formValidationStateProbe = function _formValidationStateProbe() {
     const compact = (value, max = 300) => String(value ?? '').replace(/\s+/g, ' ').trim().slice(0, max);
     const roots = [document];
     try {
@@ -5881,9 +5873,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         hash = Math.imul(hash, 16777619);
       }
     };
-    // Mix a per-agent secret into the page-side fingerprint. Password values
-    // can then affect retry detection without ever leaving the probe as text.
-    addHash(`salt:${fingerprintSalt}\u001e`);
     for (const el of queryAll('input, textarea, select, [contenteditable="true"], button, [role="button"], [onclick], [data-action]')) {
       const tag = String(el.tagName || '').toLowerCase();
       const type = String(el.getAttribute?.('type') || el.tagName || '').toLowerCase();
@@ -5903,6 +5892,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         state = compact(el.innerText || el.textContent || el.getAttribute?.('aria-label') || '', 120);
       } else {
         const value = String(el.value ?? el.textContent ?? '');
+        // Fold password text into the aggregate page-side hash so same-length
+        // corrections differ, but never include the value in the snapshot.
         state = type === 'password' ? `password-value:${value}` : value;
       }
       addHash(`${el.tagName}|${type}|${el.name || ''}|${el.id || ''}|${visible(el) ? 'visible' : 'hidden'}|${el.disabled ? 'disabled' : 'enabled'}|${state}\u001e`);

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -6152,7 +6152,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         || hasActivationHandler;
       if (!isSubmit) return null;
       const nativeSubmit = (tag === 'input' && (type === 'submit' || type === 'image'))
-        || (tag === 'button' && type === 'submit');
+        || (tag === 'button' && (!type || type === 'submit'));
       return {
         ...this._fallbackSubmitConfirmationInfo(
           host,

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2426,11 +2426,32 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         continue;
       }
       const formValidationCandidate = this._isFormValidationCandidate(fnName, fnArgs);
-      const formValidationAllFrames = fnName === 'iframe_click' || fnName === 'press_keys';
-      let detectedSubmitAction = null;
+      let formValidationCoordinateFrames = null;
+      if (
+        formValidationCandidate
+        && fnName === 'click'
+        && fnArgs?.x != null
+        && fnArgs?.y != null
+      ) {
+        formValidationCoordinateFrames = await this._iframeRectsForCoordinate(
+          tabId,
+          fnArgs.x,
+          fnArgs.y,
+        );
+      }
+      const formValidationAllFrames = fnName === 'iframe_click'
+        || fnName === 'press_keys'
+        || (Array.isArray(formValidationCoordinateFrames) && formValidationCoordinateFrames.length > 0);
+      let detectedSubmitAction = formValidationAllFrames
+        && Array.isArray(formValidationCoordinateFrames)
+        && formValidationCoordinateFrames.length > 0
+        ? await this._detectLikelySubmitAction(tabId, fnName, fnArgs, {
+            coordinateFrames: formValidationCoordinateFrames,
+          })
+        : null;
       const validationBlock = formValidationCandidate ? this._formValidationBlocks.get(tabId) : null;
       const obviousSubmitAction = formValidationCandidate
-        && this._formValidationActionLooksSubmit(fnName, fnArgs);
+        && this._formValidationActionLooksSubmit(fnName, fnArgs, null, detectedSubmitAction);
       let formValidationBefore = (validationBlock || obviousSubmitAction)
         ? await this._captureFormValidationState(tabId, { allFrames: formValidationAllFrames })
         : [];
@@ -5438,7 +5459,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   _isFormValidationCandidate(toolName, args = {}) {
     const name = String(toolName || '');
-    if (name === 'click' || name === 'click_ax' || name === 'iframe_click') return true;
+    if (name === 'click' || name === 'click_ax' || name === 'iframe_click' || name === 'execute_js') return true;
     if (name === 'set_field') return args?.submit === true;
     if (name === 'press_keys') {
       const keys = JSON.stringify(args?.key ?? args?.keys ?? '').toLowerCase();
@@ -5453,19 +5474,22 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       ? ['selector', 'ref_id', 'index', 'name', 'text', 'submit']
       : name === 'press_keys'
         ? ['selector', 'ref_id', 'index', 'key', 'keys']
+        : name === 'execute_js'
+          ? ['code']
         : ['selector', 'ref_id', 'index', 'text', 'x', 'y', 'urlFilter'];
     const identity = {};
     for (const field of fields) {
       const value = args?.[field];
       if (value == null || value === '') continue;
-      if (name === 'set_field' && field === 'text') {
+      if ((name === 'set_field' && field === 'text') || (name === 'execute_js' && field === 'code')) {
         const text = String(value);
         let hash = 2166136261;
         for (let i = 0; i < text.length; i++) {
           hash ^= text.charCodeAt(i);
           hash = Math.imul(hash, 16777619);
         }
-        identity.textFingerprint = `${text.length}:${(hash >>> 0).toString(16)}`;
+        const fingerprintField = name === 'execute_js' ? 'codeFingerprint' : 'textFingerprint';
+        identity[fingerprintField] = `${text.length}:${(hash >>> 0).toString(16)}`;
         continue;
       }
       identity[field] = typeof value === 'string' ? value.slice(0, 500) : value;
@@ -5477,6 +5501,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (detectedSubmit?.isSubmit) return true;
     const name = String(toolName || '');
     if (name === 'set_field') return args?.submit === true;
+    if (name === 'execute_js') return true;
     if (name === 'press_keys') {
       const keys = JSON.stringify(args?.key ?? args?.keys ?? '').toLowerCase();
       return /\b(?:enter|return)\b/.test(keys);
@@ -5881,7 +5906,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     };
   }
 
-  async _detectLikelySubmitAction(tabId, toolName, args = {}) {
+  async _detectLikelySubmitAction(tabId, toolName, args = {}, options = {}) {
     const name = String(toolName || '');
     const submitCapableTools = new Set(['click', 'click_ax', 'iframe_click', 'set_field', 'press_keys', 'execute_js']);
     if (!submitCapableTools.has(name)) return null;
@@ -5911,7 +5936,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       let probeArgs = args || {};
       let allFrames = name === 'iframe_click' || name === 'press_keys';
       if (name === 'click' && args?.x != null && args?.y != null && globalThis.chrome?.scripting?.executeScript) {
-        const frameCoordinateRects = await this._iframeRectsForCoordinate(tabId, args.x, args.y);
+        const frameCoordinateRects = Array.isArray(options?.coordinateFrames)
+          ? options.coordinateFrames
+          : await this._iframeRectsForCoordinate(tabId, args.x, args.y);
         if (frameCoordinateRects.length) {
           probeArgs = { ...(args || {}), __wbTopLevelCoordinateFrames: frameCoordinateRects };
           allFrames = true;

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5505,8 +5505,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return Object.keys(identity).length ? `${name}:${JSON.stringify(identity)}` : '';
   }
 
-  _formValidationActionLooksSubmit(toolName, args = {}, result = null, detectedSubmit = null) {
-    if (detectedSubmit?.isSubmit) return true;
+  _formValidationActionHasStrongSubmitEvidence(toolName, args = {}, result = null, detectedSubmit = null) {
+    if (detectedSubmit?.isSubmit === true) return true;
     const name = String(toolName || '');
     if (name === 'set_field') return args?.submit === true;
     if (name === 'execute_js') return true;
@@ -5516,11 +5516,20 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
 
-    if (result?.isSubmitControl === true) return true;
-    const tag = String(result?.tag || '').toUpperCase();
-    const type = String(result?.type || '').toLowerCase();
-    if (tag === 'BUTTON' && (result?.isSubmitControl === true || type === 'submit')) return true;
+    const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
+    if (target?.isSubmitControl === true) return true;
+    const tag = String(target?.tag || '').toUpperCase();
+    const type = String(target?.type || '').toLowerCase();
+    if (tag === 'BUTTON' && type === 'submit') return true;
     if (tag === 'INPUT' && (type === 'submit' || type === 'image')) return true;
+    const selector = String(args?.selector || '').toLowerCase();
+    return /type\s*=\s*["']?(?:submit|image)/.test(selector);
+  }
+
+  _formValidationActionLooksSubmit(toolName, args = {}, result = null, detectedSubmit = null) {
+    if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
+    const name = String(toolName || '');
+    if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
 
     const label = String(args?.text || result?.name || result?.matched || result?.text || '').trim();
     if (/^(?:continue|next|create|save|submit|add|post|publish|send|confirm|sign up|sign in|log in|register|place order|pay|checkout|update|apply|finish|done)\b/i.test(label)) {
@@ -5577,6 +5586,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       context.result,
       context.detectedSubmit,
     );
+    const strongSubmitEvidence = this._formValidationActionHasStrongSubmitEvidence(
+      context.toolName,
+      context.args,
+      context.result,
+      context.detectedSubmit,
+    );
     const includePersistentValidation = looksLikeSubmit
       && context.priorValidationFailure === true;
     const beforeAlerts = new Set(before.flatMap(state =>
@@ -5613,7 +5628,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const nativeFailureStates = sameRouteAfter.filter((state) => {
       if (state?.activeInvalid !== true) return false;
       const key = `${state?.frameId ?? ''}|${this._normalizeUrlPath(String(state?.url || ''))}`;
-      return !beforeActiveInvalid.has(key);
+      return !beforeActiveInvalid.has(key) || strongSubmitEvidence;
     });
     const nativeInvalidFields = looksLikeSubmit
       ? nativeFailureStates.flatMap(state => Array.isArray(state?.invalidFields) ? state.invalidFields : [])

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2446,10 +2446,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         || (fnName === 'click' && !!fnArgs?.selector)
         || (Array.isArray(formValidationCoordinateFrames) && formValidationCoordinateFrames.length > 0);
       const preflightSubmitDetection = formValidationCandidate
-        && (
-          fnName === 'iframe_click'
-          || (Array.isArray(formValidationCoordinateFrames) && formValidationCoordinateFrames.length > 0)
-        );
+        && ['click', 'click_ax', 'iframe_click'].includes(fnName);
       let detectedSubmitAction = preflightSubmitDetection
         ? await this._detectLikelySubmitAction(tabId, fnName, fnArgs, {
             ...(Array.isArray(formValidationCoordinateFrames)
@@ -12864,6 +12861,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                         role: el.getAttribute('role') || (el.getAttribute('contenteditable') != null ? 'contenteditable' : ''),
                         text: matches[0].txt.slice(0, 80),
                         widgetFallback: true,
+                        isEditableControl: el.isContentEditable
+                          || el.getAttribute('role') === 'textbox'
+                          || el.getAttribute('role') === 'combobox',
                       };
                     }
                   }
@@ -13057,6 +13057,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             tag: info.tag,
             type: info.type || '',
             isSubmitControl: info.isSubmitControl === true,
+            isEditableControl: info.isEditableControl === true,
             text: info.text,
             matched: args.text,
             x: clickX,

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5639,14 +5639,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // native validation via activeInvalid, but do not mislabel an unrelated
     // pre-existing alert.
     for (const state of before.length ? after : []) {
+      const route = this._normalizeUrlPath(String(state?.url || ''));
+      const includePersistentForState = includePersistentValidation
+        && (beforeRoutes.size === 0 || !route || beforeRoutes.has(route));
       for (const text of this._formValidationAlertTexts(state)) {
-        if (text && (includePersistentValidation || !beforeAlerts.has(text))) {
+        if (text && (includePersistentForState || !beforeAlerts.has(text))) {
           newAlerts.push(text);
         }
       }
       for (const field of Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : []) {
         const key = `${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
-        if (includePersistentValidation || !beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
+        if (includePersistentForState || !beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
       }
     }
 
@@ -5707,10 +5710,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     { allFrames = false, checkpointsMs = [0, 120, 350, 800, 1200] } = {},
   ) {
     const before = Array.isArray(beforeStates) ? beforeStates : [];
-    const beforeRoutes = new Set(before
-      .map(state => this._normalizeUrlPath(String(state?.url || '')))
-      .filter(Boolean));
-    let changedRouteObservedAt = null;
     const startedAt = Date.now();
     for (let checkpointIndex = 0; checkpointIndex < checkpointsMs.length; checkpointIndex += 1) {
       const checkpoint = checkpointsMs[checkpointIndex];
@@ -5725,22 +5724,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           && checkpointIndex === checkpointsMs.length - 1,
       });
       if (failure) return failure;
-      const afterRoutes = new Set(after
-        .map(state => this._normalizeUrlPath(String(state?.url || '')))
-        .filter(Boolean));
-      if (
-        beforeRoutes.size > 0
-        && afterRoutes.size > 0
-        && ![...afterRoutes].some(route => beforeRoutes.has(route))
-      ) {
-        if (changedRouteObservedAt == null) {
-          changedRouteObservedAt = Date.now();
-        } else if (Date.now() - changedRouteObservedAt >= 350) {
-          break;
-        }
-      } else {
-        changedRouteObservedAt = null;
-      }
     }
     return null;
   }

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5506,7 +5506,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   }
 
   _formValidationActionHasStrongSubmitEvidence(toolName, args = {}, result = null, detectedSubmit = null) {
-    if (detectedSubmit?.isSubmit === true) return true;
     const name = String(toolName || '');
     if (name === 'set_field') return args?.submit === true;
     if (name === 'execute_js') return true;
@@ -5517,9 +5516,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
 
     const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
-    if (target?.isSubmitControl === true) return true;
     const tag = String(target?.tag || '').toUpperCase();
     const type = String(target?.type || '').toLowerCase();
+    if (target?.isSubmitControl === false && type === 'button') return false;
+    if (detectedSubmit?.isSubmit === true) return true;
+    if (target?.isSubmitControl === true) return true;
     if (tag === 'BUTTON' && type === 'submit') return true;
     if (tag === 'INPUT' && (type === 'submit' || type === 'image')) return true;
     const selector = String(args?.selector || '').toLowerCase();
@@ -5592,7 +5593,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       context.result,
       context.detectedSubmit,
     );
-    const includePersistentValidation = looksLikeSubmit
+    const includePersistentValidation = strongSubmitEvidence
       && context.priorValidationFailure === true;
     const beforeAlerts = new Set(before.flatMap(state =>
       this._formValidationAlertTexts(state)

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2446,7 +2446,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         || (fnName === 'click' && !!fnArgs?.selector)
         || (Array.isArray(formValidationCoordinateFrames) && formValidationCoordinateFrames.length > 0);
       const preflightSubmitDetection = formValidationCandidate
-        && ['click', 'click_ax', 'iframe_click', 'press_keys'].includes(fnName);
+        && ['click', 'click_ax', 'iframe_click', 'press_keys', 'execute_js'].includes(fnName);
       let detectedSubmitAction = preflightSubmitDetection
         ? await this._detectLikelySubmitAction(tabId, fnName, fnArgs, {
             ...(Array.isArray(formValidationCoordinateFrames)
@@ -5538,6 +5538,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   _formValidationActionLooksSubmit(toolName, args = {}, result = null, detectedSubmit = null) {
     const name = String(toolName || '');
+    if (name === 'execute_js') {
+      return this._executeJsLooksLikeFormSubmit(args?.code) || detectedSubmit?.isSubmit === true;
+    }
     if (['click', 'click_ax', 'iframe_click'].includes(name)) {
       const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
       const type = String(target?.type || '').toLowerCase();
@@ -5624,12 +5627,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         context.priorValidationFailure === true
         || context.includeCorrectedPersistentValidation === true
       );
+    const validationStateScope = state =>
+      `${state?.frameId ?? ''}|${this._normalizeUrlPath(String(state?.url || ''))}`;
     const beforeAlerts = new Set(before.flatMap(state =>
       this._formValidationAlertTexts(state)
+        .map(text => `${validationStateScope(state)}|${text}`)
     ));
     const beforeAriaInvalid = new Set(before.flatMap(state =>
       (Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : [])
-        .map(field => `${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
+        .map(field => `${validationStateScope(state)}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
     ));
     const beforeActiveInvalid = new Set(before
       .filter(state => state?.activeInvalid === true)
@@ -5646,12 +5652,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const includePersistentForState = includePersistentValidation
         && (beforeRoutes.size === 0 || !route || beforeRoutes.has(route));
       for (const text of this._formValidationAlertTexts(state)) {
-        if (text && (includePersistentForState || !beforeAlerts.has(text))) {
+        const key = `${validationStateScope(state)}|${text}`;
+        if (text && (includePersistentForState || !beforeAlerts.has(key))) {
           newAlerts.push(text);
         }
       }
       for (const field of Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : []) {
-        const key = `${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
+        const key = `${validationStateScope(state)}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
         if (includePersistentForState || !beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
       }
     }

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5530,19 +5530,22 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const after = Array.isArray(afterStates) ? afterStates : [];
     if (!after.length) return null;
 
-    const beforeUrls = new Set(before.map(state => String(state?.url || '')).filter(Boolean));
+    const beforeRoutes = new Set(before
+      .map(state => this._normalizeUrlPath(String(state?.url || '')))
+      .filter(Boolean));
     const comparableAfter = after.filter((state) => {
-      const url = String(state?.url || '');
-      return beforeUrls.size === 0 || !url || beforeUrls.has(url);
+      const route = this._normalizeUrlPath(String(state?.url || ''));
+      return beforeRoutes.size === 0 || !route || beforeRoutes.has(route);
     });
     if (!comparableAfter.length) return null;
 
     const beforeAlerts = new Set(before.flatMap(state =>
-      this._formValidationAlertTexts(state).map(text => `${state?.url || ''}|${text}`)
+      this._formValidationAlertTexts(state)
+        .map(text => `${this._normalizeUrlPath(String(state?.url || ''))}|${text}`)
     ));
     const beforeAriaInvalid = new Set(before.flatMap(state =>
       (Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : [])
-        .map(field => `${state?.url || ''}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
+        .map(field => `${this._normalizeUrlPath(String(state?.url || ''))}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
     ));
     const newAlerts = [];
     const newAriaInvalid = [];
@@ -5550,11 +5553,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // by the action. With no baseline we still detect native validation via
     // activeInvalid, but do not mislabel an unrelated pre-existing alert.
     for (const state of before.length ? comparableAfter : []) {
+      const route = this._normalizeUrlPath(String(state?.url || ''));
       for (const text of this._formValidationAlertTexts(state)) {
-        if (text && !beforeAlerts.has(`${state?.url || ''}|${text}`)) newAlerts.push(text);
+        if (text && !beforeAlerts.has(`${route}|${text}`)) newAlerts.push(text);
       }
       for (const field of Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : []) {
-        const key = `${state?.url || ''}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
+        const key = `${route}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
         if (!beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
       }
     }
@@ -5616,7 +5620,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     { allFrames = false, checkpointsMs = [0, 120, 350, 800, 1200] } = {},
   ) {
     const before = Array.isArray(beforeStates) ? beforeStates : [];
-    const beforeUrls = new Set(before.map(state => String(state?.url || '')).filter(Boolean));
+    const beforeRoutes = new Set(before
+      .map(state => this._normalizeUrlPath(String(state?.url || '')))
+      .filter(Boolean));
     const startedAt = Date.now();
     for (const checkpoint of checkpointsMs) {
       const targetDelay = Math.max(0, Number(checkpoint) || 0);
@@ -5625,11 +5631,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const after = await this._captureFormValidationState(tabId, { allFrames });
       const failure = this._detectFormValidationFailure(before, after, context);
       if (failure) return failure;
-      const afterUrls = new Set(after.map(state => String(state?.url || '')).filter(Boolean));
+      const afterRoutes = new Set(after
+        .map(state => this._normalizeUrlPath(String(state?.url || '')))
+        .filter(Boolean));
       if (
-        beforeUrls.size > 0
-        && afterUrls.size > 0
-        && ![...afterUrls].some(url => beforeUrls.has(url))
+        beforeRoutes.size > 0
+        && afterRoutes.size > 0
+        && ![...afterRoutes].some(route => beforeRoutes.has(route))
       ) {
         break;
       }
@@ -5648,6 +5656,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     toolResult.validationMessages = failure.validationMessages;
     toolResult.error = failure.error;
     delete toolResult.warning;
+    // A validation-rejected click did not complete the destructive action.
+    // Do not let its generic duplicate-submit entry block the corrected retry.
+    this._recentSubmitClicks.delete(tabId);
     this._formValidationBlocks.set(tabId, {
       stateKey: failure.stateKey,
       actionKey: failure.actionKey,

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5505,10 +5505,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return Object.keys(identity).length ? `${name}:${JSON.stringify(identity)}` : '';
   }
 
+  _executeJsLooksLikeFormSubmit(code) {
+    const source = String(code || '');
+    return /\brequestSubmit\s*\(|\.submit\s*\(|\bdispatchEvent\s*\([^)]*\bsubmit\b|(?:submit|checkout|confirm|place.?order|pay)[^;\n]{0,160}\.click\s*\(/i.test(source);
+  }
+
   _formValidationActionHasStrongSubmitEvidence(toolName, args = {}, result = null, detectedSubmit = null) {
     const name = String(toolName || '');
     if (name === 'set_field') return args?.submit === true;
-    if (name === 'execute_js') return true;
+    if (name === 'execute_js') return this._executeJsLooksLikeFormSubmit(args?.code);
     if (name === 'press_keys') {
       const keys = JSON.stringify(args?.key ?? args?.keys ?? '').toLowerCase();
       return /\b(?:enter|return)\b/.test(keys);
@@ -5915,9 +5920,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         hash = Math.imul(hash, 16777619);
       }
     };
-    for (const el of queryAll('input, textarea, select, [contenteditable="true"], button, [role="button"], [onclick], [data-action]')) {
+    for (const el of queryAll('input, textarea, select, [contenteditable="true"], [role="checkbox"], [role="radio"], [role="switch"], [aria-checked], button, [role="button"], [onclick], [data-action]')) {
       const tag = String(el.tagName || '').toLowerCase();
       const type = String(el.getAttribute?.('type') || el.tagName || '').toLowerCase();
+      const role = String(el.getAttribute?.('role') || '').toLowerCase();
       let state = '';
       if (type === 'checkbox' || type === 'radio') {
         state = el.checked ? 'checked' : 'unchecked';
@@ -5925,9 +5931,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         state = Array.from(el.selectedOptions || []).map(option => option.value).join('\u001f');
       } else if (type === 'file') {
         state = String(el.files?.length || 0);
+      } else if (el.hasAttribute?.('aria-checked') || role === 'checkbox' || role === 'radio' || role === 'switch') {
+        state = `aria-checked:${compact(el.getAttribute?.('aria-checked') || 'undefined', 40)}`;
       } else if (
         tag === 'button'
-        || String(el.getAttribute?.('role') || '').toLowerCase() === 'button'
+        || role === 'button'
         || el.hasAttribute?.('onclick')
         || el.hasAttribute?.('data-action')
       ) {

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5543,13 +5543,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
-    if (detectedSubmit?.isSubmit === true) return false;
 
     const label = String(args?.text || result?.name || result?.matched || result?.text || '').trim();
+    const selector = String(args?.selector || '').toLowerCase();
+    if (detectedSubmit?.isSubmit === true) {
+      return /^(?:continue|save|submit|post|publish|send|confirm|sign up|sign in|log in|register|place order|pay|checkout|finish)\b/i.test(label)
+        || /(?:type\s*=\s*["']?(?:submit|image)|\bsubmit\b|\bcontinue\b|\bconfirm\b|\bcheckout\b|\bfinish\b)/.test(selector);
+    }
     if (/^(?:continue|next|create|save|submit|add|post|publish|send|confirm|sign up|sign in|log in|register|place order|pay|checkout|update|apply|finish|done)\b/i.test(label)) {
       return true;
     }
-    const selector = String(args?.selector || '').toLowerCase();
     return /(?:type\s*=\s*["']?(?:submit|image)|\bsubmit\b|\bcontinue\b|\bconfirm\b|\bcheckout\b|\bfinish\b)/.test(selector);
   }
 

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2439,8 +2439,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           fnArgs.y,
         );
       }
+      // CDP selector resolution pierces same-process iframe documents, so a
+      // plain click({selector}) can still dispatch inside a child frame.
       const formValidationAllFrames = fnName === 'iframe_click'
         || fnName === 'press_keys'
+        || (fnName === 'click' && !!fnArgs?.selector)
         || (Array.isArray(formValidationCoordinateFrames) && formValidationCoordinateFrames.length > 0);
       const preflightSubmitDetection = formValidationCandidate
         && (

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5523,7 +5523,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
     const tag = String(target?.tag || '').toUpperCase();
     const type = String(target?.type || '').toLowerCase();
-    if (target?.isSubmitControl === false && type === 'button') return false;
+    const strongDetectedSubmit = detectedSubmit?.validationSubmitEvidence === 'strong';
+    if (target?.isSubmitControl === false && type === 'button' && !strongDetectedSubmit) return false;
     if (detectedSubmit?.isSubmit === true) return true;
     if (target?.isSubmitControl === true) return true;
     if (tag === 'BUTTON' && type === 'submit') return true;
@@ -5537,7 +5538,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (['click', 'click_ax', 'iframe_click'].includes(name)) {
       const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
       const type = String(target?.type || '').toLowerCase();
-      if (target?.isSubmitControl === false && type === 'button') return false;
+      const strongDetectedSubmit = detectedSubmit?.validationSubmitEvidence === 'strong';
+      if (target?.isSubmitControl === false && type === 'button' && !strongDetectedSubmit) return false;
     }
     if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
@@ -6038,6 +6040,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           host,
           tool: name,
           reason: String(detected.reason || 'likely form submission').slice(0, 200),
+          validationSubmitEvidence: detected.validationSubmitEvidence === 'strong' ? 'strong' : 'heuristic',
           summary: String(detected.summary || '').slice(0, 1200),
           fields: Array.isArray(detected.fields) ? detected.fields.slice(0, 12) : [],
           changedFields: Array.isArray(detected.changedFields) ? detected.changedFields.slice(0, 8) : [],
@@ -6294,11 +6297,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         changedFields,
       };
     };
-    const submitInfo = (form, reason, pendingEl = null, pendingValue = null) => ({
+    const submitInfo = (form, reason, pendingEl = null, pendingValue = null, validationSubmitEvidence = 'strong') => ({
       isSubmit: true,
       host,
       url,
       reason,
+      validationSubmitEvidence,
       ...summarizeForm(form, pendingEl, pendingValue),
     });
     const labelControlFor = (el) => {
@@ -6319,21 +6323,37 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       } catch {}
       return target && target.nodeType === 1 ? target : null;
     };
-    const isSubmitControl = (el) => {
+    const submitControlEvidence = (el) => {
       const target = labelControlFor(el) || el;
-      if (!target || target.nodeType !== 1) return false;
+      if (!target || target.nodeType !== 1) return { isSubmit: false, strong: false };
       const candidate = target.closest?.('button,input,[role="button"],[onclick],[data-action]') || target;
       const tag = String(candidate.tagName || '').toLowerCase();
       const type = String(candidate.getAttribute?.('type') || candidate.type || '').toLowerCase();
       const role = String(candidate.getAttribute?.('role') || '').toLowerCase();
       const hasActivationHandler = candidate.hasAttribute?.('onclick') || candidate.hasAttribute?.('data-action');
       const form = candidate.form || candidate.closest?.('form');
-      if (!form) return false;
-      if (tag === 'input') return type === 'submit' || type === 'image' || type === 'button';
-      if (tag === 'button') return !type || type === 'submit' || type === 'button';
-      if (role === 'button' || hasActivationHandler) return true;
-      return false;
+      if (!form) return { isSubmit: false, strong: false };
+      const inlineHandler = String(candidate.getAttribute?.('onclick') || '');
+      const dataAction = String(candidate.getAttribute?.('data-action') || '');
+      const label = compact(
+        candidate.innerText || candidate.textContent || candidate.getAttribute?.('aria-label') || '',
+        120,
+      );
+      const explicitJsSubmit = /\brequestSubmit\s*\(|\.submit\s*\(|\bdispatchEvent\s*\([^)]*\bsubmit\b/i.test(inlineHandler)
+        || /^(?:submit|checkout|pay|place[-_ ]?order|confirm[-_ ]?order|complete[-_ ]?order|purchase|register|sign[-_ ]?in|log[-_ ]?in)$/i.test(dataAction.trim())
+        || /^(?:submit|checkout|pay|place order|confirm order|complete order|purchase|register|sign in|log in)$/i.test(label.trim());
+      if (tag === 'input') {
+        if (type === 'submit' || type === 'image') return { isSubmit: true, strong: true };
+        if (type === 'button') return { isSubmit: true, strong: explicitJsSubmit };
+      }
+      if (tag === 'button') {
+        if (!type || type === 'submit') return { isSubmit: true, strong: true };
+        if (type === 'button') return { isSubmit: true, strong: explicitJsSubmit };
+      }
+      if (role === 'button' || hasActivationHandler) return { isSubmit: true, strong: explicitJsSubmit };
+      return { isSubmit: false, strong: false };
     };
+    const isSubmitControl = el => submitControlEvidence(el).isSubmit;
     const formForSubmitControl = (el) => {
       const target = labelControlFor(el) || el;
       const candidate = target?.closest?.('button,input') || target;
@@ -6490,7 +6510,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         return form ? submitInfo(form, 'Enter key in a form field') : null;
       }
       if (target && isSubmitControl(target)) {
-        return submitInfo(formForSubmitControl(target), 'submit button/control activation');
+        const evidence = submitControlEvidence(target);
+        return submitInfo(
+          formForSubmitControl(target),
+          'submit button/control activation',
+          null,
+          null,
+          evidence.strong ? 'strong' : 'heuristic',
+        );
       }
     } catch {}
     return null;

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2676,6 +2676,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             args: fnArgs,
             result: toolResult,
             detectedSubmit: detectedSubmitAction,
+            priorValidationFailure: !!validationBlock,
           },
           { allFrames: formValidationAllFrames },
         );
@@ -5511,7 +5512,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (result?.isSubmitControl === true) return true;
     const tag = String(result?.tag || '').toUpperCase();
     const type = String(result?.type || '').toLowerCase();
-    if (tag === 'BUTTON' && result?.isSubmitControl !== false) return true;
+    if (tag === 'BUTTON' && (result?.isSubmitControl === true || type === 'submit')) return true;
     if (tag === 'INPUT' && (type === 'submit' || type === 'image')) return true;
 
     const label = String(args?.text || result?.name || result?.matched || result?.text || '').trim();
@@ -5564,6 +5565,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     });
     if (!comparableAfter.length) return null;
 
+    const looksLikeSubmit = this._formValidationActionLooksSubmit(
+      context.toolName,
+      context.args,
+      context.result,
+      context.detectedSubmit,
+    );
+    const includePersistentValidation = looksLikeSubmit
+      && context.priorValidationFailure === true;
     const beforeAlerts = new Set(before.flatMap(state =>
       this._formValidationAlertTexts(state)
         .map(text => `${this._normalizeUrlPath(String(state?.url || ''))}|${text}`)
@@ -5580,21 +5589,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     for (const state of before.length ? comparableAfter : []) {
       const route = this._normalizeUrlPath(String(state?.url || ''));
       for (const text of this._formValidationAlertTexts(state)) {
-        if (text && !beforeAlerts.has(`${route}|${text}`)) newAlerts.push(text);
+        if (text && (includePersistentValidation || !beforeAlerts.has(`${route}|${text}`))) {
+          newAlerts.push(text);
+        }
       }
       for (const field of Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : []) {
         const key = `${route}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
-        if (!beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
+        if (includePersistentValidation || !beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
       }
     }
 
     const nativeFailureStates = comparableAfter.filter(state => state?.activeInvalid === true);
-    const looksLikeSubmit = this._formValidationActionLooksSubmit(
-      context.toolName,
-      context.args,
-      context.result,
-      context.detectedSubmit,
-    );
     const nativeInvalidFields = looksLikeSubmit
       ? nativeFailureStates.flatMap(state => Array.isArray(state?.invalidFields) ? state.invalidFields : [])
       : [];

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -6147,12 +6147,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         || role === 'button'
         || hasActivationHandler;
       if (!isSubmit) return null;
-      return this._fallbackSubmitConfirmationInfo(
-        host,
-        'click',
-        'selector resolves to a submit control in shadow DOM',
-        'The selector resolves to a submit button/control that the page probe cannot inspect directly.'
-      );
+      const nativeSubmit = (tag === 'input' && (type === 'submit' || type === 'image'))
+        || (tag === 'button' && type === 'submit');
+      return {
+        ...this._fallbackSubmitConfirmationInfo(
+          host,
+          'click',
+          'selector resolves to a submit control in shadow DOM',
+          'The selector resolves to a submit button/control that the page probe cannot inspect directly.'
+        ),
+        validationSubmitEvidence: nativeSubmit ? 'strong' : 'heuristic',
+      };
     } catch {
       return null;
     }

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2442,11 +2442,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const formValidationAllFrames = fnName === 'iframe_click'
         || fnName === 'press_keys'
         || (Array.isArray(formValidationCoordinateFrames) && formValidationCoordinateFrames.length > 0);
-      let detectedSubmitAction = formValidationAllFrames
-        && Array.isArray(formValidationCoordinateFrames)
-        && formValidationCoordinateFrames.length > 0
+      const preflightSubmitDetection = formValidationCandidate
+        && (
+          fnName === 'iframe_click'
+          || (Array.isArray(formValidationCoordinateFrames) && formValidationCoordinateFrames.length > 0)
+        );
+      let detectedSubmitAction = preflightSubmitDetection
         ? await this._detectLikelySubmitAction(tabId, fnName, fnArgs, {
-            coordinateFrames: formValidationCoordinateFrames,
+            ...(Array.isArray(formValidationCoordinateFrames)
+              ? { coordinateFrames: formValidationCoordinateFrames }
+              : {}),
           })
         : null;
       const validationBlock = formValidationCandidate ? this._formValidationBlocks.get(tabId) : null;
@@ -5581,6 +5586,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       (Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : [])
         .map(field => `${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
     ));
+    const beforeActiveInvalid = new Set(before
+      .filter(state => state?.activeInvalid === true)
+      .map(state => `${state?.frameId ?? ''}|${this._normalizeUrlPath(String(state?.url || ''))}`));
     const newAlerts = [];
     const newAriaInvalid = [];
     // Custom alert/live-region and aria-invalid failures must be newly exposed
@@ -5602,7 +5610,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
     // Native browser validation prevents navigation, so only compare it on the
     // original route. Redirected pages require explicit alert/ARIA evidence.
-    const nativeFailureStates = sameRouteAfter.filter(state => state?.activeInvalid === true);
+    const nativeFailureStates = sameRouteAfter.filter((state) => {
+      if (state?.activeInvalid !== true) return false;
+      const key = `${state?.frameId ?? ''}|${this._normalizeUrlPath(String(state?.url || ''))}`;
+      return !beforeActiveInvalid.has(key);
+    });
     const nativeInvalidFields = looksLikeSubmit
       ? nativeFailureStates.flatMap(state => Array.isArray(state?.invalidFields) ? state.invalidFields : [])
       : [];

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2446,7 +2446,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         || (fnName === 'click' && !!fnArgs?.selector)
         || (Array.isArray(formValidationCoordinateFrames) && formValidationCoordinateFrames.length > 0);
       const preflightSubmitDetection = formValidationCandidate
-        && ['click', 'click_ax', 'iframe_click'].includes(fnName);
+        && ['click', 'click_ax', 'iframe_click', 'press_keys'].includes(fnName);
       let detectedSubmitAction = preflightSubmitDetection
         ? await this._detectLikelySubmitAction(tabId, fnName, fnArgs, {
             ...(Array.isArray(formValidationCoordinateFrames)
@@ -5519,7 +5519,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (name === 'execute_js') return this._executeJsLooksLikeFormSubmit(args?.code);
     if (name === 'press_keys') {
       const keys = JSON.stringify(args?.key ?? args?.keys ?? '').toLowerCase();
-      return /\b(?:enter|return)\b/.test(keys);
+      return /\b(?:enter|return)\b/.test(keys) && detectedSubmit?.isSubmit === true;
     }
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
 

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5561,11 +5561,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const beforeRoutes = new Set(before
       .map(state => this._normalizeUrlPath(String(state?.url || '')))
       .filter(Boolean));
-    const comparableAfter = after.filter((state) => {
+    const sameRouteAfter = after.filter((state) => {
       const route = this._normalizeUrlPath(String(state?.url || ''));
       return beforeRoutes.size === 0 || !route || beforeRoutes.has(route);
     });
-    if (!comparableAfter.length) return null;
 
     const looksLikeSubmit = this._formValidationActionLooksSubmit(
       context.toolName,
@@ -5577,31 +5576,33 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       && context.priorValidationFailure === true;
     const beforeAlerts = new Set(before.flatMap(state =>
       this._formValidationAlertTexts(state)
-        .map(text => `${this._normalizeUrlPath(String(state?.url || ''))}|${text}`)
     ));
     const beforeAriaInvalid = new Set(before.flatMap(state =>
       (Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : [])
-        .map(field => `${this._normalizeUrlPath(String(state?.url || ''))}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
+        .map(field => `${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
     ));
     const newAlerts = [];
     const newAriaInvalid = [];
     // Custom alert/live-region and aria-invalid failures must be newly exposed
-    // by the action. With no baseline we still detect native validation via
-    // activeInvalid, but do not mislabel an unrelated pre-existing alert.
-    for (const state of before.length ? comparableAfter : []) {
-      const route = this._normalizeUrlPath(String(state?.url || ''));
+    // by the action. Include redirected routes because servers commonly render
+    // validation feedback at a new path. With no baseline we still detect
+    // native validation via activeInvalid, but do not mislabel an unrelated
+    // pre-existing alert.
+    for (const state of before.length ? after : []) {
       for (const text of this._formValidationAlertTexts(state)) {
-        if (text && (includePersistentValidation || !beforeAlerts.has(`${route}|${text}`))) {
+        if (text && (includePersistentValidation || !beforeAlerts.has(text))) {
           newAlerts.push(text);
         }
       }
       for (const field of Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : []) {
-        const key = `${route}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
+        const key = `${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
         if (includePersistentValidation || !beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
       }
     }
 
-    const nativeFailureStates = comparableAfter.filter(state => state?.activeInvalid === true);
+    // Native browser validation prevents navigation, so only compare it on the
+    // original route. Redirected pages require explicit alert/ARIA evidence.
+    const nativeFailureStates = sameRouteAfter.filter(state => state?.activeInvalid === true);
     const nativeInvalidFields = looksLikeSubmit
       ? nativeFailureStates.flatMap(state => Array.isArray(state?.invalidFields) ? state.invalidFields : [])
       : [];
@@ -5655,6 +5656,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const beforeRoutes = new Set(before
       .map(state => this._normalizeUrlPath(String(state?.url || '')))
       .filter(Boolean));
+    let changedRouteObservedAt = null;
     const startedAt = Date.now();
     for (const checkpoint of checkpointsMs) {
       const targetDelay = Math.max(0, Number(checkpoint) || 0);
@@ -5671,7 +5673,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         && afterRoutes.size > 0
         && ![...afterRoutes].some(route => beforeRoutes.has(route))
       ) {
-        break;
+        if (changedRouteObservedAt == null) {
+          changedRouteObservedAt = Date.now();
+        } else if (Date.now() - changedRouteObservedAt >= 350) {
+          break;
+        }
+      } else {
+        changedRouteObservedAt = null;
       }
     }
     return null;

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -295,6 +295,7 @@ export class Agent {
     this._isPdfTabCache = new Map(); // tabId -> { url, isPdf }
     this._doneBlockCount = new Map(); // tabId -> consecutive done-blocks
     this._recentSubmitClicks = new Map(); // tabId -> recent submit click timestamps
+    this._formValidationBlocks = new Map(); // tabId -> validation state that must change before another submit
     this._runningTabs = new Set(); // tabIds with an active processMessage/Stream in flight
     this.completionInvariants = new Map(); // tabId -> run-scoped post-action verification state
     this._completionRunCounter = 0;
@@ -2424,10 +2425,40 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         onUpdate('warning', { message: 'API mutation blocked until /allow-api is enabled.' });
         continue;
       }
+      const formValidationCandidate = this._isFormValidationCandidate(fnName, fnArgs);
+      const formValidationAllFrames = fnName === 'iframe_click' || fnName === 'press_keys';
+      let detectedSubmitAction = null;
+      const validationBlock = formValidationCandidate ? this._formValidationBlocks.get(tabId) : null;
+      const obviousSubmitAction = formValidationCandidate
+        && this._formValidationActionLooksSubmit(fnName, fnArgs);
+      let formValidationBefore = (validationBlock || obviousSubmitAction)
+        ? await this._captureFormValidationState(tabId, { allFrames: formValidationAllFrames })
+        : [];
+      if (validationBlock) {
+        const currentValidationStateKey = this._formValidationStateKey(formValidationBefore);
+        if (currentValidationStateKey !== validationBlock.stateKey) {
+          this._formValidationBlocks.delete(tabId);
+        } else {
+          const retryActionKey = this._formValidationActionKey(fnName, fnArgs);
+          if (retryActionKey && retryActionKey === validationBlock.actionKey) {
+            const blockedResult = this._formValidationRetryBlockResult(validationBlock);
+            onUpdate('tool_call', { name: fnName, args: fnArgs });
+            onUpdate('tool_result', { name: fnName, result: blockedResult });
+            messages.push({
+              role: 'tool',
+              tool_call_id: tc.id,
+              content: this._wrapUntrusted(fnName, this._limitToolResult(blockedResult)),
+            });
+            onUpdate('warning', { message: 'Repeat submission blocked until the invalid form changes.' });
+            continue;
+          }
+        }
+      }
       const scheduledPolicy = this.scheduledRunPolicies.get(tabId);
       const scheduledBypassesGate = scheduledPolicy?.requireConsequentialConfirmation === false;
       if (!this._skipPermissionGate && !scheduledBypassesGate) {
-        const submitConfirmation = await this._detectLikelySubmitAction(tabId, fnName, fnArgs);
+        const submitConfirmation = detectedSubmitAction || await this._detectLikelySubmitAction(tabId, fnName, fnArgs);
+        detectedSubmitAction = submitConfirmation;
         if (submitConfirmation?.isSubmit) {
           const choice = await this._promptSubmitConfirmation(tabId, submitConfirmation, onUpdate);
           if (choice === null) {
@@ -2464,6 +2495,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             capabilities = capabilities.filter(capability => capability !== Capability.CLICK);
           }
         }
+      }
+      if (
+        formValidationCandidate
+        && formValidationBefore.length === 0
+        && (
+          detectedSubmitAction?.isSubmit
+          || this._skipPermissionGate
+          || scheduledBypassesGate
+        )
+      ) {
+        formValidationBefore = await this._captureFormValidationState(tabId, {
+          allFrames: formValidationAllFrames,
+        });
       }
       if (capabilities.length && !this._skipPermissionGate && !scheduledBypassesGate) {
         await this.permissions.hydrate();
@@ -2589,6 +2633,36 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         completionBatchStartState,
       });
       const toolResult = this._normalizeToolResult(fnName, rawToolResult, missingResponseOutcomeUnknown);
+      const inspectFormValidationAfter = formValidationCandidate
+        && this._formValidationActionLooksSubmit(
+          fnName,
+          fnArgs,
+          toolResult,
+          detectedSubmitAction,
+        );
+      if (
+        inspectFormValidationAfter
+        && toolResult
+        && typeof toolResult === 'object'
+        && !toolResult.done
+        && toolResult.dispatched !== false
+      ) {
+        const formValidationFailure = await this._waitForFormValidationFailure(
+          tabId,
+          formValidationBefore,
+          {
+            toolName: fnName,
+            args: fnArgs,
+            result: toolResult,
+            detectedSubmit: detectedSubmitAction,
+          },
+          { allFrames: formValidationAllFrames },
+        );
+        if (formValidationFailure) {
+          this._applyFormValidationFailure(tabId, toolResult, formValidationFailure);
+          onUpdate('warning', { message: 'Form validation failed; the page error was returned to the agent.' });
+        }
+      }
       if (fnName !== 'done') {
         this._markPlanExecutionToolCall(tabId, fnName, toolResult, {
           consequential: executionMutationEvidence,
@@ -5362,6 +5436,417 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return 'deny'; // 'deny', or anything unexpected → fail safe
   }
 
+  _isFormValidationCandidate(toolName, args = {}) {
+    const name = String(toolName || '');
+    if (name === 'click' || name === 'click_ax' || name === 'iframe_click') return true;
+    if (name === 'set_field') return args?.submit === true;
+    if (name === 'press_keys') {
+      const keys = JSON.stringify(args?.key ?? args?.keys ?? '').toLowerCase();
+      return /\b(?:enter|return)\b/.test(keys);
+    }
+    return false;
+  }
+
+  _formValidationActionKey(toolName, args = {}) {
+    const name = String(toolName || '');
+    const fields = name === 'set_field'
+      ? ['selector', 'ref_id', 'index', 'name', 'submit']
+      : name === 'press_keys'
+        ? ['selector', 'ref_id', 'index', 'key', 'keys']
+        : ['selector', 'ref_id', 'index', 'text', 'x', 'y', 'urlFilter'];
+    const identity = {};
+    for (const field of fields) {
+      const value = args?.[field];
+      if (value == null || value === '') continue;
+      identity[field] = typeof value === 'string' ? value.slice(0, 500) : value;
+    }
+    return Object.keys(identity).length ? `${name}:${JSON.stringify(identity)}` : '';
+  }
+
+  _formValidationActionLooksSubmit(toolName, args = {}, result = null, detectedSubmit = null) {
+    if (detectedSubmit?.isSubmit) return true;
+    const name = String(toolName || '');
+    if (name === 'set_field') return args?.submit === true;
+    if (name === 'press_keys') {
+      const keys = JSON.stringify(args?.key ?? args?.keys ?? '').toLowerCase();
+      return /\b(?:enter|return)\b/.test(keys);
+    }
+    if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
+
+    if (result?.isSubmitControl === true) return true;
+    const tag = String(result?.tag || '').toUpperCase();
+    const type = String(result?.type || '').toLowerCase();
+    if (tag === 'BUTTON' && result?.isSubmitControl !== false) return true;
+    if (tag === 'INPUT' && (type === 'submit' || type === 'image')) return true;
+
+    const label = String(args?.text || result?.name || result?.matched || result?.text || '').trim();
+    if (/^(?:continue|next|create|save|submit|add|post|publish|send|confirm|sign up|sign in|log in|register|place order|pay|checkout|update|apply|finish|done)\b/i.test(label)) {
+      return true;
+    }
+    const selector = String(args?.selector || '').toLowerCase();
+    return /(?:type\s*=\s*["']?(?:submit|image)|\bsubmit\b|\bcontinue\b|\bconfirm\b|\bcheckout\b|\bfinish\b)/.test(selector);
+  }
+
+  _formValidationAlertTexts(state = {}) {
+    const errorPattern = /\b(?:error|invalid|required|failed|failure|missing|must|cannot|can't|could not|unable|unsuccessful|rejected|not (?:valid|allowed|accepted|selected|saved)|please (?:correct|fix|select|choose|enter|provide)|select at least|choose at least|enter a valid)\b/i;
+    const successPattern = /\b(?:success|successfully|saved|submitted|sent|created|updated|published|completed)\b|^done\b|^thank(?:s| you)\b/i;
+    return (Array.isArray(state?.alerts) ? state.alerts : [])
+      .map(alert => String(alert?.text ?? alert ?? '').replace(/\s+/g, ' ').trim().slice(0, 500))
+      .filter((text) => {
+        if (!text) return false;
+        if (errorPattern.test(text)) return true;
+        if (successPattern.test(text)) return false;
+        return state?.alertsAreValidationOnly === true;
+      });
+  }
+
+  _formValidationStateKey(states = []) {
+    return JSON.stringify((Array.isArray(states) ? states : [])
+      .map((state) => ({
+        frameId: state?.frameId ?? null,
+        url: String(state?.url || ''),
+        invalid: (Array.isArray(state?.invalidFields) ? state.invalidFields : [])
+          .map(field => [field?.label || '', field?.type || '', field?.message || '']),
+        ariaInvalid: (Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : [])
+          .map(field => [field?.label || '', field?.type || '', field?.message || '']),
+        alerts: this._formValidationAlertTexts(state),
+        controls: String(state?.controlFingerprint || ''),
+      }))
+      .sort((a, b) => `${a.frameId}|${a.url}`.localeCompare(`${b.frameId}|${b.url}`)));
+  }
+
+  _detectFormValidationFailure(beforeStates = [], afterStates = [], context = {}) {
+    const before = Array.isArray(beforeStates) ? beforeStates : [];
+    const after = Array.isArray(afterStates) ? afterStates : [];
+    if (!after.length) return null;
+
+    const beforeUrls = new Set(before.map(state => String(state?.url || '')).filter(Boolean));
+    const comparableAfter = after.filter((state) => {
+      const url = String(state?.url || '');
+      return beforeUrls.size === 0 || !url || beforeUrls.has(url);
+    });
+    if (!comparableAfter.length) return null;
+
+    const beforeAlerts = new Set(before.flatMap(state =>
+      this._formValidationAlertTexts(state).map(text => `${state?.url || ''}|${text}`)
+    ));
+    const beforeAriaInvalid = new Set(before.flatMap(state =>
+      (Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : [])
+        .map(field => `${state?.url || ''}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
+    ));
+    const newAlerts = [];
+    const newAriaInvalid = [];
+    // Custom alert/live-region and aria-invalid failures must be newly exposed
+    // by the action. With no baseline we still detect native validation via
+    // activeInvalid, but do not mislabel an unrelated pre-existing alert.
+    for (const state of before.length ? comparableAfter : []) {
+      for (const text of this._formValidationAlertTexts(state)) {
+        if (text && !beforeAlerts.has(`${state?.url || ''}|${text}`)) newAlerts.push(text);
+      }
+      for (const field of Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : []) {
+        const key = `${state?.url || ''}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
+        if (!beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
+      }
+    }
+
+    const nativeFailureStates = comparableAfter.filter(state => state?.activeInvalid === true);
+    const looksLikeSubmit = this._formValidationActionLooksSubmit(
+      context.toolName,
+      context.args,
+      context.result,
+      context.detectedSubmit,
+    );
+    const nativeInvalidFields = looksLikeSubmit
+      ? nativeFailureStates.flatMap(state => Array.isArray(state?.invalidFields) ? state.invalidFields : [])
+      : [];
+    if (!nativeInvalidFields.length && !newAlerts.length && !newAriaInvalid.length) return null;
+
+    const invalidFields = [];
+    const fieldKeys = new Set();
+    for (const field of [...nativeInvalidFields, ...newAriaInvalid]) {
+      const normalized = {
+        label: String(field?.label || 'field').slice(0, 120),
+        type: String(field?.type || '').slice(0, 40),
+        message: String(field?.message || 'Invalid value.').slice(0, 300),
+      };
+      const key = `${normalized.label}|${normalized.type}|${normalized.message}`;
+      if (!fieldKeys.has(key)) {
+        fieldKeys.add(key);
+        invalidFields.push(normalized);
+      }
+    }
+
+    const validationMessages = [];
+    const messageSet = new Set();
+    for (const message of [
+      ...invalidFields.map(field => `${field.label}: ${field.message}`),
+      ...newAlerts,
+    ]) {
+      const compact = String(message || '').replace(/\s+/g, ' ').trim().slice(0, 500);
+      if (compact && !messageSet.has(compact)) {
+        messageSet.add(compact);
+        validationMessages.push(compact);
+      }
+    }
+    if (!validationMessages.length) validationMessages.push('The page reported that the form contains invalid fields.');
+
+    return {
+      invalidFields: invalidFields.slice(0, 12),
+      validationMessages: validationMessages.slice(0, 12),
+      stateKey: this._formValidationStateKey(after),
+      actionKey: this._formValidationActionKey(context.toolName, context.args),
+      error: `Form submission was rejected by page validation: ${validationMessages.join(' | ')} Fix the reported field(s), verify their state, and only then submit again.`,
+    };
+  }
+
+  async _waitForFormValidationFailure(
+    tabId,
+    beforeStates,
+    context,
+    { allFrames = false, checkpointsMs = [0, 120, 350, 800, 1200] } = {},
+  ) {
+    const before = Array.isArray(beforeStates) ? beforeStates : [];
+    const beforeUrls = new Set(before.map(state => String(state?.url || '')).filter(Boolean));
+    const startedAt = Date.now();
+    for (const checkpoint of checkpointsMs) {
+      const targetDelay = Math.max(0, Number(checkpoint) || 0);
+      const remaining = targetDelay - (Date.now() - startedAt);
+      if (remaining > 0) await new Promise(resolve => setTimeout(resolve, remaining));
+      const after = await this._captureFormValidationState(tabId, { allFrames });
+      const failure = this._detectFormValidationFailure(before, after, context);
+      if (failure) return failure;
+      const afterUrls = new Set(after.map(state => String(state?.url || '')).filter(Boolean));
+      if (
+        beforeUrls.size > 0
+        && afterUrls.size > 0
+        && ![...afterUrls].some(url => beforeUrls.has(url))
+      ) {
+        break;
+      }
+    }
+    return null;
+  }
+
+  _applyFormValidationFailure(tabId, toolResult, failure) {
+    if (!toolResult || typeof toolResult !== 'object' || !failure) return toolResult;
+    toolResult.success = false;
+    toolResult.noProgress = true;
+    toolResult.formValidationFailed = true;
+    toolResult.dispatched = toolResult.dispatched !== false;
+    toolResult.verified = false;
+    toolResult.invalidFields = failure.invalidFields;
+    toolResult.validationMessages = failure.validationMessages;
+    toolResult.error = failure.error;
+    delete toolResult.warning;
+    this._formValidationBlocks.set(tabId, {
+      stateKey: failure.stateKey,
+      actionKey: failure.actionKey,
+      invalidFields: failure.invalidFields,
+      validationMessages: failure.validationMessages,
+    });
+    return toolResult;
+  }
+
+  _formValidationRetryBlockResult(block) {
+    const messages = Array.isArray(block?.validationMessages) && block.validationMessages.length
+      ? block.validationMessages
+      : ['The form still contains the same invalid fields.'];
+    return {
+      success: false,
+      dispatched: false,
+      noProgress: true,
+      formValidationFailed: true,
+      blockedValidationRetry: true,
+      invalidFields: Array.isArray(block?.invalidFields) ? block.invalidFields : [],
+      validationMessages: messages,
+      error: `Blocked repeat submission because the form validation state has not changed: ${messages.join(' | ')} Fix the reported field(s) before trying to submit again.`,
+    };
+  }
+
+  async _captureFormValidationState(tabId, { allFrames = false } = {}) {
+    try {
+      let rawResults = [];
+      if (globalThis.chrome?.scripting?.executeScript) {
+        rawResults = await chrome.scripting.executeScript({
+          target: { tabId, ...(allFrames ? { allFrames: true } : {}) },
+          func: Agent._formValidationStateProbe,
+        });
+        return (Array.isArray(rawResults) ? rawResults : [])
+          .map(item => ({ frameId: item?.frameId ?? null, ...(item?.result || {}) }))
+          .filter(state => state && (state.url || state.invalidFields?.length || state.alerts?.length));
+      }
+      if (globalThis.browser?.tabs?.executeScript) {
+        let probeSource = Agent._formValidationStateProbe.toString();
+        if (!/^\s*(?:async\s+)?function\b/.test(probeSource)) probeSource = `function ${probeSource}`;
+        const code = `(() => { const __wbFormValidationProbe = (${probeSource}); return __wbFormValidationProbe(); })()`;
+        rawResults = await browser.tabs.executeScript(tabId, { code, allFrames });
+        return (Array.isArray(rawResults) ? rawResults : [])
+          .map((result, frameId) => ({ frameId, ...(result || {}) }))
+          .filter(state => state && (state.url || state.invalidFields?.length || state.alerts?.length));
+      }
+    } catch {
+      // Validation inspection is best-effort; the original tool result remains
+      // authoritative when the page or frame cannot be inspected.
+    }
+    return [];
+  }
+
+  /**
+   * Page-side form validation snapshot. Keep self-contained: Firefox
+   * serializes this function into tabs and neither browser may close over Agent.
+   */
+  static _formValidationStateProbe = function _formValidationStateProbe() {
+    const compact = (value, max = 300) => String(value ?? '').replace(/\s+/g, ' ').trim().slice(0, max);
+    const roots = [document];
+    try {
+      const walker = document.createTreeWalker(document, NodeFilter.SHOW_ELEMENT);
+      let node = walker.currentNode;
+      while (node) {
+        if (node.shadowRoot) roots.push(node.shadowRoot);
+        node = walker.nextNode();
+      }
+    } catch {}
+    const queryAll = (selector) => {
+      const found = [];
+      for (const root of roots) {
+        try { found.push(...root.querySelectorAll(selector)); } catch {}
+      }
+      return [...new Set(found)];
+    };
+    const visible = (el) => {
+      try {
+        const rect = el.getBoundingClientRect();
+        const style = getComputedStyle(el);
+        return rect.width > 0 && rect.height > 0
+          && style.display !== 'none'
+          && style.visibility !== 'hidden'
+          && Number(style.opacity || 1) > 0;
+      } catch {
+        return false;
+      }
+    };
+    const labelFor = (el) => {
+      const parts = [];
+      try {
+        if (el.id) {
+          const escaped = globalThis.CSS?.escape ? CSS.escape(el.id) : String(el.id).replace(/["\\]/g, '\\$&');
+          const label = document.querySelector(`label[for="${escaped}"]`);
+          if (label) parts.push(label.innerText || label.textContent || '');
+        }
+      } catch {}
+      try {
+        const wrappingLabel = el.closest?.('label');
+        if (wrappingLabel) parts.push(wrappingLabel.innerText || wrappingLabel.textContent || '');
+      } catch {}
+      parts.push(
+        el.getAttribute?.('aria-label') || '',
+        el.getAttribute?.('placeholder') || '',
+        el.getAttribute?.('name') || '',
+        el.getAttribute?.('id') || '',
+        el.tagName || 'field',
+      );
+      return compact(parts.find(Boolean) || 'field', 120);
+    };
+    const describedMessage = (el) => {
+      const ids = compact(el.getAttribute?.('aria-describedby') || '', 240).split(/\s+/).filter(Boolean);
+      const text = ids.map((id) => {
+        try { return document.getElementById(id)?.innerText || document.getElementById(id)?.textContent || ''; } catch { return ''; }
+      }).filter(Boolean).join(' ');
+      return compact(text || el.validationMessage || '', 300);
+    };
+    const detailFor = (el, fallback = 'Invalid value.') => ({
+      label: labelFor(el),
+      type: compact(el.getAttribute?.('type') || el.tagName || '', 40),
+      message: describedMessage(el) || fallback,
+      visible: visible(el),
+    });
+    const invalidControls = queryAll('input:invalid, textarea:invalid, select:invalid');
+    const ariaInvalidControls = queryAll('input[aria-invalid="true"], textarea[aria-invalid="true"], select[aria-invalid="true"], [contenteditable="true"][aria-invalid="true"]');
+    let active = document.activeElement;
+    try {
+      while (active?.shadowRoot?.activeElement) active = active.shadowRoot.activeElement;
+    } catch {}
+    const activeInvalid = !!active && invalidControls.includes(active);
+    const allInvalidControls = [...new Set([...invalidControls, ...ariaInvalidControls])];
+    const errorMessageIds = new Set();
+    for (const control of allInvalidControls) {
+      for (const attr of ['aria-errormessage', 'aria-describedby']) {
+        for (const id of compact(control.getAttribute?.(attr) || '', 500).split(/\s+/).filter(Boolean)) {
+          errorMessageIds.add(id);
+        }
+      }
+    }
+    const errorPattern = /\b(?:error|invalid|required|failed|failure|missing|must|cannot|can't|could not|unable|unsuccessful|rejected|not (?:valid|allowed|accepted|selected|saved)|please (?:correct|fix|select|choose|enter|provide)|select at least|choose at least|enter a valid)\b/i;
+    const successPattern = /\b(?:success|successfully|saved|submitted|sent|created|updated|published|completed)\b|^done\b|^thank(?:s| you)\b/i;
+    const alerts = queryAll('[role="alert"], [role="alertdialog"], [aria-live="assertive"], [aria-live="polite"]')
+      .filter(visible)
+      .map((el) => {
+        const text = compact(el.innerText || el.textContent || '', 500);
+        const tokens = compact([
+          el.id,
+          el.className,
+          el.getAttribute?.('data-state'),
+          el.getAttribute?.('data-status'),
+          el.getAttribute?.('aria-label'),
+        ].filter(Boolean).join(' '), 500);
+        const form = el.closest?.('form') || null;
+        const formHasInvalidControl = !!form && allInvalidControls.some(control =>
+          control.form === form || control.closest?.('form') === form
+        );
+        const explicitlyErrorLinked = !!el.id && errorMessageIds.has(el.id);
+        const validationLikely = explicitlyErrorLinked
+          || /\b(?:error|invalid|validation|danger|warning|failed|failure)\b/i.test(tokens)
+          || errorPattern.test(text)
+          || formHasInvalidControl;
+        const successLikely = successPattern.test(text) && !errorPattern.test(text);
+        return validationLikely && !successLikely ? text : '';
+      })
+      .filter(Boolean)
+      .slice(0, 12);
+
+    let hash = 2166136261;
+    const addHash = (text) => {
+      const value = String(text || '');
+      for (let i = 0; i < value.length; i++) {
+        hash ^= value.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+      }
+    };
+    for (const el of queryAll('input, textarea, select, [contenteditable="true"], button, [role="button"], [onclick], [data-action]')) {
+      const tag = String(el.tagName || '').toLowerCase();
+      const type = String(el.getAttribute?.('type') || el.tagName || '').toLowerCase();
+      let state = '';
+      if (type === 'checkbox' || type === 'radio') {
+        state = el.checked ? 'checked' : 'unchecked';
+      } else if (tag === 'select') {
+        state = Array.from(el.selectedOptions || []).map(option => option.value).join('\u001f');
+      } else if (type === 'file') {
+        state = String(el.files?.length || 0);
+      } else if (
+        tag === 'button'
+        || String(el.getAttribute?.('role') || '').toLowerCase() === 'button'
+        || el.hasAttribute?.('onclick')
+        || el.hasAttribute?.('data-action')
+      ) {
+        state = compact(el.innerText || el.textContent || el.getAttribute?.('aria-label') || '', 120);
+      } else {
+        const value = String(el.value ?? el.textContent ?? '');
+        state = type === 'password' ? `password-length:${value.length}` : value;
+      }
+      addHash(`${el.tagName}|${type}|${el.name || ''}|${el.id || ''}|${visible(el) ? 'visible' : 'hidden'}|${el.disabled ? 'disabled' : 'enabled'}|${state}\u001e`);
+    }
+
+    return {
+      url: (() => { try { return location.href || ''; } catch { return ''; } })(),
+      activeInvalid,
+      invalidFields: invalidControls.map(el => detailFor(el)).slice(0, 20),
+      ariaInvalidFields: ariaInvalidControls.map(el => detailFor(el, 'This field is marked invalid.')).slice(0, 20),
+      alerts: [...new Set(alerts)],
+      alertsAreValidationOnly: true,
+      controlFingerprint: (hash >>> 0).toString(16),
+    };
+  };
+
   _fallbackSubmitConfirmationInfo(host, tool, reason, summary = '') {
     const normalizedHost = normalizeHost(host || '') || String(host || '').trim() || 'this site';
     return {
@@ -6397,6 +6882,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this._lastInteractionRect.delete(tabId);
     this._doneBlockCount.delete(tabId);
     this._recentSubmitClicks.delete(tabId);
+    this._formValidationBlocks.delete(tabId);
     this._lastAxScopes.delete(tabId);
     this.completionInvariants.delete(tabId);
     if (!preserveRunGuard) {
@@ -11689,6 +12175,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 if (tag === 'BUTTON') return type === 'submit' || (!type && !!(control.form || control.closest?.('form')));
                 return false;
               };
+              const isEditableControl = (el) => {
+                if (!el || !el.tagName) return false;
+                if (el.isContentEditable || el.tagName === 'TEXTAREA') return true;
+                if (el.tagName !== 'INPUT') return false;
+                const type = (el.getAttribute('type') || 'text').trim().toLowerCase();
+                return !['button', 'checkbox', 'color', 'file', 'hidden', 'image', 'radio', 'range', 'reset', 'submit'].includes(type);
+              };
               const normalized = all.map(el => ({
                 el,
                 txt: (el.innerText || (_valIsLabel(el) ? el.value : '') || el.placeholder || el.ariaLabel || '').trim().toLowerCase(),
@@ -11747,9 +12240,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                     return {
                       found: true, mode: 'label', x: r.left + r.width / 2,
                       y: r.top + r.height / 2, tag: inp.tagName,
+                      type: (inp.getAttribute('type') || '').toLowerCase(),
                       width: r.width, height: r.height,
                       text: ltxt.slice(0, 80), focusedInput: true,
                       isSubmitControl: isSubmitControl(inp),
+                      isEditableControl: isEditableControl(inp),
                     };
                   }
                 }
@@ -11875,8 +12370,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 width: r.width,
                 height: r.height,
                 tag: el.tagName,
+                type: (el.getAttribute('type') || '').toLowerCase(),
                 text: (el.innerText || el.value || '').slice(0, 80),
                 isSubmitControl: isSubmitControl(el),
+                isEditableControl: isEditableControl(el),
               };
             })()
           `);
@@ -11920,6 +12417,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                     if (tag === 'BUTTON') return type === 'submit' || (!type && !!(control.form || control.closest?.('form')));
                     return false;
                   };
+                  const isEditableControl = (el) => {
+                    if (!el || !el.tagName) return false;
+                    if (el.isContentEditable || el.tagName === 'TEXTAREA') return true;
+                    if (el.tagName !== 'INPUT') return false;
+                    const type = (el.getAttribute('type') || 'text').trim().toLowerCase();
+                    return !['button', 'checkbox', 'color', 'file', 'hidden', 'image', 'radio', 'range', 'reset', 'submit'].includes(type);
+                  };
                   const normalized = all.map(el => ({ el, txt: (el.innerText || (_valIsLabel(el) ? el.value : '') || el.placeholder || el.ariaLabel || '').trim().toLowerCase() })).filter(x => !!x.txt);
 
                   // Label→input map
@@ -11958,7 +12462,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                             if (pr.width > 0 && pr.height > 0) { r = pr; break; }
                           }
                         }
-                        return { found: true, mode: 'label', x: r.left + r.width / 2, y: r.top + r.height / 2, width: r.width, height: r.height, tag: inp.tagName, text: ltxt.slice(0, 80), focusedInput: true, isSubmitControl: isSubmitControl(inp) };
+                        return { found: true, mode: 'label', x: r.left + r.width / 2, y: r.top + r.height / 2, width: r.width, height: r.height, tag: inp.tagName, type: (inp.getAttribute('type') || '').toLowerCase(), text: ltxt.slice(0, 80), focusedInput: true, isSubmitControl: isSubmitControl(inp), isEditableControl: isEditableControl(inp) };
                       }
                     }
                     return { found: false };
@@ -12023,7 +12527,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                       if (pr.width > 0 && pr.height > 0) { r = pr; break; }
                     }
                   }
-                  return { found: true, mode: usedMode, x: r.left+r.width/2, y: r.top+r.height/2, width: r.width, height: r.height, tag: el.tagName, text: (el.innerText||el.value||'').slice(0,80), isSubmitControl: isSubmitControl(el) };
+                  return { found: true, mode: usedMode, x: r.left+r.width/2, y: r.top+r.height/2, width: r.width, height: r.height, tag: el.tagName, type: (el.getAttribute('type') || '').toLowerCase(), text: (el.innerText||el.value||'').slice(0,80), isSubmitControl: isSubmitControl(el), isEditableControl: isEditableControl(el) };
                 })()
               `);
               const retryInfo = retry?.result?.value;
@@ -12358,19 +12862,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             };
           }
 
-          // Stale click detection — skip for editable targets, where re-clicking
-          // is legitimate (positions cursor / re-focuses field) and "no page change"
-          // is the expected outcome, not a failure signal.
-          const postEditable = await cdpClient.evaluate(tabId, `
-            (() => {
-              const ae = document.activeElement;
-              if (!ae) return false;
-              if (ae.isContentEditable) return true;
-              const tag = ae.tagName;
-              return tag === 'INPUT' || tag === 'TEXTAREA';
-            })()
-          `);
-          const isEditableTarget = postEditable?.result?.value === true;
+          // Stale-click detection is exempt only when the clicked target itself
+          // is text-editable. Native form validation focuses the first invalid
+          // checkbox/input after a failed submit; using document.activeElement
+          // here mislabeled the submit button as editable and hid no-progress.
+          const isEditableTarget = info.isEditableControl === true;
           const redirectedText = await newTabPromiseText;
           if (redirectedText?.redirected) {
             // The clicked link had target="_blank". We closed the spawned
@@ -12404,6 +12900,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             method: 'cdp-by-text',
             textMatch: info.mode || (args.textMatch || 'exact'),
             tag: info.tag,
+            type: info.type || '',
+            isSubmitControl: info.isSubmitControl === true,
             text: info.text,
             matched: args.text,
             x: clickX,

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5525,7 +5525,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const type = String(target?.type || '').toLowerCase();
     const strongDetectedSubmit = detectedSubmit?.validationSubmitEvidence === 'strong';
     if (target?.isSubmitControl === false && type === 'button' && !strongDetectedSubmit) return false;
-    if (detectedSubmit?.isSubmit === true) return true;
+    if (detectedSubmit?.isSubmit === true && strongDetectedSubmit) return true;
     if (target?.isSubmitControl === true) return true;
     if (tag === 'BUTTON' && type === 'submit') return true;
     if (tag === 'INPUT' && (type === 'submit' || type === 'image')) return true;
@@ -5543,6 +5543,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
+    if (detectedSubmit?.isSubmit === true) return false;
 
     const label = String(args?.text || result?.name || result?.matched || result?.text || '').trim();
     if (/^(?:continue|next|create|save|submit|add|post|publish|send|confirm|sign up|sign in|log in|register|place order|pay|checkout|update|apply|finish|done)\b/i.test(label)) {

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5450,7 +5450,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   _formValidationActionKey(toolName, args = {}) {
     const name = String(toolName || '');
     const fields = name === 'set_field'
-      ? ['selector', 'ref_id', 'index', 'name', 'submit']
+      ? ['selector', 'ref_id', 'index', 'name', 'text', 'submit']
       : name === 'press_keys'
         ? ['selector', 'ref_id', 'index', 'key', 'keys']
         : ['selector', 'ref_id', 'index', 'text', 'x', 'y', 'urlFilter'];
@@ -5458,6 +5458,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     for (const field of fields) {
       const value = args?.[field];
       if (value == null || value === '') continue;
+      if (name === 'set_field' && field === 'text') {
+        const text = String(value);
+        let hash = 2166136261;
+        for (let i = 0; i < text.length; i++) {
+          hash ^= text.charCodeAt(i);
+          hash = Math.imul(hash, 16777619);
+        }
+        identity.textFingerprint = `${text.length}:${(hash >>> 0).toString(16)}`;
+        continue;
+      }
       identity[field] = typeof value === 'string' ? value.slice(0, 500) : value;
     }
     return Object.keys(identity).length ? `${name}:${JSON.stringify(identity)}` : '';

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -296,6 +296,12 @@ export class Agent {
     this._doneBlockCount = new Map(); // tabId -> consecutive done-blocks
     this._recentSubmitClicks = new Map(); // tabId -> recent submit click timestamps
     this._formValidationBlocks = new Map(); // tabId -> validation state that must change before another submit
+    const formValidationSaltBytes = new Uint32Array(4);
+    globalThis.crypto.getRandomValues(formValidationSaltBytes);
+    this._formValidationFingerprintSalt = Array.from(
+      formValidationSaltBytes,
+      value => value.toString(16).padStart(8, '0'),
+    ).join('');
     this._runningTabs = new Set(); // tabIds with an active processMessage/Stream in flight
     this.completionInvariants = new Map(); // tabId -> run-scoped post-action verification state
     this._completionRunCounter = 0;
@@ -2450,6 +2456,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           })
         : null;
       const validationBlock = formValidationCandidate ? this._formValidationBlocks.get(tabId) : null;
+      let priorValidationFailure = !!validationBlock;
       const obviousSubmitAction = formValidationCandidate
         && this._formValidationActionLooksSubmit(fnName, fnArgs, null, detectedSubmitAction);
       let formValidationBefore = (validationBlock || obviousSubmitAction)
@@ -2459,6 +2466,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         const currentValidationStateKey = this._formValidationStateKey(formValidationBefore);
         if (currentValidationStateKey !== validationBlock.stateKey) {
           this._formValidationBlocks.delete(tabId);
+          priorValidationFailure = false;
         } else {
           const retryActionKey = this._formValidationActionKey(fnName, fnArgs);
           if (retryActionKey && retryActionKey === validationBlock.actionKey) {
@@ -2676,7 +2684,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             args: fnArgs,
             result: toolResult,
             detectedSubmit: detectedSubmitAction,
-            priorValidationFailure: !!validationBlock,
+            priorValidationFailure,
           },
           { allFrames: formValidationAllFrames },
         );
@@ -5721,6 +5729,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         rawResults = await chrome.scripting.executeScript({
           target: { tabId, ...(allFrames ? { allFrames: true } : {}) },
           func: Agent._formValidationStateProbe,
+          args: [this._formValidationFingerprintSalt],
         });
         return (Array.isArray(rawResults) ? rawResults : [])
           .map(item => ({ frameId: item?.frameId ?? null, ...(item?.result || {}) }))
@@ -5729,7 +5738,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (globalThis.browser?.tabs?.executeScript) {
         let probeSource = Agent._formValidationStateProbe.toString();
         if (!/^\s*(?:async\s+)?function\b/.test(probeSource)) probeSource = `function ${probeSource}`;
-        const code = `(() => { const __wbFormValidationProbe = (${probeSource}); return __wbFormValidationProbe(); })()`;
+        const probeSalt = JSON.stringify(this._formValidationFingerprintSalt);
+        const code = `(() => { const __wbFormValidationProbe = (${probeSource}); return __wbFormValidationProbe(${probeSalt}); })()`;
         rawResults = await browser.tabs.executeScript(tabId, { code, allFrames });
         return (Array.isArray(rawResults) ? rawResults : [])
           .map((result, frameId) => ({ frameId, ...(result || {}) }))
@@ -5746,7 +5756,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * Page-side form validation snapshot. Keep self-contained: Firefox
    * serializes this function into tabs and neither browser may close over Agent.
    */
-  static _formValidationStateProbe = function _formValidationStateProbe() {
+  static _formValidationStateProbe = function _formValidationStateProbe(fingerprintSalt = '') {
     const compact = (value, max = 300) => String(value ?? '').replace(/\s+/g, ' ').trim().slice(0, max);
     const roots = [document];
     try {
@@ -5871,6 +5881,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         hash = Math.imul(hash, 16777619);
       }
     };
+    // Mix a per-agent secret into the page-side fingerprint. Password values
+    // can then affect retry detection without ever leaving the probe as text.
+    addHash(`salt:${fingerprintSalt}\u001e`);
     for (const el of queryAll('input, textarea, select, [contenteditable="true"], button, [role="button"], [onclick], [data-action]')) {
       const tag = String(el.tagName || '').toLowerCase();
       const type = String(el.getAttribute?.('type') || el.tagName || '').toLowerCase();
@@ -5890,7 +5903,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         state = compact(el.innerText || el.textContent || el.getAttribute?.('aria-label') || '', 120);
       } else {
         const value = String(el.value ?? el.textContent ?? '');
-        state = type === 'password' ? `password-length:${value.length}` : value;
+        state = type === 'password' ? `password-value:${value}` : value;
       }
       addHash(`${el.tagName}|${type}|${el.name || ''}|${el.id || ''}|${visible(el) ? 'visible' : 'hidden'}|${el.disabled ? 'disabled' : 'enabled'}|${state}\u001e`);
     }

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2456,6 +2456,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         : null;
       const validationBlock = formValidationCandidate ? this._formValidationBlocks.get(tabId) : null;
       let priorValidationFailure = !!validationBlock;
+      let correctedPriorValidationFailure = false;
       const obviousSubmitAction = formValidationCandidate
         && this._formValidationActionLooksSubmit(fnName, fnArgs, null, detectedSubmitAction);
       let formValidationBefore = (validationBlock || obviousSubmitAction)
@@ -2466,6 +2467,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (currentValidationStateKey !== validationBlock.stateKey) {
           this._formValidationBlocks.delete(tabId);
           priorValidationFailure = false;
+          correctedPriorValidationFailure = true;
         } else {
           const retryActionKey = this._formValidationActionKey(fnName, fnArgs);
           if (retryActionKey && retryActionKey === validationBlock.actionKey) {
@@ -2684,6 +2686,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             result: toolResult,
             detectedSubmit: detectedSubmitAction,
             priorValidationFailure,
+            correctedPriorValidationFailure,
           },
           { allFrames: formValidationAllFrames },
         );
@@ -5611,7 +5614,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     );
     if (!looksLikeSubmit) return null;
     const includePersistentValidation = strongSubmitEvidence
-      && context.priorValidationFailure === true;
+      && (
+        context.priorValidationFailure === true
+        || context.includeCorrectedPersistentValidation === true
+      );
     const beforeAlerts = new Set(before.flatMap(state =>
       this._formValidationAlertTexts(state)
     ));
@@ -5703,12 +5709,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       .filter(Boolean));
     let changedRouteObservedAt = null;
     const startedAt = Date.now();
-    for (const checkpoint of checkpointsMs) {
+    for (let checkpointIndex = 0; checkpointIndex < checkpointsMs.length; checkpointIndex += 1) {
+      const checkpoint = checkpointsMs[checkpointIndex];
       const targetDelay = Math.max(0, Number(checkpoint) || 0);
       const remaining = targetDelay - (Date.now() - startedAt);
       if (remaining > 0) await new Promise(resolve => setTimeout(resolve, remaining));
       const after = await this._captureFormValidationState(tabId, { allFrames });
-      const failure = this._detectFormValidationFailure(before, after, context);
+      const failure = this._detectFormValidationFailure(before, after, {
+        ...context,
+        includeCorrectedPersistentValidation:
+          context?.correctedPriorValidationFailure === true
+          && checkpointIndex === checkpointsMs.length - 1,
+      });
       if (failure) return failure;
       const afterRoutes = new Set(after
         .map(state => this._normalizeUrlPath(String(state?.url || '')))

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -5545,7 +5545,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
       const type = String(target?.type || '').toLowerCase();
       const strongDetectedSubmit = detectedSubmit?.validationSubmitEvidence === 'strong';
-      if (target?.isSubmitControl === false && type === 'button' && !strongDetectedSubmit) return false;
+      const heuristicDetectedSubmit = detectedSubmit?.isSubmit === true && !strongDetectedSubmit;
+      if (
+        target?.isSubmitControl === false
+        && type === 'button'
+        && !strongDetectedSubmit
+        && !heuristicDetectedSubmit
+      ) return false;
     }
     if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -1587,6 +1587,13 @@ export class CDPClient {
         const found = queryDeep(document);
         if (!found) return { found: false };
         if (found.__error) return { found: false, error: found.__error };
+        const tag = String(found.tagName || '').toUpperCase();
+        const type = String(found.getAttribute?.('type') || '').trim().toLowerCase();
+        const isSubmitControl = tag === 'INPUT'
+          ? type === 'submit' || type === 'image'
+          : tag === 'BUTTON'
+            ? type === 'submit' || (!type && !!(found.form || found.closest?.('form')))
+            : false;
         if (found.tagName !== 'SELECT') { try { found.scrollIntoView({ block: 'center', inline: 'center' }); } catch (e) {} }
         const r = found.getBoundingClientRect();
         const cx = r.left + r.width / 2;
@@ -1608,7 +1615,9 @@ export class CDPClient {
           x: cx, y: cy,
           width: r.width, height: r.height,
           inViewport, hitOk,
-          tag: found.tagName,
+          tag,
+          type,
+          isSubmitControl,
           text: (found.innerText || found.value || '').slice(0, 80),
         };
       })()
@@ -1779,6 +1788,8 @@ export class CDPClient {
           success: true,
           method: info.viaCDP ? 'cdp-mouse-closed-shadow' : 'cdp-mouse',
           tag: info.tag,
+          type: info.type,
+          isSubmitControl: info.isSubmitControl === true,
           text: info.text,
           x: info.x,
           y: info.y,
@@ -1831,13 +1842,22 @@ export class CDPClient {
         };
         const el = queryDeep(document);
         if (!el) return { success: false, error: 'Element not found (fallback)' };
+        const tag = String(el.tagName || '').toUpperCase();
+        const type = String(el.getAttribute?.('type') || '').trim().toLowerCase();
+        const isSubmitControl = tag === 'INPUT'
+          ? type === 'submit' || type === 'image'
+          : tag === 'BUTTON'
+            ? type === 'submit' || (!type && !!(el.form || el.closest?.('form')))
+            : false;
         try { el.focus(); } catch (e) {}
         el.click();
         const r = el.getBoundingClientRect();
         return {
           success: true,
           method: 'js-click',
-          tag: el.tagName,
+          tag,
+          type,
+          isSubmitControl,
           text: (el.innerText || '').slice(0, 80),
           rect: { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) },
         };

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -1193,7 +1193,10 @@
     // Skip for editable targets — re-clicking a text field / contenteditable
     // is legitimate (positions cursor / re-focuses) and "no page change" is
     // the expected outcome there, not a failure signal.
-    const isEditableTarget = el.isContentEditable || el.tagName === 'INPUT' || el.tagName === 'TEXTAREA';
+    const inputType = String(el.getAttribute?.('type') || 'text').toLowerCase();
+    const isEditableTarget = el.isContentEditable
+      || el.tagName === 'TEXTAREA'
+      || (el.tagName === 'INPUT' && !['button', 'checkbox', 'color', 'file', 'hidden', 'image', 'radio', 'range', 'reset', 'submit'].includes(inputType));
     const ident = `${el.tagName}|${(el.innerText || '').slice(0, 50)}|${location.href}`;
     let warning;
     if (_lastClickIdent === ident && !isEditableTarget) {
@@ -1203,6 +1206,8 @@
     return {
       success: true,
       tag: el.tagName,
+      type: String(el.getAttribute?.('type') || '').toLowerCase(),
+      isSubmitControl: targetIsSubmitControl,
       text: el.innerText?.slice(0, 50),
       ...(clickedRect ? { rect: clickedRect } : {}),
       ...(warning ? { warning } : {}),

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4776,8 +4776,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   }
 
   _formValidationActionLooksSubmit(toolName, args = {}, result = null, detectedSubmit = null) {
-    if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
     const name = String(toolName || '');
+    if (['click', 'click_ax', 'iframe_click'].includes(name)) {
+      const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
+      const type = String(target?.type || '').toLowerCase();
+      if (target?.isSubmitControl === false && type === 'button') return false;
+    }
+    if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
 
     const label = String(args?.text || result?.name || result?.matched || result?.text || '').trim();
@@ -4841,6 +4846,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       context.result,
       context.detectedSubmit,
     );
+    if (!looksLikeSubmit) return null;
     const includePersistentValidation = strongSubmitEvidence
       && context.priorValidationFailure === true;
     const beforeAlerts = new Set(before.flatMap(state =>

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -5045,9 +5045,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       return compact(parts.find(Boolean) || 'field', 120);
     };
     const describedMessage = (el) => {
-      const ids = compact(el.getAttribute?.('aria-describedby') || '', 240).split(/\s+/).filter(Boolean);
+      const ids = [...new Set(['aria-errormessage', 'aria-describedby'].flatMap(attr =>
+        compact(el.getAttribute?.(attr) || '', 240).split(/\s+/).filter(Boolean)
+      ))];
       const text = ids.map((id) => {
-        try { return document.getElementById(id)?.innerText || document.getElementById(id)?.textContent || ''; } catch { return ''; }
+        for (const root of roots) {
+          try {
+            const message = root.getElementById?.(id);
+            if (message) return message.innerText || message.textContent || '';
+          } catch {}
+        }
+        return '';
       }).filter(Boolean).join(' ');
       return compact(text || el.validationMessage || '', 300);
     };

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2043,7 +2043,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const formValidationCandidate = this._isFormValidationCandidate(fnName, fnArgs);
       const formValidationAllFrames = fnName === 'iframe_click' || fnName === 'press_keys';
       const preflightSubmitDetection = formValidationCandidate
-        && ['click', 'click_ax', 'iframe_click', 'press_keys'].includes(fnName);
+        && ['click', 'click_ax', 'iframe_click', 'press_keys', 'execute_js'].includes(fnName);
       let detectedSubmitAction = preflightSubmitDetection
         ? await this._detectLikelySubmitAction(tabId, fnName, fnArgs)
         : null;
@@ -4788,6 +4788,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   _formValidationActionLooksSubmit(toolName, args = {}, result = null, detectedSubmit = null) {
     const name = String(toolName || '');
+    if (name === 'execute_js') {
+      return this._executeJsLooksLikeFormSubmit(args?.code) || detectedSubmit?.isSubmit === true;
+    }
     if (['click', 'click_ax', 'iframe_click'].includes(name)) {
       const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
       const type = String(target?.type || '').toLowerCase();
@@ -4874,12 +4877,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         context.priorValidationFailure === true
         || context.includeCorrectedPersistentValidation === true
       );
+    const validationStateScope = state =>
+      `${state?.frameId ?? ''}|${this._normalizeUrlPath(String(state?.url || ''))}`;
     const beforeAlerts = new Set(before.flatMap(state =>
       this._formValidationAlertTexts(state)
+        .map(text => `${validationStateScope(state)}|${text}`)
     ));
     const beforeAriaInvalid = new Set(before.flatMap(state =>
       (Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : [])
-        .map(field => `${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
+        .map(field => `${validationStateScope(state)}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
     ));
     const beforeActiveInvalid = new Set(before
       .filter(state => state?.activeInvalid === true)
@@ -4896,12 +4902,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const includePersistentForState = includePersistentValidation
         && (beforeRoutes.size === 0 || !route || beforeRoutes.has(route));
       for (const text of this._formValidationAlertTexts(state)) {
-        if (text && (includePersistentForState || !beforeAlerts.has(text))) {
+        const key = `${validationStateScope(state)}|${text}`;
+        if (text && (includePersistentForState || !beforeAlerts.has(key))) {
           newAlerts.push(text);
         }
       }
       for (const field of Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : []) {
-        const key = `${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
+        const key = `${validationStateScope(state)}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
         if (includePersistentForState || !beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
       }
     }

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4802,19 +4802,22 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const after = Array.isArray(afterStates) ? afterStates : [];
     if (!after.length) return null;
 
-    const beforeUrls = new Set(before.map(state => String(state?.url || '')).filter(Boolean));
+    const beforeRoutes = new Set(before
+      .map(state => this._normalizeUrlPath(String(state?.url || '')))
+      .filter(Boolean));
     const comparableAfter = after.filter((state) => {
-      const url = String(state?.url || '');
-      return beforeUrls.size === 0 || !url || beforeUrls.has(url);
+      const route = this._normalizeUrlPath(String(state?.url || ''));
+      return beforeRoutes.size === 0 || !route || beforeRoutes.has(route);
     });
     if (!comparableAfter.length) return null;
 
     const beforeAlerts = new Set(before.flatMap(state =>
-      this._formValidationAlertTexts(state).map(text => `${state?.url || ''}|${text}`)
+      this._formValidationAlertTexts(state)
+        .map(text => `${this._normalizeUrlPath(String(state?.url || ''))}|${text}`)
     ));
     const beforeAriaInvalid = new Set(before.flatMap(state =>
       (Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : [])
-        .map(field => `${state?.url || ''}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
+        .map(field => `${this._normalizeUrlPath(String(state?.url || ''))}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
     ));
     const newAlerts = [];
     const newAriaInvalid = [];
@@ -4822,11 +4825,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // by the action. With no baseline we still detect native validation via
     // activeInvalid, but do not mislabel an unrelated pre-existing alert.
     for (const state of before.length ? comparableAfter : []) {
+      const route = this._normalizeUrlPath(String(state?.url || ''));
       for (const text of this._formValidationAlertTexts(state)) {
-        if (text && !beforeAlerts.has(`${state?.url || ''}|${text}`)) newAlerts.push(text);
+        if (text && !beforeAlerts.has(`${route}|${text}`)) newAlerts.push(text);
       }
       for (const field of Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : []) {
-        const key = `${state?.url || ''}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
+        const key = `${route}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
         if (!beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
       }
     }
@@ -4888,7 +4892,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     { allFrames = false, checkpointsMs = [0, 120, 350, 800, 1200] } = {},
   ) {
     const before = Array.isArray(beforeStates) ? beforeStates : [];
-    const beforeUrls = new Set(before.map(state => String(state?.url || '')).filter(Boolean));
+    const beforeRoutes = new Set(before
+      .map(state => this._normalizeUrlPath(String(state?.url || '')))
+      .filter(Boolean));
     const startedAt = Date.now();
     for (const checkpoint of checkpointsMs) {
       const targetDelay = Math.max(0, Number(checkpoint) || 0);
@@ -4897,11 +4903,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const after = await this._captureFormValidationState(tabId, { allFrames });
       const failure = this._detectFormValidationFailure(before, after, context);
       if (failure) return failure;
-      const afterUrls = new Set(after.map(state => String(state?.url || '')).filter(Boolean));
+      const afterRoutes = new Set(after
+        .map(state => this._normalizeUrlPath(String(state?.url || '')))
+        .filter(Boolean));
       if (
-        beforeUrls.size > 0
-        && afterUrls.size > 0
-        && ![...afterUrls].some(url => beforeUrls.has(url))
+        beforeRoutes.size > 0
+        && afterRoutes.size > 0
+        && ![...afterRoutes].some(route => beforeRoutes.has(route))
       ) {
         break;
       }
@@ -4920,6 +4928,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     toolResult.validationMessages = failure.validationMessages;
     toolResult.error = failure.error;
     delete toolResult.warning;
+    // A validation-rejected click did not complete the destructive action.
+    // Do not let its generic duplicate-submit entry block the corrected retry.
+    this._recentSubmitClicks.delete(tabId);
     this._formValidationBlocks.set(tabId, {
       stateKey: failure.stateKey,
       actionKey: failure.actionKey,

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -192,12 +192,6 @@ export class Agent {
     this._doneBlockCount = new Map();
     this._recentSubmitClicks = new Map();
     this._formValidationBlocks = new Map(); // tabId -> validation state that must change before another submit
-    const formValidationSaltBytes = new Uint32Array(4);
-    globalThis.crypto.getRandomValues(formValidationSaltBytes);
-    this._formValidationFingerprintSalt = Array.from(
-      formValidationSaltBytes,
-      value => value.toString(16).padStart(8, '0'),
-    ).join('');
     this._runningTabs = new Set(); // tabIds with an active processMessage/Stream in flight
     this.completionInvariants = new Map(); // tabId -> run-scoped post-action verification state
     this._completionRunCounter = 0;
@@ -4980,7 +4974,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         rawResults = await chrome.scripting.executeScript({
           target: { tabId, ...(allFrames ? { allFrames: true } : {}) },
           func: Agent._formValidationStateProbe,
-          args: [this._formValidationFingerprintSalt],
         });
         return (Array.isArray(rawResults) ? rawResults : [])
           .map(item => ({ frameId: item?.frameId ?? null, ...(item?.result || {}) }))
@@ -4989,8 +4982,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (globalThis.browser?.tabs?.executeScript) {
         let probeSource = Agent._formValidationStateProbe.toString();
         if (!/^\s*(?:async\s+)?function\b/.test(probeSource)) probeSource = `function ${probeSource}`;
-        const probeSalt = JSON.stringify(this._formValidationFingerprintSalt);
-        const code = `(() => { const __wbFormValidationProbe = (${probeSource}); return __wbFormValidationProbe(${probeSalt}); })()`;
+        const code = `(() => { const __wbFormValidationProbe = (${probeSource}); return __wbFormValidationProbe(); })()`;
         rawResults = await browser.tabs.executeScript(tabId, { code, allFrames });
         return (Array.isArray(rawResults) ? rawResults : [])
           .map((result, frameId) => ({ frameId, ...(result || {}) }))
@@ -5007,7 +4999,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * Page-side form validation snapshot. Keep self-contained: Firefox
    * serializes this function into tabs and neither browser may close over Agent.
    */
-  static _formValidationStateProbe = function _formValidationStateProbe(fingerprintSalt = '') {
+  static _formValidationStateProbe = function _formValidationStateProbe() {
     const compact = (value, max = 300) => String(value ?? '').replace(/\s+/g, ' ').trim().slice(0, max);
     const roots = [document];
     try {
@@ -5132,9 +5124,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         hash = Math.imul(hash, 16777619);
       }
     };
-    // Mix a per-agent secret into the page-side fingerprint. Password values
-    // can then affect retry detection without ever leaving the probe as text.
-    addHash(`salt:${fingerprintSalt}\u001e`);
     for (const el of queryAll('input, textarea, select, [contenteditable="true"], button, [role="button"], [onclick], [data-action]')) {
       const tag = String(el.tagName || '').toLowerCase();
       const type = String(el.getAttribute?.('type') || el.tagName || '').toLowerCase();
@@ -5154,6 +5143,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         state = compact(el.innerText || el.textContent || el.getAttribute?.('aria-label') || '', 120);
       } else {
         const value = String(el.value ?? el.textContent ?? '');
+        // Fold password text into the aggregate page-side hash so same-length
+        // corrections differ, but never include the value in the snapshot.
         state = type === 'password' ? `password-value:${value}` : value;
       }
       addHash(`${el.tagName}|${type}|${el.name || ''}|${el.id || ''}|${visible(el) ? 'visible' : 'hidden'}|${el.disabled ? 'disabled' : 'enabled'}|${state}\u001e`);

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2042,14 +2042,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
       const formValidationCandidate = this._isFormValidationCandidate(fnName, fnArgs);
       const formValidationAllFrames = fnName === 'iframe_click' || fnName === 'press_keys';
-      let detectedSubmitAction = formValidationCandidate && fnName === 'iframe_click'
+      const preflightSubmitDetection = formValidationCandidate
+        && ['click', 'click_ax', 'iframe_click'].includes(fnName);
+      let detectedSubmitAction = preflightSubmitDetection
         ? await this._detectLikelySubmitAction(tabId, fnName, fnArgs)
         : null;
       const validationBlock = formValidationCandidate ? this._formValidationBlocks.get(tabId) : null;
       let priorValidationFailure = !!validationBlock;
       let correctedPriorValidationFailure = false;
       const obviousSubmitAction = formValidationCandidate
-        && this._formValidationActionLooksSubmit(fnName, fnArgs);
+        && this._formValidationActionLooksSubmit(fnName, fnArgs, null, detectedSubmitAction);
       let formValidationBefore = (validationBlock || obviousSubmitAction)
         ? await this._captureFormValidationState(tabId, { allFrames: formValidationAllFrames })
         : [];

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4884,14 +4884,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // native validation via activeInvalid, but do not mislabel an unrelated
     // pre-existing alert.
     for (const state of before.length ? after : []) {
+      const route = this._normalizeUrlPath(String(state?.url || ''));
+      const includePersistentForState = includePersistentValidation
+        && (beforeRoutes.size === 0 || !route || beforeRoutes.has(route));
       for (const text of this._formValidationAlertTexts(state)) {
-        if (text && (includePersistentValidation || !beforeAlerts.has(text))) {
+        if (text && (includePersistentForState || !beforeAlerts.has(text))) {
           newAlerts.push(text);
         }
       }
       for (const field of Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : []) {
         const key = `${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
-        if (includePersistentValidation || !beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
+        if (includePersistentForState || !beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
       }
     }
 
@@ -4952,10 +4955,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     { allFrames = false, checkpointsMs = [0, 120, 350, 800, 1200] } = {},
   ) {
     const before = Array.isArray(beforeStates) ? beforeStates : [];
-    const beforeRoutes = new Set(before
-      .map(state => this._normalizeUrlPath(String(state?.url || '')))
-      .filter(Boolean));
-    let changedRouteObservedAt = null;
     const startedAt = Date.now();
     for (let checkpointIndex = 0; checkpointIndex < checkpointsMs.length; checkpointIndex += 1) {
       const checkpoint = checkpointsMs[checkpointIndex];
@@ -4970,22 +4969,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           && checkpointIndex === checkpointsMs.length - 1,
       });
       if (failure) return failure;
-      const afterRoutes = new Set(after
-        .map(state => this._normalizeUrlPath(String(state?.url || '')))
-        .filter(Boolean));
-      if (
-        beforeRoutes.size > 0
-        && afterRoutes.size > 0
-        && ![...afterRoutes].some(route => beforeRoutes.has(route))
-      ) {
-        if (changedRouteObservedAt == null) {
-          changedRouteObservedAt = Date.now();
-        } else if (Date.now() - changedRouteObservedAt >= 350) {
-          break;
-        }
-      } else {
-        changedRouteObservedAt = null;
-      }
     }
     return null;
   }

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4754,7 +4754,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   }
 
   _formValidationActionHasStrongSubmitEvidence(toolName, args = {}, result = null, detectedSubmit = null) {
-    if (detectedSubmit?.isSubmit === true) return true;
     const name = String(toolName || '');
     if (name === 'set_field') return args?.submit === true;
     if (name === 'execute_js') return true;
@@ -4765,9 +4764,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
 
     const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
-    if (target?.isSubmitControl === true) return true;
     const tag = String(target?.tag || '').toUpperCase();
     const type = String(target?.type || '').toLowerCase();
+    if (target?.isSubmitControl === false && type === 'button') return false;
+    if (detectedSubmit?.isSubmit === true) return true;
+    if (target?.isSubmitControl === true) return true;
     if (tag === 'BUTTON' && type === 'submit') return true;
     if (tag === 'INPUT' && (type === 'submit' || type === 'image')) return true;
     const selector = String(args?.selector || '').toLowerCase();
@@ -4840,7 +4841,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       context.result,
       context.detectedSubmit,
     );
-    const includePersistentValidation = looksLikeSubmit
+    const includePersistentValidation = strongSubmitEvidence
       && context.priorValidationFailure === true;
     const beforeAlerts = new Set(before.flatMap(state =>
       this._formValidationAlertTexts(state)

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4710,7 +4710,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   _isFormValidationCandidate(toolName, args = {}) {
     const name = String(toolName || '');
-    if (name === 'click' || name === 'click_ax' || name === 'iframe_click') return true;
+    if (name === 'click' || name === 'click_ax' || name === 'iframe_click' || name === 'execute_js') return true;
     if (name === 'set_field') return args?.submit === true;
     if (name === 'press_keys') {
       const keys = JSON.stringify(args?.key ?? args?.keys ?? '').toLowerCase();
@@ -4725,19 +4725,22 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       ? ['selector', 'ref_id', 'index', 'name', 'text', 'submit']
       : name === 'press_keys'
         ? ['selector', 'ref_id', 'index', 'key', 'keys']
+        : name === 'execute_js'
+          ? ['code']
         : ['selector', 'ref_id', 'index', 'text', 'x', 'y', 'urlFilter'];
     const identity = {};
     for (const field of fields) {
       const value = args?.[field];
       if (value == null || value === '') continue;
-      if (name === 'set_field' && field === 'text') {
+      if ((name === 'set_field' && field === 'text') || (name === 'execute_js' && field === 'code')) {
         const text = String(value);
         let hash = 2166136261;
         for (let i = 0; i < text.length; i++) {
           hash ^= text.charCodeAt(i);
           hash = Math.imul(hash, 16777619);
         }
-        identity.textFingerprint = `${text.length}:${(hash >>> 0).toString(16)}`;
+        const fingerprintField = name === 'execute_js' ? 'codeFingerprint' : 'textFingerprint';
+        identity[fingerprintField] = `${text.length}:${(hash >>> 0).toString(16)}`;
         continue;
       }
       identity[field] = typeof value === 'string' ? value.slice(0, 500) : value;
@@ -4749,6 +4752,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (detectedSubmit?.isSubmit) return true;
     const name = String(toolName || '');
     if (name === 'set_field') return args?.submit === true;
+    if (name === 'execute_js') return true;
     if (name === 'press_keys') {
       const keys = JSON.stringify(args?.key ?? args?.keys ?? '').toLowerCase();
       return /\b(?:enter|return)\b/.test(keys);

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4753,10 +4753,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return Object.keys(identity).length ? `${name}:${JSON.stringify(identity)}` : '';
   }
 
+  _executeJsLooksLikeFormSubmit(code) {
+    const source = String(code || '');
+    return /\brequestSubmit\s*\(|\.submit\s*\(|\bdispatchEvent\s*\([^)]*\bsubmit\b|(?:submit|checkout|confirm|place.?order|pay)[^;\n]{0,160}\.click\s*\(/i.test(source);
+  }
+
   _formValidationActionHasStrongSubmitEvidence(toolName, args = {}, result = null, detectedSubmit = null) {
     const name = String(toolName || '');
     if (name === 'set_field') return args?.submit === true;
-    if (name === 'execute_js') return true;
+    if (name === 'execute_js') return this._executeJsLooksLikeFormSubmit(args?.code);
     if (name === 'press_keys') {
       const keys = JSON.stringify(args?.key ?? args?.keys ?? '').toLowerCase();
       return /\b(?:enter|return)\b/.test(keys);
@@ -5163,9 +5168,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         hash = Math.imul(hash, 16777619);
       }
     };
-    for (const el of queryAll('input, textarea, select, [contenteditable="true"], button, [role="button"], [onclick], [data-action]')) {
+    for (const el of queryAll('input, textarea, select, [contenteditable="true"], [role="checkbox"], [role="radio"], [role="switch"], [aria-checked], button, [role="button"], [onclick], [data-action]')) {
       const tag = String(el.tagName || '').toLowerCase();
       const type = String(el.getAttribute?.('type') || el.tagName || '').toLowerCase();
+      const role = String(el.getAttribute?.('role') || '').toLowerCase();
       let state = '';
       if (type === 'checkbox' || type === 'radio') {
         state = el.checked ? 'checked' : 'unchecked';
@@ -5173,9 +5179,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         state = Array.from(el.selectedOptions || []).map(option => option.value).join('\u001f');
       } else if (type === 'file') {
         state = String(el.files?.length || 0);
+      } else if (el.hasAttribute?.('aria-checked') || role === 'checkbox' || role === 'radio' || role === 'switch') {
+        state = `aria-checked:${compact(el.getAttribute?.('aria-checked') || 'undefined', 40)}`;
       } else if (
         tag === 'button'
-        || String(el.getAttribute?.('role') || '').toLowerCase() === 'button'
+        || role === 'button'
         || el.hasAttribute?.('onclick')
         || el.hasAttribute?.('data-action')
       ) {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4753,8 +4753,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return Object.keys(identity).length ? `${name}:${JSON.stringify(identity)}` : '';
   }
 
-  _formValidationActionLooksSubmit(toolName, args = {}, result = null, detectedSubmit = null) {
-    if (detectedSubmit?.isSubmit) return true;
+  _formValidationActionHasStrongSubmitEvidence(toolName, args = {}, result = null, detectedSubmit = null) {
+    if (detectedSubmit?.isSubmit === true) return true;
     const name = String(toolName || '');
     if (name === 'set_field') return args?.submit === true;
     if (name === 'execute_js') return true;
@@ -4764,11 +4764,20 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
 
-    if (result?.isSubmitControl === true) return true;
-    const tag = String(result?.tag || '').toUpperCase();
-    const type = String(result?.type || '').toLowerCase();
-    if (tag === 'BUTTON' && (result?.isSubmitControl === true || type === 'submit')) return true;
+    const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
+    if (target?.isSubmitControl === true) return true;
+    const tag = String(target?.tag || '').toUpperCase();
+    const type = String(target?.type || '').toLowerCase();
+    if (tag === 'BUTTON' && type === 'submit') return true;
     if (tag === 'INPUT' && (type === 'submit' || type === 'image')) return true;
+    const selector = String(args?.selector || '').toLowerCase();
+    return /type\s*=\s*["']?(?:submit|image)/.test(selector);
+  }
+
+  _formValidationActionLooksSubmit(toolName, args = {}, result = null, detectedSubmit = null) {
+    if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
+    const name = String(toolName || '');
+    if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
 
     const label = String(args?.text || result?.name || result?.matched || result?.text || '').trim();
     if (/^(?:continue|next|create|save|submit|add|post|publish|send|confirm|sign up|sign in|log in|register|place order|pay|checkout|update|apply|finish|done)\b/i.test(label)) {
@@ -4825,6 +4834,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       context.result,
       context.detectedSubmit,
     );
+    const strongSubmitEvidence = this._formValidationActionHasStrongSubmitEvidence(
+      context.toolName,
+      context.args,
+      context.result,
+      context.detectedSubmit,
+    );
     const includePersistentValidation = looksLikeSubmit
       && context.priorValidationFailure === true;
     const beforeAlerts = new Set(before.flatMap(state =>
@@ -4861,7 +4876,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const nativeFailureStates = sameRouteAfter.filter((state) => {
       if (state?.activeInvalid !== true) return false;
       const key = `${state?.frameId ?? ''}|${this._normalizeUrlPath(String(state?.url || ''))}`;
-      return !beforeActiveInvalid.has(key);
+      return !beforeActiveInvalid.has(key) || strongSubmitEvidence;
     });
     const nativeInvalidFields = looksLikeSubmit
       ? nativeFailureStates.flatMap(state => Array.isArray(state?.invalidFields) ? state.invalidFields : [])

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4773,7 +4773,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const type = String(target?.type || '').toLowerCase();
     const strongDetectedSubmit = detectedSubmit?.validationSubmitEvidence === 'strong';
     if (target?.isSubmitControl === false && type === 'button' && !strongDetectedSubmit) return false;
-    if (detectedSubmit?.isSubmit === true) return true;
+    if (detectedSubmit?.isSubmit === true && strongDetectedSubmit) return true;
     if (target?.isSubmitControl === true) return true;
     if (tag === 'BUTTON' && type === 'submit') return true;
     if (tag === 'INPUT' && (type === 'submit' || type === 'image')) return true;
@@ -4791,6 +4791,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
+    if (detectedSubmit?.isSubmit === true) return false;
 
     const label = String(args?.text || result?.name || result?.matched || result?.text || '').trim();
     if (/^(?:continue|next|create|save|submit|add|post|publish|send|confirm|sign up|sign in|log in|register|place order|pay|checkout|update|apply|finish|done)\b/i.test(label)) {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2047,6 +2047,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         : null;
       const validationBlock = formValidationCandidate ? this._formValidationBlocks.get(tabId) : null;
       let priorValidationFailure = !!validationBlock;
+      let correctedPriorValidationFailure = false;
       const obviousSubmitAction = formValidationCandidate
         && this._formValidationActionLooksSubmit(fnName, fnArgs);
       let formValidationBefore = (validationBlock || obviousSubmitAction)
@@ -2057,6 +2058,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (currentValidationStateKey !== validationBlock.stateKey) {
           this._formValidationBlocks.delete(tabId);
           priorValidationFailure = false;
+          correctedPriorValidationFailure = true;
         } else {
           const retryActionKey = this._formValidationActionKey(fnName, fnArgs);
           if (retryActionKey && retryActionKey === validationBlock.actionKey) {
@@ -2275,6 +2277,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             result: toolResult,
             detectedSubmit: detectedSubmitAction,
             priorValidationFailure,
+            correctedPriorValidationFailure,
           },
           { allFrames: formValidationAllFrames },
         );
@@ -4859,7 +4862,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     );
     if (!looksLikeSubmit) return null;
     const includePersistentValidation = strongSubmitEvidence
-      && context.priorValidationFailure === true;
+      && (
+        context.priorValidationFailure === true
+        || context.includeCorrectedPersistentValidation === true
+      );
     const beforeAlerts = new Set(before.flatMap(state =>
       this._formValidationAlertTexts(state)
     ));
@@ -4951,12 +4957,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       .filter(Boolean));
     let changedRouteObservedAt = null;
     const startedAt = Date.now();
-    for (const checkpoint of checkpointsMs) {
+    for (let checkpointIndex = 0; checkpointIndex < checkpointsMs.length; checkpointIndex += 1) {
+      const checkpoint = checkpointsMs[checkpointIndex];
       const targetDelay = Math.max(0, Number(checkpoint) || 0);
       const remaining = targetDelay - (Date.now() - startedAt);
       if (remaining > 0) await new Promise(resolve => setTimeout(resolve, remaining));
       const after = await this._captureFormValidationState(tabId, { allFrames });
-      const failure = this._detectFormValidationFailure(before, after, context);
+      const failure = this._detectFormValidationFailure(before, after, {
+        ...context,
+        includeCorrectedPersistentValidation:
+          context?.correctedPriorValidationFailure === true
+          && checkpointIndex === checkpointsMs.length - 1,
+      });
       if (failure) return failure;
       const afterRoutes = new Set(after
         .map(state => this._normalizeUrlPath(String(state?.url || '')))

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -191,6 +191,7 @@ export class Agent {
     this._isPdfTabCache = new Map();
     this._doneBlockCount = new Map();
     this._recentSubmitClicks = new Map();
+    this._formValidationBlocks = new Map(); // tabId -> validation state that must change before another submit
     this._runningTabs = new Set(); // tabIds with an active processMessage/Stream in flight
     this.completionInvariants = new Map(); // tabId -> run-scoped post-action verification state
     this._completionRunCounter = 0;
@@ -2039,10 +2040,40 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         onUpdate('warning', { message: 'API mutation blocked until /allow-api is enabled.' });
         continue;
       }
+      const formValidationCandidate = this._isFormValidationCandidate(fnName, fnArgs);
+      const formValidationAllFrames = fnName === 'iframe_click' || fnName === 'press_keys';
+      let detectedSubmitAction = null;
+      const validationBlock = formValidationCandidate ? this._formValidationBlocks.get(tabId) : null;
+      const obviousSubmitAction = formValidationCandidate
+        && this._formValidationActionLooksSubmit(fnName, fnArgs);
+      let formValidationBefore = (validationBlock || obviousSubmitAction)
+        ? await this._captureFormValidationState(tabId, { allFrames: formValidationAllFrames })
+        : [];
+      if (validationBlock) {
+        const currentValidationStateKey = this._formValidationStateKey(formValidationBefore);
+        if (currentValidationStateKey !== validationBlock.stateKey) {
+          this._formValidationBlocks.delete(tabId);
+        } else {
+          const retryActionKey = this._formValidationActionKey(fnName, fnArgs);
+          if (retryActionKey && retryActionKey === validationBlock.actionKey) {
+            const blockedResult = this._formValidationRetryBlockResult(validationBlock);
+            onUpdate('tool_call', { name: fnName, args: fnArgs });
+            onUpdate('tool_result', { name: fnName, result: blockedResult });
+            messages.push({
+              role: 'tool',
+              tool_call_id: tc.id,
+              content: this._wrapUntrusted(fnName, this._limitToolResult(blockedResult)),
+            });
+            onUpdate('warning', { message: 'Repeat submission blocked until the invalid form changes.' });
+            continue;
+          }
+        }
+      }
       const scheduledPolicy = this.scheduledRunPolicies.get(tabId);
       const scheduledBypassesGate = scheduledPolicy?.requireConsequentialConfirmation === false;
       if (!this._skipPermissionGate && !scheduledBypassesGate) {
-        const submitConfirmation = await this._detectLikelySubmitAction(tabId, fnName, fnArgs);
+        const submitConfirmation = detectedSubmitAction || await this._detectLikelySubmitAction(tabId, fnName, fnArgs);
+        detectedSubmitAction = submitConfirmation;
         if (submitConfirmation?.isSubmit) {
           const choice = await this._promptSubmitConfirmation(tabId, submitConfirmation, onUpdate);
           if (choice === null) {
@@ -2079,6 +2110,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             capabilities = capabilities.filter(capability => capability !== Capability.CLICK);
           }
         }
+      }
+      if (
+        formValidationCandidate
+        && formValidationBefore.length === 0
+        && (
+          detectedSubmitAction?.isSubmit
+          || this._skipPermissionGate
+          || scheduledBypassesGate
+        )
+      ) {
+        formValidationBefore = await this._captureFormValidationState(tabId, {
+          allFrames: formValidationAllFrames,
+        });
       }
       if (capabilities.length && !this._skipPermissionGate && !scheduledBypassesGate) {
         await this.permissions.hydrate();
@@ -2204,6 +2248,36 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         completionBatchStartState,
       });
       const toolResult = this._normalizeToolResult(fnName, rawToolResult, missingResponseOutcomeUnknown);
+      const inspectFormValidationAfter = formValidationCandidate
+        && this._formValidationActionLooksSubmit(
+          fnName,
+          fnArgs,
+          toolResult,
+          detectedSubmitAction,
+        );
+      if (
+        inspectFormValidationAfter
+        && toolResult
+        && typeof toolResult === 'object'
+        && !toolResult.done
+        && toolResult.dispatched !== false
+      ) {
+        const formValidationFailure = await this._waitForFormValidationFailure(
+          tabId,
+          formValidationBefore,
+          {
+            toolName: fnName,
+            args: fnArgs,
+            result: toolResult,
+            detectedSubmit: detectedSubmitAction,
+          },
+          { allFrames: formValidationAllFrames },
+        );
+        if (formValidationFailure) {
+          this._applyFormValidationFailure(tabId, toolResult, formValidationFailure);
+          onUpdate('warning', { message: 'Form validation failed; the page error was returned to the agent.' });
+        }
+      }
       if (fnName !== 'done') {
         this._markPlanExecutionToolCall(tabId, fnName, toolResult, {
           consequential: executionMutationEvidence,
@@ -4634,6 +4708,417 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return 'deny'; // 'deny', or anything unexpected → fail safe
   }
 
+  _isFormValidationCandidate(toolName, args = {}) {
+    const name = String(toolName || '');
+    if (name === 'click' || name === 'click_ax' || name === 'iframe_click') return true;
+    if (name === 'set_field') return args?.submit === true;
+    if (name === 'press_keys') {
+      const keys = JSON.stringify(args?.key ?? args?.keys ?? '').toLowerCase();
+      return /\b(?:enter|return)\b/.test(keys);
+    }
+    return false;
+  }
+
+  _formValidationActionKey(toolName, args = {}) {
+    const name = String(toolName || '');
+    const fields = name === 'set_field'
+      ? ['selector', 'ref_id', 'index', 'name', 'submit']
+      : name === 'press_keys'
+        ? ['selector', 'ref_id', 'index', 'key', 'keys']
+        : ['selector', 'ref_id', 'index', 'text', 'x', 'y', 'urlFilter'];
+    const identity = {};
+    for (const field of fields) {
+      const value = args?.[field];
+      if (value == null || value === '') continue;
+      identity[field] = typeof value === 'string' ? value.slice(0, 500) : value;
+    }
+    return Object.keys(identity).length ? `${name}:${JSON.stringify(identity)}` : '';
+  }
+
+  _formValidationActionLooksSubmit(toolName, args = {}, result = null, detectedSubmit = null) {
+    if (detectedSubmit?.isSubmit) return true;
+    const name = String(toolName || '');
+    if (name === 'set_field') return args?.submit === true;
+    if (name === 'press_keys') {
+      const keys = JSON.stringify(args?.key ?? args?.keys ?? '').toLowerCase();
+      return /\b(?:enter|return)\b/.test(keys);
+    }
+    if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
+
+    if (result?.isSubmitControl === true) return true;
+    const tag = String(result?.tag || '').toUpperCase();
+    const type = String(result?.type || '').toLowerCase();
+    if (tag === 'BUTTON' && result?.isSubmitControl !== false) return true;
+    if (tag === 'INPUT' && (type === 'submit' || type === 'image')) return true;
+
+    const label = String(args?.text || result?.name || result?.matched || result?.text || '').trim();
+    if (/^(?:continue|next|create|save|submit|add|post|publish|send|confirm|sign up|sign in|log in|register|place order|pay|checkout|update|apply|finish|done)\b/i.test(label)) {
+      return true;
+    }
+    const selector = String(args?.selector || '').toLowerCase();
+    return /(?:type\s*=\s*["']?(?:submit|image)|\bsubmit\b|\bcontinue\b|\bconfirm\b|\bcheckout\b|\bfinish\b)/.test(selector);
+  }
+
+  _formValidationAlertTexts(state = {}) {
+    const errorPattern = /\b(?:error|invalid|required|failed|failure|missing|must|cannot|can't|could not|unable|unsuccessful|rejected|not (?:valid|allowed|accepted|selected|saved)|please (?:correct|fix|select|choose|enter|provide)|select at least|choose at least|enter a valid)\b/i;
+    const successPattern = /\b(?:success|successfully|saved|submitted|sent|created|updated|published|completed)\b|^done\b|^thank(?:s| you)\b/i;
+    return (Array.isArray(state?.alerts) ? state.alerts : [])
+      .map(alert => String(alert?.text ?? alert ?? '').replace(/\s+/g, ' ').trim().slice(0, 500))
+      .filter((text) => {
+        if (!text) return false;
+        if (errorPattern.test(text)) return true;
+        if (successPattern.test(text)) return false;
+        return state?.alertsAreValidationOnly === true;
+      });
+  }
+
+  _formValidationStateKey(states = []) {
+    return JSON.stringify((Array.isArray(states) ? states : [])
+      .map((state) => ({
+        frameId: state?.frameId ?? null,
+        url: String(state?.url || ''),
+        invalid: (Array.isArray(state?.invalidFields) ? state.invalidFields : [])
+          .map(field => [field?.label || '', field?.type || '', field?.message || '']),
+        ariaInvalid: (Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : [])
+          .map(field => [field?.label || '', field?.type || '', field?.message || '']),
+        alerts: this._formValidationAlertTexts(state),
+        controls: String(state?.controlFingerprint || ''),
+      }))
+      .sort((a, b) => `${a.frameId}|${a.url}`.localeCompare(`${b.frameId}|${b.url}`)));
+  }
+
+  _detectFormValidationFailure(beforeStates = [], afterStates = [], context = {}) {
+    const before = Array.isArray(beforeStates) ? beforeStates : [];
+    const after = Array.isArray(afterStates) ? afterStates : [];
+    if (!after.length) return null;
+
+    const beforeUrls = new Set(before.map(state => String(state?.url || '')).filter(Boolean));
+    const comparableAfter = after.filter((state) => {
+      const url = String(state?.url || '');
+      return beforeUrls.size === 0 || !url || beforeUrls.has(url);
+    });
+    if (!comparableAfter.length) return null;
+
+    const beforeAlerts = new Set(before.flatMap(state =>
+      this._formValidationAlertTexts(state).map(text => `${state?.url || ''}|${text}`)
+    ));
+    const beforeAriaInvalid = new Set(before.flatMap(state =>
+      (Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : [])
+        .map(field => `${state?.url || ''}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
+    ));
+    const newAlerts = [];
+    const newAriaInvalid = [];
+    // Custom alert/live-region and aria-invalid failures must be newly exposed
+    // by the action. With no baseline we still detect native validation via
+    // activeInvalid, but do not mislabel an unrelated pre-existing alert.
+    for (const state of before.length ? comparableAfter : []) {
+      for (const text of this._formValidationAlertTexts(state)) {
+        if (text && !beforeAlerts.has(`${state?.url || ''}|${text}`)) newAlerts.push(text);
+      }
+      for (const field of Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : []) {
+        const key = `${state?.url || ''}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
+        if (!beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
+      }
+    }
+
+    const nativeFailureStates = comparableAfter.filter(state => state?.activeInvalid === true);
+    const looksLikeSubmit = this._formValidationActionLooksSubmit(
+      context.toolName,
+      context.args,
+      context.result,
+      context.detectedSubmit,
+    );
+    const nativeInvalidFields = looksLikeSubmit
+      ? nativeFailureStates.flatMap(state => Array.isArray(state?.invalidFields) ? state.invalidFields : [])
+      : [];
+    if (!nativeInvalidFields.length && !newAlerts.length && !newAriaInvalid.length) return null;
+
+    const invalidFields = [];
+    const fieldKeys = new Set();
+    for (const field of [...nativeInvalidFields, ...newAriaInvalid]) {
+      const normalized = {
+        label: String(field?.label || 'field').slice(0, 120),
+        type: String(field?.type || '').slice(0, 40),
+        message: String(field?.message || 'Invalid value.').slice(0, 300),
+      };
+      const key = `${normalized.label}|${normalized.type}|${normalized.message}`;
+      if (!fieldKeys.has(key)) {
+        fieldKeys.add(key);
+        invalidFields.push(normalized);
+      }
+    }
+
+    const validationMessages = [];
+    const messageSet = new Set();
+    for (const message of [
+      ...invalidFields.map(field => `${field.label}: ${field.message}`),
+      ...newAlerts,
+    ]) {
+      const compact = String(message || '').replace(/\s+/g, ' ').trim().slice(0, 500);
+      if (compact && !messageSet.has(compact)) {
+        messageSet.add(compact);
+        validationMessages.push(compact);
+      }
+    }
+    if (!validationMessages.length) validationMessages.push('The page reported that the form contains invalid fields.');
+
+    return {
+      invalidFields: invalidFields.slice(0, 12),
+      validationMessages: validationMessages.slice(0, 12),
+      stateKey: this._formValidationStateKey(after),
+      actionKey: this._formValidationActionKey(context.toolName, context.args),
+      error: `Form submission was rejected by page validation: ${validationMessages.join(' | ')} Fix the reported field(s), verify their state, and only then submit again.`,
+    };
+  }
+
+  async _waitForFormValidationFailure(
+    tabId,
+    beforeStates,
+    context,
+    { allFrames = false, checkpointsMs = [0, 120, 350, 800, 1200] } = {},
+  ) {
+    const before = Array.isArray(beforeStates) ? beforeStates : [];
+    const beforeUrls = new Set(before.map(state => String(state?.url || '')).filter(Boolean));
+    const startedAt = Date.now();
+    for (const checkpoint of checkpointsMs) {
+      const targetDelay = Math.max(0, Number(checkpoint) || 0);
+      const remaining = targetDelay - (Date.now() - startedAt);
+      if (remaining > 0) await new Promise(resolve => setTimeout(resolve, remaining));
+      const after = await this._captureFormValidationState(tabId, { allFrames });
+      const failure = this._detectFormValidationFailure(before, after, context);
+      if (failure) return failure;
+      const afterUrls = new Set(after.map(state => String(state?.url || '')).filter(Boolean));
+      if (
+        beforeUrls.size > 0
+        && afterUrls.size > 0
+        && ![...afterUrls].some(url => beforeUrls.has(url))
+      ) {
+        break;
+      }
+    }
+    return null;
+  }
+
+  _applyFormValidationFailure(tabId, toolResult, failure) {
+    if (!toolResult || typeof toolResult !== 'object' || !failure) return toolResult;
+    toolResult.success = false;
+    toolResult.noProgress = true;
+    toolResult.formValidationFailed = true;
+    toolResult.dispatched = toolResult.dispatched !== false;
+    toolResult.verified = false;
+    toolResult.invalidFields = failure.invalidFields;
+    toolResult.validationMessages = failure.validationMessages;
+    toolResult.error = failure.error;
+    delete toolResult.warning;
+    this._formValidationBlocks.set(tabId, {
+      stateKey: failure.stateKey,
+      actionKey: failure.actionKey,
+      invalidFields: failure.invalidFields,
+      validationMessages: failure.validationMessages,
+    });
+    return toolResult;
+  }
+
+  _formValidationRetryBlockResult(block) {
+    const messages = Array.isArray(block?.validationMessages) && block.validationMessages.length
+      ? block.validationMessages
+      : ['The form still contains the same invalid fields.'];
+    return {
+      success: false,
+      dispatched: false,
+      noProgress: true,
+      formValidationFailed: true,
+      blockedValidationRetry: true,
+      invalidFields: Array.isArray(block?.invalidFields) ? block.invalidFields : [],
+      validationMessages: messages,
+      error: `Blocked repeat submission because the form validation state has not changed: ${messages.join(' | ')} Fix the reported field(s) before trying to submit again.`,
+    };
+  }
+
+  async _captureFormValidationState(tabId, { allFrames = false } = {}) {
+    try {
+      let rawResults = [];
+      if (globalThis.chrome?.scripting?.executeScript) {
+        rawResults = await chrome.scripting.executeScript({
+          target: { tabId, ...(allFrames ? { allFrames: true } : {}) },
+          func: Agent._formValidationStateProbe,
+        });
+        return (Array.isArray(rawResults) ? rawResults : [])
+          .map(item => ({ frameId: item?.frameId ?? null, ...(item?.result || {}) }))
+          .filter(state => state && (state.url || state.invalidFields?.length || state.alerts?.length));
+      }
+      if (globalThis.browser?.tabs?.executeScript) {
+        let probeSource = Agent._formValidationStateProbe.toString();
+        if (!/^\s*(?:async\s+)?function\b/.test(probeSource)) probeSource = `function ${probeSource}`;
+        const code = `(() => { const __wbFormValidationProbe = (${probeSource}); return __wbFormValidationProbe(); })()`;
+        rawResults = await browser.tabs.executeScript(tabId, { code, allFrames });
+        return (Array.isArray(rawResults) ? rawResults : [])
+          .map((result, frameId) => ({ frameId, ...(result || {}) }))
+          .filter(state => state && (state.url || state.invalidFields?.length || state.alerts?.length));
+      }
+    } catch {
+      // Validation inspection is best-effort; the original tool result remains
+      // authoritative when the page or frame cannot be inspected.
+    }
+    return [];
+  }
+
+  /**
+   * Page-side form validation snapshot. Keep self-contained: Firefox
+   * serializes this function into tabs and neither browser may close over Agent.
+   */
+  static _formValidationStateProbe = function _formValidationStateProbe() {
+    const compact = (value, max = 300) => String(value ?? '').replace(/\s+/g, ' ').trim().slice(0, max);
+    const roots = [document];
+    try {
+      const walker = document.createTreeWalker(document, NodeFilter.SHOW_ELEMENT);
+      let node = walker.currentNode;
+      while (node) {
+        if (node.shadowRoot) roots.push(node.shadowRoot);
+        node = walker.nextNode();
+      }
+    } catch {}
+    const queryAll = (selector) => {
+      const found = [];
+      for (const root of roots) {
+        try { found.push(...root.querySelectorAll(selector)); } catch {}
+      }
+      return [...new Set(found)];
+    };
+    const visible = (el) => {
+      try {
+        const rect = el.getBoundingClientRect();
+        const style = getComputedStyle(el);
+        return rect.width > 0 && rect.height > 0
+          && style.display !== 'none'
+          && style.visibility !== 'hidden'
+          && Number(style.opacity || 1) > 0;
+      } catch {
+        return false;
+      }
+    };
+    const labelFor = (el) => {
+      const parts = [];
+      try {
+        if (el.id) {
+          const escaped = globalThis.CSS?.escape ? CSS.escape(el.id) : String(el.id).replace(/["\\]/g, '\\$&');
+          const label = document.querySelector(`label[for="${escaped}"]`);
+          if (label) parts.push(label.innerText || label.textContent || '');
+        }
+      } catch {}
+      try {
+        const wrappingLabel = el.closest?.('label');
+        if (wrappingLabel) parts.push(wrappingLabel.innerText || wrappingLabel.textContent || '');
+      } catch {}
+      parts.push(
+        el.getAttribute?.('aria-label') || '',
+        el.getAttribute?.('placeholder') || '',
+        el.getAttribute?.('name') || '',
+        el.getAttribute?.('id') || '',
+        el.tagName || 'field',
+      );
+      return compact(parts.find(Boolean) || 'field', 120);
+    };
+    const describedMessage = (el) => {
+      const ids = compact(el.getAttribute?.('aria-describedby') || '', 240).split(/\s+/).filter(Boolean);
+      const text = ids.map((id) => {
+        try { return document.getElementById(id)?.innerText || document.getElementById(id)?.textContent || ''; } catch { return ''; }
+      }).filter(Boolean).join(' ');
+      return compact(text || el.validationMessage || '', 300);
+    };
+    const detailFor = (el, fallback = 'Invalid value.') => ({
+      label: labelFor(el),
+      type: compact(el.getAttribute?.('type') || el.tagName || '', 40),
+      message: describedMessage(el) || fallback,
+      visible: visible(el),
+    });
+    const invalidControls = queryAll('input:invalid, textarea:invalid, select:invalid');
+    const ariaInvalidControls = queryAll('input[aria-invalid="true"], textarea[aria-invalid="true"], select[aria-invalid="true"], [contenteditable="true"][aria-invalid="true"]');
+    let active = document.activeElement;
+    try {
+      while (active?.shadowRoot?.activeElement) active = active.shadowRoot.activeElement;
+    } catch {}
+    const activeInvalid = !!active && invalidControls.includes(active);
+    const allInvalidControls = [...new Set([...invalidControls, ...ariaInvalidControls])];
+    const errorMessageIds = new Set();
+    for (const control of allInvalidControls) {
+      for (const attr of ['aria-errormessage', 'aria-describedby']) {
+        for (const id of compact(control.getAttribute?.(attr) || '', 500).split(/\s+/).filter(Boolean)) {
+          errorMessageIds.add(id);
+        }
+      }
+    }
+    const errorPattern = /\b(?:error|invalid|required|failed|failure|missing|must|cannot|can't|could not|unable|unsuccessful|rejected|not (?:valid|allowed|accepted|selected|saved)|please (?:correct|fix|select|choose|enter|provide)|select at least|choose at least|enter a valid)\b/i;
+    const successPattern = /\b(?:success|successfully|saved|submitted|sent|created|updated|published|completed)\b|^done\b|^thank(?:s| you)\b/i;
+    const alerts = queryAll('[role="alert"], [role="alertdialog"], [aria-live="assertive"], [aria-live="polite"]')
+      .filter(visible)
+      .map((el) => {
+        const text = compact(el.innerText || el.textContent || '', 500);
+        const tokens = compact([
+          el.id,
+          el.className,
+          el.getAttribute?.('data-state'),
+          el.getAttribute?.('data-status'),
+          el.getAttribute?.('aria-label'),
+        ].filter(Boolean).join(' '), 500);
+        const form = el.closest?.('form') || null;
+        const formHasInvalidControl = !!form && allInvalidControls.some(control =>
+          control.form === form || control.closest?.('form') === form
+        );
+        const explicitlyErrorLinked = !!el.id && errorMessageIds.has(el.id);
+        const validationLikely = explicitlyErrorLinked
+          || /\b(?:error|invalid|validation|danger|warning|failed|failure)\b/i.test(tokens)
+          || errorPattern.test(text)
+          || formHasInvalidControl;
+        const successLikely = successPattern.test(text) && !errorPattern.test(text);
+        return validationLikely && !successLikely ? text : '';
+      })
+      .filter(Boolean)
+      .slice(0, 12);
+
+    let hash = 2166136261;
+    const addHash = (text) => {
+      const value = String(text || '');
+      for (let i = 0; i < value.length; i++) {
+        hash ^= value.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+      }
+    };
+    for (const el of queryAll('input, textarea, select, [contenteditable="true"], button, [role="button"], [onclick], [data-action]')) {
+      const tag = String(el.tagName || '').toLowerCase();
+      const type = String(el.getAttribute?.('type') || el.tagName || '').toLowerCase();
+      let state = '';
+      if (type === 'checkbox' || type === 'radio') {
+        state = el.checked ? 'checked' : 'unchecked';
+      } else if (tag === 'select') {
+        state = Array.from(el.selectedOptions || []).map(option => option.value).join('\u001f');
+      } else if (type === 'file') {
+        state = String(el.files?.length || 0);
+      } else if (
+        tag === 'button'
+        || String(el.getAttribute?.('role') || '').toLowerCase() === 'button'
+        || el.hasAttribute?.('onclick')
+        || el.hasAttribute?.('data-action')
+      ) {
+        state = compact(el.innerText || el.textContent || el.getAttribute?.('aria-label') || '', 120);
+      } else {
+        const value = String(el.value ?? el.textContent ?? '');
+        state = type === 'password' ? `password-length:${value.length}` : value;
+      }
+      addHash(`${el.tagName}|${type}|${el.name || ''}|${el.id || ''}|${visible(el) ? 'visible' : 'hidden'}|${el.disabled ? 'disabled' : 'enabled'}|${state}\u001e`);
+    }
+
+    return {
+      url: (() => { try { return location.href || ''; } catch { return ''; } })(),
+      activeInvalid,
+      invalidFields: invalidControls.map(el => detailFor(el)).slice(0, 20),
+      ariaInvalidFields: ariaInvalidControls.map(el => detailFor(el, 'This field is marked invalid.')).slice(0, 20),
+      alerts: [...new Set(alerts)],
+      alertsAreValidationOnly: true,
+      controlFingerprint: (hash >>> 0).toString(16),
+    };
+  };
+
   _fallbackSubmitConfirmationInfo(host, tool, reason, summary = '') {
     const normalizedHost = normalizeHost(host || '') || String(host || '').trim() || 'this site';
     return {
@@ -5546,6 +6031,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this._nytimesPageGateNotified.delete(tabId);
     this._doneBlockCount.delete(tabId);
     this._recentSubmitClicks.delete(tabId);
+    this._formValidationBlocks.delete(tabId);
     this._lastAxScopes.delete(tabId);
     this.completionInvariants.delete(tabId);
     if (!preserveRunGuard) {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4790,7 +4790,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
       const type = String(target?.type || '').toLowerCase();
       const strongDetectedSubmit = detectedSubmit?.validationSubmitEvidence === 'strong';
-      if (target?.isSubmitControl === false && type === 'button' && !strongDetectedSubmit) return false;
+      const heuristicDetectedSubmit = detectedSubmit?.isSubmit === true && !strongDetectedSubmit;
+      if (
+        target?.isSubmitControl === false
+        && type === 'button'
+        && !strongDetectedSubmit
+        && !heuristicDetectedSubmit
+      ) return false;
     }
     if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4791,13 +4791,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
-    if (detectedSubmit?.isSubmit === true) return false;
 
     const label = String(args?.text || result?.name || result?.matched || result?.text || '').trim();
+    const selector = String(args?.selector || '').toLowerCase();
+    if (detectedSubmit?.isSubmit === true) {
+      return /^(?:continue|save|submit|post|publish|send|confirm|sign up|sign in|log in|register|place order|pay|checkout|finish)\b/i.test(label)
+        || /(?:type\s*=\s*["']?(?:submit|image)|\bsubmit\b|\bcontinue\b|\bconfirm\b|\bcheckout\b|\bfinish\b)/.test(selector);
+    }
     if (/^(?:continue|next|create|save|submit|add|post|publish|send|confirm|sign up|sign in|log in|register|place order|pay|checkout|update|apply|finish|done)\b/i.test(label)) {
       return true;
     }
-    const selector = String(args?.selector || '').toLowerCase();
     return /(?:type\s*=\s*["']?(?:submit|image)|\bsubmit\b|\bcontinue\b|\bconfirm\b|\bcheckout\b|\bfinish\b)/.test(selector);
   }
 

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2270,6 +2270,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             args: fnArgs,
             result: toolResult,
             detectedSubmit: detectedSubmitAction,
+            priorValidationFailure: !!validationBlock,
           },
           { allFrames: formValidationAllFrames },
         );
@@ -4762,7 +4763,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (result?.isSubmitControl === true) return true;
     const tag = String(result?.tag || '').toUpperCase();
     const type = String(result?.type || '').toLowerCase();
-    if (tag === 'BUTTON' && result?.isSubmitControl !== false) return true;
+    if (tag === 'BUTTON' && (result?.isSubmitControl === true || type === 'submit')) return true;
     if (tag === 'INPUT' && (type === 'submit' || type === 'image')) return true;
 
     const label = String(args?.text || result?.name || result?.matched || result?.text || '').trim();
@@ -4815,6 +4816,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     });
     if (!comparableAfter.length) return null;
 
+    const looksLikeSubmit = this._formValidationActionLooksSubmit(
+      context.toolName,
+      context.args,
+      context.result,
+      context.detectedSubmit,
+    );
+    const includePersistentValidation = looksLikeSubmit
+      && context.priorValidationFailure === true;
     const beforeAlerts = new Set(before.flatMap(state =>
       this._formValidationAlertTexts(state)
         .map(text => `${this._normalizeUrlPath(String(state?.url || ''))}|${text}`)
@@ -4831,21 +4840,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     for (const state of before.length ? comparableAfter : []) {
       const route = this._normalizeUrlPath(String(state?.url || ''));
       for (const text of this._formValidationAlertTexts(state)) {
-        if (text && !beforeAlerts.has(`${route}|${text}`)) newAlerts.push(text);
+        if (text && (includePersistentValidation || !beforeAlerts.has(`${route}|${text}`))) {
+          newAlerts.push(text);
+        }
       }
       for (const field of Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : []) {
         const key = `${route}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
-        if (!beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
+        if (includePersistentValidation || !beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
       }
     }
 
     const nativeFailureStates = comparableAfter.filter(state => state?.activeInvalid === true);
-    const looksLikeSubmit = this._formValidationActionLooksSubmit(
-      context.toolName,
-      context.args,
-      context.result,
-      context.detectedSubmit,
-    );
     const nativeInvalidFields = looksLikeSubmit
       ? nativeFailureStates.flatMap(state => Array.isArray(state?.invalidFields) ? state.invalidFields : [])
       : [];

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4771,7 +4771,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
     const tag = String(target?.tag || '').toUpperCase();
     const type = String(target?.type || '').toLowerCase();
-    if (target?.isSubmitControl === false && type === 'button') return false;
+    const strongDetectedSubmit = detectedSubmit?.validationSubmitEvidence === 'strong';
+    if (target?.isSubmitControl === false && type === 'button' && !strongDetectedSubmit) return false;
     if (detectedSubmit?.isSubmit === true) return true;
     if (target?.isSubmitControl === true) return true;
     if (tag === 'BUTTON' && type === 'submit') return true;
@@ -4785,7 +4786,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (['click', 'click_ax', 'iframe_click'].includes(name)) {
       const target = result?.frame && typeof result.frame === 'object' ? result.frame : result;
       const type = String(target?.type || '').toLowerCase();
-      if (target?.isSubmitControl === false && type === 'button') return false;
+      const strongDetectedSubmit = detectedSubmit?.validationSubmitEvidence === 'strong';
+      if (target?.isSubmitControl === false && type === 'button' && !strongDetectedSubmit) return false;
     }
     if (this._formValidationActionHasStrongSubmitEvidence(toolName, args, result, detectedSubmit)) return true;
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
@@ -5289,6 +5291,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           host,
           tool: name,
           reason: String(detected.reason || 'likely form submission').slice(0, 200),
+          validationSubmitEvidence: detected.validationSubmitEvidence === 'strong' ? 'strong' : 'heuristic',
           summary: String(detected.summary || '').slice(0, 1200),
           fields: Array.isArray(detected.fields) ? detected.fields.slice(0, 12) : [],
           changedFields: Array.isArray(detected.changedFields) ? detected.changedFields.slice(0, 8) : [],
@@ -5462,11 +5465,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         changedFields,
       };
     };
-    const submitInfo = (form, reason, pendingEl = null, pendingValue = null) => ({
+    const submitInfo = (form, reason, pendingEl = null, pendingValue = null, validationSubmitEvidence = 'strong') => ({
       isSubmit: true,
       host,
       url,
       reason,
+      validationSubmitEvidence,
       ...summarizeForm(form, pendingEl, pendingValue),
     });
     const labelControlFor = (el) => {
@@ -5487,21 +5491,37 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       } catch {}
       return target && target.nodeType === 1 ? target : null;
     };
-    const isSubmitControl = (el) => {
+    const submitControlEvidence = (el) => {
       const target = labelControlFor(el) || el;
-      if (!target || target.nodeType !== 1) return false;
+      if (!target || target.nodeType !== 1) return { isSubmit: false, strong: false };
       const candidate = target.closest?.('button,input,[role="button"],[onclick],[data-action]') || target;
       const tag = String(candidate.tagName || '').toLowerCase();
       const type = String(candidate.getAttribute?.('type') || candidate.type || '').toLowerCase();
       const role = String(candidate.getAttribute?.('role') || '').toLowerCase();
       const hasActivationHandler = candidate.hasAttribute?.('onclick') || candidate.hasAttribute?.('data-action');
       const form = candidate.form || candidate.closest?.('form');
-      if (!form) return false;
-      if (tag === 'input') return type === 'submit' || type === 'image' || type === 'button';
-      if (tag === 'button') return !type || type === 'submit' || type === 'button';
-      if (role === 'button' || hasActivationHandler) return true;
-      return false;
+      if (!form) return { isSubmit: false, strong: false };
+      const inlineHandler = String(candidate.getAttribute?.('onclick') || '');
+      const dataAction = String(candidate.getAttribute?.('data-action') || '');
+      const label = compact(
+        candidate.innerText || candidate.textContent || candidate.getAttribute?.('aria-label') || '',
+        120,
+      );
+      const explicitJsSubmit = /\brequestSubmit\s*\(|\.submit\s*\(|\bdispatchEvent\s*\([^)]*\bsubmit\b/i.test(inlineHandler)
+        || /^(?:submit|checkout|pay|place[-_ ]?order|confirm[-_ ]?order|complete[-_ ]?order|purchase|register|sign[-_ ]?in|log[-_ ]?in)$/i.test(dataAction.trim())
+        || /^(?:submit|checkout|pay|place order|confirm order|complete order|purchase|register|sign in|log in)$/i.test(label.trim());
+      if (tag === 'input') {
+        if (type === 'submit' || type === 'image') return { isSubmit: true, strong: true };
+        if (type === 'button') return { isSubmit: true, strong: explicitJsSubmit };
+      }
+      if (tag === 'button') {
+        if (!type || type === 'submit') return { isSubmit: true, strong: true };
+        if (type === 'button') return { isSubmit: true, strong: explicitJsSubmit };
+      }
+      if (role === 'button' || hasActivationHandler) return { isSubmit: true, strong: explicitJsSubmit };
+      return { isSubmit: false, strong: false };
     };
+    const isSubmitControl = el => submitControlEvidence(el).isSubmit;
     const formForSubmitControl = (el) => {
       const target = labelControlFor(el) || el;
       const candidate = target?.closest?.('button,input') || target;
@@ -5623,7 +5643,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         return form ? submitInfo(form, 'Enter key in a form field') : null;
       }
       if (target && isSubmitControl(target)) {
-        return submitInfo(formForSubmitControl(target), 'submit button/control activation');
+        const evidence = submitControlEvidence(target);
+        return submitInfo(
+          formForSubmitControl(target),
+          'submit button/control activation',
+          null,
+          null,
+          evidence.strong ? 'strong' : 'heuristic',
+        );
       }
     } catch {}
     return null;

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2042,7 +2042,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
       const formValidationCandidate = this._isFormValidationCandidate(fnName, fnArgs);
       const formValidationAllFrames = fnName === 'iframe_click' || fnName === 'press_keys';
-      let detectedSubmitAction = null;
+      let detectedSubmitAction = formValidationCandidate && fnName === 'iframe_click'
+        ? await this._detectLikelySubmitAction(tabId, fnName, fnArgs)
+        : null;
       const validationBlock = formValidationCandidate ? this._formValidationBlocks.get(tabId) : null;
       let priorValidationFailure = !!validationBlock;
       const obviousSubmitAction = formValidationCandidate
@@ -4832,6 +4834,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       (Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : [])
         .map(field => `${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
     ));
+    const beforeActiveInvalid = new Set(before
+      .filter(state => state?.activeInvalid === true)
+      .map(state => `${state?.frameId ?? ''}|${this._normalizeUrlPath(String(state?.url || ''))}`));
     const newAlerts = [];
     const newAriaInvalid = [];
     // Custom alert/live-region and aria-invalid failures must be newly exposed
@@ -4853,7 +4858,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
     // Native browser validation prevents navigation, so only compare it on the
     // original route. Redirected pages require explicit alert/ARIA evidence.
-    const nativeFailureStates = sameRouteAfter.filter(state => state?.activeInvalid === true);
+    const nativeFailureStates = sameRouteAfter.filter((state) => {
+      if (state?.activeInvalid !== true) return false;
+      const key = `${state?.frameId ?? ''}|${this._normalizeUrlPath(String(state?.url || ''))}`;
+      return !beforeActiveInvalid.has(key);
+    });
     const nativeInvalidFields = looksLikeSubmit
       ? nativeFailureStates.flatMap(state => Array.isArray(state?.invalidFields) ? state.invalidFields : [])
       : [];

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2043,7 +2043,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const formValidationCandidate = this._isFormValidationCandidate(fnName, fnArgs);
       const formValidationAllFrames = fnName === 'iframe_click' || fnName === 'press_keys';
       const preflightSubmitDetection = formValidationCandidate
-        && ['click', 'click_ax', 'iframe_click'].includes(fnName);
+        && ['click', 'click_ax', 'iframe_click', 'press_keys'].includes(fnName);
       let detectedSubmitAction = preflightSubmitDetection
         ? await this._detectLikelySubmitAction(tabId, fnName, fnArgs)
         : null;
@@ -4769,7 +4769,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (name === 'execute_js') return this._executeJsLooksLikeFormSubmit(args?.code);
     if (name === 'press_keys') {
       const keys = JSON.stringify(args?.key ?? args?.keys ?? '').toLowerCase();
-      return /\b(?:enter|return)\b/.test(keys);
+      return /\b(?:enter|return)\b/.test(keys) && detectedSubmit?.isSubmit === true;
     }
     if (!['click', 'click_ax', 'iframe_click'].includes(name)) return false;
 

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -192,6 +192,12 @@ export class Agent {
     this._doneBlockCount = new Map();
     this._recentSubmitClicks = new Map();
     this._formValidationBlocks = new Map(); // tabId -> validation state that must change before another submit
+    const formValidationSaltBytes = new Uint32Array(4);
+    globalThis.crypto.getRandomValues(formValidationSaltBytes);
+    this._formValidationFingerprintSalt = Array.from(
+      formValidationSaltBytes,
+      value => value.toString(16).padStart(8, '0'),
+    ).join('');
     this._runningTabs = new Set(); // tabIds with an active processMessage/Stream in flight
     this.completionInvariants = new Map(); // tabId -> run-scoped post-action verification state
     this._completionRunCounter = 0;
@@ -2044,6 +2050,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const formValidationAllFrames = fnName === 'iframe_click' || fnName === 'press_keys';
       let detectedSubmitAction = null;
       const validationBlock = formValidationCandidate ? this._formValidationBlocks.get(tabId) : null;
+      let priorValidationFailure = !!validationBlock;
       const obviousSubmitAction = formValidationCandidate
         && this._formValidationActionLooksSubmit(fnName, fnArgs);
       let formValidationBefore = (validationBlock || obviousSubmitAction)
@@ -2053,6 +2060,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         const currentValidationStateKey = this._formValidationStateKey(formValidationBefore);
         if (currentValidationStateKey !== validationBlock.stateKey) {
           this._formValidationBlocks.delete(tabId);
+          priorValidationFailure = false;
         } else {
           const retryActionKey = this._formValidationActionKey(fnName, fnArgs);
           if (retryActionKey && retryActionKey === validationBlock.actionKey) {
@@ -2270,7 +2278,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             args: fnArgs,
             result: toolResult,
             detectedSubmit: detectedSubmitAction,
-            priorValidationFailure: !!validationBlock,
+            priorValidationFailure,
           },
           { allFrames: formValidationAllFrames },
         );
@@ -4972,6 +4980,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         rawResults = await chrome.scripting.executeScript({
           target: { tabId, ...(allFrames ? { allFrames: true } : {}) },
           func: Agent._formValidationStateProbe,
+          args: [this._formValidationFingerprintSalt],
         });
         return (Array.isArray(rawResults) ? rawResults : [])
           .map(item => ({ frameId: item?.frameId ?? null, ...(item?.result || {}) }))
@@ -4980,7 +4989,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (globalThis.browser?.tabs?.executeScript) {
         let probeSource = Agent._formValidationStateProbe.toString();
         if (!/^\s*(?:async\s+)?function\b/.test(probeSource)) probeSource = `function ${probeSource}`;
-        const code = `(() => { const __wbFormValidationProbe = (${probeSource}); return __wbFormValidationProbe(); })()`;
+        const probeSalt = JSON.stringify(this._formValidationFingerprintSalt);
+        const code = `(() => { const __wbFormValidationProbe = (${probeSource}); return __wbFormValidationProbe(${probeSalt}); })()`;
         rawResults = await browser.tabs.executeScript(tabId, { code, allFrames });
         return (Array.isArray(rawResults) ? rawResults : [])
           .map((result, frameId) => ({ frameId, ...(result || {}) }))
@@ -4997,7 +5007,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * Page-side form validation snapshot. Keep self-contained: Firefox
    * serializes this function into tabs and neither browser may close over Agent.
    */
-  static _formValidationStateProbe = function _formValidationStateProbe() {
+  static _formValidationStateProbe = function _formValidationStateProbe(fingerprintSalt = '') {
     const compact = (value, max = 300) => String(value ?? '').replace(/\s+/g, ' ').trim().slice(0, max);
     const roots = [document];
     try {
@@ -5122,6 +5132,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         hash = Math.imul(hash, 16777619);
       }
     };
+    // Mix a per-agent secret into the page-side fingerprint. Password values
+    // can then affect retry detection without ever leaving the probe as text.
+    addHash(`salt:${fingerprintSalt}\u001e`);
     for (const el of queryAll('input, textarea, select, [contenteditable="true"], button, [role="button"], [onclick], [data-action]')) {
       const tag = String(el.tagName || '').toLowerCase();
       const type = String(el.getAttribute?.('type') || el.tagName || '').toLowerCase();
@@ -5141,7 +5154,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         state = compact(el.innerText || el.textContent || el.getAttribute?.('aria-label') || '', 120);
       } else {
         const value = String(el.value ?? el.textContent ?? '');
-        state = type === 'password' ? `password-length:${value.length}` : value;
+        state = type === 'password' ? `password-value:${value}` : value;
       }
       addHash(`${el.tagName}|${type}|${el.name || ''}|${el.id || ''}|${visible(el) ? 'visible' : 'hidden'}|${el.disabled ? 'disabled' : 'enabled'}|${state}\u001e`);
     }

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4722,7 +4722,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   _formValidationActionKey(toolName, args = {}) {
     const name = String(toolName || '');
     const fields = name === 'set_field'
-      ? ['selector', 'ref_id', 'index', 'name', 'submit']
+      ? ['selector', 'ref_id', 'index', 'name', 'text', 'submit']
       : name === 'press_keys'
         ? ['selector', 'ref_id', 'index', 'key', 'keys']
         : ['selector', 'ref_id', 'index', 'text', 'x', 'y', 'urlFilter'];
@@ -4730,6 +4730,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     for (const field of fields) {
       const value = args?.[field];
       if (value == null || value === '') continue;
+      if (name === 'set_field' && field === 'text') {
+        const text = String(value);
+        let hash = 2166136261;
+        for (let i = 0; i < text.length; i++) {
+          hash ^= text.charCodeAt(i);
+          hash = Math.imul(hash, 16777619);
+        }
+        identity.textFingerprint = `${text.length}:${(hash >>> 0).toString(16)}`;
+        continue;
+      }
       identity[field] = typeof value === 'string' ? value.slice(0, 500) : value;
     }
     return Object.keys(identity).length ? `${name}:${JSON.stringify(identity)}` : '';

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -4812,11 +4812,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const beforeRoutes = new Set(before
       .map(state => this._normalizeUrlPath(String(state?.url || '')))
       .filter(Boolean));
-    const comparableAfter = after.filter((state) => {
+    const sameRouteAfter = after.filter((state) => {
       const route = this._normalizeUrlPath(String(state?.url || ''));
       return beforeRoutes.size === 0 || !route || beforeRoutes.has(route);
     });
-    if (!comparableAfter.length) return null;
 
     const looksLikeSubmit = this._formValidationActionLooksSubmit(
       context.toolName,
@@ -4828,31 +4827,33 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       && context.priorValidationFailure === true;
     const beforeAlerts = new Set(before.flatMap(state =>
       this._formValidationAlertTexts(state)
-        .map(text => `${this._normalizeUrlPath(String(state?.url || ''))}|${text}`)
     ));
     const beforeAriaInvalid = new Set(before.flatMap(state =>
       (Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : [])
-        .map(field => `${this._normalizeUrlPath(String(state?.url || ''))}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
+        .map(field => `${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`)
     ));
     const newAlerts = [];
     const newAriaInvalid = [];
     // Custom alert/live-region and aria-invalid failures must be newly exposed
-    // by the action. With no baseline we still detect native validation via
-    // activeInvalid, but do not mislabel an unrelated pre-existing alert.
-    for (const state of before.length ? comparableAfter : []) {
-      const route = this._normalizeUrlPath(String(state?.url || ''));
+    // by the action. Include redirected routes because servers commonly render
+    // validation feedback at a new path. With no baseline we still detect
+    // native validation via activeInvalid, but do not mislabel an unrelated
+    // pre-existing alert.
+    for (const state of before.length ? after : []) {
       for (const text of this._formValidationAlertTexts(state)) {
-        if (text && (includePersistentValidation || !beforeAlerts.has(`${route}|${text}`))) {
+        if (text && (includePersistentValidation || !beforeAlerts.has(text))) {
           newAlerts.push(text);
         }
       }
       for (const field of Array.isArray(state?.ariaInvalidFields) ? state.ariaInvalidFields : []) {
-        const key = `${route}|${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
+        const key = `${field?.label || ''}|${field?.type || ''}|${field?.message || ''}`;
         if (includePersistentValidation || !beforeAriaInvalid.has(key)) newAriaInvalid.push(field);
       }
     }
 
-    const nativeFailureStates = comparableAfter.filter(state => state?.activeInvalid === true);
+    // Native browser validation prevents navigation, so only compare it on the
+    // original route. Redirected pages require explicit alert/ARIA evidence.
+    const nativeFailureStates = sameRouteAfter.filter(state => state?.activeInvalid === true);
     const nativeInvalidFields = looksLikeSubmit
       ? nativeFailureStates.flatMap(state => Array.isArray(state?.invalidFields) ? state.invalidFields : [])
       : [];
@@ -4906,6 +4907,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const beforeRoutes = new Set(before
       .map(state => this._normalizeUrlPath(String(state?.url || '')))
       .filter(Boolean));
+    let changedRouteObservedAt = null;
     const startedAt = Date.now();
     for (const checkpoint of checkpointsMs) {
       const targetDelay = Math.max(0, Number(checkpoint) || 0);
@@ -4922,7 +4924,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         && afterRoutes.size > 0
         && ![...afterRoutes].some(route => beforeRoutes.has(route))
       ) {
-        break;
+        if (changedRouteObservedAt == null) {
+          changedRouteObservedAt = Date.now();
+        } else if (Date.now() - changedRouteObservedAt >= 350) {
+          break;
+        }
+      } else {
+        changedRouteObservedAt = null;
       }
     }
     return null;

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1492,6 +1492,8 @@
     return {
       success: true,
       tag: el.tagName,
+      type: String(el.getAttribute?.('type') || '').toLowerCase(),
+      isSubmitControl: targetIsSubmitControl,
       text: el.innerText?.slice(0, 50),
       ...(clickedRect ? { rect: clickedRect } : {}),
       ...(warning ? { warning } : {}),

--- a/test/run.js
+++ b/test/run.js
@@ -22912,6 +22912,14 @@ test('form validation classifier surfaces native and custom submission errors', 
     assert.ok(persistentNativeSubmit, `${AgentClass.name}: already-focused native invalid field was missed on a real submit`);
     assert.match(persistentNativeSubmit.error, /compatible with at least one application/i);
 
+    const executeJsReadback = agent._detectFormValidationFailure(alreadyActive, alreadyActive, {
+      toolName: 'execute_js',
+      args: { code: 'return document.title' },
+      result: { success: true, result: 'Example' },
+      detectedSubmit: { isSubmit: true },
+    });
+    assert.equal(executeJsReadback, null, `${AgentClass.name}: execute_js readback was treated as a failed submit`);
+
     const customAfter = [{
       ...before[0],
       invalidFields: [],
@@ -22999,6 +23007,17 @@ test('form validation classifier surfaces native and custom submission errors', 
       { isSubmit: true },
     ), false, `${AgentClass.name}: explicit non-submit metadata did not override conservative preflight`);
     assert.equal(agent._formValidationActionLooksSubmit(
+      'execute_js',
+      { code: 'return document.title' },
+      { success: true, result: 'Example' },
+      { isSubmit: true },
+    ), false, `${AgentClass.name}: non-submit execute_js inherited conservative submit detection`);
+    assert.equal(agent._formValidationActionLooksSubmit(
+      'execute_js',
+      { code: 'document.querySelector("form").requestSubmit()' },
+      { success: true, result: null },
+    ), true, `${AgentClass.name}: requestSubmit execute_js was not recognized as a submit`);
+    assert.equal(agent._formValidationActionLooksSubmit(
       'click',
       { selector: '#open-help' },
       { success: true, tag: 'BUTTON', text: 'Open help' },
@@ -23052,7 +23071,7 @@ test('form validation probes resolve aria-errormessage text in document and shad
   }
 });
 
-test('form validation probes distinguish same-length password corrections without returning passwords', () => {
+test('form validation probes fingerprint password and ARIA checked-state corrections', () => {
   const secretControl = {
     tagName: 'INPUT',
     name: 'password',
@@ -23066,7 +23085,21 @@ test('form validation probes distinguish same-length password corrections withou
     hasAttribute() { return false; },
     getBoundingClientRect() { return { width: 120, height: 24 }; },
   };
-  const controlsSelector = 'input, textarea, select, [contenteditable="true"], button, [role="button"], [onclick], [data-action]';
+  let ariaChecked = 'false';
+  const ariaCheckedControl = {
+    tagName: 'DIV',
+    name: 'application',
+    id: 'application',
+    disabled: false,
+    getAttribute(name) {
+      if (name === 'role') return 'checkbox';
+      if (name === 'aria-checked') return ariaChecked;
+      return '';
+    },
+    hasAttribute(name) { return name === 'aria-checked'; },
+    getBoundingClientRect() { return { width: 120, height: 24 }; },
+  };
+  const controlsSelector = 'input, textarea, select, [contenteditable="true"], [role="checkbox"], [role="radio"], [role="switch"], [aria-checked], button, [role="button"], [onclick], [data-action]';
   const sandbox = {
     NodeFilter: { SHOW_ELEMENT: 1 },
     getComputedStyle: () => ({
@@ -23083,7 +23116,7 @@ test('form validation probes distinguish same-length password corrections withou
         };
       },
       querySelectorAll(selector) {
-        return selector === controlsSelector ? [secretControl] : [];
+        return selector === controlsSelector ? [secretControl, ariaCheckedControl] : [];
       },
     },
   };
@@ -23103,6 +23136,17 @@ test('form validation probes distinguish same-length password corrections withou
       JSON.stringify([first, second]),
       /first1|second/,
       `${AgentClass.name}: validation snapshot exposed a password value`,
+    );
+
+    secretControl.value = 'second';
+    ariaChecked = 'false';
+    const unchecked = vm.runInNewContext(`(${probeSource})()`, sandbox);
+    ariaChecked = 'true';
+    const checked = vm.runInNewContext(`(${probeSource})()`, sandbox);
+    assert.notEqual(
+      unchecked.controlFingerprint,
+      checked.controlFingerprint,
+      `${AgentClass.name}: aria-checked correction kept the validation state unchanged`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -23248,6 +23248,44 @@ test('form validation polling catches delayed errors', async () => {
       assert.equal(captures, 2, `${AgentClass.name}: validation polling did not retry after redirect to ${redirectedUrl}`);
     }
 
+    const hydratedRoute = `${url}/error`;
+    const redirectedShell = [{
+      frameId: 0,
+      url: hydratedRoute,
+      activeInvalid: false,
+      invalidFields: [],
+      ariaInvalidFields: [],
+      alerts: [],
+      controlFingerprint: 'redirected-shell',
+    }];
+    const hydratedError = [{
+      ...redirectedShell[0],
+      alerts: ['Server rejected this value after hydration.'],
+    }];
+    const hydratedAgent = new AgentClass({ getVisionProvider: async () => null });
+    let hydratedCaptures = 0;
+    hydratedAgent._captureFormValidationState = async () => {
+      hydratedCaptures += 1;
+      return structuredClone(hydratedCaptures < 3 ? redirectedShell : hydratedError);
+    };
+    const hydratedFailure = await hydratedAgent._waitForFormValidationFailure(
+      5116,
+      [{
+        ...redirectedShell[0],
+        url,
+        controlFingerprint: 'submitted',
+      }],
+      {
+        toolName: 'click',
+        args: { text: 'Submit' },
+        result: { success: true, tag: 'BUTTON', type: 'submit', isSubmitControl: true },
+      },
+      { checkpointsMs: [0, 360, 420] },
+    );
+    assert.ok(hydratedFailure, `${AgentClass.name}: hydrated validation feedback was missed after a different-path redirect`);
+    assert.match(hydratedFailure.error, /after hydration/i);
+    assert.equal(hydratedCaptures, 3, `${AgentClass.name}: redirected shell stopped polling before the late checkpoint`);
+
     const remainingError = [{
       frameId: 0,
       url,

--- a/test/run.js
+++ b/test/run.js
@@ -22936,6 +22936,15 @@ test('form validation classifier surfaces native and custom submission errors', 
     assert.notEqual(failedSetFieldKey, correctedSetFieldKey, `${AgentClass.name}: corrected set_field value kept the failed retry key`);
     assert.doesNotMatch(failedSetFieldKey, /wrong@example\.com/, `${AgentClass.name}: set_field retry key retained raw typed text`);
     assert.doesNotMatch(correctedSetFieldKey, /correct@example\.com/, `${AgentClass.name}: corrected retry key retained raw typed text`);
+
+    const failedExecuteJsKey = agent._formValidationActionKey('execute_js', {
+      code: 'document.querySelector("form").requestSubmit()',
+    });
+    const correctedExecuteJsKey = agent._formValidationActionKey('execute_js', {
+      code: 'document.querySelector("#checkout").requestSubmit()',
+    });
+    assert.notEqual(failedExecuteJsKey, correctedExecuteJsKey, `${AgentClass.name}: corrected execute_js kept the failed retry key`);
+    assert.doesNotMatch(failedExecuteJsKey, /requestSubmit/, `${AgentClass.name}: execute_js retry key retained raw code`);
   }
 });
 
@@ -22979,6 +22988,156 @@ test('form validation polling catches delayed errors', async () => {
     assert.ok(failure, `${AgentClass.name}: delayed validation feedback was missed`);
     assert.match(failure.error, /server rejected this value/i);
     assert.equal(captures, 2, `${AgentClass.name}: validation polling did not retry after a same-form redirect`);
+  }
+});
+
+test('coordinate iframe submits capture validation state in all frames', async () => {
+  const agent = new AgentCh({ getVisionProvider: async () => null });
+  const tabId = 5118;
+  const url = 'https://merchant.example/checkout';
+  const before = [{
+    frameId: 0,
+    url,
+    activeInvalid: false,
+    invalidFields: [],
+    ariaInvalidFields: [],
+    alerts: [],
+    controlFingerprint: 'top',
+  }, {
+    frameId: 3,
+    url: 'https://payments.example/card',
+    activeInvalid: false,
+    invalidFields: [],
+    ariaInvalidFields: [],
+    alerts: [],
+    controlFingerprint: 'card-ready',
+  }];
+  const after = structuredClone(before);
+  after[1].activeInvalid = true;
+  after[1].invalidFields = [{
+    label: 'Card number',
+    type: 'text',
+    message: 'Enter a valid card number.',
+  }];
+  after[1].controlFingerprint = 'card-invalid';
+
+  const captureOptions = [];
+  let captures = 0;
+  agent._ensureGateSetting = async () => false;
+  agent._skipPermissionGate = false;
+  agent._currentUrl = async () => url;
+  agent._recordProgressObservation = async () => null;
+  agent._autoRecordProgressAction = () => null;
+  agent._progressWarningForAction = () => '';
+  agent._persist = () => {};
+  agent._iframeRectsForCoordinate = async () => [{
+    left: 20,
+    top: 40,
+    width: 400,
+    height: 250,
+    url: 'https://payments.example/card',
+    host: 'payments.example',
+    index: 0,
+  }];
+  agent._detectLikelySubmitAction = async () => ({
+    isSubmit: true,
+    host: 'payments.example',
+    tool: 'click',
+    reason: 'submit button/control activation',
+  });
+  agent._promptSubmitConfirmation = async () => 'once';
+  agent._captureFormValidationState = async (_tabId, options = {}) => {
+    captureOptions.push(options);
+    captures += 1;
+    return structuredClone(captures === 1 ? before : after);
+  };
+  agent.executeTool = async () => ({
+    success: true,
+    dispatched: true,
+    text: 'Pay',
+  });
+
+  const messages = [];
+  await agent._executeToolBatch(
+    tabId,
+    [{
+      id: 'coordinate_iframe_submit',
+      function: { name: 'click', arguments: '{"x":120,"y":160}' },
+    }],
+    messages,
+    () => {},
+    { supportsVision: false },
+    '',
+    new Set(['click']),
+    1,
+  );
+
+  assert.ok(captureOptions.length >= 2, 'Chrome: coordinate iframe submit did not capture before and after states');
+  assert.ok(captureOptions.every(options => options.allFrames === true), 'Chrome: coordinate iframe validation capture omitted child frames');
+  const result = JSON.parse(agent._unwrapUntrusted(messages[0].content));
+  assert.equal(result.formValidationFailed, true, 'Chrome: child-frame validation failure was not returned');
+  assert.match(result.error, /valid card number/i);
+});
+
+test('execute_js submissions receive form validation feedback', async () => {
+  const url = 'https://example.com/checkout';
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getVisionProvider: async () => null });
+    const tabId = 5119;
+    const before = [{
+      frameId: 0,
+      url,
+      activeInvalid: false,
+      invalidFields: [],
+      ariaInvalidFields: [],
+      alerts: [],
+      controlFingerprint: 'ready',
+    }];
+    const after = [{
+      ...before[0],
+      alerts: ['Please correct the payment details.'],
+      controlFingerprint: 'script-error',
+    }];
+    let captures = 0;
+    agent._ensureGateSetting = async () => true;
+    agent._skipPermissionGate = true;
+    agent._currentUrl = async () => url;
+    agent._recordProgressObservation = async () => null;
+    agent._autoRecordProgressAction = () => null;
+    agent._progressWarningForAction = () => '';
+    agent._persist = () => {};
+    agent._captureFormValidationState = async () => {
+      captures += 1;
+      return structuredClone(captures === 1 ? before : after);
+    };
+    agent.executeTool = async () => ({
+      success: true,
+      dispatched: true,
+      result: null,
+    });
+
+    const messages = [];
+    await agent._executeToolBatch(
+      tabId,
+      [{
+        id: 'execute_js_submit',
+        function: {
+          name: 'execute_js',
+          arguments: '{"code":"document.querySelector(\\\"form\\\").requestSubmit()"}',
+        },
+      }],
+      messages,
+      () => {},
+      { supportsVision: false },
+      '',
+      new Set(['execute_js']),
+      1,
+    );
+
+    assert.ok(captures >= 2, `${AgentClass.name}: execute_js submit did not capture validation states`);
+    const result = JSON.parse(agent._unwrapUntrusted(messages[0].content));
+    assert.equal(result.formValidationFailed, true, `${AgentClass.name}: execute_js validation failure was not returned`);
+    assert.match(result.error, /correct the payment details/i);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -22899,6 +22899,8 @@ test('form validation classifier surfaces native and custom submission errors', 
       toolName: 'click',
       args: { text: 'Continue' },
       result: { success: true, tag: 'BUTTON', type: 'button', isSubmitControl: false },
+      detectedSubmit: { isSubmit: true },
+      priorValidationFailure: true,
     });
     assert.equal(correctiveNative, null, `${AgentClass.name}: pre-existing native validation blocked a corrective button`);
 
@@ -22924,6 +22926,15 @@ test('form validation classifier surfaces native and custom submission errors', 
     });
     assert.ok(customFailure, `${AgentClass.name}: custom validation alert was missed`);
     assert.match(customFailure.error, /correct the highlighted fields/i);
+
+    const correctivePersistentAlert = agent._detectFormValidationFailure(customAfter, customAfter, {
+      toolName: 'click',
+      args: { text: 'Continue' },
+      result: { success: true, tag: 'BUTTON', type: 'button', isSubmitControl: false },
+      detectedSubmit: { isSubmit: true },
+      priorValidationFailure: true,
+    });
+    assert.equal(correctivePersistentAlert, null, `${AgentClass.name}: conservative preflight revived a persistent alert for a corrective button`);
 
     const existingAlert = agent._detectFormValidationFailure(customAfter, customAfter, {
       toolName: 'click',

--- a/test/run.js
+++ b/test/run.js
@@ -22935,6 +22935,30 @@ test('form validation classifier surfaces native and custom submission errors', 
     assert.ok(customFailure, `${AgentClass.name}: custom validation alert was missed`);
     assert.match(customFailure.error, /correct the highlighted fields/i);
 
+    const sharedAlertBefore = [{
+      ...before[0],
+      alerts: ['Required'],
+    }];
+    const sharedAlertAfter = [
+      sharedAlertBefore[0],
+      {
+        ...before[0],
+        frameId: 7,
+        alerts: ['Required'],
+        controlFingerprint: 'iframe-required',
+      },
+    ];
+    const sharedAlertFailure = agent._detectFormValidationFailure(sharedAlertBefore, sharedAlertAfter, {
+      toolName: 'iframe_click',
+      args: { selector: '#submit', urlFilter: 'addons.mozilla.org' },
+      result: {
+        success: true,
+        frame: { tag: 'BUTTON', type: 'submit', isSubmitControl: true },
+      },
+      detectedSubmit: { isSubmit: true, validationSubmitEvidence: 'strong' },
+    });
+    assert.ok(sharedAlertFailure, `${AgentClass.name}: duplicate alert text in a newly invalid iframe was deduplicated against another frame`);
+
     const correctivePersistentAlert = agent._detectFormValidationFailure(customAfter, customAfter, {
       toolName: 'click',
       args: { text: 'Continue' },
@@ -23082,7 +23106,7 @@ test('form validation classifier surfaces native and custom submission errors', 
       { code: 'return document.title' },
       { success: true, result: 'Example' },
       { isSubmit: true },
-    ), false, `${AgentClass.name}: non-submit execute_js inherited conservative submit detection`);
+    ), true, `${AgentClass.name}: detected dynamic execute_js submit was ignored by validation inspection`);
     assert.equal(agent._formValidationActionLooksSubmit(
       'execute_js',
       { code: 'document.querySelector("form").requestSubmit()' },
@@ -23758,7 +23782,7 @@ test('execute_js submissions receive form validation feedback', async () => {
         id: 'execute_js_submit',
         function: {
           name: 'execute_js',
-          arguments: '{"code":"document.querySelector(\\\"form\\\").requestSubmit()"}',
+          arguments: '{"code":"submitCheckout()"}',
         },
       }],
       messages,
@@ -23832,7 +23856,11 @@ test('agent returns form validation messages and blocks unchanged repeat submits
       if (args?.text === 'Continue' && currentState[0].invalidFields.length) {
         currentState = [{ ...currentState[0], activeInvalid: true }];
       } else if (args?.text === 'Continue') {
-        currentState = [{ ...currentState[0], url: `${url}success` }];
+        currentState = [{
+          ...currentState[0],
+          url: `${url}success`,
+          alerts: [],
+        }];
       }
       const isSubmit = args?.text === 'Continue';
       return {

--- a/test/run.js
+++ b/test/run.js
@@ -25497,7 +25497,39 @@ test('chrome submit detector fail-closes CDP-only submit selector targets', () =
   assert.match(agent, /selector resolves to a submit control in shadow DOM/, 'chrome: CDP selector fallback should force submit confirmation for CDP-only submit controls');
   assert.match(agent, /_detectCdpSubmitSelector[\s\S]*type === 'image' \|\| type === 'button'[\s\S]*!type \|\| type === 'submit' \|\| type === 'button'/, 'chrome: CDP selector fallback should fail closed for JS-driven type=button form controls');
   assert.match(agent, /_detectCdpSubmitSelector[\s\S]*const role = String\(attrs\.role \|\| ''\)\.toLowerCase\(\);[\s\S]*Object\.prototype\.hasOwnProperty\.call\(attrs, 'onclick'\)[\s\S]*role === 'button'[\s\S]*hasActivationHandler/, 'chrome: CDP selector fallback should fail closed for non-native JS-driven controls');
-  assert.match(agent, /const nativeSubmit = \(tag === 'input'[\s\S]*validationSubmitEvidence: nativeSubmit \? 'strong' : 'heuristic'/, 'chrome: CDP selector fallback should preserve strong native-submit evidence');
+  assert.match(agent, /const nativeSubmit = \(tag === 'input'[\s\S]*tag === 'button' && \(!type \|\| type === 'submit'\)[\s\S]*validationSubmitEvidence: nativeSubmit \? 'strong' : 'heuristic'/, 'chrome: CDP selector fallback should preserve strong native-submit evidence, including default-type buttons');
+});
+
+test('chrome CDP submit selector treats default buttons as strong native submits', async () => {
+  const previousChrome = globalThis.chrome;
+  const originals = {
+    attach: cdpClientCh.attach,
+    resolveSelector: cdpClientCh.resolveSelector,
+    describeNode: cdpClientCh.describeNode,
+  };
+  try {
+    globalThis.chrome = { ...(previousChrome || {}), debugger: {} };
+    cdpClientCh.attach = async () => ({ attached: true });
+    cdpClientCh.resolveSelector = async () => ({ found: true, nodeId: 41 });
+    let attributes = [];
+    cdpClientCh.describeNode = async () => ({
+      node: { nodeName: 'BUTTON', attributes },
+    });
+    const agent = new AgentCh({ getVisionProvider: async () => null });
+
+    const defaultButton = await agent._detectCdpSubmitSelector(23, '#shadow-submit', 'example.com');
+    assert.equal(defaultButton?.validationSubmitEvidence, 'strong', 'default-type button should carry strong native-submit evidence');
+
+    attributes = ['type', 'button'];
+    const scriptButton = await agent._detectCdpSubmitSelector(23, '#shadow-continue', 'example.com');
+    assert.equal(scriptButton?.validationSubmitEvidence, 'heuristic', 'type=button should remain heuristic without stronger JS evidence');
+  } finally {
+    cdpClientCh.attach = originals.attach;
+    cdpClientCh.resolveSelector = originals.resolveSelector;
+    cdpClientCh.describeNode = originals.describeNode;
+    if (previousChrome === undefined) delete globalThis.chrome;
+    else globalThis.chrome = previousChrome;
+  }
 });
 
 test('firefox submit detector serializes static probe as a function expression', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -22952,14 +22952,18 @@ test('form validation polling catches delayed errors', async () => {
       alerts: [],
       controlFingerprint: 'unchanged',
     }];
-    const delayed = [{
+    const redirected = [{
       ...before[0],
+      url: `${url}?error=pending#payment`,
+    }];
+    const delayed = [{
+      ...redirected[0],
       alerts: ['Server rejected this value.'],
     }];
     let captures = 0;
     agent._captureFormValidationState = async () => {
       captures += 1;
-      return structuredClone(captures === 1 ? before : delayed);
+      return structuredClone(captures === 1 ? redirected : delayed);
     };
 
     const failure = await agent._waitForFormValidationFailure(
@@ -22974,7 +22978,7 @@ test('form validation polling catches delayed errors', async () => {
     );
     assert.ok(failure, `${AgentClass.name}: delayed validation feedback was missed`);
     assert.match(failure.error, /server rejected this value/i);
-    assert.equal(captures, 2, `${AgentClass.name}: validation polling did not retry after the immediate snapshot`);
+    assert.equal(captures, 2, `${AgentClass.name}: validation polling did not retry after a same-form redirect`);
   }
 });
 
@@ -23061,11 +23065,18 @@ test('agent returns form validation messages and blocks unchanged repeat submits
     };
 
     const runSubmit = id => runClick(id, 'Continue');
+    agent._recentSubmitClicks.set(tabId, [{
+      key: `continue|${url}`,
+      ts: Date.now(),
+      url,
+      text: 'Continue',
+    }]);
     const failed = await runSubmit('submit_validation_failure');
     assert.equal(failed.success, false, `${AgentClass.name}: invalid submit was reported successful`);
     assert.equal(failed.formValidationFailed, true, `${AgentClass.name}: missing formValidationFailed marker`);
     assert.match(failed.error, /compatible with at least one application/i);
     assert.equal(executions, 1, `${AgentClass.name}: first submit did not execute exactly once`);
+    assert.equal(agent._recentSubmitClicks.has(tabId), false, `${AgentClass.name}: rejected submit kept a stale duplicate-click block`);
 
     const blocked = await runSubmit('submit_validation_retry');
     assert.equal(blocked.blockedValidationRetry, true, `${AgentClass.name}: unchanged invalid form was resubmitted`);

--- a/test/run.js
+++ b/test/run.js
@@ -22948,6 +22948,29 @@ test('form validation classifier surfaces native and custom submission errors', 
   }
 });
 
+test('form validation probes resolve aria-errormessage text in document and shadow roots', () => {
+  for (const [label, rel] of [
+    ['chrome', 'src/chrome/src/agent/agent.js'],
+    ['firefox', 'src/firefox/src/agent/agent.js'],
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+    const probeStart = source.indexOf('static _formValidationStateProbe');
+    const probeEnd = source.indexOf('_fallbackSubmitConfirmationInfo', probeStart);
+    assert.ok(probeStart >= 0 && probeEnd > probeStart, `${label}: form validation probe should be bounded`);
+    const probe = source.slice(probeStart, probeEnd);
+    assert.match(
+      probe,
+      /\['aria-errormessage', 'aria-describedby'\]\.flatMap/,
+      `${label}: invalid-field details should include aria-errormessage references`,
+    );
+    assert.match(
+      probe,
+      /for \(const root of roots\)[\s\S]*root\.getElementById\?\.\(id\)/,
+      `${label}: ARIA error references should resolve inside collected shadow roots`,
+    );
+  }
+});
+
 test('form validation polling catches delayed errors', async () => {
   const url = 'https://example.com/form';
   for (const AgentClass of [AgentCh, AgentFx]) {

--- a/test/run.js
+++ b/test/run.js
@@ -23001,16 +23001,12 @@ test('form validation probes resolve aria-errormessage text in document and shad
 });
 
 test('form validation probes distinguish same-length password corrections without returning passwords', () => {
-  const priorDocument = globalThis.document;
-  const priorNodeFilter = globalThis.NodeFilter;
-  const priorGetComputedStyle = globalThis.getComputedStyle;
-  let passwordValue = 'first1';
-  const passwordField = {
+  const secretControl = {
     tagName: 'INPUT',
     name: 'password',
     id: 'password',
     disabled: false,
-    get value() { return passwordValue; },
+    value: 'first1',
     getAttribute(name) {
       if (name === 'type') return 'password';
       return '';
@@ -23019,15 +23015,14 @@ test('form validation probes distinguish same-length password corrections withou
     getBoundingClientRect() { return { width: 120, height: 24 }; },
   };
   const controlsSelector = 'input, textarea, select, [contenteditable="true"], button, [role="button"], [onclick], [data-action]';
-
-  try {
-    globalThis.NodeFilter = { SHOW_ELEMENT: 1 };
-    globalThis.getComputedStyle = () => ({
+  const sandbox = {
+    NodeFilter: { SHOW_ELEMENT: 1 },
+    getComputedStyle: () => ({
       display: 'block',
       visibility: 'visible',
       opacity: '1',
-    });
-    globalThis.document = {
+    }),
+    document: {
       activeElement: null,
       createTreeWalker() {
         return {
@@ -23036,33 +23031,27 @@ test('form validation probes distinguish same-length password corrections withou
         };
       },
       querySelectorAll(selector) {
-        return selector === controlsSelector ? [passwordField] : [];
+        return selector === controlsSelector ? [secretControl] : [];
       },
-    };
+    },
+  };
 
-    for (const AgentClass of [AgentCh, AgentFx]) {
-      passwordValue = 'first1';
-      const first = AgentClass._formValidationStateProbe('test-only-secret');
-      passwordValue = 'second';
-      const second = AgentClass._formValidationStateProbe('test-only-secret');
-      assert.notEqual(
-        first.controlFingerprint,
-        second.controlFingerprint,
-        `${AgentClass.name}: same-length password correction kept the validation state unchanged`,
-      );
-      assert.doesNotMatch(
-        JSON.stringify([first, second]),
-        /first1|second/,
-        `${AgentClass.name}: validation snapshot exposed a password value`,
-      );
-    }
-  } finally {
-    if (priorDocument === undefined) delete globalThis.document;
-    else globalThis.document = priorDocument;
-    if (priorNodeFilter === undefined) delete globalThis.NodeFilter;
-    else globalThis.NodeFilter = priorNodeFilter;
-    if (priorGetComputedStyle === undefined) delete globalThis.getComputedStyle;
-    else globalThis.getComputedStyle = priorGetComputedStyle;
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const probeSource = AgentClass._formValidationStateProbe.toString();
+    secretControl.value = 'first1';
+    const first = vm.runInNewContext(`(${probeSource})()`, sandbox);
+    secretControl.value = 'second';
+    const second = vm.runInNewContext(`(${probeSource})()`, sandbox);
+    assert.notEqual(
+      first.controlFingerprint,
+      second.controlFingerprint,
+      `${AgentClass.name}: same-length password correction kept the validation state unchanged`,
+    );
+    assert.doesNotMatch(
+      JSON.stringify([first, second]),
+      /first1|second/,
+      `${AgentClass.name}: validation snapshot exposed a password value`,
+    );
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -22738,7 +22738,7 @@ test('submit confirmation honors scheduled and global gate bypasses', async () =
         1,
       );
 
-      assert.equal(submitProbeCalls, 0, `${AgentClass.name} ${scenario.label}: submit probe should be skipped before bypassed prompts`);
+      assert.equal(submitProbeCalls, 1, `${AgentClass.name} ${scenario.label}: validation preflight should run even when the submit prompt is bypassed`);
       assert.equal(executed, true, `${AgentClass.name} ${scenario.label}: bypassed submit tool should execute`);
       assert.equal(messages.length, 1, `${AgentClass.name} ${scenario.label}: expected one tool result`);
       assert.equal(JSON.parse(agent._unwrapUntrusted(messages[0].content)).success, true, `${AgentClass.name} ${scenario.label}: tool result should be successful`);
@@ -23611,6 +23611,82 @@ test('unattended iframe submits preflight validation in all frames', async () =>
     const result = JSON.parse(agent._unwrapUntrusted(messages[0].content).split('\n', 1)[0]);
     assert.equal(result.formValidationFailed, true, `${AgentClass.name}: unattended iframe validation failure was missed`);
     assert.match(result.error, /card verification failed/i);
+  }
+});
+
+test('unattended custom submits preflight validation', async () => {
+  const url = 'https://example.com/checkout';
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getVisionProvider: async () => null });
+    const tabId = AgentClass === AgentCh ? 5124 : 5125;
+    const before = [{
+      frameId: 0,
+      url,
+      activeInvalid: false,
+      invalidFields: [],
+      ariaInvalidFields: [],
+      alerts: [],
+      controlFingerprint: 'ready',
+    }];
+    const after = [{
+      ...before[0],
+      alerts: ['Please correct the highlighted fields.'],
+      controlFingerprint: 'rejected',
+    }];
+
+    let detections = 0;
+    let captures = 0;
+    agent._ensureGateSetting = async () => true;
+    agent._skipPermissionGate = true;
+    agent._currentUrl = async () => url;
+    agent._recordProgressObservation = async () => null;
+    agent._autoRecordProgressAction = () => null;
+    agent._progressWarningForAction = () => '';
+    agent._persist = () => {};
+    agent._detectLikelySubmitAction = async (_tabId, toolName) => {
+      detections += 1;
+      assert.equal(toolName, 'click');
+      return {
+        isSubmit: true,
+        host: 'example.com',
+        tool: 'click',
+        reason: 'button inside a form',
+        validationSubmitEvidence: 'heuristic',
+      };
+    };
+    agent._captureFormValidationState = async () => {
+      captures += 1;
+      return structuredClone(captures === 1 ? before : after);
+    };
+    agent.executeTool = async () => ({
+      success: true,
+      dispatched: true,
+      tag: 'BUTTON',
+      type: 'button',
+      isSubmitControl: false,
+      text: 'Continue',
+    });
+
+    const messages = [];
+    await agent._executeToolBatch(
+      tabId,
+      [{
+        id: 'unattended_custom_submit',
+        function: { name: 'click', arguments: '{"text":"Continue"}' },
+      }],
+      messages,
+      () => {},
+      { supportsVision: false },
+      '',
+      new Set(['click']),
+      1,
+    );
+
+    assert.equal(detections, 1, `${AgentClass.name}: unattended custom submit skipped preflight detection`);
+    assert.ok(captures >= 2, `${AgentClass.name}: unattended custom submit skipped validation capture`);
+    const result = JSON.parse(agent._unwrapUntrusted(messages[0].content));
+    assert.equal(result.formValidationFailed, true, `${AgentClass.name}: unattended custom submit missed validation feedback`);
+    assert.match(result.error, /correct the highlighted fields/i);
   }
 });
 
@@ -25189,6 +25265,7 @@ test('submit controls bypass native select guards in click paths', () => {
   assert.match(chromeAgent, /const coordSelCheck = info\.isSubmitControl \? null : await cdpClient\.evaluate/, 'chrome agent: submit text clicks should skip coordinate select guard');
   assert.match(chromeAgent, /const postClickSel1 = info\.isSubmitControl \? null : await cdpClient\.evaluate/, 'chrome agent: submit text clicks should skip post-click select false errors');
   assert.match(chromeAgent, /isEditableControl: isEditableControl\(el\)/, 'chrome agent: resolved click target should expose its own editability');
+  assert.match(chromeAgent, /widgetFallback: true,[\s\S]*isEditableControl: el\.isContentEditable[\s\S]*role'\) === 'textbox'[\s\S]*role'\) === 'combobox'/, 'chrome agent: widened text-click fallback should preserve contenteditable/widget editability');
   assert.match(chromeAgent, /const isEditableTarget = info\.isEditableControl === true;/, 'chrome agent: stale-click exemption should use the clicked target, not post-submit focus');
 
   for (const [label, rel] of [

--- a/test/run.js
+++ b/test/run.js
@@ -22936,6 +22936,23 @@ test('form validation classifier surfaces native and custom submission errors', 
     });
     assert.equal(correctivePersistentAlert, null, `${AgentClass.name}: conservative preflight revived a persistent alert for a corrective button`);
 
+    const revealedRequiredRow = [{
+      ...before[0],
+      ariaInvalidFields: [{
+        label: 'Phone number',
+        type: 'tel',
+        message: 'This field is required.',
+      }],
+      controlFingerprint: 'phone-row-added',
+    }];
+    const revealedRowFailure = agent._detectFormValidationFailure(before, revealedRequiredRow, {
+      toolName: 'click',
+      args: { text: 'Add phone' },
+      result: { success: true, tag: 'BUTTON', type: 'button', isSubmitControl: false },
+      detectedSubmit: { isSubmit: true },
+    });
+    assert.equal(revealedRowFailure, null, `${AgentClass.name}: revealing a blank required row was treated as a failed submit`);
+
     const existingAlert = agent._detectFormValidationFailure(customAfter, customAfter, {
       toolName: 'click',
       args: { text: 'Open help' },
@@ -22975,6 +22992,12 @@ test('form validation classifier surfaces native and custom submission errors', 
       { text: 'Choose application' },
       { success: true, tag: 'BUTTON', type: 'button', text: 'Choose application', isSubmitControl: false },
     ), false, `${AgentClass.name}: corrective type=button was misclassified as a submit`);
+    assert.equal(agent._formValidationActionLooksSubmit(
+      'click',
+      { text: 'Add address' },
+      { success: true, tag: 'BUTTON', type: 'button', text: 'Add address', isSubmitControl: false },
+      { isSubmit: true },
+    ), false, `${AgentClass.name}: explicit non-submit metadata did not override conservative preflight`);
     assert.equal(agent._formValidationActionLooksSubmit(
       'click',
       { selector: '#open-help' },

--- a/test/run.js
+++ b/test/run.js
@@ -22902,6 +22902,14 @@ test('form validation classifier surfaces native and custom submission errors', 
     });
     assert.equal(correctiveNative, null, `${AgentClass.name}: pre-existing native validation blocked a corrective button`);
 
+    const persistentNativeSubmit = agent._detectFormValidationFailure(alreadyActive, alreadyActive, {
+      toolName: 'click',
+      args: { text: 'Submit' },
+      result: { success: true, tag: 'BUTTON', type: 'submit', isSubmitControl: true },
+    });
+    assert.ok(persistentNativeSubmit, `${AgentClass.name}: already-focused native invalid field was missed on a real submit`);
+    assert.match(persistentNativeSubmit.error, /compatible with at least one application/i);
+
     const customAfter = [{
       ...before[0],
       invalidFields: [],

--- a/test/run.js
+++ b/test/run.js
@@ -16096,8 +16096,16 @@ test('Chrome selector click distinguishes pre-dispatch failure from uncertain di
     width: 30,
     height: 40,
     tag: 'BUTTON',
+    type: 'button',
+    isSubmitControl: false,
     text: 'Submit',
   });
+  client.sendCommand = async () => ({});
+  const ordinaryButton = await client.clickElement(42, '#open-help');
+  assert.equal(ordinaryButton.success, true);
+  assert.equal(ordinaryButton.type, 'button', 'selector clicks should preserve the resolved button type');
+  assert.equal(ordinaryButton.isSubmitControl, false, 'selector clicks should preserve non-submit metadata');
+
   client.sendCommand = async (_tabId, _method, params) => {
     if (params.type === 'mousePressed') throw new Error('dispatch response lost');
     return {};
@@ -16109,6 +16117,13 @@ test('Chrome selector click distinguishes pre-dispatch failure from uncertain di
   const uncertain = await client.clickElement(42, '#submit');
   assert.equal(uncertain.success, false);
   assert.equal(uncertain.dispatched, true, 'a mousePressed attempt must fail closed when later fallback also fails');
+
+  const source = fs.readFileSync(path.join(ROOT, 'src/chrome/src/cdp/cdp-client.js'), 'utf8');
+  assert.match(
+    source,
+    /const isSubmitControl = tag === 'INPUT'[\s\S]*tag === 'BUTTON'[\s\S]*isSubmitControl,/,
+    'selector resolution should derive submit metadata from the target element',
+  );
 });
 
 test('Chrome selector type distinguishes pre-dispatch failure from uncertain dispatch', async () => {
@@ -22899,6 +22914,15 @@ test('form validation classifier surfaces native and custom submission errors', 
     });
     assert.equal(existingAlert, null, `${AgentClass.name}: pre-existing alert was misclassified as a new form error`);
 
+    const persistentAlert = agent._detectFormValidationFailure(customAfter, customAfter, {
+      toolName: 'click',
+      args: { text: 'Submit' },
+      result: { success: true, tag: 'BUTTON', type: 'submit', isSubmitControl: true },
+      priorValidationFailure: true,
+    });
+    assert.ok(persistentAlert, `${AgentClass.name}: persistent alert was lost on a failed resubmit`);
+    assert.match(persistentAlert.error, /correct the highlighted fields/i);
+
     const successfulAfter = [{
       ...before[0],
       invalidFields: [],
@@ -22922,6 +22946,11 @@ test('form validation classifier surfaces native and custom submission errors', 
       { text: 'Choose application' },
       { success: true, tag: 'BUTTON', type: 'button', text: 'Choose application', isSubmitControl: false },
     ), false, `${AgentClass.name}: corrective type=button was misclassified as a submit`);
+    assert.equal(agent._formValidationActionLooksSubmit(
+      'click',
+      { selector: '#open-help' },
+      { success: true, tag: 'BUTTON', text: 'Open help' },
+    ), false, `${AgentClass.name}: selector-clicked button with missing metadata was misclassified as a submit`);
 
     const failedSetFieldKey = agent._formValidationActionKey('set_field', {
       ref_id: 'ref_email',

--- a/test/run.js
+++ b/test/run.js
@@ -23007,6 +23007,20 @@ test('form validation classifier surfaces native and custom submission errors', 
       { isSubmit: true },
     ), false, `${AgentClass.name}: explicit non-submit metadata did not override conservative preflight`);
     assert.equal(agent._formValidationActionLooksSubmit(
+      'click',
+      { text: 'Pay' },
+      { success: true, tag: 'BUTTON', type: 'button', text: 'Pay', isSubmitControl: false },
+      { isSubmit: true, validationSubmitEvidence: 'strong' },
+    ), true, `${AgentClass.name}: strong custom-submit preflight was discarded for type=button`);
+    const customButtonFailure = agent._detectFormValidationFailure(before, revealedRequiredRow, {
+      toolName: 'click',
+      args: { text: 'Pay' },
+      result: { success: true, tag: 'BUTTON', type: 'button', text: 'Pay', isSubmitControl: false },
+      detectedSubmit: { isSubmit: true, validationSubmitEvidence: 'strong' },
+    });
+    assert.ok(customButtonFailure, `${AgentClass.name}: custom type=button submit skipped its validation failure`);
+    assert.match(customButtonFailure.error, /phone number/i);
+    assert.equal(agent._formValidationActionLooksSubmit(
       'execute_js',
       { code: 'return document.title' },
       { success: true, result: 'Example' },
@@ -25086,6 +25100,10 @@ test('submit detector source covers submit controls, Enter, set_field, iframes, 
     assert.match(agent, /const escaped = selector\.replace[\s\S]*return root\.querySelector\(escaped\)/, `${label}: safe selector fallback should retry escaped colons`);
     assert.match(agent, /const labelControlFor = \(el\) => \{[\s\S]*String\(el\.tagName \|\| ''\)\.toUpperCase\(\) !== 'LABEL'[\s\S]*el\.htmlFor[\s\S]*doc\.getElementById\(el\.htmlFor\)[\s\S]*button,input,textarea,select/, `${label}: submit probe should resolve labels to associated controls`);
     assert.match(agent, /const target = labelControlFor\(el\) \|\| el;[\s\S]*const candidate = target\.closest\?\.\('button,input,\[role="button"\],\[onclick\],\[data-action\]'\)/, `${label}: submit-control detection should inspect label-backed controls`);
+    assert.match(agent, /const submitControlEvidence = \(el\) => \{/, `${label}: custom submit controls should classify preflight evidence strength`);
+    assert.match(agent, /const submitInfo = \(form, reason, pendingEl = null, pendingValue = null, validationSubmitEvidence = 'strong'\)/, `${label}: submit summaries should carry preflight evidence strength`);
+    assert.match(agent, /evidence\.strong \? 'strong' : 'heuristic'/, `${label}: custom submit probes should label strong and heuristic evidence`);
+    assert.match(agent, /detected\.validationSubmitEvidence === 'strong' \? 'strong' : 'heuristic'/, `${label}: submit evidence strength should survive page-probe normalization`);
     assert.match(agent, /const findTopmostModal = \(\) => \{[\s\S]*dialog\[open\][\s\S]*\[role="dialog"\]\[aria-modal="true"\][\s\S]*\[class\*="DialogOverlay"\]/, `${label}: text submit probing should mirror modal scoping`);
     assert.match(agent, /Array\.from\(\(findTopmostModal\(\) \|\| doc\)\.querySelectorAll/, `${label}: text submit probing should search inside the topmost modal when present`);
   }

--- a/test/run.js
+++ b/test/run.js
@@ -22922,6 +22922,20 @@ test('form validation classifier surfaces native and custom submission errors', 
       { text: 'Choose application' },
       { success: true, tag: 'BUTTON', type: 'button', text: 'Choose application', isSubmitControl: false },
     ), false, `${AgentClass.name}: corrective type=button was misclassified as a submit`);
+
+    const failedSetFieldKey = agent._formValidationActionKey('set_field', {
+      ref_id: 'ref_email',
+      text: 'wrong@example.com',
+      submit: true,
+    });
+    const correctedSetFieldKey = agent._formValidationActionKey('set_field', {
+      ref_id: 'ref_email',
+      text: 'correct@example.com',
+      submit: true,
+    });
+    assert.notEqual(failedSetFieldKey, correctedSetFieldKey, `${AgentClass.name}: corrected set_field value kept the failed retry key`);
+    assert.doesNotMatch(failedSetFieldKey, /wrong@example\.com/, `${AgentClass.name}: set_field retry key retained raw typed text`);
+    assert.doesNotMatch(correctedSetFieldKey, /correct@example\.com/, `${AgentClass.name}: corrected retry key retained raw typed text`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -23019,6 +23019,12 @@ test('form validation classifier surfaces native and custom submission errors', 
       { isSubmit: true, validationSubmitEvidence: 'strong' },
     ), true, `${AgentClass.name}: strong custom-submit preflight was discarded for type=button`);
     assert.equal(agent._formValidationActionLooksSubmit(
+      'click',
+      { selector: '#save' },
+      { success: true },
+      { isSubmit: true, validationSubmitEvidence: 'strong' },
+    ), true, `${AgentClass.name}: strong CDP-only submit evidence was discarded without result metadata`);
+    assert.equal(agent._formValidationActionLooksSubmit(
       'click_ax',
       { ref_id: 'ref_choose_application' },
       { success: true, tag: 'button', name: 'Choose application' },
@@ -25362,6 +25368,7 @@ test('chrome submit detector fail-closes CDP-only submit selector targets', () =
   assert.match(agent, /selector resolves to a submit control in shadow DOM/, 'chrome: CDP selector fallback should force submit confirmation for CDP-only submit controls');
   assert.match(agent, /_detectCdpSubmitSelector[\s\S]*type === 'image' \|\| type === 'button'[\s\S]*!type \|\| type === 'submit' \|\| type === 'button'/, 'chrome: CDP selector fallback should fail closed for JS-driven type=button form controls');
   assert.match(agent, /_detectCdpSubmitSelector[\s\S]*const role = String\(attrs\.role \|\| ''\)\.toLowerCase\(\);[\s\S]*Object\.prototype\.hasOwnProperty\.call\(attrs, 'onclick'\)[\s\S]*role === 'button'[\s\S]*hasActivationHandler/, 'chrome: CDP selector fallback should fail closed for non-native JS-driven controls');
+  assert.match(agent, /const nativeSubmit = \(tag === 'input'[\s\S]*validationSubmitEvidence: nativeSubmit \? 'strong' : 'heuristic'/, 'chrome: CDP selector fallback should preserve strong native-submit evidence');
 });
 
 test('firefox submit detector serializes static probe as a function expression', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -22930,7 +22930,7 @@ test('form validation classifier surfaces native and custom submission errors', 
       toolName: 'click_ax',
       args: { ref_id: 'ref_submit' },
       result: { success: true, tag: 'BUTTON' },
-      detectedSubmit: { isSubmit: true },
+      detectedSubmit: { isSubmit: true, validationSubmitEvidence: 'strong' },
     });
     assert.ok(customFailure, `${AgentClass.name}: custom validation alert was missed`);
     assert.match(customFailure.error, /correct the highlighted fields/i);
@@ -23012,6 +23012,24 @@ test('form validation classifier surfaces native and custom submission errors', 
       { success: true, tag: 'BUTTON', type: 'button', text: 'Pay', isSubmitControl: false },
       { isSubmit: true, validationSubmitEvidence: 'strong' },
     ), true, `${AgentClass.name}: strong custom-submit preflight was discarded for type=button`);
+    assert.equal(agent._formValidationActionLooksSubmit(
+      'click_ax',
+      { ref_id: 'ref_choose_application' },
+      { success: true, tag: 'button', name: 'Choose application' },
+      { isSubmit: true, validationSubmitEvidence: 'heuristic' },
+    ), false, `${AgentClass.name}: heuristic AX preflight was promoted to strong submit evidence`);
+    assert.equal(agent._formValidationActionLooksSubmit(
+      'iframe_click',
+      { selector: '#add-phone', text: 'Add phone' },
+      { success: true, frame: { tag: 'BUTTON', text: 'Add phone' } },
+      { isSubmit: true, validationSubmitEvidence: 'heuristic' },
+    ), false, `${AgentClass.name}: heuristic iframe preflight was re-promoted by its Add label`);
+    assert.equal(agent._formValidationActionLooksSubmit(
+      'click_ax',
+      { ref_id: 'ref_pay' },
+      { success: true, tag: 'button', name: 'Pay' },
+      { isSubmit: true, validationSubmitEvidence: 'strong' },
+    ), true, `${AgentClass.name}: strong AX custom-submit preflight was weakened`);
     const customButtonFailure = agent._detectFormValidationFailure(before, revealedRequiredRow, {
       toolName: 'click',
       args: { text: 'Pay' },
@@ -23020,6 +23038,13 @@ test('form validation classifier surfaces native and custom submission errors', 
     });
     assert.ok(customButtonFailure, `${AgentClass.name}: custom type=button submit skipped its validation failure`);
     assert.match(customButtonFailure.error, /phone number/i);
+    const correctiveAxResult = agent._detectFormValidationFailure(before, revealedRequiredRow, {
+      toolName: 'click_ax',
+      args: { ref_id: 'ref_add_phone' },
+      result: { success: true, tag: 'button', name: 'Add phone' },
+      detectedSubmit: { isSubmit: true, validationSubmitEvidence: 'heuristic' },
+    });
+    assert.equal(correctiveAxResult, null, `${AgentClass.name}: heuristic AX correction was reported as a failed submission`);
     assert.equal(agent._formValidationActionLooksSubmit(
       'execute_js',
       { code: 'return document.title' },
@@ -23266,6 +23291,7 @@ test('coordinate iframe submits capture validation state in all frames', async (
     host: 'payments.example',
     tool: 'click',
     reason: 'submit button/control activation',
+    validationSubmitEvidence: 'strong',
   });
   agent._promptSubmitConfirmation = async () => 'once';
   agent._captureFormValidationState = async (_tabId, options = {}) => {
@@ -23345,6 +23371,7 @@ test('unattended iframe submits preflight validation in all frames', async () =>
         host: 'payments.example',
         tool: 'iframe_click',
         reason: 'submit button/control activation',
+        validationSubmitEvidence: 'strong',
       };
     };
     agent._captureFormValidationState = async (_tabId, options = {}) => {

--- a/test/run.js
+++ b/test/run.js
@@ -22845,6 +22845,244 @@ test('approved iframe submit keeps host gate fail-closed without urlFilter', asy
   }
 });
 
+test('form validation classifier surfaces native and custom submission errors', () => {
+  const url = 'https://addons.mozilla.org/en-US/developers/addon/webbrain/versions/submit/';
+  const invalidField = {
+    label: 'Firefox',
+    type: 'checkbox',
+    message: 'Your extension has to be compatible with at least one application.',
+  };
+
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getVisionProvider: async () => null });
+    const before = [{
+      frameId: 0,
+      url,
+      activeInvalid: false,
+      invalidFields: [invalidField],
+      ariaInvalidFields: [],
+      alerts: [],
+      controlFingerprint: 'unchecked',
+    }];
+    const nativeAfter = [{
+      ...before[0],
+      activeInvalid: true,
+    }];
+    const nativeFailure = agent._detectFormValidationFailure(before, nativeAfter, {
+      toolName: 'click',
+      args: { text: 'Continue' },
+      result: { success: true, tag: 'BUTTON' },
+    });
+    assert.ok(nativeFailure, `${AgentClass.name}: native validation failure was missed`);
+    assert.match(nativeFailure.error, /compatible with at least one application/i);
+    assert.deepEqual(nativeFailure.invalidFields[0], invalidField);
+
+    const customAfter = [{
+      ...before[0],
+      invalidFields: [],
+      alerts: ['Please correct the highlighted fields.'],
+      controlFingerprint: 'custom-error',
+    }];
+    const customFailure = agent._detectFormValidationFailure(before, customAfter, {
+      toolName: 'click_ax',
+      args: { ref_id: 'ref_submit' },
+      result: { success: true, tag: 'BUTTON' },
+      detectedSubmit: { isSubmit: true },
+    });
+    assert.ok(customFailure, `${AgentClass.name}: custom validation alert was missed`);
+    assert.match(customFailure.error, /correct the highlighted fields/i);
+
+    const existingAlert = agent._detectFormValidationFailure(customAfter, customAfter, {
+      toolName: 'click',
+      args: { text: 'Open help' },
+      result: { success: true, tag: 'BUTTON' },
+    });
+    assert.equal(existingAlert, null, `${AgentClass.name}: pre-existing alert was misclassified as a new form error`);
+
+    const successfulAfter = [{
+      ...before[0],
+      invalidFields: [],
+      alerts: ['Saved successfully'],
+      controlFingerprint: 'saved',
+    }];
+    const successfulAnnouncement = agent._detectFormValidationFailure(before, successfulAfter, {
+      toolName: 'click',
+      args: { text: 'Save' },
+      result: { success: true, tag: 'BUTTON', type: 'submit', isSubmitControl: true },
+    });
+    assert.equal(successfulAnnouncement, null, `${AgentClass.name}: success announcement was misclassified as validation failure`);
+
+    assert.equal(agent._formValidationActionLooksSubmit(
+      'click',
+      { text: 'Continue' },
+      { success: true, tag: 'DIV', text: 'Continue', isSubmitControl: false },
+    ), true, `${AgentClass.name}: custom submit-looking control skipped validation inspection`);
+    assert.equal(agent._formValidationActionLooksSubmit(
+      'click',
+      { text: 'Choose application' },
+      { success: true, tag: 'BUTTON', type: 'button', text: 'Choose application', isSubmitControl: false },
+    ), false, `${AgentClass.name}: corrective type=button was misclassified as a submit`);
+  }
+});
+
+test('form validation polling catches delayed errors', async () => {
+  const url = 'https://example.com/form';
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getVisionProvider: async () => null });
+    const before = [{
+      frameId: 0,
+      url,
+      activeInvalid: false,
+      invalidFields: [],
+      ariaInvalidFields: [],
+      alerts: [],
+      controlFingerprint: 'unchanged',
+    }];
+    const delayed = [{
+      ...before[0],
+      alerts: ['Server rejected this value.'],
+    }];
+    let captures = 0;
+    agent._captureFormValidationState = async () => {
+      captures += 1;
+      return structuredClone(captures === 1 ? before : delayed);
+    };
+
+    const failure = await agent._waitForFormValidationFailure(
+      5116,
+      before,
+      {
+        toolName: 'click',
+        args: { text: 'Submit' },
+        result: { success: true, tag: 'BUTTON', type: 'submit', isSubmitControl: true },
+      },
+      { checkpointsMs: [0, 0] },
+    );
+    assert.ok(failure, `${AgentClass.name}: delayed validation feedback was missed`);
+    assert.match(failure.error, /server rejected this value/i);
+    assert.equal(captures, 2, `${AgentClass.name}: validation polling did not retry after the immediate snapshot`);
+  }
+});
+
+test('agent returns form validation messages and blocks unchanged repeat submits', async () => {
+  const url = 'https://addons.mozilla.org/en-US/developers/addon/webbrain/versions/submit/';
+  const invalidField = {
+    label: 'Firefox',
+    type: 'checkbox',
+    message: 'Your extension has to be compatible with at least one application.',
+  };
+
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getVisionProvider: async () => null });
+    const tabId = 5117;
+    let executions = 0;
+    let prompts = 0;
+    let currentState = [{
+      frameId: 0,
+      url,
+      activeInvalid: false,
+      invalidFields: [invalidField],
+      ariaInvalidFields: [],
+      alerts: [],
+      controlFingerprint: 'unchecked',
+    }];
+
+    agent._ensureGateSetting = async () => false;
+    agent._skipPermissionGate = false;
+    agent._currentUrl = async () => url;
+    agent._recordProgressObservation = async () => null;
+    agent._autoRecordProgressAction = () => null;
+    agent._progressWarningForAction = () => '';
+    agent._persist = () => {};
+    agent._captureFormValidationState = async () => structuredClone(currentState);
+    agent._detectLikelySubmitAction = async (_tabId, _toolName, args) => (
+      args?.text === 'Continue'
+        ? {
+            isSubmit: true,
+            host: 'addons.mozilla.org',
+            tool: 'click',
+            reason: 'submit button/control activation',
+          }
+        : null
+    );
+    agent._promptSubmitConfirmation = async () => {
+      prompts += 1;
+      return 'once';
+    };
+    agent.executeTool = async (_tabId, _toolName, args) => {
+      executions += 1;
+      if (args?.text === 'Continue' && currentState[0].invalidFields.length) {
+        currentState = [{ ...currentState[0], activeInvalid: true }];
+      } else if (args?.text === 'Continue') {
+        currentState = [{ ...currentState[0], url: `${url}success` }];
+      }
+      const isSubmit = args?.text === 'Continue';
+      return {
+        success: true,
+        dispatched: true,
+        tag: 'BUTTON',
+        type: isSubmit ? 'submit' : 'button',
+        isSubmitControl: isSubmit,
+        text: args?.text || '',
+      };
+    };
+
+    const runClick = async (id, text) => {
+      const messages = [];
+      await agent._executeToolBatch(
+        tabId,
+        [{
+          id,
+          function: { name: 'click', arguments: JSON.stringify({ text }) },
+        }],
+        messages,
+        () => {},
+        { supportsVision: false },
+        '',
+        new Set(['click']),
+        1,
+      );
+      assert.equal(messages.length, 1, `${AgentClass.name}: expected one tool result`);
+      return JSON.parse(agent._unwrapUntrusted(messages[0].content));
+    };
+
+    const runSubmit = id => runClick(id, 'Continue');
+    const failed = await runSubmit('submit_validation_failure');
+    assert.equal(failed.success, false, `${AgentClass.name}: invalid submit was reported successful`);
+    assert.equal(failed.formValidationFailed, true, `${AgentClass.name}: missing formValidationFailed marker`);
+    assert.match(failed.error, /compatible with at least one application/i);
+    assert.equal(executions, 1, `${AgentClass.name}: first submit did not execute exactly once`);
+
+    const blocked = await runSubmit('submit_validation_retry');
+    assert.equal(blocked.blockedValidationRetry, true, `${AgentClass.name}: unchanged invalid form was resubmitted`);
+    assert.match(blocked.error, /validation state has not changed/i);
+    assert.equal(executions, 1, `${AgentClass.name}: blocked retry still dispatched`);
+    assert.equal(prompts, 1, `${AgentClass.name}: blocked retry asked for submit confirmation again`);
+
+    agent._skipPermissionGate = true;
+    const correction = await runClick('validation_correction_button', 'Choose application');
+    agent._skipPermissionGate = false;
+    assert.equal(correction.success, true, `${AgentClass.name}: corrective type=button was blocked`);
+    assert.equal(correction.blockedValidationRetry, undefined, `${AgentClass.name}: corrective type=button was treated as a repeat submit`);
+    assert.equal(executions, 2, `${AgentClass.name}: corrective type=button did not dispatch`);
+    assert.equal(prompts, 1, `${AgentClass.name}: corrective type=button requested submit confirmation`);
+
+    currentState = [{
+      frameId: 0,
+      url,
+      activeInvalid: false,
+      invalidFields: [],
+      ariaInvalidFields: [],
+      alerts: [],
+      controlFingerprint: 'checked',
+    }];
+    const successful = await runSubmit('submit_after_correction');
+    assert.equal(successful.success, true, `${AgentClass.name}: corrected form remained blocked`);
+    assert.equal(executions, 3, `${AgentClass.name}: corrected form was not submitted`);
+    assert.equal(prompts, 2, `${AgentClass.name}: corrected submit did not receive fresh confirmation`);
+  }
+});
+
 test('submit confirmation card has no always-allow path', async () => {
   for (const AgentClass of [AgentCh, AgentFx]) {
     const agent = new AgentClass({ getVisionProvider: async () => null });
@@ -24214,6 +24452,8 @@ test('submit controls bypass native select guards in click paths', () => {
   assert.match(chromeAgent, /isSubmitControl: isSubmitControl\(el\)/, 'chrome agent: text-resolved controls should expose submit metadata');
   assert.match(chromeAgent, /const coordSelCheck = info\.isSubmitControl \? null : await cdpClient\.evaluate/, 'chrome agent: submit text clicks should skip coordinate select guard');
   assert.match(chromeAgent, /const postClickSel1 = info\.isSubmitControl \? null : await cdpClient\.evaluate/, 'chrome agent: submit text clicks should skip post-click select false errors');
+  assert.match(chromeAgent, /isEditableControl: isEditableControl\(el\)/, 'chrome agent: resolved click target should expose its own editability');
+  assert.match(chromeAgent, /const isEditableTarget = info\.isEditableControl === true;/, 'chrome agent: stale-click exemption should use the clicked target, not post-submit focus');
 
   for (const [label, rel] of [
     ['chrome', 'src/chrome/src/content/content.js'],
@@ -24224,7 +24464,10 @@ test('submit controls bypass native select guards in click paths', () => {
     assert.match(content, /const targetIsSubmitControl = _isSubmitControl\(el\);/, `${label}: click path should classify submit target before select guards`);
     assert.ok(content.includes('if (!(el instanceof HTMLSelectElement) && !targetIsSubmitControl) {'), `${label}: nearby select guard should not block submit controls`);
     assert.ok(content.includes('if (!targetIsSubmitControl && postActive && postActive !== el && postActive instanceof HTMLSelectElement) {'), `${label}: post-click select false error should not block submit controls`);
+    assert.match(content, /isSubmitControl: targetIsSubmitControl,/, `${label}: successful clicks should preserve submit classification for post-click validation`);
   }
+  const chromeContent = fs.readFileSync(path.join(ROOT, 'src/chrome/src/content/content.js'), 'utf8');
+  assert.match(chromeContent, /el\.tagName === 'INPUT' && !\['button', 'checkbox'[\s\S]*?'submit'\]\.includes\(inputType\)/, 'chrome: checkbox/radio focus must not receive the text-editable stale-click exemption');
 });
 
 test('accessibility ref lookup rejects disconnected elements', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -23089,6 +23089,30 @@ test('form validation classifier surfaces native and custom submission errors', 
       { success: true, result: null },
     ), true, `${AgentClass.name}: requestSubmit execute_js was not recognized as a submit`);
     assert.equal(agent._formValidationActionLooksSubmit(
+      'press_keys',
+      { key: 'Enter' },
+      { success: true },
+    ), false, `${AgentClass.name}: Enter without focused form context was treated as a submit`);
+    assert.equal(agent._formValidationActionLooksSubmit(
+      'press_keys',
+      { key: 'Enter' },
+      { success: true },
+      { isSubmit: true, validationSubmitEvidence: 'strong' },
+    ), true, `${AgentClass.name}: Enter in a detected form was not recognized as a submit`);
+    const comboboxEnterFailure = agent._detectFormValidationFailure(before, customAfter, {
+      toolName: 'press_keys',
+      args: { key: 'Enter' },
+      result: { success: true },
+    });
+    assert.equal(comboboxEnterFailure, null, `${AgentClass.name}: non-form Enter misclassified a revealed alert as submit validation`);
+    const formEnterFailure = agent._detectFormValidationFailure(before, customAfter, {
+      toolName: 'press_keys',
+      args: { key: 'Enter' },
+      result: { success: true },
+      detectedSubmit: { isSubmit: true, validationSubmitEvidence: 'strong' },
+    });
+    assert.ok(formEnterFailure, `${AgentClass.name}: detected form Enter skipped validation feedback`);
+    assert.equal(agent._formValidationActionLooksSubmit(
       'click',
       { selector: '#open-help' },
       { success: true, tag: 'BUTTON', text: 'Open help' },

--- a/test/run.js
+++ b/test/run.js
@@ -23008,6 +23008,12 @@ test('form validation classifier surfaces native and custom submission errors', 
     ), false, `${AgentClass.name}: explicit non-submit metadata did not override conservative preflight`);
     assert.equal(agent._formValidationActionLooksSubmit(
       'click',
+      { text: 'Continue' },
+      { success: true, tag: 'BUTTON', type: 'button', text: 'Continue', isSubmitControl: false },
+      { isSubmit: true, validationSubmitEvidence: 'heuristic' },
+    ), true, `${AgentClass.name}: heuristic Continue submit was vetoed by type=button metadata`);
+    assert.equal(agent._formValidationActionLooksSubmit(
+      'click',
       { text: 'Pay' },
       { success: true, tag: 'BUTTON', type: 'button', text: 'Pay', isSubmitControl: false },
       { isSubmit: true, validationSubmitEvidence: 'strong' },
@@ -23050,6 +23056,14 @@ test('form validation classifier surfaces native and custom submission errors', 
     });
     assert.ok(customButtonFailure, `${AgentClass.name}: custom type=button submit skipped its validation failure`);
     assert.match(customButtonFailure.error, /phone number/i);
+    const heuristicButtonFailure = agent._detectFormValidationFailure(before, customAfter, {
+      toolName: 'click',
+      args: { text: 'Continue' },
+      result: { success: true, tag: 'BUTTON', type: 'button', text: 'Continue', isSubmitControl: false },
+      detectedSubmit: { isSubmit: true, validationSubmitEvidence: 'heuristic' },
+    });
+    assert.ok(heuristicButtonFailure, `${AgentClass.name}: heuristic Continue submit skipped its validation failure`);
+    assert.match(heuristicButtonFailure.error, /correct the highlighted fields/i);
     const correctiveAxResult = agent._detectFormValidationFailure(before, revealedRequiredRow, {
       toolName: 'click_ax',
       args: { ref_id: 'ref_add_phone' },

--- a/test/run.js
+++ b/test/run.js
@@ -23396,6 +23396,81 @@ test('coordinate iframe submits capture validation state in all frames', async (
   assert.match(result.error, /valid card number/i);
 });
 
+test('Chrome selector submits capture validation state in all frames', async () => {
+  const agent = new AgentCh({ getVisionProvider: async () => null });
+  const tabId = 5123;
+  const url = 'https://merchant.example/checkout';
+  const before = [{
+    frameId: 0,
+    url,
+    activeInvalid: false,
+    invalidFields: [],
+    ariaInvalidFields: [],
+    alerts: [],
+    controlFingerprint: 'top',
+  }, {
+    frameId: 4,
+    url: 'https://payments.example/card',
+    activeInvalid: false,
+    invalidFields: [],
+    ariaInvalidFields: [],
+    alerts: [],
+    controlFingerprint: 'card-ready',
+  }];
+  const after = structuredClone(before);
+  after[1].activeInvalid = true;
+  after[1].invalidFields = [{
+    label: 'Card number',
+    type: 'text',
+    message: 'Enter a valid card number.',
+  }];
+  after[1].controlFingerprint = 'card-invalid';
+
+  const captureOptions = [];
+  let captures = 0;
+  agent._ensureGateSetting = async () => true;
+  agent._skipPermissionGate = true;
+  agent._currentUrl = async () => url;
+  agent._recordProgressObservation = async () => null;
+  agent._autoRecordProgressAction = () => null;
+  agent._progressWarningForAction = () => '';
+  agent._persist = () => {};
+  agent._captureFormValidationState = async (_tabId, options = {}) => {
+    captureOptions.push(options);
+    captures += 1;
+    return structuredClone(captures === 1 ? before : after);
+  };
+  agent.executeTool = async () => ({
+    success: true,
+    dispatched: true,
+    tag: 'BUTTON',
+    type: 'submit',
+    isSubmitControl: true,
+    text: 'Pay',
+  });
+
+  const messages = [];
+  await agent._executeToolBatch(
+    tabId,
+    [{
+      id: 'selector_iframe_submit',
+      function: { name: 'click', arguments: '{"selector":"#pay"}' },
+    }],
+    messages,
+    () => {},
+    { supportsVision: false },
+    '',
+    new Set(['click']),
+    1,
+  );
+
+  assert.ok(captureOptions.length >= 2, 'Chrome: selector iframe submit did not capture before and after states');
+  assert.ok(captureOptions.every(options => options.allFrames === true), 'Chrome: selector iframe validation capture omitted child frames');
+  const result = JSON.parse(agent._unwrapUntrusted(messages[0].content));
+  assert.equal(result.formValidationFailed, true, 'Chrome: selector child-frame validation failure was not returned');
+  assert.match(result.error, /valid card number/i);
+});
+
 test('unattended iframe submits preflight validation in all frames', async () => {
   const url = 'https://merchant.example/checkout';
   for (const AgentClass of [AgentCh, AgentFx]) {

--- a/test/run.js
+++ b/test/run.js
@@ -23058,43 +23058,48 @@ test('form validation probes distinguish same-length password corrections withou
 test('form validation polling catches delayed errors', async () => {
   const url = 'https://example.com/form';
   for (const AgentClass of [AgentCh, AgentFx]) {
-    const agent = new AgentClass({ getVisionProvider: async () => null });
-    const before = [{
-      frameId: 0,
-      url,
-      activeInvalid: false,
-      invalidFields: [],
-      ariaInvalidFields: [],
-      alerts: [],
-      controlFingerprint: 'unchanged',
-    }];
-    const redirected = [{
-      ...before[0],
-      url: `${url}?error=pending#payment`,
-    }];
-    const delayed = [{
-      ...redirected[0],
-      alerts: ['Server rejected this value.'],
-    }];
-    let captures = 0;
-    agent._captureFormValidationState = async () => {
-      captures += 1;
-      return structuredClone(captures === 1 ? redirected : delayed);
-    };
+    for (const redirectedUrl of [
+      `${url}?error=pending#payment`,
+      `${url}/error`,
+    ]) {
+      const agent = new AgentClass({ getVisionProvider: async () => null });
+      const before = [{
+        frameId: 0,
+        url,
+        activeInvalid: false,
+        invalidFields: [],
+        ariaInvalidFields: [],
+        alerts: [],
+        controlFingerprint: 'unchanged',
+      }];
+      const redirected = [{
+        ...before[0],
+        url: redirectedUrl,
+      }];
+      const delayed = [{
+        ...redirected[0],
+        alerts: ['Server rejected this value.'],
+      }];
+      let captures = 0;
+      agent._captureFormValidationState = async () => {
+        captures += 1;
+        return structuredClone(captures === 1 ? redirected : delayed);
+      };
 
-    const failure = await agent._waitForFormValidationFailure(
-      5116,
-      before,
-      {
-        toolName: 'click',
-        args: { text: 'Submit' },
-        result: { success: true, tag: 'BUTTON', type: 'submit', isSubmitControl: true },
-      },
-      { checkpointsMs: [0, 0] },
-    );
-    assert.ok(failure, `${AgentClass.name}: delayed validation feedback was missed`);
-    assert.match(failure.error, /server rejected this value/i);
-    assert.equal(captures, 2, `${AgentClass.name}: validation polling did not retry after a same-form redirect`);
+      const failure = await agent._waitForFormValidationFailure(
+        5116,
+        before,
+        {
+          toolName: 'click',
+          args: { text: 'Submit' },
+          result: { success: true, tag: 'BUTTON', type: 'submit', isSubmitControl: true },
+        },
+        { checkpointsMs: [0, 0] },
+      );
+      assert.ok(failure, `${AgentClass.name}: delayed validation feedback was missed at ${redirectedUrl}`);
+      assert.match(failure.error, /server rejected this value/i);
+      assert.equal(captures, 2, `${AgentClass.name}: validation polling did not retry after redirect to ${redirectedUrl}`);
+    }
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -23019,6 +23019,18 @@ test('form validation classifier surfaces native and custom submission errors', 
       { isSubmit: true, validationSubmitEvidence: 'heuristic' },
     ), false, `${AgentClass.name}: heuristic AX preflight was promoted to strong submit evidence`);
     assert.equal(agent._formValidationActionLooksSubmit(
+      'click_ax',
+      { ref_id: 'ref_continue' },
+      { success: true, tag: 'div', name: 'Continue' },
+      { isSubmit: true, validationSubmitEvidence: 'heuristic' },
+    ), true, `${AgentClass.name}: heuristic custom Continue control skipped validation inspection`);
+    assert.equal(agent._formValidationActionLooksSubmit(
+      'click_ax',
+      { ref_id: 'ref_save' },
+      { success: true, tag: 'div', name: 'Save' },
+      { isSubmit: true, validationSubmitEvidence: 'heuristic' },
+    ), true, `${AgentClass.name}: heuristic custom Save control skipped validation inspection`);
+    assert.equal(agent._formValidationActionLooksSubmit(
       'iframe_click',
       { selector: '#add-phone', text: 'Add phone' },
       { success: true, frame: { tag: 'BUTTON', text: 'Add phone' } },

--- a/test/run.js
+++ b/test/run.js
@@ -23247,6 +23247,63 @@ test('form validation polling catches delayed errors', async () => {
       assert.match(failure.error, /server rejected this value/i);
       assert.equal(captures, 2, `${AgentClass.name}: validation polling did not retry after redirect to ${redirectedUrl}`);
     }
+
+    const remainingError = [{
+      frameId: 0,
+      url,
+      activeInvalid: false,
+      invalidFields: [],
+      ariaInvalidFields: [{
+        label: 'Phone number',
+        type: 'tel',
+        message: 'This field is required.',
+      }],
+      alerts: ['Please correct the highlighted fields.'],
+      controlFingerprint: 'email-fixed-phone-missing',
+    }];
+    const clearedError = [{
+      ...remainingError[0],
+      ariaInvalidFields: [],
+      alerts: [],
+      controlFingerprint: 'submitted',
+    }];
+    const correctedContext = {
+      toolName: 'click',
+      args: { text: 'Submit' },
+      result: { success: true, tag: 'BUTTON', type: 'submit', isSubmitControl: true },
+      priorValidationFailure: false,
+      correctedPriorValidationFailure: true,
+    };
+
+    const correctedAgent = new AgentClass({ getVisionProvider: async () => null });
+    let persistentCaptures = 0;
+    correctedAgent._captureFormValidationState = async () => {
+      persistentCaptures += 1;
+      return structuredClone(remainingError);
+    };
+    const persistentFailure = await correctedAgent._waitForFormValidationFailure(
+      5116,
+      remainingError,
+      correctedContext,
+      { checkpointsMs: [0, 0] },
+    );
+    assert.ok(persistentFailure, `${AgentClass.name}: remaining validation error was lost after a partial correction`);
+    assert.match(persistentFailure.error, /phone number|highlighted fields/i);
+    assert.equal(persistentCaptures, 2, `${AgentClass.name}: corrected persistent error was accepted before the final checkpoint`);
+
+    let clearingCaptures = 0;
+    correctedAgent._captureFormValidationState = async () => {
+      clearingCaptures += 1;
+      return structuredClone(clearingCaptures === 1 ? remainingError : clearedError);
+    };
+    const clearedFailure = await correctedAgent._waitForFormValidationFailure(
+      5116,
+      remainingError,
+      correctedContext,
+      { checkpointsMs: [0, 0] },
+    );
+    assert.equal(clearedFailure, null, `${AgentClass.name}: a clearing stale error blocked a corrected successful submit`);
+    assert.equal(clearingCaptures, 2, `${AgentClass.name}: corrected submit did not wait for stale validation to clear`);
   }
 });
 
@@ -23620,6 +23677,11 @@ test('agent returns form validation messages and blocks unchanged repeat submits
       validationContexts.at(-1)?.priorValidationFailure,
       false,
       `${AgentClass.name}: corrected state kept stale prior-validation detection enabled`,
+    );
+    assert.equal(
+      validationContexts.at(-1)?.correctedPriorValidationFailure,
+      true,
+      `${AgentClass.name}: corrected state did not preserve deferred prior-validation context`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -22892,6 +22892,16 @@ test('form validation classifier surfaces native and custom submission errors', 
     assert.match(nativeFailure.error, /compatible with at least one application/i);
     assert.deepEqual(nativeFailure.invalidFields[0], invalidField);
 
+    const alreadyActive = [{
+      ...nativeAfter[0],
+    }];
+    const correctiveNative = agent._detectFormValidationFailure(alreadyActive, alreadyActive, {
+      toolName: 'click',
+      args: { text: 'Continue' },
+      result: { success: true, tag: 'BUTTON', type: 'button', isSubmitControl: false },
+    });
+    assert.equal(correctiveNative, null, `${AgentClass.name}: pre-existing native validation blocked a corrective button`);
+
     const customAfter = [{
       ...before[0],
       invalidFields: [],
@@ -23189,6 +23199,90 @@ test('coordinate iframe submits capture validation state in all frames', async (
   const result = JSON.parse(agent._unwrapUntrusted(messages[0].content));
   assert.equal(result.formValidationFailed, true, 'Chrome: child-frame validation failure was not returned');
   assert.match(result.error, /valid card number/i);
+});
+
+test('unattended iframe submits preflight validation in all frames', async () => {
+  const url = 'https://merchant.example/checkout';
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getVisionProvider: async () => null });
+    const tabId = AgentClass === AgentCh ? 5121 : 5122;
+    const before = [{
+      frameId: 0,
+      url,
+      activeInvalid: false,
+      invalidFields: [],
+      ariaInvalidFields: [],
+      alerts: [],
+      controlFingerprint: 'top',
+    }, {
+      frameId: 2,
+      url: 'https://payments.example/card',
+      activeInvalid: false,
+      invalidFields: [],
+      ariaInvalidFields: [],
+      alerts: [],
+      controlFingerprint: 'card-ready',
+    }];
+    const after = structuredClone(before);
+    after[1].alerts = ['Card verification failed.'];
+    after[1].controlFingerprint = 'card-error';
+
+    let detections = 0;
+    let captures = 0;
+    const captureOptions = [];
+    agent._ensureGateSetting = async () => true;
+    agent._skipPermissionGate = true;
+    agent._currentUrl = async () => url;
+    agent._recordProgressObservation = async () => null;
+    agent._autoRecordProgressAction = () => null;
+    agent._progressWarningForAction = () => '';
+    agent._persist = () => {};
+    agent._detectLikelySubmitAction = async (_tabId, toolName) => {
+      detections += 1;
+      assert.equal(toolName, 'iframe_click');
+      return {
+        isSubmit: true,
+        host: 'payments.example',
+        tool: 'iframe_click',
+        reason: 'submit button/control activation',
+      };
+    };
+    agent._captureFormValidationState = async (_tabId, options = {}) => {
+      captureOptions.push(options);
+      captures += 1;
+      return structuredClone(captures === 1 ? before : after);
+    };
+    agent.executeTool = async () => ({
+      success: true,
+      dispatched: true,
+      frame: { tag: 'BUTTON', type: 'button' },
+    });
+
+    const messages = [];
+    await agent._executeToolBatch(
+      tabId,
+      [{
+        id: 'unattended_iframe_submit',
+        function: {
+          name: 'iframe_click',
+          arguments: '{"selector":"#pay","urlFilter":"payments.example"}',
+        },
+      }],
+      messages,
+      () => {},
+      { supportsVision: false },
+      '',
+      new Set(['iframe_click']),
+      1,
+    );
+
+    assert.equal(detections, 1, `${AgentClass.name}: iframe submit was not preflight-detected`);
+    assert.ok(captureOptions.length >= 2, `${AgentClass.name}: iframe validation state was not checked`);
+    assert.ok(captureOptions.every(options => options.allFrames === true), `${AgentClass.name}: iframe validation omitted child frames`);
+    const result = JSON.parse(agent._unwrapUntrusted(messages[0].content).split('\n', 1)[0]);
+    assert.equal(result.formValidationFailed, true, `${AgentClass.name}: unattended iframe validation failure was missed`);
+    assert.match(result.error, /card verification failed/i);
+  }
 });
 
 test('execute_js submissions receive form validation feedback', async () => {

--- a/test/run.js
+++ b/test/run.js
@@ -23000,6 +23000,72 @@ test('form validation probes resolve aria-errormessage text in document and shad
   }
 });
 
+test('form validation probes distinguish same-length password corrections without returning passwords', () => {
+  const priorDocument = globalThis.document;
+  const priorNodeFilter = globalThis.NodeFilter;
+  const priorGetComputedStyle = globalThis.getComputedStyle;
+  let passwordValue = 'first1';
+  const passwordField = {
+    tagName: 'INPUT',
+    name: 'password',
+    id: 'password',
+    disabled: false,
+    get value() { return passwordValue; },
+    getAttribute(name) {
+      if (name === 'type') return 'password';
+      return '';
+    },
+    hasAttribute() { return false; },
+    getBoundingClientRect() { return { width: 120, height: 24 }; },
+  };
+  const controlsSelector = 'input, textarea, select, [contenteditable="true"], button, [role="button"], [onclick], [data-action]';
+
+  try {
+    globalThis.NodeFilter = { SHOW_ELEMENT: 1 };
+    globalThis.getComputedStyle = () => ({
+      display: 'block',
+      visibility: 'visible',
+      opacity: '1',
+    });
+    globalThis.document = {
+      activeElement: null,
+      createTreeWalker() {
+        return {
+          currentNode: null,
+          nextNode() { return null; },
+        };
+      },
+      querySelectorAll(selector) {
+        return selector === controlsSelector ? [passwordField] : [];
+      },
+    };
+
+    for (const AgentClass of [AgentCh, AgentFx]) {
+      passwordValue = 'first1';
+      const first = AgentClass._formValidationStateProbe('test-only-secret');
+      passwordValue = 'second';
+      const second = AgentClass._formValidationStateProbe('test-only-secret');
+      assert.notEqual(
+        first.controlFingerprint,
+        second.controlFingerprint,
+        `${AgentClass.name}: same-length password correction kept the validation state unchanged`,
+      );
+      assert.doesNotMatch(
+        JSON.stringify([first, second]),
+        /first1|second/,
+        `${AgentClass.name}: validation snapshot exposed a password value`,
+      );
+    }
+  } finally {
+    if (priorDocument === undefined) delete globalThis.document;
+    else globalThis.document = priorDocument;
+    if (priorNodeFilter === undefined) delete globalThis.NodeFilter;
+    else globalThis.NodeFilter = priorNodeFilter;
+    if (priorGetComputedStyle === undefined) delete globalThis.getComputedStyle;
+    else globalThis.getComputedStyle = priorGetComputedStyle;
+  }
+});
+
 test('form validation polling catches delayed errors', async () => {
   const url = 'https://example.com/form';
   for (const AgentClass of [AgentCh, AgentFx]) {
@@ -23224,6 +23290,12 @@ test('agent returns form validation messages and blocks unchanged repeat submits
     agent._progressWarningForAction = () => '';
     agent._persist = () => {};
     agent._captureFormValidationState = async () => structuredClone(currentState);
+    const validationContexts = [];
+    const waitForFormValidationFailure = agent._waitForFormValidationFailure.bind(agent);
+    agent._waitForFormValidationFailure = async (currentTabId, before, context, options) => {
+      validationContexts.push(context);
+      return waitForFormValidationFailure(currentTabId, before, context, options);
+    };
     agent._detectLikelySubmitAction = async (_tabId, _toolName, args) => (
       args?.text === 'Continue'
         ? {
@@ -23309,13 +23381,19 @@ test('agent returns form validation messages and blocks unchanged repeat submits
       activeInvalid: false,
       invalidFields: [],
       ariaInvalidFields: [],
-      alerts: [],
+      alerts: ['Your extension has to be compatible with at least one application.'],
+      alertsAreValidationOnly: true,
       controlFingerprint: 'checked',
     }];
     const successful = await runSubmit('submit_after_correction');
     assert.equal(successful.success, true, `${AgentClass.name}: corrected form remained blocked`);
     assert.equal(executions, 3, `${AgentClass.name}: corrected form was not submitted`);
     assert.equal(prompts, 2, `${AgentClass.name}: corrected submit did not receive fresh confirmation`);
+    assert.equal(
+      validationContexts.at(-1)?.priorValidationFailure,
+      false,
+      `${AgentClass.name}: corrected state kept stale prior-validation detection enabled`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

- inspect native constraint errors, `aria-invalid` fields, and validation-specific live regions after form submissions in both Chrome and Firefox
- poll briefly for validation feedback rendered after asynchronous handlers or server responses
- distinguish success announcements from validation failures
- block only an unchanged retry of the same failed submit action while allowing corrective form controls and newly revealed UI
- preserve submit metadata from content and CDP click paths and add mirrored regression coverage

## Root cause

Submit tools could report success immediately after dispatch without reading validation UI. The first fix also treated every live-region update as an error, inspected only synchronous feedback, used inconsistent native/custom submit classifiers, and reused the broad confirmation detector when blocking retries. That could misreport successful saves, miss delayed/custom failures, or prevent corrective buttons from running.

## Impact

Agents now receive the page's actionable validation message, can correct the reported field, and cannot blindly repeat the exact unchanged submission. Successful same-page submissions and non-submit recovery controls are no longer converted into validation failures.

## Validation

- `node --check` for both agents, both content scripts, and `test/run.js`
- `git diff --check origin/main...HEAD`
- `node test/run.js` — 1000 passed, 1 unrelated pre-existing release-metadata failure (`package.json` is `25.0.2`; newest changelog entry is `25.0.0`)
- `npm run test:security` — 60/60 checks passed
- headless Playwright probe confirmed success live regions are ignored, delayed server errors are captured, custom submit controls are inspected, and corrective UI changes invalidate the retry block
