### PR TITLE
Fix AMO uploads and unsafe navigation

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -10615,7 +10615,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
     // Tools handled by the background/service worker
     if (name === 'navigate') {
-      let rawUrl = String(args.url || '').trim();
+      const requestedUrl = String(args.url || '').trim();
+      let rawUrl = requestedUrl;
       if (!rawUrl) {
         return {
           success: false,
@@ -10653,6 +10654,26 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           };
         }
       }
+      let parsedUrl;
+      try {
+        parsedUrl = new URL(rawUrl);
+      } catch {
+        return {
+          success: false,
+          dispatched: false,
+          noDispatch: true,
+          error: 'navigate: invalid URL. Provide an absolute http:// or https:// URL.',
+        };
+      }
+      if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+        return {
+          success: false,
+          dispatched: false,
+          noDispatch: true,
+          error: `navigate: unsupported URL scheme "${parsedUrl.protocol}". Only http:// and https:// navigations are allowed; use page interaction tools instead of javascript:, data:, file:, or extension URLs.`,
+        };
+      }
+      rawUrl = parsedUrl.toString();
       // Guard against discarding unsaved work. Re-navigating (even to the
       // same URL) resets forms like GitHub's "New release" page, silently
       // dropping the tag, title, and any attached binaries. A model that
@@ -10663,7 +10684,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (blocked) return blocked;
       }
 
-      await chrome.tabs.update(tabId, { url: rawUrl });
+      try {
+        await chrome.tabs.update(tabId, { url: rawUrl });
+      } catch (e) {
+        return {
+          success: false,
+          dispatched: false,
+          noDispatch: true,
+          error: `navigate: browser rejected the navigation: ${e?.message || String(e)}`,
+        };
+      }
       // Wait for navigation to commit so we can report the real final URL
       // (which may differ from rawUrl after redirects or auth walls).
       await new Promise(r => setTimeout(r, 2000));
@@ -10672,7 +10702,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         const tab = await chrome.tabs.get(tabId);
         if (tab && tab.url) finalUrl = tab.url;
       } catch {}
-      return { success: true, dispatched: true, url: finalUrl, requestedUrl: rawUrl };
+      return { success: true, dispatched: true, url: finalUrl, requestedUrl };
     }
 
     if (name === 'go_back' || name === 'go_forward') {
@@ -12096,16 +12126,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         return { success: false, error: 'upload_file needs either downloadId (from download_files / list_downloads — preferred) or filePath (absolute local path).' };
       }
       let uploadDispatched = false;
+      let uploadQuery = null;
       try {
         await cdpClient.attach(tabId);
-        const nodeIds = await cdpClient.querySelectorPierce(tabId, args.selector);
-        if (!nodeIds || nodeIds.length === 0) {
+        uploadQuery = await cdpClient.querySelectorPierce(tabId, args.selector);
+        const objectIds = uploadQuery?.objectIds || [];
+        if (objectIds.length === 0) {
           return { success: false, error: `File input not found for selector "${args.selector}". Re-inspect the page with get_interactive_elements or get_accessibility_tree to find the real <input type=file> (some upload widgets hide it until you click their "add files" button first).` };
         }
-        if (nodeIds.length > 1) {
+        if (objectIds.length > 1) {
           return {
             success: false,
-            error: `Selector "${args.selector}" matched ${nodeIds.length} elements across the document and open shadow roots. Use an exact, unique selector for the intended <input type=file>; do not use a generic input[type=file] selector when multiple inputs exist.`,
+            error: `Selector "${args.selector}" matched ${objectIds.length} elements across the document and open shadow roots. Use an exact, unique selector for the intended <input type=file>; do not use a generic input[type=file] selector when multiple inputs exist.`,
           };
         }
 
@@ -12134,7 +12166,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         const pathConfirmed = !!(probe && probe.exists && probe.readable === true);
 
         uploadDispatched = true;
-        await cdpClient.setFileInputFiles(tabId, nodeIds[0], [args.filePath]);
+        await cdpClient.setFileInputFiles(tabId, objectIds[0], [args.filePath]);
 
         // Verify the file actually attached. CDP's DOM.setFileInputFiles does
         // NOT throw on a non-existent path — it silently attaches a 0-byte
@@ -12146,7 +12178,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         let files = null;
         let readOk = false;
         try {
-          files = await cdpClient.getFileInputFiles(tabId, nodeIds[0]);
+          files = await cdpClient.getFileInputFiles(tabId, objectIds[0]);
           readOk = Array.isArray(files);
         } catch { readOk = false; }
 
@@ -12197,6 +12229,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         return { success: true, file: args.filePath, verified: false, note: 'Attachment could not be verified (the input.files list was unreadable), but the local path validated as readable. If the file does not appear attached on the page, re-check the selector.' };
       } catch (e) {
         return { success: false, dispatched: uploadDispatched, error: `Upload failed: ${e.message}` };
+      } finally {
+        await cdpClient.releaseObjectGroup(tabId, uploadQuery?.objectGroup);
       }
     }
 

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -561,11 +561,12 @@ export class CDPClient {
   /**
    * Query a selector in the main document and all open shadow roots.
    * DOM.querySelectorAll only searches the supplied root node; its protocol
-   * schema has no shadow-piercing option. Resolve matches in page JS, then
-   * convert the returned DOM objects back to nodeIds for DOM.setFileInputFiles.
+   * schema has no shadow-piercing option. Resolve matches in page JS and keep
+   * their Runtime object handles alive until the caller finishes using them.
+   * This avoids frontend nodeIds, which are invalidated whenever another CDP
+   * consumer refreshes Chrome's DOM mirror with DOM.getDocument.
    */
   async querySelectorPierce(tabId, selector) {
-    await this.sendCommand(tabId, 'DOM.enable');
     await this.sendCommand(tabId, 'Runtime.enable');
     const objectGroup = `webbrain-query-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     try {
@@ -591,25 +592,36 @@ export class CDPClient {
         throw new Error(evaluated.exceptionDetails.text || 'Selector evaluation failed');
       }
       const arrayObjectId = evaluated?.result?.objectId;
-      if (!arrayObjectId) return [];
+      if (!arrayObjectId) {
+        await this.releaseObjectGroup(tabId, objectGroup);
+        return { objectIds: [], objectGroup: null };
+      }
       const properties = await this.sendCommand(tabId, 'Runtime.getProperties', {
         objectId: arrayObjectId,
         ownProperties: true,
       });
-      const nodeIds = [];
+      const objectIds = [];
       for (const property of properties?.result || []) {
         if (!/^\d+$/.test(property?.name || '')) continue;
         const objectId = property?.value?.objectId;
         if (!objectId) continue;
-        const requested = await this.sendCommand(tabId, 'DOM.requestNode', { objectId });
-        if (requested?.nodeId) nodeIds.push(requested.nodeId);
+        objectIds.push(objectId);
       }
-      return nodeIds;
-    } finally {
-      try {
-        await this.sendCommand(tabId, 'Runtime.releaseObjectGroup', { objectGroup });
-      } catch {}
+      return { objectIds, objectGroup };
+    } catch (error) {
+      await this.releaseObjectGroup(tabId, objectGroup);
+      throw error;
     }
+  }
+
+  /**
+   * Release Runtime objects returned by querySelectorPierce.
+   */
+  async releaseObjectGroup(tabId, objectGroup) {
+    if (!objectGroup) return;
+    try {
+      await this.sendCommand(tabId, 'Runtime.releaseObjectGroup', { objectGroup });
+    } catch {}
   }
 
   /**
@@ -913,10 +925,9 @@ export class CDPClient {
   /**
    * Set file input files (for upload).
    */
-  async setFileInputFiles(tabId, nodeId, filePaths) {
-    await this.sendCommand(tabId, 'DOM.enable');
+  async setFileInputFiles(tabId, objectId, filePaths) {
     await this.sendCommand(tabId, 'DOM.setFileInputFiles', {
-      nodeId,
+      objectId,
       files: filePaths,
     });
     return { success: true };
@@ -1228,12 +1239,8 @@ export class CDPClient {
    * is not a file input / could not be resolved. `readable` is true/false when
    * the probe ran, or null if it couldn't be determined.
    */
-  async getFileInputFiles(tabId, nodeId) {
-    await this.sendCommand(tabId, 'DOM.enable');
+  async getFileInputFiles(tabId, objectId) {
     await this.sendCommand(tabId, 'Runtime.enable');
-    const resolved = await this.sendCommand(tabId, 'DOM.resolveNode', { nodeId });
-    const objectId = resolved?.object?.objectId;
-    if (!objectId) return null;
     const res = await this.sendCommand(tabId, 'Runtime.callFunctionOn', {
       functionDeclaration: `async function () {
         if (!this.files) return null;

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -9391,7 +9391,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
     // Tools handled by the background/service worker
     if (name === 'navigate') {
-      const rawUrl = String(args.url || '').trim();
+      const requestedUrl = String(args.url || '').trim();
+      let rawUrl = requestedUrl;
       if (!rawUrl) {
         return {
           success: false,
@@ -9400,6 +9401,51 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           error: 'navigate: url is required',
         };
       }
+      // Match Chrome's existing behavior for relative and protocol-relative
+      // inputs while still requiring the resolved destination to be HTTP(S).
+      if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(rawUrl)) {
+        try {
+          const tab = await browser.tabs.get(tabId);
+          const base = tab && tab.url;
+          if (base && /^https?:/i.test(base)) {
+            rawUrl = new URL(rawUrl, base).toString();
+          } else {
+            return {
+              success: false,
+              dispatched: false,
+              noDispatch: true,
+              error: `navigate: "${args.url}" is not an absolute URL. Provide the full URL including scheme and host (e.g. "https://dashboard.stripe.com/${String(args.url).replace(/^\/+/, '')}"). Do NOT pass bare paths — they resolve to local files.`,
+            };
+          }
+        } catch (e) {
+          return {
+            success: false,
+            dispatched: false,
+            noDispatch: true,
+            error: `navigate: cannot resolve relative URL "${args.url}" — no current tab URL available. Pass an absolute URL starting with https://.`,
+          };
+        }
+      }
+      let parsedUrl;
+      try {
+        parsedUrl = new URL(rawUrl);
+      } catch {
+        return {
+          success: false,
+          dispatched: false,
+          noDispatch: true,
+          error: 'navigate: invalid URL. Provide an absolute http:// or https:// URL.',
+        };
+      }
+      if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+        return {
+          success: false,
+          dispatched: false,
+          noDispatch: true,
+          error: `navigate: unsupported URL scheme "${parsedUrl.protocol}". Only http:// and https:// navigations are allowed; use page interaction tools instead of javascript:, data:, file:, or extension URLs.`,
+        };
+      }
+      rawUrl = parsedUrl.toString();
       // Guard against discarding unsaved work. Re-navigating (even to the
       // same URL) resets forms like GitHub's "New release" page, silently
       // dropping the tag, title, and any attached binaries. A model that
@@ -9410,10 +9456,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (blocked) return blocked;
       }
 
-      await browser.tabs.update(tabId, { url: rawUrl });
+      try {
+        await browser.tabs.update(tabId, { url: rawUrl });
+      } catch (e) {
+        return {
+          success: false,
+          dispatched: false,
+          noDispatch: true,
+          error: `navigate: browser rejected the navigation: ${e?.message || String(e)}`,
+        };
+      }
       // Wait a moment for navigation
       await new Promise(r => setTimeout(r, 2000));
-      return { success: true, dispatched: true, url: rawUrl };
+      return { success: true, dispatched: true, url: rawUrl, requestedUrl };
     }
 
     if (name === 'go_back' || name === 'go_forward') {

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -800,7 +800,53 @@ test('ambiguity: two Cancels return rich candidates with ancestor', async (page)
   }
 });
 
-// ─── click_ax same-page anchors ─────────────────────────────────────────────
+// ─── CDP upload selector bridge ─────────────────────────────────────────────
+test('CDP upload selector bridge resolves hidden and open-shadow file inputs', async (page) => {
+  await page.setContent(`<!doctype html>
+    <input id="upload-addon" type="file" hidden>
+    <div id="shadow-host"></div>
+    <script>
+      document.querySelector('#shadow-host')
+        .attachShadow({ mode: 'open' })
+        .innerHTML = '<input id="shadow-upload" type="file">';
+    </script>`);
+
+  const session = await page.context().newCDPSession(page);
+  const client = new CDPClient();
+  client.sendCommand = async (_tabId, method, params = {}) => session.send(method, params);
+
+  const fixtureFile = path.join(root, 'package.json');
+  const attachThroughSelector = async (selector) => {
+    const query = await client.querySelectorPierce(42, selector);
+    if (query.objectIds.length !== 1 || !query.objectIds[0]) {
+      throw new Error(`file input did not resolve to one CDP object handle: ${JSON.stringify(query)}`);
+    }
+    try {
+      // Refreshing Chrome's DOM mirror invalidates frontend nodeIds. Runtime
+      // object handles must remain valid across an unrelated DOM traversal.
+      await session.send('DOM.getDocument', { depth: -1, pierce: true });
+      await client.setFileInputFiles(42, query.objectIds[0], [fixtureFile]);
+      const files = await client.getFileInputFiles(42, query.objectIds[0]);
+      if (files?.[0]?.name !== 'package.json') {
+        throw new Error(`attached FileList was not readable through the Runtime handle: ${JSON.stringify(files)}`);
+      }
+    } finally {
+      await client.releaseObjectGroup(42, query.objectGroup);
+    }
+  };
+
+  await attachThroughSelector('#upload-addon');
+  await attachThroughSelector('#shadow-upload');
+  const attached = await page.evaluate(() => ({
+    hidden: document.querySelector('#upload-addon').files[0]?.name || '',
+    shadow: document.querySelector('#shadow-host').shadowRoot
+      .querySelector('#shadow-upload').files[0]?.name || '',
+  }));
+  if (attached.hidden !== 'package.json' || attached.shadow !== 'package.json') {
+    throw new Error(`DOM.setFileInputFiles did not attach through resolved nodes: ${JSON.stringify(attached)}`);
+  }
+});
+
 for (const browserKind of ['chrome', 'firefox']) {
   test(`file picker guard (${browserKind}): blocks the native chooser and returns the exact input`, async (page) => {
     await setupContentHtml(page, `<!doctype html>
@@ -1606,6 +1652,7 @@ test('ax_resolve_rect: English action labels stay blocked under Turkish locale c
   }
 });
 
+// ─── click_ax same-page anchors ─────────────────────────────────────────────
 test('click_ax: same-page anchor reports hash and scroll completion', async (page) => {
   await setup(page, 'anchor-click.html');
   const before = await page.evaluate(() => ({ hash: location.hash, scrollY: window.scrollY }));

--- a/test/run.js
+++ b/test/run.js
@@ -16264,7 +16264,7 @@ test('CDP input dispatchers never call the nonexistent Input.enable command', as
   assert.doesNotMatch(source, /Input\.enable/, 'Chrome CDP client must not reintroduce the unsupported Input.enable command');
 });
 
-test('CDP querySelectorPierce resolves open-shadow matches to DOM nodeIds', async () => {
+test('CDP querySelectorPierce keeps open-shadow Runtime object handles alive until release', async () => {
   const client = new CDPClient();
   const commands = [];
   client.sendCommand = async (_tabId, method, params = {}) => {
@@ -16283,20 +16283,31 @@ test('CDP querySelectorPierce resolves open-shadow matches to DOM nodeIds', asyn
         ],
       };
     }
-    if (method === 'DOM.requestNode') {
-      return { nodeId: params.objectId === 'input-a' ? 501 : 502 };
-    }
     return {};
   };
 
-  const nodeIds = await client.querySelectorPierce(42, '#shadow-upload');
-  assert.deepEqual(nodeIds, [501, 502]);
+  const query = await client.querySelectorPierce(42, '#shadow-upload');
+  assert.deepEqual(query.objectIds, ['input-a', 'input-b']);
+  assert.ok(query.objectGroup, 'querySelectorPierce must return the owning object group');
+  assert.equal(
+    commands.some(command => command.method === 'DOM.getDocument' || command.method === 'DOM.requestNode'),
+    false,
+    'Runtime handles must not depend on Chrome frontend nodeIds or the mutable DOM mirror',
+  );
   assert.equal(
     commands.some(command => command.method === 'DOM.querySelectorAll'),
     false,
     'document-root DOM.querySelectorAll cannot pierce open shadow roots',
   );
+  assert.equal(
+    commands.some(command => command.method === 'Runtime.releaseObjectGroup'),
+    false,
+    'query handles must remain alive for upload_file to consume',
+  );
+
+  await client.releaseObjectGroup(42, query.objectGroup);
   assert.equal(commands.at(-1).method, 'Runtime.releaseObjectGroup');
+  assert.deepEqual(commands.at(-1).params, { objectGroup: query.objectGroup });
 });
 
 test('Chrome selector click distinguishes pre-dispatch failure from uncertain dispatch', async () => {
@@ -33028,6 +33039,7 @@ test('upload_file prefers downloadId over a supplied stale filePath (chrome)', a
   const originalCdp = {
     attach: cdpClientCh.attach,
     querySelectorPierce: cdpClientCh.querySelectorPierce,
+    releaseObjectGroup: cdpClientCh.releaseObjectGroup,
     probeLocalFile: cdpClientCh.probeLocalFile,
     setFileInputFiles: cdpClientCh.setFileInputFiles,
     getFileInputFiles: cdpClientCh.getFileInputFiles,
@@ -33035,7 +33047,9 @@ test('upload_file prefers downloadId over a supplied stale filePath (chrome)', a
   const realPath = '/Users/x/Downloads/real.zip';
   const stalePath = '/Users/Shared/made-up.zip';
   const uploaded = [];
-  let selectorMatches = [501];
+  const releasedGroups = [];
+  let queryCount = 0;
+  let selectorMatches = ['input-501'];
 
   try {
     globalThis.chrome = {
@@ -33048,12 +33062,19 @@ test('upload_file prefers downloadId over a supplied stale filePath (chrome)', a
       },
     };
     cdpClientCh.attach = async (tabId) => ({ tabId, attached: true });
-    cdpClientCh.querySelectorPierce = async () => selectorMatches;
+    cdpClientCh.querySelectorPierce = async () => ({
+      objectIds: selectorMatches,
+      objectGroup: `upload-query-${++queryCount}`,
+    });
+    cdpClientCh.releaseObjectGroup = async (_tabId, objectGroup) => {
+      releasedGroups.push(objectGroup);
+    };
     cdpClientCh.probeLocalFile = async (_tabId, filePath) => {
       assert.equal(filePath, realPath, 'downloadId-resolved path should override stale filePath before probing');
       return { exists: true, readable: true, size: 123 };
     };
-    cdpClientCh.setFileInputFiles = async (_tabId, _nodeId, files) => {
+    cdpClientCh.setFileInputFiles = async (_tabId, objectId, files) => {
+      assert.equal(objectId, 'input-501');
       uploaded.push(files);
     };
     cdpClientCh.getFileInputFiles = async () => [{ name: 'real.zip', size: 123, readable: true }];
@@ -33066,8 +33087,9 @@ test('upload_file prefers downloadId over a supplied stale filePath (chrome)', a
     assert.equal(result.file, realPath);
     assert.equal(args.filePath, realPath);
     assert.deepEqual(uploaded, [[realPath]]);
+    assert.deepEqual(releasedGroups, ['upload-query-1'], 'successful uploads must release selector handles');
 
-    selectorMatches = [501, 502];
+    selectorMatches = ['input-501', 'input-502'];
     const ambiguous = await agent.executeTool(42, 'upload_file', {
       selector: 'input[type=file]',
       downloadId: 9123,
@@ -33076,6 +33098,11 @@ test('upload_file prefers downloadId over a supplied stale filePath (chrome)', a
     assert.match(ambiguous.error, /matched 2 elements/);
     assert.match(ambiguous.error, /exact, unique selector/);
     assert.deepEqual(uploaded, [[realPath]], 'ambiguous selectors must fail before attaching the file');
+    assert.deepEqual(
+      releasedGroups,
+      ['upload-query-1', 'upload-query-2'],
+      'early upload failures must release selector handles',
+    );
   } finally {
     if (originalChrome === undefined) delete globalThis.chrome;
     else globalThis.chrome = originalChrome;
@@ -33461,6 +33488,157 @@ test('getScratchpad returns the current pinned scratchpad body (chrome & firefox
 test('resize_window is gated as a browser-window action', () => {
   assert.equal(capabilityFor('resize_window', { width: 1280, height: 720 }), Capability.WINDOW);
   assert.equal(capabilityForCh('resize_window', { width: 1280, height: 720 }), CapabilityCh.WINDOW);
+});
+
+test('navigate rejects non-web schemes and contains browser API failures', async () => {
+  const originalChrome = globalThis.chrome;
+  const originalBrowser = globalThis.browser;
+  const originalSetTimeout = globalThis.setTimeout;
+  const unsafeUrls = [
+    'javascript:document.body.textContent="owned"',
+    'java\nscript:alert(1)',
+    'data:text/html,<h1>owned</h1>',
+    'file:///Users/example/secret.txt',
+    'chrome-extension://abcdefghijklmnop/page.html',
+    'moz-extension://abcdefghijklmnop/page.html',
+  ];
+  try {
+    globalThis.setTimeout = (fn, _delay, ...args) => originalSetTimeout(fn, 0, ...args);
+
+    let chromeUrl = 'https://trusted.example/base/page';
+    const chromeUpdates = [];
+    globalThis.chrome = {
+      tabs: {
+        async get() {
+          return { id: 42, url: chromeUrl };
+        },
+        async update(_tabId, { url }) {
+          chromeUpdates.push(url);
+          if (url === 'https://reject.example/') throw new Error('synthetic Chrome rejection');
+          chromeUrl = url;
+          return { id: 42, url };
+        },
+      },
+    };
+    const chromeAgent = new AgentCh({});
+    for (const url of unsafeUrls) {
+      const result = await chromeAgent.executeTool(42, 'navigate', { url, force: true });
+      assert.equal(result.success, false, `chrome should reject ${url}`);
+      assert.equal(result.dispatched, false);
+      assert.equal(result.noDispatch, true);
+      assert.match(result.error, /Only http:\/\/ and https:\/\//);
+    }
+    assert.deepEqual(chromeUpdates, [], 'Chrome must reject unsafe schemes before tabs.update');
+
+    const chromeMalformed = await chromeAgent.executeTool(42, 'navigate', {
+      url: 'https://',
+      force: true,
+    });
+    assert.equal(chromeMalformed.success, false);
+    assert.equal(chromeMalformed.dispatched, false);
+    assert.equal(chromeMalformed.noDispatch, true);
+    assert.match(chromeMalformed.error, /invalid URL/);
+    assert.deepEqual(chromeUpdates, [], 'Chrome must reject malformed URLs before tabs.update');
+
+    const chromeRelative = await chromeAgent.executeTool(42, 'navigate', { url: '/next', force: true });
+    assert.equal(chromeRelative.success, true);
+    assert.equal(chromeUpdates.at(-1), 'https://trusted.example/next');
+    assert.equal(chromeRelative.requestedUrl, '/next');
+
+    const chromeHttps = await chromeAgent.executeTool(42, 'navigate', {
+      url: 'https://safe.example/path',
+      force: true,
+    });
+    assert.equal(chromeHttps.success, true);
+    assert.equal(chromeUpdates.at(-1), 'https://safe.example/path');
+
+    const chromeBareHost = await chromeAgent.executeTool(42, 'navigate', {
+      url: 'https://mastodon.turk',
+      force: true,
+    });
+    assert.equal(chromeBareHost.success, true);
+    assert.equal(chromeBareHost.url, 'https://mastodon.turk/');
+    assert.equal(chromeBareHost.requestedUrl, 'https://mastodon.turk');
+
+    const chromeRejected = await chromeAgent.executeTool(42, 'navigate', {
+      url: 'https://reject.example/',
+      force: true,
+    });
+    assert.equal(chromeRejected.success, false);
+    assert.equal(chromeRejected.dispatched, false);
+    assert.equal(chromeRejected.noDispatch, true);
+    assert.match(chromeRejected.error, /synthetic Chrome rejection/);
+
+    let firefoxUrl = 'https://trusted.example/base/page';
+    const firefoxUpdates = [];
+    globalThis.browser = {
+      tabs: {
+        async get() {
+          return { id: 42, url: firefoxUrl };
+        },
+        async update(_tabId, { url }) {
+          firefoxUpdates.push(url);
+          if (url === 'https://reject.example/') throw new Error('synthetic Firefox rejection');
+          firefoxUrl = url;
+          return { id: 42, url };
+        },
+      },
+    };
+    const firefoxAgent = new AgentFx({});
+    for (const url of unsafeUrls) {
+      const result = await firefoxAgent.executeTool(42, 'navigate', { url, force: true });
+      assert.equal(result.success, false, `firefox should reject ${url}`);
+      assert.equal(result.dispatched, false);
+      assert.equal(result.noDispatch, true);
+      assert.match(result.error, /Only http:\/\/ and https:\/\//);
+    }
+    assert.deepEqual(firefoxUpdates, [], 'Firefox must reject unsafe schemes before tabs.update');
+
+    const firefoxMalformed = await firefoxAgent.executeTool(42, 'navigate', {
+      url: 'https://',
+      force: true,
+    });
+    assert.equal(firefoxMalformed.success, false);
+    assert.equal(firefoxMalformed.dispatched, false);
+    assert.equal(firefoxMalformed.noDispatch, true);
+    assert.match(firefoxMalformed.error, /invalid URL/);
+    assert.deepEqual(firefoxUpdates, [], 'Firefox must reject malformed URLs before tabs.update');
+
+    const firefoxRelative = await firefoxAgent.executeTool(42, 'navigate', { url: '/next', force: true });
+    assert.equal(firefoxRelative.success, true);
+    assert.equal(firefoxUpdates.at(-1), 'https://trusted.example/next');
+    assert.equal(firefoxRelative.requestedUrl, '/next');
+
+    const firefoxProtocolRelative = await firefoxAgent.executeTool(42, 'navigate', {
+      url: '//cdn.example/a',
+      force: true,
+    });
+    assert.equal(firefoxProtocolRelative.success, true);
+    assert.equal(firefoxUpdates.at(-1), 'https://cdn.example/a');
+    assert.equal(firefoxProtocolRelative.requestedUrl, '//cdn.example/a');
+
+    const firefoxHttps = await firefoxAgent.executeTool(42, 'navigate', {
+      url: 'https://safe.example/path',
+      force: true,
+    });
+    assert.equal(firefoxHttps.success, true);
+    assert.equal(firefoxUpdates.at(-1), 'https://safe.example/path');
+
+    const firefoxRejected = await firefoxAgent.executeTool(42, 'navigate', {
+      url: 'https://reject.example/',
+      force: true,
+    });
+    assert.equal(firefoxRejected.success, false);
+    assert.equal(firefoxRejected.dispatched, false);
+    assert.equal(firefoxRejected.noDispatch, true);
+    assert.match(firefoxRejected.error, /synthetic Firefox rejection/);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    if (originalChrome === undefined) delete globalThis.chrome;
+    else globalThis.chrome = originalChrome;
+    if (originalBrowser === undefined) delete globalThis.browser;
+    else globalThis.browser = originalBrowser;
+  }
 });
 
 test('navigation host resolves relative / protocol-relative against current page', () => {


### PR DESCRIPTION
## Summary

- resolve hidden and open-shadow file inputs through stable CDP Runtime object handles
- keep selector handles alive through upload verification and release them deterministically
- reject malformed and non-HTTP(S) navigation before browser dispatch in Chrome and Firefox
- contain browser navigation rejections as structured tool failures
- preserve Chrome `requestedUrl` and add Firefox relative/protocol-relative URL parity

## Root cause

The Chrome upload bridge converted Runtime objects into frontend DOM node IDs without a reliable DOM mirror, so real Chromium could return node ID `0` for AMO's hidden file input. Refreshing that mirror would also invalidate previously returned node IDs. Separately, unsupported schemes such as `javascript:` reached the browser navigation API, whose rejection escaped and terminated the agent run.

## Impact

AMO uploads can target hidden or open-shadow file inputs without opening a native picker, and unsupported navigation schemes now fail safely without ending the run.

## Validation

- `node test/run.js`: 1013 passed, 1 pre-existing failure (`package.json` 25.1.0 vs newest changelog entry 25.0.0)
- `npm run test:fixtures`: 98/98 passed
- `npm run test:security`: 60/60 passed
- syntax checks and `git diff --check` passed