### PR TITLE
Reconnect interrupted extension runs

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2298,7 +2298,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return false;
   }
 
-  async _executeToolBatch(tabId, toolCalls, messages, onUpdate, provider, partialAssistantText = null, allowedToolNames = AGENT_TOOL_NAMES, step = null) {
+  async _executeToolBatch(tabId, toolCalls, messages, onUpdate, provider, partialAssistantText = null, allowedToolNames = AGENT_TOOL_NAMES, step = null, runOptions = {}) {
     let didStateChange = false;
     const completionBatchStartState = this.completionInvariants.get(tabId) || null;
     // Set of tools whose side effect can navigate the page. We snapshot the
@@ -2658,7 +2658,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         beforeUrl = await this._currentUrl(tabId);
       }
 
-      onUpdate('tool_call', { name: fnName, args: fnArgs });
+      onUpdate('tool_call', {
+        name: fnName,
+        args: fnArgs,
+        outcomeUnknown: missingResponseOutcomeUnknown,
+      });
+      if (missingResponseOutcomeUnknown && typeof runOptions?.beforeConsequentialTool === 'function') {
+        try {
+          await runOptions.beforeConsequentialTool({ name: fnName });
+        } catch {}
+      }
       const _toolStart = Date.now();
       const rawToolResult = await this.executeTool(tabId, fnName, fnArgs, onUpdate, {
         completionBatchStartState,
@@ -3031,6 +3040,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         tool_call_id: tc.id,
         content: resultContent,
       });
+      if (missingResponseOutcomeUnknown && typeof runOptions?.afterConsequentialTool === 'function') {
+        const conversationDurable = await this._persistNow(tabId).catch(() => false);
+        if (conversationDurable) {
+          try {
+            await runOptions.afterConsequentialTool({ name: fnName });
+          } catch {}
+        }
+      }
 
       // A response can disappear while the page is navigating or reloading,
       // even for a read-only observation. Do not execute the rest of this
@@ -15585,7 +15602,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }, result.responseItems, result.reasoningContent, provider));
 
         const batchResult = await this._executeToolBatch(
-          tabId, result.toolCalls, messages, onUpdate, provider, result.content, allowedToolNames, steps
+          tabId, result.toolCalls, messages, onUpdate, provider, result.content, allowedToolNames, steps, runOptions
         );
         if (batchResult.action === 'return') {
           finalResponse = batchResult.value;
@@ -15995,7 +16012,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           }, responseItems, reasoningContent, provider));
 
           const batchResult = await this._executeToolBatch(
-            tabId, toolCalls, messages, onUpdate, provider, fullText, allowedToolNames, steps
+            tabId, toolCalls, messages, onUpdate, provider, fullText, allowedToolNames, steps, runOptions
           );
           if (batchResult.action === 'return') {
             return finish(batchResult.value, batchResult.status);

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -4624,9 +4624,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       this._persist(tabId);
       return false;
     }
+    const previousRequestId = this.submittedRunRequestIds.get(tabId);
     this.submittedRunRequestIds.set(tabId, cleanRequestId);
-    await this._persistNow(tabId);
-    return true;
+    try {
+      await this._persistNow(tabId);
+      return true;
+    } catch {
+      if (previousRequestId) this.submittedRunRequestIds.set(tabId, previousRequestId);
+      else this.submittedRunRequestIds.delete(tabId);
+      return false;
+    }
   }
 
   async hasDurableSubmittedTurn(tabId, requestId = '') {

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -15000,14 +15000,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * Continue processing from where we left off (after max steps).
    * Adds a "please continue" user message and resumes the agent loop.
    */
-  async continueProcessing(tabId, onUpdate = () => {}, mode = 'ask') {
+  async continueProcessing(tabId, onUpdate = () => {}, mode = 'ask', runOptions = {}) {
     return this.processMessage(
       tabId,
       'Please continue from where you left off.',
       onUpdate,
       mode,
       [],
-      { trustedContinuation: true },
+      { ...runOptions, trustedContinuation: true },
     );
   }
 
@@ -15299,6 +15299,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this._preactivateNyTimesSkillForRun(tabId, mode);
 
     const provider = this.providerManager.getActive();
+
+    if (typeof runOptions?.isDetachedStartCancelled === 'function'
+        && runOptions.isDetachedStartCancelled()) {
+      this.abortFlags.delete(tabId);
+      return 'Stopped by user before the run started.';
+    }
 
     // Clear any stale abort flag before any LLM work. The planner gate makes a
     // paid LLM call and checks/consumes this flag, so a leftover flag from a

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -88,6 +88,7 @@ export class Agent {
     this._progressSessionCounter = 0;
     this.conversationModes = new Map(); // tabId -> 'ask' | 'act' | 'dev'
     this.conversationIds = new Map(); // tabId -> stable conversationId (regenerated on clearConversation)
+    this.submittedRunRequestIds = new Map(); // tabId -> request whose user turn is durable in storage.session
     this.plannerFollowUpSkipTabs = new Set(); // tabIds allowed one short follow-up after an approved try-mode plan
     this.hydratedTabs = new Set(); // tabIds we've already pulled from storage
     this.persistTimers = new Map(); // tabId -> debounce handle
@@ -4563,6 +4564,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (entry.conversationId) {
           this.conversationIds.set(tabId, entry.conversationId);
         }
+        if (entry.submittedRunRequestId) {
+          this.submittedRunRequestIds.set(tabId, String(entry.submittedRunRequestId));
+        }
         if (Array.isArray(entry.progressLedger)) {
           this.progressLedgers.set(tabId, entry.progressLedger);
         }
@@ -4571,6 +4575,32 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }
       }
     } catch (e) { /* session storage may be unavailable */ }
+  }
+
+  _conversationStorageEntry(tabId) {
+    const messages = this.conversations.get(tabId);
+    if (!messages) return null;
+    return {
+      mode: this.conversationModes.get(tabId) || 'ask',
+      messages,
+      conversationId: this.conversationIds.get(tabId) || null,
+      submittedRunRequestId: this.submittedRunRequestIds.get(tabId) || null,
+      progressLedger: this.progressLedgers.get(tabId) || [],
+      progressSession: this.progressSessions.get(tabId) || null,
+    };
+  }
+
+  async _persistNow(tabId) {
+    if (tabId == null) return false;
+    const existing = this.persistTimers.get(tabId);
+    if (existing) {
+      clearTimeout(existing);
+      this.persistTimers.delete(tabId);
+    }
+    const entry = this._conversationStorageEntry(tabId);
+    if (!entry) return false;
+    await chrome.storage.session.set({ [this._convKey(tabId)]: entry });
+    return true;
   }
 
   /**
@@ -4583,19 +4613,27 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (existing) clearTimeout(existing);
     const handle = setTimeout(() => {
       this.persistTimers.delete(tabId);
-      const messages = this.conversations.get(tabId);
-      if (!messages) return;
-      const mode = this.conversationModes.get(tabId) || 'ask';
-      const conversationId = this.conversationIds.get(tabId) || null;
-      const progressLedger = this.progressLedgers.get(tabId) || [];
-      const progressSession = this.progressSessions.get(tabId) || null;
-      try {
-        chrome.storage.session.set({
-          [this._convKey(tabId)]: { mode, messages, conversationId, progressLedger, progressSession },
-        }).catch(() => {});
-      } catch (e) { /* ignore */ }
+      this._persistNow(tabId).catch(() => {});
     }, 300);
     this.persistTimers.set(tabId, handle);
+  }
+
+  async _persistSubmittedTurn(tabId, requestId = '') {
+    const cleanRequestId = String(requestId || '');
+    if (!cleanRequestId) {
+      this._persist(tabId);
+      return false;
+    }
+    this.submittedRunRequestIds.set(tabId, cleanRequestId);
+    await this._persistNow(tabId);
+    return true;
+  }
+
+  async hasDurableSubmittedTurn(tabId, requestId = '') {
+    const cleanRequestId = String(requestId || '');
+    if (!cleanRequestId) return false;
+    await this._hydrate(tabId);
+    return this.submittedRunRequestIds.get(tabId) === cleanRequestId;
   }
 
   /**
@@ -5028,7 +5066,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // transcript.
     const priorMessages = runIntent ? messages.slice() : null;
     messages.push(enriched);
-    this._persist(tabId);
+    await this._persistSubmittedTurn(tabId, runOptions?.detachedRequestId);
     if (!runIntent) {
       this.plannerFollowUpSkipTabs.delete(tabId);
       return { proceed: true, requestKind: 'execute', requiresStateChange: false };
@@ -7069,6 +7107,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this.mastodonStates.delete(tabId);
     this.conversationModes.delete(tabId);
     this.conversationIds.delete(tabId);
+    this.submittedRunRequestIds.delete(tabId);
     this._lastInputTokens.delete(tabId);
     this._lastEstCharsAtReport.delete(tabId);
     this._compactCooldown.delete(tabId);
@@ -15267,7 +15306,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const msg = this._devModeBlockedMessage(provider);
       messages.push(enriched);
       messages.push({ role: 'assistant', content: msg });
-      this._persist(tabId);
+      await this._persistSubmittedTurn(tabId, runOptions?.detachedRequestId);
       onUpdate('warning', { message: msg });
       return (finalResponse = msg);
     }

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -1207,25 +1207,64 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 });
 
 const RUN_UI_PREFIX = 'runUi:';
+const runUiPersistenceQueues = new Map();
+const runUiPersistenceFailures = new Map();
+
+function cloneRunUiSnapshot(snapshot) {
+  try {
+    return structuredClone(snapshot);
+  } catch {
+    return JSON.parse(JSON.stringify(snapshot));
+  }
+}
+
+function persistRunUiSnapshot(tabId, snapshot) {
+  const requestId = String(snapshot?.requestId || '');
+  if (runUiPersistenceFailures.get(tabId) === requestId) return Promise.resolve(false);
+  const stableSnapshot = cloneRunUiSnapshot(snapshot);
+  const previous = runUiPersistenceQueues.get(tabId) || Promise.resolve(true);
+  const write = previous.catch(() => false).then(async () => {
+    if (runUiPersistenceFailures.get(tabId) === requestId) return false;
+    try {
+      await chrome.storage.session?.set({ [RUN_UI_PREFIX + tabId]: stableSnapshot });
+      return true;
+    } catch {
+      runUiPersistenceFailures.set(tabId, requestId);
+      try { await chrome.storage.session?.remove(RUN_UI_PREFIX + tabId); } catch {}
+      return false;
+    }
+  });
+  runUiPersistenceQueues.set(tabId, write);
+  write.finally(() => {
+    if (runUiPersistenceQueues.get(tabId) === write) runUiPersistenceQueues.delete(tabId);
+  }).catch(() => {});
+  return write;
+}
+
+function flushRunUiSnapshot(tabId, requestId) {
+  const pending = runUiPersistenceQueues.get(tabId);
+  if (pending) return pending;
+  return Promise.resolve(runUiPersistenceFailures.get(tabId) !== String(requestId || ''));
+}
+
 const runUiJournal = new RunUiJournal({
   onChange(tabId, snapshot) {
-    try {
-      chrome.storage.session?.set({ [RUN_UI_PREFIX + tabId]: snapshot }).catch(() => {});
-    } catch {}
+    void persistRunUiSnapshot(tabId, snapshot);
   },
 });
 
-function beginRunUiSnapshot(tabId, requestId) {
-  return runUiJournal.begin(tabId, requestId);
+function beginRunUiSnapshot(tabId, requestId, metadata = {}) {
+  runUiPersistenceFailures.delete(tabId);
+  return runUiJournal.begin(tabId, requestId, metadata);
 }
 
-async function beginContinuationRunUiSnapshot(tabId, requestId) {
+async function beginContinuationRunUiSnapshot(tabId, requestId, metadata = {}) {
   const existing = await getRunUiSnapshot(tabId);
   const sameNonTerminalRun = existing
     && String(existing.requestId || '') === String(requestId || '')
     && !['completed', 'stopped', 'failed', 'cancelled'].includes(existing.status);
-  if (sameNonTerminalRun) return runUiJournal.resume(tabId, requestId);
-  return beginRunUiSnapshot(tabId, requestId);
+  if (sameNonTerminalRun) return runUiJournal.resume(tabId, requestId, metadata);
+  return beginRunUiSnapshot(tabId, requestId, metadata);
 }
 
 function recordRunUiEvent(tabId, requestId, type, data) {
@@ -1261,7 +1300,13 @@ async function getRunUiSnapshot(tabId) {
 
 function clearRunUiSnapshot(tabId) {
   runUiJournal.clear(tabId);
-  try { chrome.storage.session?.remove(RUN_UI_PREFIX + tabId).catch(() => {}); } catch {}
+  runUiPersistenceFailures.delete(tabId);
+  const previous = runUiPersistenceQueues.get(tabId) || Promise.resolve();
+  const removal = previous.catch(() => {}).then(() => chrome.storage.session?.remove(RUN_UI_PREFIX + tabId));
+  runUiPersistenceQueues.set(tabId, removal);
+  removal.finally(() => {
+    if (runUiPersistenceQueues.get(tabId) === removal) runUiPersistenceQueues.delete(tabId);
+  }).catch(() => {});
 }
 
 function sendAgentUpdate(tabId, requestId, type, data) {
@@ -1907,7 +1952,7 @@ async function handleMessage(msg, sender) {
       if (!tabId) throw new Error('No tab ID');
       assertRunCanStart(tabId, msg);
       const mode = msg.mode || 'ask';
-      const runUi = await beginContinuationRunUiSnapshot(tabId, msg.requestId);
+      const runUi = await beginContinuationRunUiSnapshot(tabId, msg.requestId, { mode, kind: 'chat' });
       const releaseRunKeepalive = acquireRunKeepalive();
 
       // /allow-api flag is per-conversation. The sidebar tracks it locally
@@ -1948,6 +1993,11 @@ async function handleMessage(msg, sender) {
           intentFailureMessage: msg.intentFailureMessage,
           detachedRequestId: runUi.requestId,
           isDetachedStartCancelled: () => isDetachedRunStartCancelled(tabId, msg),
+          beforeConsequentialTool: () => flushRunUiSnapshot(tabId, runUi.requestId),
+          afterConsequentialTool: async ({ name } = {}) => {
+            runUiJournal.settleToolCall(tabId, runUi.requestId, name);
+            return flushRunUiSnapshot(tabId, runUi.requestId);
+          },
         };
         result = await agent.processMessage(tabId, msg.text, (type, data) => {
           updates.push({ type, data });
@@ -2055,7 +2105,7 @@ async function handleMessage(msg, sender) {
       if (!tabId) throw new Error('No tab ID');
       assertRunCanStart(tabId, msg);
       const mode = msg.mode || 'ask';
-      const runUi = await beginContinuationRunUiSnapshot(tabId, msg.requestId);
+      const runUi = await beginContinuationRunUiSnapshot(tabId, msg.requestId, { mode, kind: 'continue' });
       const releaseRunKeepalive = acquireRunKeepalive();
 
       sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
@@ -2068,7 +2118,13 @@ async function handleMessage(msg, sender) {
           if (type === 'error') userMemoryTurnHadError = true;
           sendAgentUpdate(tabId, runUi.requestId, type, data);
         }, mode, {
+          detachedRequestId: runUi.requestId,
           isDetachedStartCancelled: () => isDetachedRunStartCancelled(tabId, msg),
+          beforeConsequentialTool: () => flushRunUiSnapshot(tabId, runUi.requestId),
+          afterConsequentialTool: async ({ name } = {}) => {
+            runUiJournal.settleToolCall(tabId, runUi.requestId, name);
+            return flushRunUiSnapshot(tabId, runUi.requestId);
+          },
         });
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
@@ -2152,6 +2208,8 @@ async function handleMessage(msg, sender) {
         starting: !!starting,
         startingRequestId: starting?.requestId || null,
         submittedTurnDurable,
+        runUiDurable: !runUiSnapshot
+          || runUiPersistenceFailures.get(tabId) !== String(runUiSnapshot.requestId || ''),
         detachedError,
         runUi: runUiSnapshotForRequest(runUiSnapshot, requestedRequestId),
       };

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -1271,9 +1271,63 @@ function sendAgentUpdate(tabId, requestId, type, data) {
 }
 
 function assertNoActiveTabRun(tabId) {
+  if (agent.activeRunState(tabId)?.running || detachedRunStarts.has(tabId)) {
+    throw new Error('A run is already active for this tab.');
+  }
+}
+
+const detachedRunStarts = new Map();
+const RUN_KEEPALIVE_INTERVAL_MS = 20_000;
+
+function assertRunCanStart(tabId, msg) {
+  const reserved = detachedRunStarts.get(tabId);
+  const internalRequestId = String(msg?.__detachedRunRequestId || '');
+  if (reserved) {
+    if (!internalRequestId || internalRequestId !== reserved.requestId) {
+      throw new Error('A run is already active for this tab.');
+    }
+  }
   if (agent.activeRunState(tabId)?.running) {
     throw new Error('A run is already active for this tab.');
   }
+}
+
+function acquireRunKeepalive() {
+  let released = false;
+  const touch = () => {
+    try {
+      chrome.runtime.getPlatformInfo().catch(() => {});
+    } catch {}
+  };
+  touch();
+  const timer = setInterval(touch, RUN_KEEPALIVE_INTERVAL_MS);
+  return () => {
+    if (released) return;
+    released = true;
+    clearInterval(timer);
+  };
+}
+
+function launchDetachedRun(action, msg, sender) {
+  const tabId = msg.tabId || sender.tab?.id;
+  if (!tabId) throw new Error('No tab ID');
+  assertNoActiveTabRun(tabId);
+  const requestId = String(msg.requestId || `req_${tabId}_${Date.now()}`);
+  const entry = { requestId, promise: null };
+  detachedRunStarts.set(tabId, entry);
+  const task = Promise.resolve().then(() => handleMessage({
+    ...msg,
+    action,
+    requestId,
+    __detachedRunRequestId: requestId,
+  }, sender));
+  entry.promise = task;
+  task.catch((error) => {
+    console.warn(`[WebBrain] detached ${action} run failed:`, error);
+  }).finally(() => {
+    if (detachedRunStarts.get(tabId) === entry) detachedRunStarts.delete(tabId);
+  });
+  return { ok: true, accepted: true, requestId };
 }
 
 function sendAgentRunComplete(tabId, snapshot = null) {
@@ -1782,12 +1836,19 @@ async function handleMessage(msg, sender) {
       };
     }
 
+    case 'chat_start':
+      return launchDetachedRun('chat', msg, sender);
+
+    case 'continue_start':
+      return launchDetachedRun('continue', msg, sender);
+
     case 'chat': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) throw new Error('No tab ID');
-      assertNoActiveTabRun(tabId);
+      assertRunCanStart(tabId, msg);
       const mode = msg.mode || 'ask';
       const runUi = beginRunUiSnapshot(tabId, msg.requestId);
+      const releaseRunKeepalive = acquireRunKeepalive();
 
       // /allow-api flag is per-conversation. The sidebar tracks it locally
       // but sends it on every chat call so the agent stays in sync after a
@@ -1870,6 +1931,7 @@ async function handleMessage(msg, sender) {
           sendAgentRunComplete(tabId, snapshot);
         }
         sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
+        releaseRunKeepalive();
       }
     }
 
@@ -1879,6 +1941,7 @@ async function handleMessage(msg, sender) {
       assertNoActiveTabRun(tabId);
       const mode = msg.mode || 'ask';
       const runUi = beginRunUiSnapshot(tabId, msg.requestId);
+      const releaseRunKeepalive = acquireRunKeepalive();
 
       if (msg.apiMutationsAllowed) agent.setApiMutationsAllowed(tabId, true);
 
@@ -1921,15 +1984,17 @@ async function handleMessage(msg, sender) {
         );
         sendAgentRunComplete(tabId, snapshot);
         sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
+        releaseRunKeepalive();
       }
     }
 
     case 'continue': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) throw new Error('No tab ID');
-      assertNoActiveTabRun(tabId);
+      assertRunCanStart(tabId, msg);
       const mode = msg.mode || 'ask';
       const runUi = beginRunUiSnapshot(tabId, msg.requestId);
+      const releaseRunKeepalive = acquireRunKeepalive();
 
       sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
       let userMemoryTurnContextTaken = false;
@@ -1965,6 +2030,7 @@ async function handleMessage(msg, sender) {
         );
         sendAgentRunComplete(tabId, snapshot);
         sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
+        releaseRunKeepalive();
       }
     }
 
@@ -2003,7 +2069,14 @@ async function handleMessage(msg, sender) {
     case 'agent_run_state': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) return { ok: false, error: 'No tab ID' };
-      return { ok: true, ...agent.activeRunState(tabId), runUi: await getRunUiSnapshot(tabId) };
+      const starting = detachedRunStarts.get(tabId) || null;
+      return {
+        ok: true,
+        ...agent.activeRunState(tabId),
+        starting: !!starting,
+        startingRequestId: starting?.requestId || null,
+        runUi: await getRunUiSnapshot(tabId),
+      };
     }
 
     case 'agent_run_ack': {

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -37,7 +37,7 @@ import {
 } from './recorder/host.js';
 import { RUN_CAPTURE_START_ERROR_PREFIX, createRunCaptureController } from './run-capture.js';
 import { normalizeOllamaLaunchHandoff } from './ollama-handoff.js';
-import { RunUiJournal } from './run-ui-journal.js';
+import { RunUiJournal, runUiSnapshotForRequest } from './run-ui-journal.js';
 import {
   USER_MEMORY_AUTO_CAPTURE_KEY,
   USER_MEMORY_ENABLED_KEY,
@@ -2112,6 +2112,7 @@ async function handleMessage(msg, sender) {
       const submittedTurnDurable = requestedRequestId
         ? await agent.hasDurableSubmittedTurn(tabId, requestedRequestId)
         : false;
+      const runUiSnapshot = await getRunUiSnapshot(tabId);
       return {
         ok: true,
         ...agent.activeRunState(tabId),
@@ -2119,7 +2120,7 @@ async function handleMessage(msg, sender) {
         startingRequestId: starting?.requestId || null,
         submittedTurnDurable,
         detachedError,
-        runUi: await getRunUiSnapshot(tabId),
+        runUi: runUiSnapshotForRequest(runUiSnapshot, requestedRequestId),
       };
     }
 

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -1277,7 +1277,28 @@ function assertNoActiveTabRun(tabId) {
 }
 
 const detachedRunStarts = new Map();
+const detachedRunFailures = new Map();
 const RUN_KEEPALIVE_INTERVAL_MS = 20_000;
+const DETACHED_RUN_FAILURE_TTL_MS = 60_000;
+
+function clearDetachedRunFailure(tabId) {
+  const failure = detachedRunFailures.get(tabId);
+  if (failure?.expiryTimer) clearTimeout(failure.expiryTimer);
+  detachedRunFailures.delete(tabId);
+}
+
+function rememberDetachedRunFailure(tabId, requestId, error) {
+  clearDetachedRunFailure(tabId);
+  const failure = {
+    requestId,
+    message: String(error?.message || error || 'Detached run failed.'),
+    expiryTimer: null,
+  };
+  failure.expiryTimer = setTimeout(() => {
+    if (detachedRunFailures.get(tabId) === failure) detachedRunFailures.delete(tabId);
+  }, DETACHED_RUN_FAILURE_TTL_MS);
+  detachedRunFailures.set(tabId, failure);
+}
 
 function assertRunCanStart(tabId, msg) {
   const reserved = detachedRunStarts.get(tabId);
@@ -1312,6 +1333,7 @@ function launchDetachedRun(action, msg, sender) {
   const tabId = msg.tabId || sender.tab?.id;
   if (!tabId) throw new Error('No tab ID');
   assertNoActiveTabRun(tabId);
+  clearDetachedRunFailure(tabId);
   const requestId = String(msg.requestId || `req_${tabId}_${Date.now()}`);
   const entry = { requestId, promise: null };
   detachedRunStarts.set(tabId, entry);
@@ -1323,6 +1345,7 @@ function launchDetachedRun(action, msg, sender) {
   }, sender));
   entry.promise = task;
   task.catch((error) => {
+    rememberDetachedRunFailure(tabId, requestId, error);
     console.warn(`[WebBrain] detached ${action} run failed:`, error);
   }).finally(() => {
     if (detachedRunStarts.get(tabId) === entry) detachedRunStarts.delete(tabId);
@@ -1420,6 +1443,7 @@ chrome.windows?.onRemoved?.addListener?.((windowId) => {
 chrome.tabs.onRemoved.addListener((tabId) => {
   panelTabs.delete(tabId);
   clearRunUiSnapshot(tabId);
+  clearDetachedRunFailure(tabId);
   clearTimeout(pendingContextMenuNotifications.get(tabId));
   pendingContextMenuNotifications.delete(tabId);
   contextMenuStorage.cleanup(tabId);
@@ -2070,11 +2094,17 @@ async function handleMessage(msg, sender) {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) return { ok: false, error: 'No tab ID' };
       const starting = detachedRunStarts.get(tabId) || null;
+      const requestedRequestId = String(msg.requestId || '');
+      const failure = detachedRunFailures.get(tabId) || null;
+      const detachedError = requestedRequestId && failure?.requestId === requestedRequestId
+        ? { requestId: failure.requestId, message: failure.message }
+        : null;
       return {
         ok: true,
         ...agent.activeRunState(tabId),
         starting: !!starting,
         startingRequestId: starting?.requestId || null,
+        detachedError,
         runUi: await getRunUiSnapshot(tabId),
       };
     }

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -1880,7 +1880,7 @@ async function handleMessage(msg, sender) {
       if (!tabId) throw new Error('No tab ID');
       assertRunCanStart(tabId, msg);
       const mode = msg.mode || 'ask';
-      const runUi = beginRunUiSnapshot(tabId, msg.requestId);
+      const runUi = await beginContinuationRunUiSnapshot(tabId, msg.requestId);
       const releaseRunKeepalive = acquireRunKeepalive();
 
       // /allow-api flag is per-conversation. The sidebar tracks it locally
@@ -1919,6 +1919,7 @@ async function handleMessage(msg, sender) {
           ...(msg.recommendedAction ? { recommendedAction: msg.recommendedAction } : {}),
           locale: msg.locale,
           intentFailureMessage: msg.intentFailureMessage,
+          detachedRequestId: runUi.requestId,
         };
         result = await agent.processMessage(tabId, msg.text, (type, data) => {
           updates.push({ type, data });
@@ -2108,11 +2109,15 @@ async function handleMessage(msg, sender) {
       const detachedError = requestedRequestId && failure?.requestId === requestedRequestId
         ? { requestId: failure.requestId, message: failure.message }
         : null;
+      const submittedTurnDurable = requestedRequestId
+        ? await agent.hasDurableSubmittedTurn(tabId, requestedRequestId)
+        : false;
       return {
         ok: true,
         ...agent.activeRunState(tabId),
         starting: !!starting,
         startingRequestId: starting?.requestId || null,
+        submittedTurnDurable,
         detachedError,
         runUi: await getRunUiSnapshot(tabId),
       };

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -1310,6 +1310,7 @@ function rememberDetachedRunFailure(tabId, requestId, error) {
 }
 
 function assertRunCanStart(tabId, msg) {
+  assertDetachedRunStartNotCancelled(tabId, msg);
   const reserved = detachedRunStarts.get(tabId);
   const internalRequestId = String(msg?.__detachedRunRequestId || '');
   if (reserved) {
@@ -1320,6 +1321,27 @@ function assertRunCanStart(tabId, msg) {
   if (agent.activeRunState(tabId)?.running) {
     throw new Error('A run is already active for this tab.');
   }
+}
+
+function isDetachedRunStartCancelled(tabId, msg) {
+  const internalRequestId = String(msg?.__detachedRunRequestId || '');
+  const reserved = detachedRunStarts.get(tabId);
+  return !!internalRequestId
+    && reserved?.requestId === internalRequestId
+    && reserved.cancelled === true;
+}
+
+function assertDetachedRunStartNotCancelled(tabId, msg) {
+  if (isDetachedRunStartCancelled(tabId, msg)) {
+    throw new Error('Run stopped by user before it started.');
+  }
+}
+
+function cancelDetachedRunStart(tabId) {
+  const reserved = detachedRunStarts.get(tabId);
+  if (!reserved) return false;
+  reserved.cancelled = true;
+  return true;
 }
 
 function acquireRunKeepalive() {
@@ -1344,14 +1366,18 @@ function launchDetachedRun(action, msg, sender) {
   assertNoActiveTabRun(tabId);
   clearDetachedRunFailure(tabId);
   const requestId = String(msg.requestId || `req_${tabId}_${Date.now()}`);
-  const entry = { requestId, promise: null };
+  const entry = { requestId, promise: null, cancelled: false };
   detachedRunStarts.set(tabId, entry);
-  const task = Promise.resolve().then(() => handleMessage({
-    ...msg,
-    action,
-    requestId,
-    __detachedRunRequestId: requestId,
-  }, sender));
+  const task = Promise.resolve().then(() => {
+    const detachedMessage = {
+      ...msg,
+      action,
+      requestId,
+      __detachedRunRequestId: requestId,
+    };
+    assertDetachedRunStartNotCancelled(tabId, detachedMessage);
+    return handleMessage(detachedMessage, sender);
+  });
   entry.promise = task;
   task.catch((error) => {
     rememberDetachedRunFailure(tabId, requestId, error);
@@ -1386,6 +1412,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg?.type !== 'WB_STOP_AGENT') return; // not ours
   const tabId = sender?.tab?.id;
   if (tabId != null) {
+    cancelDetachedRunStart(tabId);
     try { agent.abort(tabId); } catch { /* ignore */ }
     // Always clear the sender tab's page-owned indicator, even when the run
     // already ended or this service worker lost its in-memory run state.
@@ -1920,6 +1947,7 @@ async function handleMessage(msg, sender) {
           locale: msg.locale,
           intentFailureMessage: msg.intentFailureMessage,
           detachedRequestId: runUi.requestId,
+          isDetachedStartCancelled: () => isDetachedRunStartCancelled(tabId, msg),
         };
         result = await agent.processMessage(tabId, msg.text, (type, data) => {
           updates.push({ type, data });
@@ -2039,7 +2067,9 @@ async function handleMessage(msg, sender) {
         result = await agent.continueProcessing(tabId, (type, data) => {
           if (type === 'error') userMemoryTurnHadError = true;
           sendAgentUpdate(tabId, runUi.requestId, type, data);
-        }, mode);
+        }, mode, {
+          isDetachedStartCancelled: () => isDetachedRunStartCancelled(tabId, msg),
+        });
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
           userText: 'Please continue from where you left off.',
@@ -2096,7 +2126,10 @@ async function handleMessage(msg, sender) {
 
     case 'abort': {
       const tabId = msg.tabId || sender.tab?.id;
-      if (tabId) agent.abort(tabId);
+      if (tabId) {
+        cancelDetachedRunStart(tabId);
+        agent.abort(tabId);
+      }
       return { ok: true };
     }
 

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -1219,6 +1219,15 @@ function beginRunUiSnapshot(tabId, requestId) {
   return runUiJournal.begin(tabId, requestId);
 }
 
+async function beginContinuationRunUiSnapshot(tabId, requestId) {
+  const existing = await getRunUiSnapshot(tabId);
+  const sameNonTerminalRun = existing
+    && String(existing.requestId || '') === String(requestId || '')
+    && !['completed', 'stopped', 'failed', 'cancelled'].includes(existing.status);
+  if (sameNonTerminalRun) return runUiJournal.resume(tabId, requestId);
+  return beginRunUiSnapshot(tabId, requestId);
+}
+
 function recordRunUiEvent(tabId, requestId, type, data) {
   return runUiJournal.record(tabId, requestId, type, data, agent.currentRunId.get(tabId));
 }
@@ -2017,7 +2026,7 @@ async function handleMessage(msg, sender) {
       if (!tabId) throw new Error('No tab ID');
       assertRunCanStart(tabId, msg);
       const mode = msg.mode || 'ask';
-      const runUi = beginRunUiSnapshot(tabId, msg.requestId);
+      const runUi = await beginContinuationRunUiSnapshot(tabId, msg.requestId);
       const releaseRunKeepalive = acquireRunKeepalive();
 
       sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');

--- a/src/chrome/src/run-reconnect.js
+++ b/src/chrome/src/run-reconnect.js
@@ -65,6 +65,7 @@ export async function runDetachedWithReconnect({
   reconnectDelaysMs = [250, 500, 1000, 2000, 4000],
   maxResumeAttempts = 3,
   maxUncertainStartRetries = 2,
+  maxAcknowledgedStartRetries = 2,
   maxMissingStateProbes = 6,
   maxConnectionFailures = 12,
 } = {}) {
@@ -78,8 +79,10 @@ export async function runDetachedWithReconnect({
   let actionPayload = payload;
   let resumeAttempts = 0;
   let uncertainStartRetries = 0;
+  let acknowledgedStartRetries = 0;
   let everReconnected = false;
   let startWasUncertain = false;
+  let startObserved = false;
 
   while (true) {
     let startAcknowledged = false;
@@ -156,6 +159,7 @@ export async function runDetachedWithReconnect({
         // than risking duplicate page actions.
         startAcknowledged = true;
         startWasUncertain = false;
+        startObserved = true;
         if (wasDisconnected) {
           everReconnected = true;
           wasDisconnected = false;
@@ -166,6 +170,11 @@ export async function runDetachedWithReconnect({
 
       if (state?.running === true || state?.starting === true) {
         throw new Error('Another run became active while reconnecting.');
+      }
+
+      if (sameSnapshot && snapshot.status === 'awaiting_plan') {
+        if (!shouldResume()) throw new Error('Run recovery was cancelled.');
+        throw new Error('Plan approval expired after the extension background restarted. Review the plan and run the request again.');
       }
 
       if (sameSnapshot && !TERMINAL_RUN_STATUSES.has(snapshot.status)) {
@@ -202,6 +211,18 @@ export async function runDetachedWithReconnect({
         if (!shouldResume()) throw new Error('Run recovery was cancelled.');
         uncertainStartRetries += 1;
         onStatus({ phase: 'retrying_start', requestId, attempt: uncertainStartRetries });
+        break;
+      }
+      if (startAcknowledged
+          && !startObserved
+          && state?.submittedTurnDurable !== true
+          && missingStateProbes >= 2
+          && acknowledgedStartRetries < maxAcknowledgedStartRetries) {
+        if (!shouldResume()) throw new Error('Run recovery was cancelled.');
+        acknowledgedStartRetries += 1;
+        action = initialAction;
+        actionPayload = payload;
+        onStatus({ phase: 'retrying_start', requestId, attempt: acknowledgedStartRetries });
         break;
       }
       if (startAcknowledged && missingStateProbes >= maxMissingStateProbes) {

--- a/src/chrome/src/run-reconnect.js
+++ b/src/chrome/src/run-reconnect.js
@@ -41,6 +41,21 @@ function runResponseFromSnapshot(snapshot, { reconnected = false, resumed = fals
   };
 }
 
+function terminalResponseForRecordedError(snapshot) {
+  if (snapshot?.hadError !== true) return null;
+  const events = Array.isArray(snapshot.events) ? snapshot.events : [];
+  const reachedStepLimit = events.some(event => event?.type === 'max_steps_reached');
+  const fallback = snapshot.lastError
+    || (reachedStepLimit
+      ? 'The run reached its maximum step limit.'
+      : 'The run stopped after recording an error.');
+  return {
+    ...snapshot,
+    status: reachedStepLimit ? 'completed' : 'failed',
+    finalContent: String(snapshot.finalContent || (reachedStepLimit ? '' : `Error: ${fallback}`)),
+  };
+}
+
 /**
  * Starts a detached background run and follows its persisted UI journal.
  *
@@ -68,6 +83,8 @@ export async function runDetachedWithReconnect({
   maxAcknowledgedStartRetries = 2,
   maxMissingStateProbes = 6,
   maxConnectionFailures = 12,
+  probeFirst = false,
+  requireDurableSubmittedTurn = false,
 } = {}) {
   if (typeof start !== 'function' || typeof probe !== 'function') {
     throw new Error('Detached run recovery requires start and probe functions.');
@@ -82,23 +99,28 @@ export async function runDetachedWithReconnect({
   let acknowledgedStartRetries = 0;
   let everReconnected = false;
   let startWasUncertain = false;
-  let startObserved = false;
+  let startObserved = probeFirst;
+  let skipStart = probeFirst;
 
   while (true) {
-    let startAcknowledged = false;
-    try {
-      const ack = await start(action, actionPayload);
-      if (ack?.accepted === false) throw new Error(ack.error || 'The background rejected the run.');
-      if (ack?.requestId && !requestMatches(ack.requestId, requestId)) {
-        throw new Error('The background acknowledged a different run request.');
+    let startAcknowledged = skipStart;
+    if (skipStart) {
+      skipStart = false;
+    } else {
+      try {
+        const ack = await start(action, actionPayload);
+        if (ack?.accepted === false) throw new Error(ack.error || 'The background rejected the run.');
+        if (ack?.requestId && !requestMatches(ack.requestId, requestId)) {
+          throw new Error('The background acknowledged a different run request.');
+        }
+        startAcknowledged = true;
+        startWasUncertain = false;
+      } catch (error) {
+        if (!isConnectionError?.(error)) throw error;
+        startWasUncertain = true;
+        everReconnected = true;
+        onStatus({ phase: 'reconnecting', requestId, error });
       }
-      startAcknowledged = true;
-      startWasUncertain = false;
-    } catch (error) {
-      if (!isConnectionError?.(error)) throw error;
-      startWasUncertain = true;
-      everReconnected = true;
-      onStatus({ phase: 'reconnecting', requestId, error });
     }
 
     let missingStateProbes = 0;
@@ -179,6 +201,22 @@ export async function runDetachedWithReconnect({
 
       if (sameSnapshot && !TERMINAL_RUN_STATUSES.has(snapshot.status)) {
         if (!shouldResume()) throw new Error('Run recovery was cancelled.');
+        const recordedTerminal = terminalResponseForRecordedError(snapshot);
+        if (recordedTerminal) {
+          return runResponseFromSnapshot(recordedTerminal, {
+            reconnected: true,
+            resumed: resumeAttempts > 0,
+          });
+        }
+        if (snapshot.pendingToolCall) {
+          throw new Error(`Run recovery stopped because the outcome of ${snapshot.pendingToolCall.name || 'a page action'} is uncertain. Check the page before retrying to avoid repeating the action.`);
+        }
+        if (state?.runUiDurable === false) {
+          throw new Error('Run recovery stopped because its latest checkpoint was not persisted. Check the page before retrying to avoid duplicate actions.');
+        }
+        if (requireDurableSubmittedTurn && state?.submittedTurnDurable !== true) {
+          throw new Error('Run recovery stopped because the submitted turn was not persisted before the sidebar reloaded. Retry the request manually.');
+        }
         if (resumeAttempts >= maxResumeAttempts) {
           throw new Error('The extension background restarted repeatedly and the run could not be recovered.');
         }
@@ -340,4 +378,4 @@ export async function sendPlanResponseWithReconnect({
   throw lastConnectionError || new Error('Could not reconnect to submit the plan decision.');
 }
 
-export { TERMINAL_RUN_STATUSES, runResponseFromSnapshot };
+export { TERMINAL_RUN_STATUSES, runResponseFromSnapshot, terminalResponseForRecordedError };

--- a/src/chrome/src/run-reconnect.js
+++ b/src/chrome/src/run-reconnect.js
@@ -145,6 +145,12 @@ export async function runDetachedWithReconnect({
 
       if (sameStartingRun || sameLiveRun) {
         missingStateProbes = 0;
+        // Observing our request proves the uncertain start was delivered.
+        // Never retry the original start after this point: if state later
+        // disappears, fail or resume from a matching journal snapshot rather
+        // than risking duplicate page actions.
+        startAcknowledged = true;
+        startWasUncertain = false;
         if (wasDisconnected) {
           everReconnected = true;
           wasDisconnected = false;

--- a/src/chrome/src/run-reconnect.js
+++ b/src/chrome/src/run-reconnect.js
@@ -1,0 +1,290 @@
+const TERMINAL_RUN_STATUSES = new Set(['completed', 'stopped', 'failed', 'cancelled']);
+
+function defaultWait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function requestMatches(value, requestId) {
+  return value != null && String(value) === String(requestId);
+}
+
+function runResponseFromSnapshot(snapshot, { reconnected = false, resumed = false } = {}) {
+  const updates = (Array.isArray(snapshot?.events) ? snapshot.events : [])
+    .filter(event => event?.type && event.type !== 'run_complete')
+    .map(event => ({ type: event.type, data: event.data }));
+  if (snapshot?.status === 'failed' && !updates.some(update => update.type === 'error')) {
+    updates.push({
+      type: 'error',
+      data: {
+        message: snapshot.lastError
+          || String(snapshot.finalContent || '').replace(/^Error:\s*/i, '')
+          || 'The run stopped after the extension background restarted.',
+      },
+    });
+  }
+  return {
+    content: String(snapshot?.finalContent || ''),
+    updates,
+    requestId: snapshot?.requestId || null,
+    runId: snapshot?.runId || null,
+    runStatus: snapshot?.status || null,
+    success: snapshot?.status === 'completed',
+    successfulDone: snapshot?.successfulDone === true,
+    hadError: snapshot?.hadError === true || snapshot?.status === 'failed',
+    reconnected,
+    resumed,
+  };
+}
+
+/**
+ * Starts a detached background run and follows its persisted UI journal.
+ *
+ * The initiating runtime message is intentionally short-lived. If the
+ * background context restarts, a non-terminal snapshot with no live owner is
+ * resumed through `resumeAction`. Short state probes double as a run lease for
+ * event-page/service-worker lifecycles.
+ */
+export async function runDetachedWithReconnect({
+  initialAction,
+  resumeAction = 'continue_start',
+  payload,
+  resumePayload = null,
+  start,
+  probe,
+  isConnectionError,
+  onStatus = () => {},
+  onState = () => {},
+  shouldResume = () => true,
+  wait = defaultWait,
+  pollIntervalMs = 1200,
+  reconnectDelaysMs = [250, 500, 1000, 2000, 4000],
+  maxResumeAttempts = 3,
+  maxUncertainStartRetries = 2,
+  maxMissingStateProbes = 6,
+  maxConnectionFailures = 12,
+} = {}) {
+  if (typeof start !== 'function' || typeof probe !== 'function') {
+    throw new Error('Detached run recovery requires start and probe functions.');
+  }
+  const requestId = String(payload?.requestId || '');
+  if (!requestId) throw new Error('Detached run recovery requires a requestId.');
+
+  let action = initialAction;
+  let actionPayload = payload;
+  let resumeAttempts = 0;
+  let uncertainStartRetries = 0;
+  let everReconnected = false;
+  let startWasUncertain = false;
+
+  while (true) {
+    let startAcknowledged = false;
+    try {
+      const ack = await start(action, actionPayload);
+      if (ack?.accepted === false) throw new Error(ack.error || 'The background rejected the run.');
+      if (ack?.requestId && !requestMatches(ack.requestId, requestId)) {
+        throw new Error('The background acknowledged a different run request.');
+      }
+      startAcknowledged = true;
+      startWasUncertain = false;
+    } catch (error) {
+      if (!isConnectionError?.(error)) throw error;
+      startWasUncertain = true;
+      everReconnected = true;
+      onStatus({ phase: 'reconnecting', requestId, error });
+    }
+
+    let missingStateProbes = 0;
+    let connectionFailures = 0;
+    let wasDisconnected = startWasUncertain;
+
+    while (true) {
+      const reconnectDelay = reconnectDelaysMs[
+        Math.min(connectionFailures, Math.max(0, reconnectDelaysMs.length - 1))
+      ] ?? pollIntervalMs;
+      await wait(wasDisconnected ? reconnectDelay : pollIntervalMs);
+
+      let state;
+      try {
+        state = await probe({ requestId });
+        connectionFailures = 0;
+        try {
+          await onState(state);
+        } catch {}
+      } catch (error) {
+        if (!isConnectionError?.(error)) throw error;
+        connectionFailures += 1;
+        wasDisconnected = true;
+        everReconnected = true;
+        onStatus({ phase: 'reconnecting', requestId, error, attempt: connectionFailures });
+        if (connectionFailures >= maxConnectionFailures) {
+          throw new Error('Could not reconnect to the extension background.');
+        }
+        continue;
+      }
+
+      const snapshot = state?.runUi && typeof state.runUi === 'object' ? state.runUi : null;
+      const sameSnapshot = requestMatches(snapshot?.requestId, requestId);
+      const sameStartingRun = state?.starting === true
+        && requestMatches(state?.startingRequestId, requestId);
+      const sameLiveRun = state?.running === true && sameSnapshot;
+
+      if (sameSnapshot && TERMINAL_RUN_STATUSES.has(snapshot.status)) {
+        if (wasDisconnected) {
+          everReconnected = true;
+          onStatus({ phase: 'reconnected', requestId, state });
+        }
+        return runResponseFromSnapshot(snapshot, {
+          reconnected: everReconnected,
+          resumed: resumeAttempts > 0,
+        });
+      }
+
+      if (sameStartingRun || sameLiveRun) {
+        missingStateProbes = 0;
+        if (wasDisconnected) {
+          everReconnected = true;
+          wasDisconnected = false;
+          onStatus({ phase: 'reconnected', requestId, state });
+        }
+        continue;
+      }
+
+      if (state?.running === true || state?.starting === true) {
+        throw new Error('Another run became active while reconnecting.');
+      }
+
+      if (sameSnapshot && !TERMINAL_RUN_STATUSES.has(snapshot.status)) {
+        if (!shouldResume()) throw new Error('Run recovery was cancelled.');
+        if (resumeAttempts >= maxResumeAttempts) {
+          throw new Error('The extension background restarted repeatedly and the run could not be recovered.');
+        }
+        resumeAttempts += 1;
+        everReconnected = true;
+        action = resumeAction;
+        actionPayload = {
+          tabId: payload.tabId,
+          requestId,
+          mode: payload.mode,
+          ...(resumePayload || {}),
+        };
+        onStatus({ phase: 'resuming', requestId, state, attempt: resumeAttempts });
+        break;
+      }
+
+      missingStateProbes += 1;
+      if (startWasUncertain
+          && missingStateProbes >= 2
+          && uncertainStartRetries < maxUncertainStartRetries) {
+        uncertainStartRetries += 1;
+        onStatus({ phase: 'retrying_start', requestId, attempt: uncertainStartRetries });
+        break;
+      }
+      if (startAcknowledged && missingStateProbes >= maxMissingStateProbes) {
+        throw new Error('The background acknowledged the run but did not publish recoverable run state.');
+      }
+      if (startWasUncertain
+          && uncertainStartRetries >= maxUncertainStartRetries
+          && missingStateProbes >= maxMissingStateProbes) {
+        throw new Error('Could not reconnect to the extension background.');
+      }
+    }
+  }
+}
+
+function matchingPlanResolution(state, planId) {
+  const resolution = state?.runUi?.lastPlanResolution;
+  if (!resolution || !requestMatches(resolution.planId, planId)) return null;
+  return resolution;
+}
+
+/**
+ * Delivers a plan decision across a transient runtime-message disconnect.
+ *
+ * A lost reply is not treated as a failed approval: the durable run journal
+ * records the resolution, so a probe can prove that the first delivery won
+ * without sending a duplicate decision.
+ */
+export async function sendPlanResponseWithReconnect({
+  payload,
+  requestId = '',
+  send,
+  probe,
+  isConnectionError,
+  onStatus = () => {},
+  onState = () => {},
+  wait = defaultWait,
+  reconnectDelaysMs = [250, 500, 1000, 2000, 4000],
+  maxAttempts = 8,
+} = {}) {
+  if (typeof send !== 'function' || typeof probe !== 'function') {
+    throw new Error('Plan response recovery requires send and probe functions.');
+  }
+  const planId = String(payload?.planId || '');
+  if (!planId) throw new Error('Plan response recovery requires a planId.');
+  const expectedRequestId = String(requestId || '');
+  let lastConnectionError = null;
+  let reconnected = false;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const response = await send(payload);
+      if (response?.matched) return { ...response, reconnected };
+    } catch (error) {
+      if (!isConnectionError?.(error)) throw error;
+      lastConnectionError = error;
+      onStatus({ phase: 'reconnecting', planId, attempt: attempt + 1, error });
+    }
+
+    const delay = reconnectDelaysMs[
+      Math.min(attempt, Math.max(0, reconnectDelaysMs.length - 1))
+    ] ?? 1000;
+    await wait(delay);
+
+    let state;
+    try {
+      state = await probe({ planId, requestId: expectedRequestId });
+      try {
+        await onState(state);
+      } catch {}
+    } catch (error) {
+      if (!isConnectionError?.(error)) throw error;
+      lastConnectionError = error;
+      onStatus({ phase: 'reconnecting', planId, attempt: attempt + 1, error });
+      continue;
+    }
+
+    const resolution = matchingPlanResolution(state, planId);
+    if (resolution) {
+      reconnected = true;
+      onStatus({ phase: 'reconnected', planId, state });
+      return {
+        ok: true,
+        matched: String(resolution.decision || '') === String(payload?.decision || ''),
+        recovered: true,
+        reconnected: true,
+      };
+    }
+
+    const sameRequest = !expectedRequestId
+      || requestMatches(state?.runUi?.requestId, expectedRequestId);
+    const samePendingPlan = requestMatches(state?.pendingPlan?.planId, planId);
+    if (samePendingPlan && sameRequest) {
+      reconnected = true;
+      onStatus({ phase: 'reconnected', planId, state });
+      continue;
+    }
+
+    return {
+      ok: false,
+      matched: false,
+      restarted: sameRequest
+        && state?.runUi?.status === 'awaiting_plan'
+        && !state?.pendingPlan,
+      reconnected,
+    };
+  }
+
+  throw lastConnectionError || new Error('Could not reconnect to submit the plan decision.');
+}
+
+export { TERMINAL_RUN_STATUSES, runResponseFromSnapshot };

--- a/src/chrome/src/run-reconnect.js
+++ b/src/chrome/src/run-reconnect.js
@@ -1,5 +1,10 @@
 const TERMINAL_RUN_STATUSES = new Set(['completed', 'stopped', 'failed', 'cancelled']);
 
+export function isBackgroundConnectionError(error) {
+  const message = String(error?.message || error || '');
+  return /Could not establish connection|Receiving end does not exist|Extension context invalidated|message (?:channel|port) closed|No response from WebBrain background|background script may have restarted|extension connection was lost/i.test(message);
+}
+
 function defaultWait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/src/chrome/src/run-reconnect.js
+++ b/src/chrome/src/run-reconnect.js
@@ -194,6 +194,7 @@ export async function runDetachedWithReconnect({
       if (startWasUncertain
           && missingStateProbes >= 2
           && uncertainStartRetries < maxUncertainStartRetries) {
+        if (!shouldResume()) throw new Error('Run recovery was cancelled.');
         uncertainStartRetries += 1;
         onStatus({ phase: 'retrying_start', requestId, attempt: uncertainStartRetries });
         break;

--- a/src/chrome/src/run-reconnect.js
+++ b/src/chrome/src/run-reconnect.js
@@ -185,7 +185,14 @@ export async function runDetachedWithReconnect({
         resumeAttempts += 1;
         everReconnected = true;
         const retryFreshChat = initialAction === 'chat_start'
-          && state?.submittedTurnDurable !== true;
+          && state?.submittedTurnDurable !== true
+          && !startObserved
+          && Number(snapshot.seq || 0) === 0;
+        if (initialAction === 'chat_start'
+            && state?.submittedTurnDurable !== true
+            && !retryFreshChat) {
+          throw new Error('Run recovery stopped because the submitted turn was not persisted after live progress. Retry the request manually to avoid duplicate page actions.');
+        }
         action = retryFreshChat ? initialAction : resumeAction;
         actionPayload = retryFreshChat
           ? payload

--- a/src/chrome/src/run-reconnect.js
+++ b/src/chrome/src/run-reconnect.js
@@ -170,14 +170,23 @@ export async function runDetachedWithReconnect({
         }
         resumeAttempts += 1;
         everReconnected = true;
-        action = resumeAction;
-        actionPayload = {
-          tabId: payload.tabId,
+        const retryFreshChat = initialAction === 'chat_start'
+          && state?.submittedTurnDurable !== true;
+        action = retryFreshChat ? initialAction : resumeAction;
+        actionPayload = retryFreshChat
+          ? payload
+          : {
+              tabId: payload.tabId,
+              requestId,
+              mode: payload.mode,
+              ...(resumePayload || {}),
+            };
+        onStatus({
+          phase: retryFreshChat ? 'retrying_start' : 'resuming',
           requestId,
-          mode: payload.mode,
-          ...(resumePayload || {}),
-        };
-        onStatus({ phase: 'resuming', requestId, state, attempt: resumeAttempts });
+          state,
+          attempt: resumeAttempts,
+        });
         break;
       }
 

--- a/src/chrome/src/run-reconnect.js
+++ b/src/chrome/src/run-reconnect.js
@@ -123,6 +123,10 @@ export async function runDetachedWithReconnect({
       }
 
       const snapshot = state?.runUi && typeof state.runUi === 'object' ? state.runUi : null;
+      const detachedError = state?.detachedError;
+      if (requestMatches(detachedError?.requestId, requestId)) {
+        throw new Error(detachedError?.message || 'Detached run failed.');
+      }
       const sameSnapshot = requestMatches(snapshot?.requestId, requestId);
       const sameStartingRun = state?.starting === true
         && requestMatches(state?.startingRequestId, requestId);

--- a/src/chrome/src/run-ui-journal.js
+++ b/src/chrome/src/run-ui-journal.js
@@ -49,7 +49,11 @@ export class RunUiJournal {
       truncatedBeforeSeq: 0,
       events: [],
       pendingPlanId: null,
+      lastPlanResolution: null,
       finalContent: '',
+      successfulDone: false,
+      hadError: false,
+      lastError: '',
       startedAt: Date.now(),
       endedAt: null,
     };
@@ -75,10 +79,28 @@ export class RunUiJournal {
     if (type === 'plan_review') {
       snapshot.status = 'awaiting_plan';
       snapshot.pendingPlanId = String(data?.planId || '') || null;
+      snapshot.lastPlanResolution = null;
     }
     if (type === 'plan_resolved') {
       snapshot.status = 'running';
       if (!data?.planId || String(data.planId) === String(snapshot.pendingPlanId)) snapshot.pendingPlanId = null;
+      snapshot.lastPlanResolution = {
+        planId: String(data?.planId || ''),
+        decision: String(data?.decision || ''),
+      };
+    }
+    if (type === 'tool_result'
+        && data?.name === 'done'
+        && data?.result?.done === true
+        && data?.result?.outcome === 'success'
+        && data?.result?.success !== false
+        && !data?.result?.error
+        && !data?.result?.blockedDone) {
+      snapshot.successfulDone = true;
+    }
+    if (type === 'error' || type === 'attachment_rejected' || type === 'max_steps_reached') {
+      snapshot.hadError = true;
+      snapshot.lastError = String(data?.message || data?.error || '').slice(0, 2000);
     }
     this._changed(tabId, snapshot);
     return { ...event, requestId: snapshot.requestId, runId: snapshot.runId };
@@ -108,6 +130,12 @@ export class RunUiJournal {
 
   restore(tabId, snapshot) {
     if (!snapshot || typeof snapshot !== 'object') return null;
+    if (snapshot.successfulDone !== true) snapshot.successfulDone = false;
+    if (snapshot.hadError !== true) snapshot.hadError = false;
+    if (typeof snapshot.lastError !== 'string') snapshot.lastError = '';
+    if (!snapshot.lastPlanResolution || typeof snapshot.lastPlanResolution !== 'object') {
+      snapshot.lastPlanResolution = null;
+    }
     this.snapshots.set(tabId, snapshot);
     return snapshot;
   }

--- a/src/chrome/src/run-ui-journal.js
+++ b/src/chrome/src/run-ui-journal.js
@@ -44,10 +44,12 @@ export class RunUiJournal {
     return snapshot;
   }
 
-  begin(tabId, requestId = '') {
+  begin(tabId, requestId = '', metadata = {}) {
     const snapshot = {
       tabId,
       requestId: createRunRequestId(tabId, requestId),
+      mode: String(metadata?.mode || ''),
+      kind: metadata?.kind === 'continue' ? 'continue' : 'chat',
       runId: null,
       status: 'running',
       seq: 0,
@@ -60,6 +62,7 @@ export class RunUiJournal {
       successfulDone: false,
       hadError: false,
       lastError: '',
+      pendingToolCall: null,
       startedAt: Date.now(),
       endedAt: null,
     };
@@ -67,9 +70,13 @@ export class RunUiJournal {
     return this._changed(tabId, snapshot);
   }
 
-  resume(tabId, requestId = '') {
+  resume(tabId, requestId = '', metadata = {}) {
     const snapshot = this.snapshots.get(tabId);
     if (!snapshot || String(snapshot.requestId) !== String(requestId)) return null;
+    if (metadata?.mode) snapshot.mode = String(metadata.mode);
+    if (!snapshot.kind && metadata?.kind) {
+      snapshot.kind = metadata.kind === 'continue' ? 'continue' : 'chat';
+    }
     snapshot.status = 'running';
     snapshot.pendingPlanId = null;
     snapshot.finalContent = '';
@@ -106,6 +113,12 @@ export class RunUiJournal {
         decision: String(data?.decision || ''),
       };
     }
+    if (type === 'tool_call' && data?.outcomeUnknown === true) {
+      snapshot.pendingToolCall = {
+        name: String(data?.name || ''),
+        seq: event.seq,
+      };
+    }
     if (type === 'tool_result'
         && data?.name === 'done'
         && data?.result?.done === true
@@ -117,10 +130,22 @@ export class RunUiJournal {
     }
     if (type === 'error' || type === 'attachment_rejected' || type === 'max_steps_reached') {
       snapshot.hadError = true;
-      snapshot.lastError = String(data?.message || data?.error || '').slice(0, 2000);
+      snapshot.lastError = String(
+        data?.message
+        || data?.error
+        || (type === 'max_steps_reached' ? 'The run reached its maximum step limit.' : ''),
+      ).slice(0, 2000);
     }
     this._changed(tabId, snapshot);
     return { ...event, requestId: snapshot.requestId, runId: snapshot.runId };
+  }
+
+  settleToolCall(tabId, requestId, name = '') {
+    const snapshot = this.snapshots.get(tabId);
+    if (!snapshot || snapshot.requestId !== requestId || !snapshot.pendingToolCall) return null;
+    if (name && snapshot.pendingToolCall.name && snapshot.pendingToolCall.name !== String(name)) return null;
+    snapshot.pendingToolCall = null;
+    return this._changed(tabId, snapshot);
   }
 
   finish(tabId, requestId, status, finalContent = '', runId = null) {
@@ -129,6 +154,7 @@ export class RunUiJournal {
     snapshot.runId = runId || snapshot.runId || null;
     snapshot.status = status;
     snapshot.pendingPlanId = null;
+    snapshot.pendingToolCall = null;
     snapshot.finalContent = String(finalContent || '').slice(0, 30000);
     snapshot.endedAt = Date.now();
     const event = {
@@ -150,6 +176,11 @@ export class RunUiJournal {
     if (snapshot.successfulDone !== true) snapshot.successfulDone = false;
     if (snapshot.hadError !== true) snapshot.hadError = false;
     if (typeof snapshot.lastError !== 'string') snapshot.lastError = '';
+    if (!snapshot.pendingToolCall || typeof snapshot.pendingToolCall !== 'object') {
+      snapshot.pendingToolCall = null;
+    }
+    if (typeof snapshot.mode !== 'string') snapshot.mode = '';
+    if (snapshot.kind !== 'continue' && snapshot.kind !== 'chat') snapshot.kind = 'chat';
     if (!snapshot.lastPlanResolution || typeof snapshot.lastPlanResolution !== 'object') {
       snapshot.lastPlanResolution = null;
     }

--- a/src/chrome/src/run-ui-journal.js
+++ b/src/chrome/src/run-ui-journal.js
@@ -61,6 +61,17 @@ export class RunUiJournal {
     return this._changed(tabId, snapshot);
   }
 
+  resume(tabId, requestId = '') {
+    const snapshot = this.snapshots.get(tabId);
+    if (!snapshot || String(snapshot.requestId) !== String(requestId)) return null;
+    snapshot.status = 'running';
+    snapshot.pendingPlanId = null;
+    snapshot.finalContent = '';
+    snapshot.successfulDone = false;
+    snapshot.endedAt = null;
+    return this._changed(tabId, snapshot);
+  }
+
   record(tabId, requestId, type, data, runId = null) {
     const snapshot = this.snapshots.get(tabId);
     if (!snapshot || snapshot.requestId !== requestId) return null;

--- a/src/chrome/src/run-ui-journal.js
+++ b/src/chrome/src/run-ui-journal.js
@@ -5,6 +5,12 @@ export function createRunRequestId(tabId, supplied = '') {
   return clean || `req_${tabId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
+export function runUiSnapshotForRequest(snapshot, requestedRequestId = '') {
+  const requested = String(requestedRequestId || '');
+  if (!requested) return snapshot || null;
+  return String(snapshot?.requestId || '') === requested ? snapshot : null;
+}
+
 export function compactRunUiData(type, data) {
   if (!data || typeof data !== 'object') return data;
   if (type === 'tool_result') {

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -7409,6 +7409,12 @@ modeDevBtn?.addEventListener('click', async () => {
 async function abortRun() {
   const tabId = currentTabId;
   if (!isTabProcessing(tabId)) return;
+  const requestId = String(
+    localRunRequestIds.get(Number(tabId))
+      || currentAssistantEl?.dataset?.runRequestId
+      || '',
+  );
+  if (requestId) cancelledRunRecoveryRequestIds.add(requestId);
   setTabAbortRequested(tabId, true);
   showActivity(t('sp.activity.stopping'));
 

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -13,6 +13,7 @@ import { formatSelectionPromptForDisplay } from '../context-menu-storage.js';
 import { deleteChatHistoryRecord, saveChatHistoryRecord } from './chat-history-store.js';
 import { claimRunError } from './run-error-dedupe.js';
 import { RUN_CAPTURE_START_ERROR_PREFIX } from '../run-capture.js';
+import { runDetachedWithReconnect, sendPlanResponseWithReconnect } from '../run-reconnect.js';
 import {
   STORAGE_KEY as STORE_REVIEW_STORAGE_KEY,
   recordSuccessfulTask,
@@ -911,6 +912,7 @@ const awaitingPlanReviewTabs = new Set();
 const processingTabs = new Set();
 const abortRequestedTabs = new Set();
 const localRunRequestIds = new Map();
+const cancelledRunRecoveryRequestIds = new Set();
 let recommendationsRequestId = 0;
 let providerSelectionRequestId = 0;
 let providerTestRequestId = 0;
@@ -3215,6 +3217,10 @@ async function restoreActiveRunState(tabId = currentTabId) {
   } catch {
     return;
   }
+  await applyActiveRunState(numericTabId, state);
+}
+
+async function applyActiveRunState(numericTabId, state) {
   if (!sameTabId(currentTabId, numericTabId) || !sameTabId(renderedTabId, numericTabId)) return;
   const runUi = state?.runUi && typeof state.runUi === 'object' ? state.runUi : null;
   if (runUi?.requestId) {
@@ -5187,7 +5193,7 @@ async function sendMessage(extraChatParams = {}) {
   let completedSuccessfully = false;
   let promptEligibleCompletion = false;
   try {
-    const res = await sendToBackground('chat', {
+    const res = await sendRunWithReconnect('chat_start', {
       tabId,
       requestId,
       text,
@@ -5209,7 +5215,7 @@ async function sendMessage(extraChatParams = {}) {
       chatHistoryRecordIdsByTab.set(tabId, res.conversationId);
     }
     accepted = true;
-    completedSuccessfully = updatesContainSuccessfulDone(res?.updates);
+    completedSuccessfully = res?.successfulDone === true || updatesContainSuccessfulDone(res?.updates);
     promptEligibleCompletion = completedSuccessfully || isSuccessfulAskCompletion(modeForSend, res);
     const returnedErrorUpdate = Array.isArray(res?.updates)
       ? res.updates.find(u => u?.type === 'error')
@@ -5279,6 +5285,7 @@ async function sendMessage(extraChatParams = {}) {
     }
   } finally {
     if (localRunRequestIds.get(tabId) === requestId) localRunRequestIds.delete(tabId);
+    cancelledRunRecoveryRequestIds.delete(requestId);
     if (activeChatPayloadsByTab.get(tabId) === activePayloadState) {
       scheduleActiveChatPayloadCleanup(tabId, activePayloadState);
     }
@@ -5749,6 +5756,10 @@ function handleAgentUpdateMessage(msg) {
       break;
 
     case 'plan_review':
+      invalidatePlanReviewCards({
+        tabId: msg.tabId ?? currentTabId,
+        requestId: msg.requestId,
+      });
       renderPlanReviewCard({ ...data, tabId: msg.tabId ?? currentTabId, requestId: msg.requestId, runId: msg.runId });
       break;
 
@@ -6082,11 +6093,12 @@ function renderPlanReviewCard(data) {
     .find(card => String(card.dataset.planId || '') === planId
       && String(card.dataset.tabId || '') === String(tabId)
       && (!data.requestId || card.dataset.runRequestId === String(data.requestId))
-      && (!data.runId || card.dataset.runId === String(data.runId))
-      && !card.classList.contains('plan-reviewed'));
+      && (!data.runId || card.dataset.runId === String(data.runId)));
   if (existing) {
-    bindPlanReviewCard(existing);
-    setPlanReviewAwaiting(tabId, true, existing.closest('.message.assistant'));
+    if (!existing.classList.contains('plan-reviewed')) {
+      bindPlanReviewCard(existing);
+      setPlanReviewAwaiting(tabId, true, existing.closest('.message.assistant'));
+    }
     scrollToBottom();
     return;
   }
@@ -6179,9 +6191,14 @@ function submitPlanReview(card, tabId, planId, action, editedText) {
   card.classList.add('plan-reviewed');
   setPlanReviewAwaiting(tabId, false);
   if (action !== 'approve') {
+    const requestId = String(card.dataset.runRequestId || '');
+    if (requestId) cancelledRunRecoveryRequestIds.add(requestId);
+    setTabAbortRequested(tabId, true);
     card.remove();
     scrollToBottom();
-    sendToBackground('plan_response', { tabId, planId, decision: action, editedText, markdownMode }).catch(() => {});
+    sendPlanReviewDecisionWithReconnect({
+      tabId, planId, decision: action, editedText, markdownMode,
+    }, requestId).catch(() => {});
     return;
   }
   for (const el of card.querySelectorAll('button, textarea')) {
@@ -6194,7 +6211,10 @@ function submitPlanReview(card, tabId, planId, action, editedText) {
     ? 'WebBrain reloaded or the background worker stopped before this plan could be approved. Reload the sidebar and try again.'
     : expiredText();
 
-  sendToBackground('plan_response', { tabId, planId, decision: action, editedText, markdownMode })
+  sendPlanReviewDecisionWithReconnect(
+    { tabId, planId, decision: action, editedText, markdownMode },
+    String(card.dataset.runRequestId || ''),
+  )
     .then((res) => {
       if (action !== 'approve') return;
       if (res?.matched) {
@@ -6211,8 +6231,11 @@ function submitPlanReview(card, tabId, planId, action, editedText) {
       if (action === 'approve') {
         note.textContent = failureText(error);
         card.appendChild(note);
-        setPlanReviewAwaiting(tabId, false);
-        if (activeAssistantEl) clearPlanReviewActiveRun(activeAssistantEl, tabId);
+        card.classList.remove('plan-reviewed');
+        for (const el of card.querySelectorAll('button, textarea')) {
+          el.disabled = false;
+        }
+        setPlanReviewAwaiting(tabId, true, activeAssistantEl || card.closest('.message.assistant'));
         scrollToBottom();
       }
     });
@@ -6803,7 +6826,7 @@ async function continueAgent(options = {}) {
     showActivity(t('sp.activity.continuing'));
     localRunRequestIds.set(tabId, requestId);
 
-    const res = await sendToBackground('continue', {
+    const res = await sendRunWithReconnect('continue_start', {
       tabId,
       requestId,
       mode: modeForSend,
@@ -6830,6 +6853,7 @@ async function continueAgent(options = {}) {
     }
   } finally {
     if (localRunRequestIds.get(tabId) === requestId) localRunRequestIds.delete(tabId);
+    cancelledRunRecoveryRequestIds.delete(requestId);
     if (currentTabId === tabId && assistantEl) finalizeSteps(assistantEl);
     clearAssistantTextStreamState(assistantEl);
     setTabProcessing(tabId, false);
@@ -7176,6 +7200,51 @@ function startInputPlaceholderRotation() {
 function isBackgroundConnectionError(error) {
   const message = String(error?.message || error || '');
   return /Could not establish connection|Receiving end does not exist|Extension context invalidated|No response from WebBrain background|background script may have restarted|extension connection was lost/i.test(message);
+}
+
+function sendPlanReviewDecisionWithReconnect(payload, requestId = '') {
+  const tabId = Number(payload?.tabId);
+  return sendPlanResponseWithReconnect({
+    payload,
+    requestId,
+    send: nextPayload => sendToBackground('plan_response', nextPayload),
+    probe: () => sendToBackground('agent_run_state', { tabId }),
+    isConnectionError: isBackgroundConnectionError,
+    onState: state => applyActiveRunState(tabId, state),
+    onStatus: ({ phase }) => {
+      if (!sameTabId(currentTabId, tabId)) return;
+      if (phase === 'reconnecting') showActivity('Reconnecting…');
+      if (phase === 'reconnected' && !isAwaitingPlanReviewForTab(tabId)) {
+        showActivity('Reconnected — continuing…');
+      }
+    },
+  });
+}
+
+async function sendRunWithReconnect(initialAction, payload) {
+  const tabId = Number(payload?.tabId);
+  const requestId = String(payload?.requestId || '');
+  cancelledRunRecoveryRequestIds.delete(requestId);
+  return runDetachedWithReconnect({
+    initialAction,
+    payload,
+    start: (action, nextPayload) => sendToBackground(action, nextPayload),
+    probe: () => sendToBackground('agent_run_state', { tabId }),
+    isConnectionError: isBackgroundConnectionError,
+    onState: state => applyActiveRunState(tabId, state),
+    shouldResume: () => !isTabAbortRequested(tabId)
+      && !cancelledRunRecoveryRequestIds.has(requestId),
+    onStatus: ({ phase }) => {
+      if (!sameTabId(currentTabId, tabId)) return;
+      if (phase === 'reconnecting' || phase === 'retrying_start') {
+        showActivity('Reconnecting…');
+      } else if (phase === 'resuming') {
+        showActivity('Reconnected — resuming…');
+      } else if (phase === 'reconnected' && !isAwaitingPlanReviewForTab(tabId)) {
+        showActivity('Reconnected — continuing…');
+      }
+    },
+  });
 }
 
 function formatBackgroundSendError(action, message) {

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -917,6 +917,7 @@ const processingTabs = new Set();
 const abortRequestedTabs = new Set();
 const localRunRequestIds = new Map();
 const cancelledRunRecoveryRequestIds = new Set();
+const adoptedRunRecoveryRequestIds = new Set();
 let recommendationsRequestId = 0;
 let providerSelectionRequestId = 0;
 let providerTestRequestId = 0;
@@ -3222,6 +3223,71 @@ async function restoreActiveRunState(tabId = currentTabId) {
     return;
   }
   await applyActiveRunState(numericTabId, state);
+  void adoptRestoredRunState(numericTabId, state);
+}
+
+function isTerminalRunUiStatus(status) {
+  return ['completed', 'stopped', 'failed', 'cancelled'].includes(String(status || ''));
+}
+
+async function adoptRestoredRunState(tabId, state) {
+  const runUi = state?.runUi && typeof state.runUi === 'object' ? state.runUi : null;
+  const requestId = String(runUi?.requestId || '');
+  if (!requestId
+      || isTerminalRunUiStatus(runUi.status)
+      || runUi.status === 'awaiting_plan'
+      || localRunRequestIds.has(Number(tabId))
+      || adoptedRunRecoveryRequestIds.has(requestId)) return;
+
+  adoptedRunRecoveryRequestIds.add(requestId);
+  localRunRequestIds.set(Number(tabId), requestId);
+  setTabProcessing(tabId, true);
+  setTabAbortRequested(tabId, false);
+  syncSendButtonState();
+  if (sameTabId(currentTabId, tabId)) showActivity('Reconnecting…');
+  const assistantEl = messagesEl.querySelector(`.message.assistant[data-run-request-id="${CSS.escape(requestId)}"]`)
+    || currentAssistantEl;
+  const mode = ['ask', 'act', 'dev'].includes(runUi.mode)
+    ? runUi.mode
+    : (['ask', 'act', 'dev'].includes(assistantEl?.dataset?.runMode) ? assistantEl.dataset.runMode : agentMode);
+
+  try {
+    const res = await sendRunWithReconnect('continue_start', {
+      tabId,
+      requestId,
+      mode,
+    }, {
+      probeFirst: true,
+      requireDurableSubmittedTurn: runUi.kind !== 'continue',
+    });
+    const returnedErrorUpdate = Array.isArray(res?.updates)
+      ? res.updates.find(update => update?.type === 'error')
+      : null;
+    if (returnedErrorUpdate && sameTabId(currentTabId, tabId) && !isTabAbortRequested(tabId)) {
+      renderAgentErrorUpdate(returnedErrorUpdate.data, tabId, requestId);
+    }
+  } catch (error) {
+    if (sameTabId(currentTabId, tabId) && !isTabAbortRequested(tabId)) {
+      renderAgentErrorUpdate({ message: error.message }, tabId, requestId);
+    }
+  } finally {
+    adoptedRunRecoveryRequestIds.delete(requestId);
+    if (localRunRequestIds.get(Number(tabId)) === requestId) {
+      localRunRequestIds.delete(Number(tabId));
+      setTabProcessing(tabId, false);
+      setTabAbortRequested(tabId, false);
+    }
+    if (sameTabId(currentTabId, tabId)) {
+      if (assistantEl) finalizeSteps(assistantEl);
+      syncSendButtonState();
+      hideActivity();
+      if (currentAssistantEl === assistantEl) currentAssistantEl = null;
+      if (sameTabId(renderedTabId, tabId)) {
+        await flushRenderedTabChat();
+        await flushChatHistorySnapshot(tabId, { refreshTabInfo: true });
+      }
+    }
+  }
 }
 
 async function applyActiveRunState(numericTabId, state) {
@@ -6223,6 +6289,7 @@ function submitPlanReview(card, tabId, planId, action, editedText) {
       if (action !== 'approve') return;
       if (res?.matched) {
         card.remove();
+        void restoreActiveRunState(tabId);
       } else {
         note.textContent = expiredText();
         card.appendChild(note);
@@ -7223,7 +7290,7 @@ function sendPlanReviewDecisionWithReconnect(payload, requestId = '') {
   });
 }
 
-async function sendRunWithReconnect(initialAction, payload) {
+async function sendRunWithReconnect(initialAction, payload, recoveryOptions = {}) {
   const tabId = Number(payload?.tabId);
   const requestId = String(payload?.requestId || '');
   cancelledRunRecoveryRequestIds.delete(requestId);
@@ -7249,6 +7316,7 @@ async function sendRunWithReconnect(initialAction, payload) {
         showActivity('Reconnected — continuing…');
       }
     },
+    ...recoveryOptions,
   });
 }
 

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -3280,7 +3280,7 @@ async function applyActiveRunState(numericTabId, state) {
     return;
   }
   invalidatePlanReviewCards({ tabId: numericTabId });
-  if (state?.running) {
+  if (state?.running || state?.starting) {
     setTabProcessing(numericTabId, true);
     setTabAbortRequested(numericTabId, false);
     hideRecommendedActions();

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -7208,7 +7208,10 @@ function sendPlanReviewDecisionWithReconnect(payload, requestId = '') {
     payload,
     requestId,
     send: nextPayload => sendToBackground('plan_response', nextPayload),
-    probe: () => sendToBackground('agent_run_state', { tabId }),
+    probe: ({ requestId: probedRequestId } = {}) => sendToBackground('agent_run_state', {
+      tabId,
+      requestId: probedRequestId || requestId,
+    }),
     isConnectionError: isBackgroundConnectionError,
     onState: state => applyActiveRunState(tabId, state),
     onStatus: ({ phase }) => {
@@ -7229,7 +7232,10 @@ async function sendRunWithReconnect(initialAction, payload) {
     initialAction,
     payload,
     start: (action, nextPayload) => sendToBackground(action, nextPayload),
-    probe: () => sendToBackground('agent_run_state', { tabId }),
+    probe: ({ requestId: probedRequestId } = {}) => sendToBackground('agent_run_state', {
+      tabId,
+      requestId: probedRequestId || requestId,
+    }),
     isConnectionError: isBackgroundConnectionError,
     onState: state => applyActiveRunState(tabId, state),
     shouldResume: () => !isTabAbortRequested(tabId)

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -13,7 +13,11 @@ import { formatSelectionPromptForDisplay } from '../context-menu-storage.js';
 import { deleteChatHistoryRecord, saveChatHistoryRecord } from './chat-history-store.js';
 import { claimRunError } from './run-error-dedupe.js';
 import { RUN_CAPTURE_START_ERROR_PREFIX } from '../run-capture.js';
-import { runDetachedWithReconnect, sendPlanResponseWithReconnect } from '../run-reconnect.js';
+import {
+  isBackgroundConnectionError,
+  runDetachedWithReconnect,
+  sendPlanResponseWithReconnect,
+} from '../run-reconnect.js';
 import {
   STORAGE_KEY as STORE_REVIEW_STORAGE_KEY,
   recordSuccessfulTask,
@@ -7197,11 +7201,6 @@ function startInputPlaceholderRotation() {
 
 // --- Communication ---
 
-function isBackgroundConnectionError(error) {
-  const message = String(error?.message || error || '');
-  return /Could not establish connection|Receiving end does not exist|Extension context invalidated|No response from WebBrain background|background script may have restarted|extension connection was lost/i.test(message);
-}
-
 function sendPlanReviewDecisionWithReconnect(payload, requestId = '') {
   const tabId = Number(payload?.tabId);
   return sendPlanResponseWithReconnect({
@@ -7254,7 +7253,7 @@ async function sendRunWithReconnect(initialAction, payload) {
 }
 
 function formatBackgroundSendError(action, message) {
-  if (/Could not establish connection|Receiving end does not exist|Extension context invalidated/i.test(String(message || ''))) {
+  if (isBackgroundConnectionError(message)) {
     return `WebBrain extension connection was lost while sending "${action}". Reload the sidebar/extension and try again.`;
   }
   return message;

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -21,7 +21,7 @@
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'; connect-src * data: blob: http://* ws://*;",
   "background": {
     "page": "src/background.html",
-    "persistent": false
+    "persistent": true
   },
   "sidebar_action": {
     "default_title": "WebBrain",

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1963,7 +1963,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return false;
   }
 
-  async _executeToolBatch(tabId, toolCalls, messages, onUpdate, provider, partialAssistantText = null, allowedToolNames = AGENT_TOOL_NAMES, step = null) {
+  async _executeToolBatch(tabId, toolCalls, messages, onUpdate, provider, partialAssistantText = null, allowedToolNames = AGENT_TOOL_NAMES, step = null, runOptions = {}) {
     let didStateChange = false;
     const completionBatchStartState = this.completionInvariants.get(tabId) || null;
     const navNotices = [];
@@ -2295,7 +2295,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         beforeUrl = await this._currentUrl(tabId);
       }
 
-      onUpdate('tool_call', { name: fnName, args: fnArgs });
+      onUpdate('tool_call', {
+        name: fnName,
+        args: fnArgs,
+        outcomeUnknown: missingResponseOutcomeUnknown,
+      });
+      if (missingResponseOutcomeUnknown && typeof runOptions?.beforeConsequentialTool === 'function') {
+        try {
+          await runOptions.beforeConsequentialTool({ name: fnName });
+        } catch {}
+      }
       const _toolStart = Date.now();
       const rawToolResult = await this.executeTool(tabId, fnName, fnArgs, onUpdate, {
         completionBatchStartState,
@@ -2655,6 +2664,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         tool_call_id: tc.id,
         content: resultContent,
       });
+      if (missingResponseOutcomeUnknown && typeof runOptions?.afterConsequentialTool === 'function') {
+        const conversationDurable = await this._persistNow(tabId).catch(() => false);
+        if (conversationDurable) {
+          try {
+            await runOptions.afterConsequentialTool({ name: fnName });
+          } catch {}
+        }
+      }
       // A response can disappear while the page is navigating or reloading,
       // even for a read-only observation. Do not execute the rest of this
       // model-produced batch against unverified page state. Preserve provider
@@ -11592,7 +11609,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }, result.responseItems, result.reasoningContent, provider));
 
         const batchResult = await this._executeToolBatch(
-          tabId, result.toolCalls, messages, onUpdate, provider, result.content, allowedToolNames, steps
+          tabId, result.toolCalls, messages, onUpdate, provider, result.content, allowedToolNames, steps, runOptions
         );
         if (batchResult.action === 'return') {
           finalResponse = batchResult.value;
@@ -11983,7 +12000,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             tool_calls: toolCalls,
           }, responseItems, reasoningContent, provider));
           const batchResult = await this._executeToolBatch(
-            tabId, toolCalls, messages, onUpdate, provider, fullText, allowedToolNames, steps
+            tabId, toolCalls, messages, onUpdate, provider, fullText, allowedToolNames, steps, runOptions
           );
           if (batchResult.action === 'return') {
             return finish(batchResult.value, batchResult.status);

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -428,9 +428,16 @@ export class Agent {
       this._persist(tabId);
       return false;
     }
+    const previousRequestId = this.submittedRunRequestIds.get(tabId);
     this.submittedRunRequestIds.set(tabId, cleanRequestId);
-    await this._persistNow(tabId);
-    return true;
+    try {
+      await this._persistNow(tabId);
+      return true;
+    } catch {
+      if (previousRequestId) this.submittedRunRequestIds.set(tabId, previousRequestId);
+      else this.submittedRunRequestIds.delete(tabId);
+      return false;
+    }
   }
 
   async hasDurableSubmittedTurn(tabId, requestId = '') {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -11042,14 +11042,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   /**
    * Continue processing from where we left off (after max steps).
    */
-  async continueProcessing(tabId, onUpdate = () => {}, mode = 'ask') {
+  async continueProcessing(tabId, onUpdate = () => {}, mode = 'ask', runOptions = {}) {
     return this.processMessage(
       tabId,
       'Please continue from where you left off.',
       onUpdate,
       mode,
       [],
-      { trustedContinuation: true },
+      { ...runOptions, trustedContinuation: true },
     );
   }
 
@@ -11319,6 +11319,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this._preactivateNyTimesSkillForRun(tabId, mode);
 
     const provider = this.providerManager.getActive();
+
+    if (typeof runOptions?.isDetachedStartCancelled === 'function'
+        && runOptions.isDetachedStartCancelled()) {
+      this.abortFlags.delete(tabId);
+      return 'Stopped by user before the run started.';
+    }
 
     // Clear any stale abort flag before any LLM work. The planner gate makes a
     // paid LLM call and checks/consumes this flag, so a leftover flag from a

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -85,6 +85,7 @@ export class Agent {
     this._progressSessionCounter = 0;
     this.conversationIds = new Map(); // tabId -> stable conversationId (regenerated on clearConversation)
     this.conversationModes = new Map(); // tabId -> 'ask' | 'act' | 'dev'
+    this.submittedRunRequestIds = new Map(); // tabId -> request whose user turn is durable in storage.session
     this.plannerFollowUpSkipTabs = new Set(); // tabIds allowed one short follow-up after an approved try-mode plan
     this.hydratedTabs = new Set(); // tabIds we've already pulled from storage
     this.persistTimers = new Map(); // tabId -> debounce handle
@@ -367,6 +368,9 @@ export class Agent {
         if (entry.conversationId) {
           this.conversationIds.set(tabId, entry.conversationId);
         }
+        if (entry.submittedRunRequestId) {
+          this.submittedRunRequestIds.set(tabId, String(entry.submittedRunRequestId));
+        }
         if (Array.isArray(entry.progressLedger)) {
           this.progressLedgers.set(tabId, entry.progressLedger);
         }
@@ -375,6 +379,32 @@ export class Agent {
         }
       }
     } catch (e) { /* session storage may be unavailable */ }
+  }
+
+  _conversationStorageEntry(tabId) {
+    const messages = this.conversations.get(tabId);
+    if (!messages) return null;
+    return {
+      mode: this.conversationModes.get(tabId) || 'ask',
+      messages,
+      conversationId: this.conversationIds.get(tabId) || null,
+      submittedRunRequestId: this.submittedRunRequestIds.get(tabId) || null,
+      progressLedger: this.progressLedgers.get(tabId) || [],
+      progressSession: this.progressSessions.get(tabId) || null,
+    };
+  }
+
+  async _persistNow(tabId) {
+    if (tabId == null) return false;
+    const existing = this.persistTimers.get(tabId);
+    if (existing) {
+      clearTimeout(existing);
+      this.persistTimers.delete(tabId);
+    }
+    const entry = this._conversationStorageEntry(tabId);
+    if (!entry) return false;
+    await browser.storage.session.set({ [this._convKey(tabId)]: entry });
+    return true;
   }
 
   /**
@@ -387,19 +417,27 @@ export class Agent {
     if (existing) clearTimeout(existing);
     const handle = setTimeout(() => {
       this.persistTimers.delete(tabId);
-      const messages = this.conversations.get(tabId);
-      if (!messages) return;
-      const mode = this.conversationModes.get(tabId) || 'ask';
-      const conversationId = this.conversationIds.get(tabId) || null;
-      const progressLedger = this.progressLedgers.get(tabId) || [];
-      const progressSession = this.progressSessions.get(tabId) || null;
-      try {
-        browser.storage.session.set({
-          [this._convKey(tabId)]: { mode, messages, conversationId, progressLedger, progressSession },
-        }).catch(() => {});
-      } catch (e) { /* ignore */ }
+      this._persistNow(tabId).catch(() => {});
     }, 300);
     this.persistTimers.set(tabId, handle);
+  }
+
+  async _persistSubmittedTurn(tabId, requestId = '') {
+    const cleanRequestId = String(requestId || '');
+    if (!cleanRequestId) {
+      this._persist(tabId);
+      return false;
+    }
+    this.submittedRunRequestIds.set(tabId, cleanRequestId);
+    await this._persistNow(tabId);
+    return true;
+  }
+
+  async hasDurableSubmittedTurn(tabId, requestId = '') {
+    const cleanRequestId = String(requestId || '');
+    if (!cleanRequestId) return false;
+    await this._hydrate(tabId);
+    return this.submittedRunRequestIds.get(tabId) === cleanRequestId;
   }
 
   async getConversationId(tabId) {
@@ -4283,7 +4321,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // transcript.
     const priorMessages = runIntent ? messages.slice() : null;
     messages.push(enriched);
-    this._persist(tabId);
+    await this._persistSubmittedTurn(tabId, runOptions?.detachedRequestId);
     if (!runIntent) {
       this.plannerFollowUpSkipTabs.delete(tabId);
       return { proceed: true, requestKind: 'execute', requiresStateChange: false };
@@ -6142,6 +6180,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this.mastodonStates.delete(tabId);
     this.conversationModes.delete(tabId);
     this.conversationIds.delete(tabId);
+    this.submittedRunRequestIds.delete(tabId);
     this._lastInputTokens.delete(tabId);
     this._lastEstCharsAtReport.delete(tabId);
     this._compactCooldown.delete(tabId);
@@ -11287,7 +11326,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const msg = this._devModeBlockedMessage(provider);
       messages.push(enriched);
       messages.push({ role: 'assistant', content: msg });
-      this._persist(tabId);
+      await this._persistSubmittedTurn(tabId, runOptions?.detachedRequestId);
       onUpdate('warning', { message: msg });
       return (finalResponse = msg);
     }

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -1325,23 +1325,64 @@ browser.tabs.onRemoved.addListener((tabId) => {
 });
 
 const RUN_UI_PREFIX = 'runUi:';
+const runUiPersistenceQueues = new Map();
+const runUiPersistenceFailures = new Map();
+
+function cloneRunUiSnapshot(snapshot) {
+  try {
+    return structuredClone(snapshot);
+  } catch {
+    return JSON.parse(JSON.stringify(snapshot));
+  }
+}
+
+function persistRunUiSnapshot(tabId, snapshot) {
+  const requestId = String(snapshot?.requestId || '');
+  if (runUiPersistenceFailures.get(tabId) === requestId) return Promise.resolve(false);
+  const stableSnapshot = cloneRunUiSnapshot(snapshot);
+  const previous = runUiPersistenceQueues.get(tabId) || Promise.resolve(true);
+  const write = previous.catch(() => false).then(async () => {
+    if (runUiPersistenceFailures.get(tabId) === requestId) return false;
+    try {
+      await browser.storage.session?.set({ [RUN_UI_PREFIX + tabId]: stableSnapshot });
+      return true;
+    } catch {
+      runUiPersistenceFailures.set(tabId, requestId);
+      try { await browser.storage.session?.remove(RUN_UI_PREFIX + tabId); } catch {}
+      return false;
+    }
+  });
+  runUiPersistenceQueues.set(tabId, write);
+  write.finally(() => {
+    if (runUiPersistenceQueues.get(tabId) === write) runUiPersistenceQueues.delete(tabId);
+  }).catch(() => {});
+  return write;
+}
+
+function flushRunUiSnapshot(tabId, requestId) {
+  const pending = runUiPersistenceQueues.get(tabId);
+  if (pending) return pending;
+  return Promise.resolve(runUiPersistenceFailures.get(tabId) !== String(requestId || ''));
+}
+
 const runUiJournal = new RunUiJournal({
   onChange(tabId, snapshot) {
-    try { browser.storage.session?.set({ [RUN_UI_PREFIX + tabId]: snapshot }).catch(() => {}); } catch {}
+    void persistRunUiSnapshot(tabId, snapshot);
   },
 });
 
-function beginRunUiSnapshot(tabId, requestId) {
-  return runUiJournal.begin(tabId, requestId);
+function beginRunUiSnapshot(tabId, requestId, metadata = {}) {
+  runUiPersistenceFailures.delete(tabId);
+  return runUiJournal.begin(tabId, requestId, metadata);
 }
 
-async function beginContinuationRunUiSnapshot(tabId, requestId) {
+async function beginContinuationRunUiSnapshot(tabId, requestId, metadata = {}) {
   const existing = await getRunUiSnapshot(tabId);
   const sameNonTerminalRun = existing
     && String(existing.requestId || '') === String(requestId || '')
     && !['completed', 'stopped', 'failed', 'cancelled'].includes(existing.status);
-  if (sameNonTerminalRun) return runUiJournal.resume(tabId, requestId);
-  return beginRunUiSnapshot(tabId, requestId);
+  if (sameNonTerminalRun) return runUiJournal.resume(tabId, requestId, metadata);
+  return beginRunUiSnapshot(tabId, requestId, metadata);
 }
 
 function recordRunUiEvent(tabId, requestId, type, data) {
@@ -1377,7 +1418,13 @@ async function getRunUiSnapshot(tabId) {
 
 function clearRunUiSnapshot(tabId) {
   runUiJournal.clear(tabId);
-  try { browser.storage.session?.remove(RUN_UI_PREFIX + tabId).catch(() => {}); } catch {}
+  runUiPersistenceFailures.delete(tabId);
+  const previous = runUiPersistenceQueues.get(tabId) || Promise.resolve();
+  const removal = previous.catch(() => {}).then(() => browser.storage.session?.remove(RUN_UI_PREFIX + tabId));
+  runUiPersistenceQueues.set(tabId, removal);
+  removal.finally(() => {
+    if (runUiPersistenceQueues.get(tabId) === removal) runUiPersistenceQueues.delete(tabId);
+  }).catch(() => {});
 }
 
 function sendAgentUpdate(tabId, requestId, type, data) {
@@ -1662,7 +1709,7 @@ async function handleMessage(msg, sender) {
       if (!tabId) throw new Error('No tab ID');
       assertRunCanStart(tabId, msg);
       const mode = msg.mode || 'ask';
-      const runUi = await beginContinuationRunUiSnapshot(tabId, msg.requestId);
+      const runUi = await beginContinuationRunUiSnapshot(tabId, msg.requestId, { mode, kind: 'chat' });
       const releaseRunKeepalive = acquireRunKeepalive();
 
       if (msg.apiMutationsAllowed) agent.setApiMutationsAllowed(tabId, true);
@@ -1691,6 +1738,11 @@ async function handleMessage(msg, sender) {
           intentFailureMessage: msg.intentFailureMessage,
           detachedRequestId: runUi.requestId,
           isDetachedStartCancelled: () => isDetachedRunStartCancelled(tabId, msg),
+          beforeConsequentialTool: () => flushRunUiSnapshot(tabId, runUi.requestId),
+          afterConsequentialTool: async ({ name } = {}) => {
+            runUiJournal.settleToolCall(tabId, runUi.requestId, name);
+            return flushRunUiSnapshot(tabId, runUi.requestId);
+          },
         };
         result = await agent.processMessage(tabId, msg.text, (type, data) => {
           updates.push({ type, data });
@@ -1788,7 +1840,7 @@ async function handleMessage(msg, sender) {
       if (!tabId) throw new Error('No tab ID');
       assertRunCanStart(tabId, msg);
       const mode = msg.mode || 'ask';
-      const runUi = await beginContinuationRunUiSnapshot(tabId, msg.requestId);
+      const runUi = await beginContinuationRunUiSnapshot(tabId, msg.requestId, { mode, kind: 'continue' });
       const releaseRunKeepalive = acquireRunKeepalive();
 
       sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
@@ -1801,7 +1853,13 @@ async function handleMessage(msg, sender) {
           if (type === 'error') userMemoryTurnHadError = true;
           sendAgentUpdate(tabId, runUi.requestId, type, data);
         }, mode, {
+          detachedRequestId: runUi.requestId,
           isDetachedStartCancelled: () => isDetachedRunStartCancelled(tabId, msg),
+          beforeConsequentialTool: () => flushRunUiSnapshot(tabId, runUi.requestId),
+          afterConsequentialTool: async ({ name } = {}) => {
+            runUiJournal.settleToolCall(tabId, runUi.requestId, name);
+            return flushRunUiSnapshot(tabId, runUi.requestId);
+          },
         });
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
@@ -1871,6 +1929,8 @@ async function handleMessage(msg, sender) {
         starting: !!starting,
         startingRequestId: starting?.requestId || null,
         submittedTurnDurable,
+        runUiDurable: !runUiSnapshot
+          || runUiPersistenceFailures.get(tabId) !== String(runUiSnapshot.requestId || ''),
         detachedError,
         runUi: runUiSnapshotForRequest(runUiSnapshot, requestedRequestId),
       };

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -1381,9 +1381,63 @@ function sendAgentUpdate(tabId, requestId, type, data) {
 }
 
 function assertNoActiveTabRun(tabId) {
+  if (agent.activeRunState(tabId)?.running || detachedRunStarts.has(tabId)) {
+    throw new Error('A run is already active for this tab.');
+  }
+}
+
+const detachedRunStarts = new Map();
+const RUN_KEEPALIVE_INTERVAL_MS = 20_000;
+
+function assertRunCanStart(tabId, msg) {
+  const reserved = detachedRunStarts.get(tabId);
+  const internalRequestId = String(msg?.__detachedRunRequestId || '');
+  if (reserved) {
+    if (!internalRequestId || internalRequestId !== reserved.requestId) {
+      throw new Error('A run is already active for this tab.');
+    }
+  }
   if (agent.activeRunState(tabId)?.running) {
     throw new Error('A run is already active for this tab.');
   }
+}
+
+function acquireRunKeepalive() {
+  let released = false;
+  const touch = () => {
+    try {
+      browser.runtime.getPlatformInfo().catch(() => {});
+    } catch {}
+  };
+  touch();
+  const timer = setInterval(touch, RUN_KEEPALIVE_INTERVAL_MS);
+  return () => {
+    if (released) return;
+    released = true;
+    clearInterval(timer);
+  };
+}
+
+function launchDetachedRun(action, msg, sender) {
+  const tabId = msg.tabId || sender.tab?.id;
+  if (!tabId) throw new Error('No tab ID');
+  assertNoActiveTabRun(tabId);
+  const requestId = String(msg.requestId || `req_${tabId}_${Date.now()}`);
+  const entry = { requestId, promise: null };
+  detachedRunStarts.set(tabId, entry);
+  const task = Promise.resolve().then(() => handleMessage({
+    ...msg,
+    action,
+    requestId,
+    __detachedRunRequestId: requestId,
+  }, sender));
+  entry.promise = task;
+  task.catch((error) => {
+    console.warn(`[WebBrain] detached ${action} run failed:`, error);
+  }).finally(() => {
+    if (detachedRunStarts.get(tabId) === entry) detachedRunStarts.delete(tabId);
+  });
+  return { ok: true, accepted: true, requestId };
 }
 
 function sendAgentRunComplete(tabId, snapshot = null) {
@@ -1537,12 +1591,19 @@ async function handleMessage(msg, sender) {
       };
     }
 
+    case 'chat_start':
+      return launchDetachedRun('chat', msg, sender);
+
+    case 'continue_start':
+      return launchDetachedRun('continue', msg, sender);
+
     case 'chat': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) throw new Error('No tab ID');
-      assertNoActiveTabRun(tabId);
+      assertRunCanStart(tabId, msg);
       const mode = msg.mode || 'ask';
       const runUi = beginRunUiSnapshot(tabId, msg.requestId);
+      const releaseRunKeepalive = acquireRunKeepalive();
 
       if (msg.apiMutationsAllowed) agent.setApiMutationsAllowed(tabId, true);
 
@@ -1608,6 +1669,7 @@ async function handleMessage(msg, sender) {
           sendAgentRunComplete(tabId, snapshot);
         }
         sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
+        releaseRunKeepalive();
       }
     }
 
@@ -1617,6 +1679,7 @@ async function handleMessage(msg, sender) {
       assertNoActiveTabRun(tabId);
       const mode = msg.mode || 'ask';
       const runUi = beginRunUiSnapshot(tabId, msg.requestId);
+      const releaseRunKeepalive = acquireRunKeepalive();
 
       if (msg.apiMutationsAllowed) agent.setApiMutationsAllowed(tabId, true);
 
@@ -1654,15 +1717,17 @@ async function handleMessage(msg, sender) {
         const snapshot = finishRunUiSnapshot(tabId, runUi.requestId, terminalRunUiStatus(result, userMemoryTurnHadError ? [{ type: 'error' }] : [], runError), result || (runError ? `Error: ${runError.message}` : ''));
         sendAgentRunComplete(tabId, snapshot);
         sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
+        releaseRunKeepalive();
       }
     }
 
     case 'continue': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) throw new Error('No tab ID');
-      assertNoActiveTabRun(tabId);
+      assertRunCanStart(tabId, msg);
       const mode = msg.mode || 'ask';
       const runUi = beginRunUiSnapshot(tabId, msg.requestId);
+      const releaseRunKeepalive = acquireRunKeepalive();
 
       sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
       let userMemoryTurnContextTaken = false;
@@ -1693,6 +1758,7 @@ async function handleMessage(msg, sender) {
         const snapshot = finishRunUiSnapshot(tabId, runUi.requestId, terminalRunUiStatus(result, userMemoryTurnHadError ? [{ type: 'error' }] : [], runError), result || (runError ? `Error: ${runError.message}` : ''));
         sendAgentRunComplete(tabId, snapshot);
         sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
+        releaseRunKeepalive();
       }
     }
 
@@ -1722,7 +1788,14 @@ async function handleMessage(msg, sender) {
     case 'agent_run_state': {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) return { ok: false, error: 'No tab ID' };
-      return { ok: true, ...agent.activeRunState(tabId), runUi: await getRunUiSnapshot(tabId) };
+      const starting = detachedRunStarts.get(tabId) || null;
+      return {
+        ok: true,
+        ...agent.activeRunState(tabId),
+        starting: !!starting,
+        startingRequestId: starting?.requestId || null,
+        runUi: await getRunUiSnapshot(tabId),
+      };
     }
 
     case 'agent_run_ack': {

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -1335,6 +1335,15 @@ function beginRunUiSnapshot(tabId, requestId) {
   return runUiJournal.begin(tabId, requestId);
 }
 
+async function beginContinuationRunUiSnapshot(tabId, requestId) {
+  const existing = await getRunUiSnapshot(tabId);
+  const sameNonTerminalRun = existing
+    && String(existing.requestId || '') === String(requestId || '')
+    && !['completed', 'stopped', 'failed', 'cancelled'].includes(existing.status);
+  if (sameNonTerminalRun) return runUiJournal.resume(tabId, requestId);
+  return beginRunUiSnapshot(tabId, requestId);
+}
+
 function recordRunUiEvent(tabId, requestId, type, data) {
   return runUiJournal.record(tabId, requestId, type, data, agent.currentRunId.get(tabId));
 }
@@ -1750,7 +1759,7 @@ async function handleMessage(msg, sender) {
       if (!tabId) throw new Error('No tab ID');
       assertRunCanStart(tabId, msg);
       const mode = msg.mode || 'ask';
-      const runUi = beginRunUiSnapshot(tabId, msg.requestId);
+      const runUi = await beginContinuationRunUiSnapshot(tabId, msg.requestId);
       const releaseRunKeepalive = acquireRunKeepalive();
 
       sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -1421,6 +1421,7 @@ function rememberDetachedRunFailure(tabId, requestId, error) {
 }
 
 function assertRunCanStart(tabId, msg) {
+  assertDetachedRunStartNotCancelled(tabId, msg);
   const reserved = detachedRunStarts.get(tabId);
   const internalRequestId = String(msg?.__detachedRunRequestId || '');
   if (reserved) {
@@ -1431,6 +1432,27 @@ function assertRunCanStart(tabId, msg) {
   if (agent.activeRunState(tabId)?.running) {
     throw new Error('A run is already active for this tab.');
   }
+}
+
+function isDetachedRunStartCancelled(tabId, msg) {
+  const internalRequestId = String(msg?.__detachedRunRequestId || '');
+  const reserved = detachedRunStarts.get(tabId);
+  return !!internalRequestId
+    && reserved?.requestId === internalRequestId
+    && reserved.cancelled === true;
+}
+
+function assertDetachedRunStartNotCancelled(tabId, msg) {
+  if (isDetachedRunStartCancelled(tabId, msg)) {
+    throw new Error('Run stopped by user before it started.');
+  }
+}
+
+function cancelDetachedRunStart(tabId) {
+  const reserved = detachedRunStarts.get(tabId);
+  if (!reserved) return false;
+  reserved.cancelled = true;
+  return true;
 }
 
 function acquireRunKeepalive() {
@@ -1455,14 +1477,18 @@ function launchDetachedRun(action, msg, sender) {
   assertNoActiveTabRun(tabId);
   clearDetachedRunFailure(tabId);
   const requestId = String(msg.requestId || `req_${tabId}_${Date.now()}`);
-  const entry = { requestId, promise: null };
+  const entry = { requestId, promise: null, cancelled: false };
   detachedRunStarts.set(tabId, entry);
-  const task = Promise.resolve().then(() => handleMessage({
-    ...msg,
-    action,
-    requestId,
-    __detachedRunRequestId: requestId,
-  }, sender));
+  const task = Promise.resolve().then(() => {
+    const detachedMessage = {
+      ...msg,
+      action,
+      requestId,
+      __detachedRunRequestId: requestId,
+    };
+    assertDetachedRunStartNotCancelled(tabId, detachedMessage);
+    return handleMessage(detachedMessage, sender);
+  });
   entry.promise = task;
   task.catch((error) => {
     rememberDetachedRunFailure(tabId, requestId, error);
@@ -1497,6 +1523,7 @@ browser.runtime.onMessage.addListener((msg, sender) => {
   if (msg?.type !== 'WB_STOP_AGENT') return; // not ours
   const tabId = sender?.tab?.id;
   if (tabId != null) {
+    cancelDetachedRunStart(tabId);
     try { agent.abort(tabId); } catch { /* ignore */ }
     // Always clear the sender tab's page-owned indicator, even when the run
     // already ended or this background lost its in-memory run state.
@@ -1663,6 +1690,7 @@ async function handleMessage(msg, sender) {
           locale: msg.locale,
           intentFailureMessage: msg.intentFailureMessage,
           detachedRequestId: runUi.requestId,
+          isDetachedStartCancelled: () => isDetachedRunStartCancelled(tabId, msg),
         };
         result = await agent.processMessage(tabId, msg.text, (type, data) => {
           updates.push({ type, data });
@@ -1772,7 +1800,9 @@ async function handleMessage(msg, sender) {
         result = await agent.continueProcessing(tabId, (type, data) => {
           if (type === 'error') userMemoryTurnHadError = true;
           sendAgentUpdate(tabId, runUi.requestId, type, data);
-        }, mode);
+        }, mode, {
+          isDetachedStartCancelled: () => isDetachedRunStartCancelled(tabId, msg),
+        });
 
         const userMemoryPayload = takeUserMemoryTurnExtractionPayload(tabId, {
           userText: 'Please continue from where you left off.',
@@ -1815,7 +1845,10 @@ async function handleMessage(msg, sender) {
 
     case 'abort': {
       const tabId = msg.tabId || sender.tab?.id;
-      if (tabId) agent.abort(tabId);
+      if (tabId) {
+        cancelDetachedRunStart(tabId);
+        agent.abort(tabId);
+      }
       return { ok: true };
     }
 

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -26,7 +26,7 @@ import {
   createContextMenuStorage,
 } from './context-menu-storage.js';
 import { normalizeOllamaLaunchHandoff } from './ollama-handoff.js';
-import { RunUiJournal } from './run-ui-journal.js';
+import { RunUiJournal, runUiSnapshotForRequest } from './run-ui-journal.js';
 import {
   USER_MEMORY_AUTO_CAPTURE_KEY,
   USER_MEMORY_ENABLED_KEY,
@@ -1831,6 +1831,7 @@ async function handleMessage(msg, sender) {
       const submittedTurnDurable = requestedRequestId
         ? await agent.hasDurableSubmittedTurn(tabId, requestedRequestId)
         : false;
+      const runUiSnapshot = await getRunUiSnapshot(tabId);
       return {
         ok: true,
         ...agent.activeRunState(tabId),
@@ -1838,7 +1839,7 @@ async function handleMessage(msg, sender) {
         startingRequestId: starting?.requestId || null,
         submittedTurnDurable,
         detachedError,
-        runUi: await getRunUiSnapshot(tabId),
+        runUi: runUiSnapshotForRequest(runUiSnapshot, requestedRequestId),
       };
     }
 

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -1321,6 +1321,7 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo) => {
 browser.tabs.onRemoved.addListener((tabId) => {
   activeIndicatorTabs.delete(tabId);
   clearRunUiSnapshot(tabId);
+  clearDetachedRunFailure(tabId);
 });
 
 const RUN_UI_PREFIX = 'runUi:';
@@ -1387,7 +1388,28 @@ function assertNoActiveTabRun(tabId) {
 }
 
 const detachedRunStarts = new Map();
+const detachedRunFailures = new Map();
 const RUN_KEEPALIVE_INTERVAL_MS = 20_000;
+const DETACHED_RUN_FAILURE_TTL_MS = 60_000;
+
+function clearDetachedRunFailure(tabId) {
+  const failure = detachedRunFailures.get(tabId);
+  if (failure?.expiryTimer) clearTimeout(failure.expiryTimer);
+  detachedRunFailures.delete(tabId);
+}
+
+function rememberDetachedRunFailure(tabId, requestId, error) {
+  clearDetachedRunFailure(tabId);
+  const failure = {
+    requestId,
+    message: String(error?.message || error || 'Detached run failed.'),
+    expiryTimer: null,
+  };
+  failure.expiryTimer = setTimeout(() => {
+    if (detachedRunFailures.get(tabId) === failure) detachedRunFailures.delete(tabId);
+  }, DETACHED_RUN_FAILURE_TTL_MS);
+  detachedRunFailures.set(tabId, failure);
+}
 
 function assertRunCanStart(tabId, msg) {
   const reserved = detachedRunStarts.get(tabId);
@@ -1422,6 +1444,7 @@ function launchDetachedRun(action, msg, sender) {
   const tabId = msg.tabId || sender.tab?.id;
   if (!tabId) throw new Error('No tab ID');
   assertNoActiveTabRun(tabId);
+  clearDetachedRunFailure(tabId);
   const requestId = String(msg.requestId || `req_${tabId}_${Date.now()}`);
   const entry = { requestId, promise: null };
   detachedRunStarts.set(tabId, entry);
@@ -1433,6 +1456,7 @@ function launchDetachedRun(action, msg, sender) {
   }, sender));
   entry.promise = task;
   task.catch((error) => {
+    rememberDetachedRunFailure(tabId, requestId, error);
     console.warn(`[WebBrain] detached ${action} run failed:`, error);
   }).finally(() => {
     if (detachedRunStarts.get(tabId) === entry) detachedRunStarts.delete(tabId);
@@ -1789,11 +1813,17 @@ async function handleMessage(msg, sender) {
       const tabId = msg.tabId || sender.tab?.id;
       if (!tabId) return { ok: false, error: 'No tab ID' };
       const starting = detachedRunStarts.get(tabId) || null;
+      const requestedRequestId = String(msg.requestId || '');
+      const failure = detachedRunFailures.get(tabId) || null;
+      const detachedError = requestedRequestId && failure?.requestId === requestedRequestId
+        ? { requestId: failure.requestId, message: failure.message }
+        : null;
       return {
         ok: true,
         ...agent.activeRunState(tabId),
         starting: !!starting,
         startingRequestId: starting?.requestId || null,
+        detachedError,
         runUi: await getRunUiSnapshot(tabId),
       };
     }

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -1635,7 +1635,7 @@ async function handleMessage(msg, sender) {
       if (!tabId) throw new Error('No tab ID');
       assertRunCanStart(tabId, msg);
       const mode = msg.mode || 'ask';
-      const runUi = beginRunUiSnapshot(tabId, msg.requestId);
+      const runUi = await beginContinuationRunUiSnapshot(tabId, msg.requestId);
       const releaseRunKeepalive = acquireRunKeepalive();
 
       if (msg.apiMutationsAllowed) agent.setApiMutationsAllowed(tabId, true);
@@ -1662,6 +1662,7 @@ async function handleMessage(msg, sender) {
           ...(msg.recommendedAction ? { recommendedAction: msg.recommendedAction } : {}),
           locale: msg.locale,
           intentFailureMessage: msg.intentFailureMessage,
+          detachedRequestId: runUi.requestId,
         };
         result = await agent.processMessage(tabId, msg.text, (type, data) => {
           updates.push({ type, data });
@@ -1827,11 +1828,15 @@ async function handleMessage(msg, sender) {
       const detachedError = requestedRequestId && failure?.requestId === requestedRequestId
         ? { requestId: failure.requestId, message: failure.message }
         : null;
+      const submittedTurnDurable = requestedRequestId
+        ? await agent.hasDurableSubmittedTurn(tabId, requestedRequestId)
+        : false;
       return {
         ok: true,
         ...agent.activeRunState(tabId),
         starting: !!starting,
         startingRequestId: starting?.requestId || null,
+        submittedTurnDurable,
         detachedError,
         runUi: await getRunUiSnapshot(tabId),
       };

--- a/src/firefox/src/run-reconnect.js
+++ b/src/firefox/src/run-reconnect.js
@@ -65,6 +65,7 @@ export async function runDetachedWithReconnect({
   reconnectDelaysMs = [250, 500, 1000, 2000, 4000],
   maxResumeAttempts = 3,
   maxUncertainStartRetries = 2,
+  maxAcknowledgedStartRetries = 2,
   maxMissingStateProbes = 6,
   maxConnectionFailures = 12,
 } = {}) {
@@ -78,8 +79,10 @@ export async function runDetachedWithReconnect({
   let actionPayload = payload;
   let resumeAttempts = 0;
   let uncertainStartRetries = 0;
+  let acknowledgedStartRetries = 0;
   let everReconnected = false;
   let startWasUncertain = false;
+  let startObserved = false;
 
   while (true) {
     let startAcknowledged = false;
@@ -156,6 +159,7 @@ export async function runDetachedWithReconnect({
         // than risking duplicate page actions.
         startAcknowledged = true;
         startWasUncertain = false;
+        startObserved = true;
         if (wasDisconnected) {
           everReconnected = true;
           wasDisconnected = false;
@@ -166,6 +170,11 @@ export async function runDetachedWithReconnect({
 
       if (state?.running === true || state?.starting === true) {
         throw new Error('Another run became active while reconnecting.');
+      }
+
+      if (sameSnapshot && snapshot.status === 'awaiting_plan') {
+        if (!shouldResume()) throw new Error('Run recovery was cancelled.');
+        throw new Error('Plan approval expired after the extension background restarted. Review the plan and run the request again.');
       }
 
       if (sameSnapshot && !TERMINAL_RUN_STATUSES.has(snapshot.status)) {
@@ -202,6 +211,18 @@ export async function runDetachedWithReconnect({
         if (!shouldResume()) throw new Error('Run recovery was cancelled.');
         uncertainStartRetries += 1;
         onStatus({ phase: 'retrying_start', requestId, attempt: uncertainStartRetries });
+        break;
+      }
+      if (startAcknowledged
+          && !startObserved
+          && state?.submittedTurnDurable !== true
+          && missingStateProbes >= 2
+          && acknowledgedStartRetries < maxAcknowledgedStartRetries) {
+        if (!shouldResume()) throw new Error('Run recovery was cancelled.');
+        acknowledgedStartRetries += 1;
+        action = initialAction;
+        actionPayload = payload;
+        onStatus({ phase: 'retrying_start', requestId, attempt: acknowledgedStartRetries });
         break;
       }
       if (startAcknowledged && missingStateProbes >= maxMissingStateProbes) {

--- a/src/firefox/src/run-reconnect.js
+++ b/src/firefox/src/run-reconnect.js
@@ -41,6 +41,21 @@ function runResponseFromSnapshot(snapshot, { reconnected = false, resumed = fals
   };
 }
 
+function terminalResponseForRecordedError(snapshot) {
+  if (snapshot?.hadError !== true) return null;
+  const events = Array.isArray(snapshot.events) ? snapshot.events : [];
+  const reachedStepLimit = events.some(event => event?.type === 'max_steps_reached');
+  const fallback = snapshot.lastError
+    || (reachedStepLimit
+      ? 'The run reached its maximum step limit.'
+      : 'The run stopped after recording an error.');
+  return {
+    ...snapshot,
+    status: reachedStepLimit ? 'completed' : 'failed',
+    finalContent: String(snapshot.finalContent || (reachedStepLimit ? '' : `Error: ${fallback}`)),
+  };
+}
+
 /**
  * Starts a detached background run and follows its persisted UI journal.
  *
@@ -68,6 +83,8 @@ export async function runDetachedWithReconnect({
   maxAcknowledgedStartRetries = 2,
   maxMissingStateProbes = 6,
   maxConnectionFailures = 12,
+  probeFirst = false,
+  requireDurableSubmittedTurn = false,
 } = {}) {
   if (typeof start !== 'function' || typeof probe !== 'function') {
     throw new Error('Detached run recovery requires start and probe functions.');
@@ -82,23 +99,28 @@ export async function runDetachedWithReconnect({
   let acknowledgedStartRetries = 0;
   let everReconnected = false;
   let startWasUncertain = false;
-  let startObserved = false;
+  let startObserved = probeFirst;
+  let skipStart = probeFirst;
 
   while (true) {
-    let startAcknowledged = false;
-    try {
-      const ack = await start(action, actionPayload);
-      if (ack?.accepted === false) throw new Error(ack.error || 'The background rejected the run.');
-      if (ack?.requestId && !requestMatches(ack.requestId, requestId)) {
-        throw new Error('The background acknowledged a different run request.');
+    let startAcknowledged = skipStart;
+    if (skipStart) {
+      skipStart = false;
+    } else {
+      try {
+        const ack = await start(action, actionPayload);
+        if (ack?.accepted === false) throw new Error(ack.error || 'The background rejected the run.');
+        if (ack?.requestId && !requestMatches(ack.requestId, requestId)) {
+          throw new Error('The background acknowledged a different run request.');
+        }
+        startAcknowledged = true;
+        startWasUncertain = false;
+      } catch (error) {
+        if (!isConnectionError?.(error)) throw error;
+        startWasUncertain = true;
+        everReconnected = true;
+        onStatus({ phase: 'reconnecting', requestId, error });
       }
-      startAcknowledged = true;
-      startWasUncertain = false;
-    } catch (error) {
-      if (!isConnectionError?.(error)) throw error;
-      startWasUncertain = true;
-      everReconnected = true;
-      onStatus({ phase: 'reconnecting', requestId, error });
     }
 
     let missingStateProbes = 0;
@@ -179,6 +201,22 @@ export async function runDetachedWithReconnect({
 
       if (sameSnapshot && !TERMINAL_RUN_STATUSES.has(snapshot.status)) {
         if (!shouldResume()) throw new Error('Run recovery was cancelled.');
+        const recordedTerminal = terminalResponseForRecordedError(snapshot);
+        if (recordedTerminal) {
+          return runResponseFromSnapshot(recordedTerminal, {
+            reconnected: true,
+            resumed: resumeAttempts > 0,
+          });
+        }
+        if (snapshot.pendingToolCall) {
+          throw new Error(`Run recovery stopped because the outcome of ${snapshot.pendingToolCall.name || 'a page action'} is uncertain. Check the page before retrying to avoid repeating the action.`);
+        }
+        if (state?.runUiDurable === false) {
+          throw new Error('Run recovery stopped because its latest checkpoint was not persisted. Check the page before retrying to avoid duplicate actions.');
+        }
+        if (requireDurableSubmittedTurn && state?.submittedTurnDurable !== true) {
+          throw new Error('Run recovery stopped because the submitted turn was not persisted before the sidebar reloaded. Retry the request manually.');
+        }
         if (resumeAttempts >= maxResumeAttempts) {
           throw new Error('The extension background restarted repeatedly and the run could not be recovered.');
         }
@@ -340,4 +378,4 @@ export async function sendPlanResponseWithReconnect({
   throw lastConnectionError || new Error('Could not reconnect to submit the plan decision.');
 }
 
-export { TERMINAL_RUN_STATUSES, runResponseFromSnapshot };
+export { TERMINAL_RUN_STATUSES, runResponseFromSnapshot, terminalResponseForRecordedError };

--- a/src/firefox/src/run-reconnect.js
+++ b/src/firefox/src/run-reconnect.js
@@ -145,6 +145,12 @@ export async function runDetachedWithReconnect({
 
       if (sameStartingRun || sameLiveRun) {
         missingStateProbes = 0;
+        // Observing our request proves the uncertain start was delivered.
+        // Never retry the original start after this point: if state later
+        // disappears, fail or resume from a matching journal snapshot rather
+        // than risking duplicate page actions.
+        startAcknowledged = true;
+        startWasUncertain = false;
         if (wasDisconnected) {
           everReconnected = true;
           wasDisconnected = false;

--- a/src/firefox/src/run-reconnect.js
+++ b/src/firefox/src/run-reconnect.js
@@ -1,0 +1,290 @@
+const TERMINAL_RUN_STATUSES = new Set(['completed', 'stopped', 'failed', 'cancelled']);
+
+function defaultWait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function requestMatches(value, requestId) {
+  return value != null && String(value) === String(requestId);
+}
+
+function runResponseFromSnapshot(snapshot, { reconnected = false, resumed = false } = {}) {
+  const updates = (Array.isArray(snapshot?.events) ? snapshot.events : [])
+    .filter(event => event?.type && event.type !== 'run_complete')
+    .map(event => ({ type: event.type, data: event.data }));
+  if (snapshot?.status === 'failed' && !updates.some(update => update.type === 'error')) {
+    updates.push({
+      type: 'error',
+      data: {
+        message: snapshot.lastError
+          || String(snapshot.finalContent || '').replace(/^Error:\s*/i, '')
+          || 'The run stopped after the extension background restarted.',
+      },
+    });
+  }
+  return {
+    content: String(snapshot?.finalContent || ''),
+    updates,
+    requestId: snapshot?.requestId || null,
+    runId: snapshot?.runId || null,
+    runStatus: snapshot?.status || null,
+    success: snapshot?.status === 'completed',
+    successfulDone: snapshot?.successfulDone === true,
+    hadError: snapshot?.hadError === true || snapshot?.status === 'failed',
+    reconnected,
+    resumed,
+  };
+}
+
+/**
+ * Starts a detached background run and follows its persisted UI journal.
+ *
+ * The initiating runtime message is intentionally short-lived. If the
+ * background context restarts, a non-terminal snapshot with no live owner is
+ * resumed through `resumeAction`. Short state probes double as a run lease for
+ * event-page/service-worker lifecycles.
+ */
+export async function runDetachedWithReconnect({
+  initialAction,
+  resumeAction = 'continue_start',
+  payload,
+  resumePayload = null,
+  start,
+  probe,
+  isConnectionError,
+  onStatus = () => {},
+  onState = () => {},
+  shouldResume = () => true,
+  wait = defaultWait,
+  pollIntervalMs = 1200,
+  reconnectDelaysMs = [250, 500, 1000, 2000, 4000],
+  maxResumeAttempts = 3,
+  maxUncertainStartRetries = 2,
+  maxMissingStateProbes = 6,
+  maxConnectionFailures = 12,
+} = {}) {
+  if (typeof start !== 'function' || typeof probe !== 'function') {
+    throw new Error('Detached run recovery requires start and probe functions.');
+  }
+  const requestId = String(payload?.requestId || '');
+  if (!requestId) throw new Error('Detached run recovery requires a requestId.');
+
+  let action = initialAction;
+  let actionPayload = payload;
+  let resumeAttempts = 0;
+  let uncertainStartRetries = 0;
+  let everReconnected = false;
+  let startWasUncertain = false;
+
+  while (true) {
+    let startAcknowledged = false;
+    try {
+      const ack = await start(action, actionPayload);
+      if (ack?.accepted === false) throw new Error(ack.error || 'The background rejected the run.');
+      if (ack?.requestId && !requestMatches(ack.requestId, requestId)) {
+        throw new Error('The background acknowledged a different run request.');
+      }
+      startAcknowledged = true;
+      startWasUncertain = false;
+    } catch (error) {
+      if (!isConnectionError?.(error)) throw error;
+      startWasUncertain = true;
+      everReconnected = true;
+      onStatus({ phase: 'reconnecting', requestId, error });
+    }
+
+    let missingStateProbes = 0;
+    let connectionFailures = 0;
+    let wasDisconnected = startWasUncertain;
+
+    while (true) {
+      const reconnectDelay = reconnectDelaysMs[
+        Math.min(connectionFailures, Math.max(0, reconnectDelaysMs.length - 1))
+      ] ?? pollIntervalMs;
+      await wait(wasDisconnected ? reconnectDelay : pollIntervalMs);
+
+      let state;
+      try {
+        state = await probe({ requestId });
+        connectionFailures = 0;
+        try {
+          await onState(state);
+        } catch {}
+      } catch (error) {
+        if (!isConnectionError?.(error)) throw error;
+        connectionFailures += 1;
+        wasDisconnected = true;
+        everReconnected = true;
+        onStatus({ phase: 'reconnecting', requestId, error, attempt: connectionFailures });
+        if (connectionFailures >= maxConnectionFailures) {
+          throw new Error('Could not reconnect to the extension background.');
+        }
+        continue;
+      }
+
+      const snapshot = state?.runUi && typeof state.runUi === 'object' ? state.runUi : null;
+      const sameSnapshot = requestMatches(snapshot?.requestId, requestId);
+      const sameStartingRun = state?.starting === true
+        && requestMatches(state?.startingRequestId, requestId);
+      const sameLiveRun = state?.running === true && sameSnapshot;
+
+      if (sameSnapshot && TERMINAL_RUN_STATUSES.has(snapshot.status)) {
+        if (wasDisconnected) {
+          everReconnected = true;
+          onStatus({ phase: 'reconnected', requestId, state });
+        }
+        return runResponseFromSnapshot(snapshot, {
+          reconnected: everReconnected,
+          resumed: resumeAttempts > 0,
+        });
+      }
+
+      if (sameStartingRun || sameLiveRun) {
+        missingStateProbes = 0;
+        if (wasDisconnected) {
+          everReconnected = true;
+          wasDisconnected = false;
+          onStatus({ phase: 'reconnected', requestId, state });
+        }
+        continue;
+      }
+
+      if (state?.running === true || state?.starting === true) {
+        throw new Error('Another run became active while reconnecting.');
+      }
+
+      if (sameSnapshot && !TERMINAL_RUN_STATUSES.has(snapshot.status)) {
+        if (!shouldResume()) throw new Error('Run recovery was cancelled.');
+        if (resumeAttempts >= maxResumeAttempts) {
+          throw new Error('The extension background restarted repeatedly and the run could not be recovered.');
+        }
+        resumeAttempts += 1;
+        everReconnected = true;
+        action = resumeAction;
+        actionPayload = {
+          tabId: payload.tabId,
+          requestId,
+          mode: payload.mode,
+          ...(resumePayload || {}),
+        };
+        onStatus({ phase: 'resuming', requestId, state, attempt: resumeAttempts });
+        break;
+      }
+
+      missingStateProbes += 1;
+      if (startWasUncertain
+          && missingStateProbes >= 2
+          && uncertainStartRetries < maxUncertainStartRetries) {
+        uncertainStartRetries += 1;
+        onStatus({ phase: 'retrying_start', requestId, attempt: uncertainStartRetries });
+        break;
+      }
+      if (startAcknowledged && missingStateProbes >= maxMissingStateProbes) {
+        throw new Error('The background acknowledged the run but did not publish recoverable run state.');
+      }
+      if (startWasUncertain
+          && uncertainStartRetries >= maxUncertainStartRetries
+          && missingStateProbes >= maxMissingStateProbes) {
+        throw new Error('Could not reconnect to the extension background.');
+      }
+    }
+  }
+}
+
+function matchingPlanResolution(state, planId) {
+  const resolution = state?.runUi?.lastPlanResolution;
+  if (!resolution || !requestMatches(resolution.planId, planId)) return null;
+  return resolution;
+}
+
+/**
+ * Delivers a plan decision across a transient runtime-message disconnect.
+ *
+ * A lost reply is not treated as a failed approval: the durable run journal
+ * records the resolution, so a probe can prove that the first delivery won
+ * without sending a duplicate decision.
+ */
+export async function sendPlanResponseWithReconnect({
+  payload,
+  requestId = '',
+  send,
+  probe,
+  isConnectionError,
+  onStatus = () => {},
+  onState = () => {},
+  wait = defaultWait,
+  reconnectDelaysMs = [250, 500, 1000, 2000, 4000],
+  maxAttempts = 8,
+} = {}) {
+  if (typeof send !== 'function' || typeof probe !== 'function') {
+    throw new Error('Plan response recovery requires send and probe functions.');
+  }
+  const planId = String(payload?.planId || '');
+  if (!planId) throw new Error('Plan response recovery requires a planId.');
+  const expectedRequestId = String(requestId || '');
+  let lastConnectionError = null;
+  let reconnected = false;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const response = await send(payload);
+      if (response?.matched) return { ...response, reconnected };
+    } catch (error) {
+      if (!isConnectionError?.(error)) throw error;
+      lastConnectionError = error;
+      onStatus({ phase: 'reconnecting', planId, attempt: attempt + 1, error });
+    }
+
+    const delay = reconnectDelaysMs[
+      Math.min(attempt, Math.max(0, reconnectDelaysMs.length - 1))
+    ] ?? 1000;
+    await wait(delay);
+
+    let state;
+    try {
+      state = await probe({ planId, requestId: expectedRequestId });
+      try {
+        await onState(state);
+      } catch {}
+    } catch (error) {
+      if (!isConnectionError?.(error)) throw error;
+      lastConnectionError = error;
+      onStatus({ phase: 'reconnecting', planId, attempt: attempt + 1, error });
+      continue;
+    }
+
+    const resolution = matchingPlanResolution(state, planId);
+    if (resolution) {
+      reconnected = true;
+      onStatus({ phase: 'reconnected', planId, state });
+      return {
+        ok: true,
+        matched: String(resolution.decision || '') === String(payload?.decision || ''),
+        recovered: true,
+        reconnected: true,
+      };
+    }
+
+    const sameRequest = !expectedRequestId
+      || requestMatches(state?.runUi?.requestId, expectedRequestId);
+    const samePendingPlan = requestMatches(state?.pendingPlan?.planId, planId);
+    if (samePendingPlan && sameRequest) {
+      reconnected = true;
+      onStatus({ phase: 'reconnected', planId, state });
+      continue;
+    }
+
+    return {
+      ok: false,
+      matched: false,
+      restarted: sameRequest
+        && state?.runUi?.status === 'awaiting_plan'
+        && !state?.pendingPlan,
+      reconnected,
+    };
+  }
+
+  throw lastConnectionError || new Error('Could not reconnect to submit the plan decision.');
+}
+
+export { TERMINAL_RUN_STATUSES, runResponseFromSnapshot };

--- a/src/firefox/src/run-reconnect.js
+++ b/src/firefox/src/run-reconnect.js
@@ -1,5 +1,10 @@
 const TERMINAL_RUN_STATUSES = new Set(['completed', 'stopped', 'failed', 'cancelled']);
 
+export function isBackgroundConnectionError(error) {
+  const message = String(error?.message || error || '');
+  return /Could not establish connection|Receiving end does not exist|Extension context invalidated|message (?:channel|port) closed|No response from WebBrain background|background script may have restarted|extension connection was lost/i.test(message);
+}
+
 function defaultWait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/src/firefox/src/run-reconnect.js
+++ b/src/firefox/src/run-reconnect.js
@@ -194,6 +194,7 @@ export async function runDetachedWithReconnect({
       if (startWasUncertain
           && missingStateProbes >= 2
           && uncertainStartRetries < maxUncertainStartRetries) {
+        if (!shouldResume()) throw new Error('Run recovery was cancelled.');
         uncertainStartRetries += 1;
         onStatus({ phase: 'retrying_start', requestId, attempt: uncertainStartRetries });
         break;

--- a/src/firefox/src/run-reconnect.js
+++ b/src/firefox/src/run-reconnect.js
@@ -185,7 +185,14 @@ export async function runDetachedWithReconnect({
         resumeAttempts += 1;
         everReconnected = true;
         const retryFreshChat = initialAction === 'chat_start'
-          && state?.submittedTurnDurable !== true;
+          && state?.submittedTurnDurable !== true
+          && !startObserved
+          && Number(snapshot.seq || 0) === 0;
+        if (initialAction === 'chat_start'
+            && state?.submittedTurnDurable !== true
+            && !retryFreshChat) {
+          throw new Error('Run recovery stopped because the submitted turn was not persisted after live progress. Retry the request manually to avoid duplicate page actions.');
+        }
         action = retryFreshChat ? initialAction : resumeAction;
         actionPayload = retryFreshChat
           ? payload

--- a/src/firefox/src/run-reconnect.js
+++ b/src/firefox/src/run-reconnect.js
@@ -170,14 +170,23 @@ export async function runDetachedWithReconnect({
         }
         resumeAttempts += 1;
         everReconnected = true;
-        action = resumeAction;
-        actionPayload = {
-          tabId: payload.tabId,
+        const retryFreshChat = initialAction === 'chat_start'
+          && state?.submittedTurnDurable !== true;
+        action = retryFreshChat ? initialAction : resumeAction;
+        actionPayload = retryFreshChat
+          ? payload
+          : {
+              tabId: payload.tabId,
+              requestId,
+              mode: payload.mode,
+              ...(resumePayload || {}),
+            };
+        onStatus({
+          phase: retryFreshChat ? 'retrying_start' : 'resuming',
           requestId,
-          mode: payload.mode,
-          ...(resumePayload || {}),
-        };
-        onStatus({ phase: 'resuming', requestId, state, attempt: resumeAttempts });
+          state,
+          attempt: resumeAttempts,
+        });
         break;
       }
 

--- a/src/firefox/src/run-reconnect.js
+++ b/src/firefox/src/run-reconnect.js
@@ -123,6 +123,10 @@ export async function runDetachedWithReconnect({
       }
 
       const snapshot = state?.runUi && typeof state.runUi === 'object' ? state.runUi : null;
+      const detachedError = state?.detachedError;
+      if (requestMatches(detachedError?.requestId, requestId)) {
+        throw new Error(detachedError?.message || 'Detached run failed.');
+      }
       const sameSnapshot = requestMatches(snapshot?.requestId, requestId);
       const sameStartingRun = state?.starting === true
         && requestMatches(state?.startingRequestId, requestId);

--- a/src/firefox/src/run-ui-journal.js
+++ b/src/firefox/src/run-ui-journal.js
@@ -49,7 +49,11 @@ export class RunUiJournal {
       truncatedBeforeSeq: 0,
       events: [],
       pendingPlanId: null,
+      lastPlanResolution: null,
       finalContent: '',
+      successfulDone: false,
+      hadError: false,
+      lastError: '',
       startedAt: Date.now(),
       endedAt: null,
     };
@@ -75,10 +79,28 @@ export class RunUiJournal {
     if (type === 'plan_review') {
       snapshot.status = 'awaiting_plan';
       snapshot.pendingPlanId = String(data?.planId || '') || null;
+      snapshot.lastPlanResolution = null;
     }
     if (type === 'plan_resolved') {
       snapshot.status = 'running';
       if (!data?.planId || String(data.planId) === String(snapshot.pendingPlanId)) snapshot.pendingPlanId = null;
+      snapshot.lastPlanResolution = {
+        planId: String(data?.planId || ''),
+        decision: String(data?.decision || ''),
+      };
+    }
+    if (type === 'tool_result'
+        && data?.name === 'done'
+        && data?.result?.done === true
+        && data?.result?.outcome === 'success'
+        && data?.result?.success !== false
+        && !data?.result?.error
+        && !data?.result?.blockedDone) {
+      snapshot.successfulDone = true;
+    }
+    if (type === 'error' || type === 'attachment_rejected' || type === 'max_steps_reached') {
+      snapshot.hadError = true;
+      snapshot.lastError = String(data?.message || data?.error || '').slice(0, 2000);
     }
     this._changed(tabId, snapshot);
     return { ...event, requestId: snapshot.requestId, runId: snapshot.runId };
@@ -108,6 +130,12 @@ export class RunUiJournal {
 
   restore(tabId, snapshot) {
     if (!snapshot || typeof snapshot !== 'object') return null;
+    if (snapshot.successfulDone !== true) snapshot.successfulDone = false;
+    if (snapshot.hadError !== true) snapshot.hadError = false;
+    if (typeof snapshot.lastError !== 'string') snapshot.lastError = '';
+    if (!snapshot.lastPlanResolution || typeof snapshot.lastPlanResolution !== 'object') {
+      snapshot.lastPlanResolution = null;
+    }
     this.snapshots.set(tabId, snapshot);
     return snapshot;
   }

--- a/src/firefox/src/run-ui-journal.js
+++ b/src/firefox/src/run-ui-journal.js
@@ -44,10 +44,12 @@ export class RunUiJournal {
     return snapshot;
   }
 
-  begin(tabId, requestId = '') {
+  begin(tabId, requestId = '', metadata = {}) {
     const snapshot = {
       tabId,
       requestId: createRunRequestId(tabId, requestId),
+      mode: String(metadata?.mode || ''),
+      kind: metadata?.kind === 'continue' ? 'continue' : 'chat',
       runId: null,
       status: 'running',
       seq: 0,
@@ -60,6 +62,7 @@ export class RunUiJournal {
       successfulDone: false,
       hadError: false,
       lastError: '',
+      pendingToolCall: null,
       startedAt: Date.now(),
       endedAt: null,
     };
@@ -67,9 +70,13 @@ export class RunUiJournal {
     return this._changed(tabId, snapshot);
   }
 
-  resume(tabId, requestId = '') {
+  resume(tabId, requestId = '', metadata = {}) {
     const snapshot = this.snapshots.get(tabId);
     if (!snapshot || String(snapshot.requestId) !== String(requestId)) return null;
+    if (metadata?.mode) snapshot.mode = String(metadata.mode);
+    if (!snapshot.kind && metadata?.kind) {
+      snapshot.kind = metadata.kind === 'continue' ? 'continue' : 'chat';
+    }
     snapshot.status = 'running';
     snapshot.pendingPlanId = null;
     snapshot.finalContent = '';
@@ -106,6 +113,12 @@ export class RunUiJournal {
         decision: String(data?.decision || ''),
       };
     }
+    if (type === 'tool_call' && data?.outcomeUnknown === true) {
+      snapshot.pendingToolCall = {
+        name: String(data?.name || ''),
+        seq: event.seq,
+      };
+    }
     if (type === 'tool_result'
         && data?.name === 'done'
         && data?.result?.done === true
@@ -117,10 +130,22 @@ export class RunUiJournal {
     }
     if (type === 'error' || type === 'attachment_rejected' || type === 'max_steps_reached') {
       snapshot.hadError = true;
-      snapshot.lastError = String(data?.message || data?.error || '').slice(0, 2000);
+      snapshot.lastError = String(
+        data?.message
+        || data?.error
+        || (type === 'max_steps_reached' ? 'The run reached its maximum step limit.' : ''),
+      ).slice(0, 2000);
     }
     this._changed(tabId, snapshot);
     return { ...event, requestId: snapshot.requestId, runId: snapshot.runId };
+  }
+
+  settleToolCall(tabId, requestId, name = '') {
+    const snapshot = this.snapshots.get(tabId);
+    if (!snapshot || snapshot.requestId !== requestId || !snapshot.pendingToolCall) return null;
+    if (name && snapshot.pendingToolCall.name && snapshot.pendingToolCall.name !== String(name)) return null;
+    snapshot.pendingToolCall = null;
+    return this._changed(tabId, snapshot);
   }
 
   finish(tabId, requestId, status, finalContent = '', runId = null) {
@@ -129,6 +154,7 @@ export class RunUiJournal {
     snapshot.runId = runId || snapshot.runId || null;
     snapshot.status = status;
     snapshot.pendingPlanId = null;
+    snapshot.pendingToolCall = null;
     snapshot.finalContent = String(finalContent || '').slice(0, 30000);
     snapshot.endedAt = Date.now();
     const event = {
@@ -150,6 +176,11 @@ export class RunUiJournal {
     if (snapshot.successfulDone !== true) snapshot.successfulDone = false;
     if (snapshot.hadError !== true) snapshot.hadError = false;
     if (typeof snapshot.lastError !== 'string') snapshot.lastError = '';
+    if (!snapshot.pendingToolCall || typeof snapshot.pendingToolCall !== 'object') {
+      snapshot.pendingToolCall = null;
+    }
+    if (typeof snapshot.mode !== 'string') snapshot.mode = '';
+    if (snapshot.kind !== 'continue' && snapshot.kind !== 'chat') snapshot.kind = 'chat';
     if (!snapshot.lastPlanResolution || typeof snapshot.lastPlanResolution !== 'object') {
       snapshot.lastPlanResolution = null;
     }

--- a/src/firefox/src/run-ui-journal.js
+++ b/src/firefox/src/run-ui-journal.js
@@ -61,6 +61,17 @@ export class RunUiJournal {
     return this._changed(tabId, snapshot);
   }
 
+  resume(tabId, requestId = '') {
+    const snapshot = this.snapshots.get(tabId);
+    if (!snapshot || String(snapshot.requestId) !== String(requestId)) return null;
+    snapshot.status = 'running';
+    snapshot.pendingPlanId = null;
+    snapshot.finalContent = '';
+    snapshot.successfulDone = false;
+    snapshot.endedAt = null;
+    return this._changed(tabId, snapshot);
+  }
+
   record(tabId, requestId, type, data, runId = null) {
     const snapshot = this.snapshots.get(tabId);
     if (!snapshot || snapshot.requestId !== requestId) return null;

--- a/src/firefox/src/run-ui-journal.js
+++ b/src/firefox/src/run-ui-journal.js
@@ -5,6 +5,12 @@ export function createRunRequestId(tabId, supplied = '') {
   return clean || `req_${tabId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
+export function runUiSnapshotForRequest(snapshot, requestedRequestId = '') {
+  const requested = String(requestedRequestId || '');
+  if (!requested) return snapshot || null;
+  return String(snapshot?.requestId || '') === requested ? snapshot : null;
+}
+
 export function compactRunUiData(type, data) {
   if (!data || typeof data !== 'object') return data;
   if (type === 'tool_result') {

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -13,6 +13,7 @@ import { formatSelectionPromptForDisplay } from '../context-menu-storage.js';
 import { deleteChatHistoryRecord, saveChatHistoryRecord } from './chat-history-store.js';
 import { claimRunError } from './run-error-dedupe.js';
 import { RUN_CAPTURE_START_ERROR_PREFIX } from '../run-capture.js';
+import { runDetachedWithReconnect, sendPlanResponseWithReconnect } from '../run-reconnect.js';
 import {
   STORAGE_KEY as STORE_REVIEW_STORAGE_KEY,
   recordSuccessfulTask,
@@ -769,6 +770,7 @@ const awaitingPlanReviewTabs = new Set();
 const processingTabs = new Set();
 const abortRequestedTabs = new Set();
 const localRunRequestIds = new Map();
+const cancelledRunRecoveryRequestIds = new Set();
 let recommendationsRequestId = 0;
 let providerSelectionRequestId = 0;
 let providerTestRequestId = 0;
@@ -3060,6 +3062,10 @@ async function restoreActiveRunState(tabId = currentTabId) {
   } catch {
     return;
   }
+  await applyActiveRunState(numericTabId, state);
+}
+
+async function applyActiveRunState(numericTabId, state) {
   if (!sameTabId(currentTabId, numericTabId) || !sameTabId(renderedTabId, numericTabId)) return;
   const runUi = state?.runUi && typeof state.runUi === 'object' ? state.runUi : null;
   if (runUi?.requestId) {
@@ -4922,7 +4928,7 @@ async function sendMessage(extraChatParams = {}) {
   let completedSuccessfully = false;
   let promptEligibleCompletion = false;
   try {
-    const res = await sendToBackground('chat', {
+    const res = await sendRunWithReconnect('chat_start', {
       tabId,
       requestId,
       text,
@@ -4944,7 +4950,7 @@ async function sendMessage(extraChatParams = {}) {
       chatHistoryRecordIdsByTab.set(tabId, res.conversationId);
     }
     accepted = true;
-    completedSuccessfully = updatesContainSuccessfulDone(res?.updates);
+    completedSuccessfully = res?.successfulDone === true || updatesContainSuccessfulDone(res?.updates);
     promptEligibleCompletion = completedSuccessfully || isSuccessfulAskCompletion(modeForSend, res);
     const returnedErrorUpdate = Array.isArray(res?.updates)
       ? res.updates.find(u => u?.type === 'error')
@@ -5014,6 +5020,7 @@ async function sendMessage(extraChatParams = {}) {
     }
   } finally {
     if (localRunRequestIds.get(tabId) === requestId) localRunRequestIds.delete(tabId);
+    cancelledRunRecoveryRequestIds.delete(requestId);
     if (activeChatPayloadsByTab.get(tabId) === activePayloadState) {
       scheduleActiveChatPayloadCleanup(tabId, activePayloadState);
     }
@@ -5268,6 +5275,10 @@ function handleAgentUpdateMessage(msg) {
       break;
 
     case 'plan_review':
+      invalidatePlanReviewCards({
+        tabId: msg.tabId ?? currentTabId,
+        requestId: msg.requestId,
+      });
       renderPlanReviewCard({ ...data, tabId: msg.tabId ?? currentTabId, requestId: msg.requestId, runId: msg.runId });
       break;
 
@@ -5734,11 +5745,12 @@ function renderPlanReviewCard(data) {
     .find(card => String(card.dataset.planId || '') === planId
       && String(card.dataset.tabId || '') === String(tabId)
       && (!data.requestId || card.dataset.runRequestId === String(data.requestId))
-      && (!data.runId || card.dataset.runId === String(data.runId))
-      && !card.classList.contains('plan-reviewed'));
+      && (!data.runId || card.dataset.runId === String(data.runId)));
   if (existing) {
-    bindPlanReviewCard(existing);
-    setPlanReviewAwaiting(tabId, true, existing.closest('.message.assistant'));
+    if (!existing.classList.contains('plan-reviewed')) {
+      bindPlanReviewCard(existing);
+      setPlanReviewAwaiting(tabId, true, existing.closest('.message.assistant'));
+    }
     scrollToBottom();
     return;
   }
@@ -5831,9 +5843,14 @@ function submitPlanReview(card, tabId, planId, action, editedText) {
   card.classList.add('plan-reviewed');
   setPlanReviewAwaiting(tabId, false);
   if (action !== 'approve') {
+    const requestId = String(card.dataset.runRequestId || '');
+    if (requestId) cancelledRunRecoveryRequestIds.add(requestId);
+    setTabAbortRequested(tabId, true);
     card.remove();
     scrollToBottom();
-    sendToBackground('plan_response', { tabId, planId, decision: action, editedText, markdownMode }).catch(() => {});
+    sendPlanReviewDecisionWithReconnect({
+      tabId, planId, decision: action, editedText, markdownMode,
+    }, requestId).catch(() => {});
     return;
   }
   for (const el of card.querySelectorAll('button, textarea')) {
@@ -5846,7 +5863,10 @@ function submitPlanReview(card, tabId, planId, action, editedText) {
     ? 'WebBrain reloaded or the background worker stopped before this plan could be approved. Reload the sidebar and try again.'
     : expiredText();
 
-  sendToBackground('plan_response', { tabId, planId, decision: action, editedText, markdownMode })
+  sendPlanReviewDecisionWithReconnect(
+    { tabId, planId, decision: action, editedText, markdownMode },
+    String(card.dataset.runRequestId || ''),
+  )
     .then((res) => {
       if (action !== 'approve') return;
       if (res?.matched) {
@@ -5863,8 +5883,11 @@ function submitPlanReview(card, tabId, planId, action, editedText) {
       if (action === 'approve') {
         note.textContent = failureText(error);
         card.appendChild(note);
-        setPlanReviewAwaiting(tabId, false);
-        if (activeAssistantEl) clearPlanReviewActiveRun(activeAssistantEl, tabId);
+        card.classList.remove('plan-reviewed');
+        for (const el of card.querySelectorAll('button, textarea')) {
+          el.disabled = false;
+        }
+        setPlanReviewAwaiting(tabId, true, activeAssistantEl || card.closest('.message.assistant'));
         scrollToBottom();
       }
     });
@@ -6451,7 +6474,7 @@ async function continueAgent(options = {}) {
     showActivity(t('sp.activity.continuing'));
     localRunRequestIds.set(tabId, requestId);
 
-    const res = await sendToBackground('continue', {
+    const res = await sendRunWithReconnect('continue_start', {
       tabId,
       requestId,
       mode: modeForSend,
@@ -6478,6 +6501,7 @@ async function continueAgent(options = {}) {
     }
   } finally {
     if (localRunRequestIds.get(tabId) === requestId) localRunRequestIds.delete(tabId);
+    cancelledRunRecoveryRequestIds.delete(requestId);
     if (currentTabId === tabId && assistantEl) finalizeSteps(assistantEl);
     clearAssistantTextStreamState(assistantEl);
     setTabProcessing(tabId, false);
@@ -6808,6 +6832,51 @@ function startInputPlaceholderRotation() {
 function isBackgroundConnectionError(error) {
   const message = String(error?.message || error || '');
   return /Could not establish connection|Receiving end does not exist|Extension context invalidated|No response from WebBrain background|background script may have restarted|extension connection was lost/i.test(message);
+}
+
+function sendPlanReviewDecisionWithReconnect(payload, requestId = '') {
+  const tabId = Number(payload?.tabId);
+  return sendPlanResponseWithReconnect({
+    payload,
+    requestId,
+    send: nextPayload => sendToBackground('plan_response', nextPayload),
+    probe: () => sendToBackground('agent_run_state', { tabId }),
+    isConnectionError: isBackgroundConnectionError,
+    onState: state => applyActiveRunState(tabId, state),
+    onStatus: ({ phase }) => {
+      if (!sameTabId(currentTabId, tabId)) return;
+      if (phase === 'reconnecting') showActivity('Reconnecting…');
+      if (phase === 'reconnected' && !isAwaitingPlanReviewForTab(tabId)) {
+        showActivity('Reconnected — continuing…');
+      }
+    },
+  });
+}
+
+async function sendRunWithReconnect(initialAction, payload) {
+  const tabId = Number(payload?.tabId);
+  const requestId = String(payload?.requestId || '');
+  cancelledRunRecoveryRequestIds.delete(requestId);
+  return runDetachedWithReconnect({
+    initialAction,
+    payload,
+    start: (action, nextPayload) => sendToBackground(action, nextPayload),
+    probe: () => sendToBackground('agent_run_state', { tabId }),
+    isConnectionError: isBackgroundConnectionError,
+    onState: state => applyActiveRunState(tabId, state),
+    shouldResume: () => !isTabAbortRequested(tabId)
+      && !cancelledRunRecoveryRequestIds.has(requestId),
+    onStatus: ({ phase }) => {
+      if (!sameTabId(currentTabId, tabId)) return;
+      if (phase === 'reconnecting' || phase === 'retrying_start') {
+        showActivity('Reconnecting…');
+      } else if (phase === 'resuming') {
+        showActivity('Reconnected — resuming…');
+      } else if (phase === 'reconnected' && !isAwaitingPlanReviewForTab(tabId)) {
+        showActivity('Reconnected — continuing…');
+      }
+    },
+  });
 }
 
 function formatBackgroundSendError(action, message) {

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -6967,6 +6967,12 @@ modeDevBtn?.addEventListener('click', async () => {
 stopBtn.addEventListener('click', async () => {
   const tabId = currentTabId;
   if (!isTabProcessing(tabId)) return;
+  const requestId = String(
+    localRunRequestIds.get(Number(tabId))
+      || currentAssistantEl?.dataset?.runRequestId
+      || '',
+  );
+  if (requestId) cancelledRunRecoveryRequestIds.add(requestId);
   setTabAbortRequested(tabId, true);
   showActivity(t('sp.activity.stopping'));
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -775,6 +775,7 @@ const processingTabs = new Set();
 const abortRequestedTabs = new Set();
 const localRunRequestIds = new Map();
 const cancelledRunRecoveryRequestIds = new Set();
+const adoptedRunRecoveryRequestIds = new Set();
 let recommendationsRequestId = 0;
 let providerSelectionRequestId = 0;
 let providerTestRequestId = 0;
@@ -3067,6 +3068,71 @@ async function restoreActiveRunState(tabId = currentTabId) {
     return;
   }
   await applyActiveRunState(numericTabId, state);
+  void adoptRestoredRunState(numericTabId, state);
+}
+
+function isTerminalRunUiStatus(status) {
+  return ['completed', 'stopped', 'failed', 'cancelled'].includes(String(status || ''));
+}
+
+async function adoptRestoredRunState(tabId, state) {
+  const runUi = state?.runUi && typeof state.runUi === 'object' ? state.runUi : null;
+  const requestId = String(runUi?.requestId || '');
+  if (!requestId
+      || isTerminalRunUiStatus(runUi.status)
+      || runUi.status === 'awaiting_plan'
+      || localRunRequestIds.has(Number(tabId))
+      || adoptedRunRecoveryRequestIds.has(requestId)) return;
+
+  adoptedRunRecoveryRequestIds.add(requestId);
+  localRunRequestIds.set(Number(tabId), requestId);
+  setTabProcessing(tabId, true);
+  setTabAbortRequested(tabId, false);
+  syncSendButtonState();
+  if (sameTabId(currentTabId, tabId)) showActivity('Reconnecting…');
+  const assistantEl = messagesEl.querySelector(`.message.assistant[data-run-request-id="${CSS.escape(requestId)}"]`)
+    || currentAssistantEl;
+  const mode = ['ask', 'act', 'dev'].includes(runUi.mode)
+    ? runUi.mode
+    : (['ask', 'act', 'dev'].includes(assistantEl?.dataset?.runMode) ? assistantEl.dataset.runMode : agentMode);
+
+  try {
+    const res = await sendRunWithReconnect('continue_start', {
+      tabId,
+      requestId,
+      mode,
+    }, {
+      probeFirst: true,
+      requireDurableSubmittedTurn: runUi.kind !== 'continue',
+    });
+    const returnedErrorUpdate = Array.isArray(res?.updates)
+      ? res.updates.find(update => update?.type === 'error')
+      : null;
+    if (returnedErrorUpdate && sameTabId(currentTabId, tabId) && !isTabAbortRequested(tabId)) {
+      renderAgentErrorUpdate(returnedErrorUpdate.data, tabId, requestId);
+    }
+  } catch (error) {
+    if (sameTabId(currentTabId, tabId) && !isTabAbortRequested(tabId)) {
+      renderAgentErrorUpdate({ message: error.message }, tabId, requestId);
+    }
+  } finally {
+    adoptedRunRecoveryRequestIds.delete(requestId);
+    if (localRunRequestIds.get(Number(tabId)) === requestId) {
+      localRunRequestIds.delete(Number(tabId));
+      setTabProcessing(tabId, false);
+      setTabAbortRequested(tabId, false);
+    }
+    if (sameTabId(currentTabId, tabId)) {
+      if (assistantEl) finalizeSteps(assistantEl);
+      syncSendButtonState();
+      hideActivity();
+      if (currentAssistantEl === assistantEl) currentAssistantEl = null;
+      if (sameTabId(renderedTabId, tabId)) {
+        await flushRenderedTabChat();
+        await flushChatHistorySnapshot(tabId, { refreshTabInfo: true });
+      }
+    }
+  }
 }
 
 async function applyActiveRunState(numericTabId, state) {
@@ -5875,6 +5941,7 @@ function submitPlanReview(card, tabId, planId, action, editedText) {
       if (action !== 'approve') return;
       if (res?.matched) {
         card.remove();
+        void restoreActiveRunState(tabId);
       } else {
         note.textContent = expiredText();
         card.appendChild(note);
@@ -6855,7 +6922,7 @@ function sendPlanReviewDecisionWithReconnect(payload, requestId = '') {
   });
 }
 
-async function sendRunWithReconnect(initialAction, payload) {
+async function sendRunWithReconnect(initialAction, payload, recoveryOptions = {}) {
   const tabId = Number(payload?.tabId);
   const requestId = String(payload?.requestId || '');
   cancelledRunRecoveryRequestIds.delete(requestId);
@@ -6881,6 +6948,7 @@ async function sendRunWithReconnect(initialAction, payload) {
         showActivity('Reconnected — continuing…');
       }
     },
+    ...recoveryOptions,
   });
 }
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -13,7 +13,11 @@ import { formatSelectionPromptForDisplay } from '../context-menu-storage.js';
 import { deleteChatHistoryRecord, saveChatHistoryRecord } from './chat-history-store.js';
 import { claimRunError } from './run-error-dedupe.js';
 import { RUN_CAPTURE_START_ERROR_PREFIX } from '../run-capture.js';
-import { runDetachedWithReconnect, sendPlanResponseWithReconnect } from '../run-reconnect.js';
+import {
+  isBackgroundConnectionError,
+  runDetachedWithReconnect,
+  sendPlanResponseWithReconnect,
+} from '../run-reconnect.js';
 import {
   STORAGE_KEY as STORE_REVIEW_STORAGE_KEY,
   recordSuccessfulTask,
@@ -6829,11 +6833,6 @@ function startInputPlaceholderRotation() {
 
 // --- Communication ---
 
-function isBackgroundConnectionError(error) {
-  const message = String(error?.message || error || '');
-  return /Could not establish connection|Receiving end does not exist|Extension context invalidated|No response from WebBrain background|background script may have restarted|extension connection was lost/i.test(message);
-}
-
 function sendPlanReviewDecisionWithReconnect(payload, requestId = '') {
   const tabId = Number(payload?.tabId);
   return sendPlanResponseWithReconnect({
@@ -6886,7 +6885,7 @@ async function sendRunWithReconnect(initialAction, payload) {
 }
 
 function formatBackgroundSendError(action, message) {
-  if (/Could not establish connection|Receiving end does not exist|Extension context invalidated/i.test(String(message || ''))) {
+  if (isBackgroundConnectionError(message)) {
     return `WebBrain extension connection was lost while sending "${action}". Reload the sidebar/extension and try again.`;
   }
   return message;

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -3115,7 +3115,7 @@ async function applyActiveRunState(numericTabId, state) {
     return;
   }
   invalidatePlanReviewCards({ tabId: numericTabId });
-  if (state?.running) {
+  if (state?.running || state?.starting) {
     setTabProcessing(numericTabId, true);
     setTabAbortRequested(numericTabId, false);
     hideRecommendedActions();

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -6840,7 +6840,10 @@ function sendPlanReviewDecisionWithReconnect(payload, requestId = '') {
     payload,
     requestId,
     send: nextPayload => sendToBackground('plan_response', nextPayload),
-    probe: () => sendToBackground('agent_run_state', { tabId }),
+    probe: ({ requestId: probedRequestId } = {}) => sendToBackground('agent_run_state', {
+      tabId,
+      requestId: probedRequestId || requestId,
+    }),
     isConnectionError: isBackgroundConnectionError,
     onState: state => applyActiveRunState(tabId, state),
     onStatus: ({ phase }) => {
@@ -6861,7 +6864,10 @@ async function sendRunWithReconnect(initialAction, payload) {
     initialAction,
     payload,
     start: (action, nextPayload) => sendToBackground(action, nextPayload),
-    probe: () => sendToBackground('agent_run_state', { tabId }),
+    probe: ({ requestId: probedRequestId } = {}) => sendToBackground('agent_run_state', {
+      tabId,
+      requestId: probedRequestId || requestId,
+    }),
     isConnectionError: isBackgroundConnectionError,
     onState: state => applyActiveRunState(tabId, state),
     shouldResume: () => !isTabAbortRequested(tabId)

--- a/test/run.js
+++ b/test/run.js
@@ -36612,6 +36612,25 @@ test('submitted chat durability marker is persisted atomically with the user tur
         false,
         `${label}: durability proof must stay request-scoped`,
       );
+
+      globalThis[apiName].storage.session.set = async () => {
+        throw new Error('QUOTA_BYTES exceeded');
+      };
+      const quotaLimited = new AgentClass({});
+      quotaLimited.conversations.set(tabId, [
+        { role: 'system', content: 'System prompt' },
+        { role: 'user', content: 'A large but otherwise valid submitted prompt' },
+      ]);
+      assert.equal(
+        await quotaLimited._persistSubmittedTurn(tabId, `${requestId}-quota`),
+        false,
+        `${label}: a session-storage quota failure should only disable recovery durability`,
+      );
+      assert.equal(
+        await quotaLimited.hasDurableSubmittedTurn(tabId, `${requestId}-quota`),
+        false,
+        `${label}: a failed storage write must not be advertised as durable`,
+      );
     } finally {
       if (previousApi === undefined) delete globalThis[apiName];
       else globalThis[apiName] = previousApi;
@@ -36976,6 +36995,11 @@ test('reconnect protocol is wired through both sidepanels and backgrounds', () =
     assert.match(panel, /showActivity\('Reconnecting…'\)/, `${label}: reconnect attempts should be visible`);
     assert.match(panel, /onState: state => applyActiveRunState\(tabId, state\)/, `${label}: reconnect probes should replay missed UI journal events`);
     assert.match(panel, /cancelledRunRecoveryRequestIds/, `${label}: user cancellation should block automatic resume`);
+    const stopSection = panel.slice(
+      panel.indexOf('// --- Stop / Abort ---'),
+      panel.indexOf('// --- Voice input', panel.indexOf('// --- Stop / Abort ---')),
+    );
+    assert.match(stopSection, /localRunRequestIds\.get\(Number\(tabId\)\)[\s\S]*?cancelledRunRecoveryRequestIds\.add\(requestId\)[\s\S]*?setTabAbortRequested\(tabId, true\)/, `${label}: Stop should persist request-scoped cancellation before its UI timeout clears`);
     assert.match(background, /case 'chat_start':[\s\S]*?launchDetachedRun\('chat'/, `${label}: background should acknowledge detached chat starts`);
     assert.match(background, /case 'continue_start':[\s\S]*?launchDetachedRun\('continue'/, `${label}: background should acknowledge detached continuation starts`);
     assert.match(background, /case 'chat':[\s\S]*?await beginContinuationRunUiSnapshot\(tabId, msg\.requestId\)/, `${label}: replayed fresh chats should preserve journal sequence numbers`);

--- a/test/run.js
+++ b/test/run.js
@@ -36575,6 +36575,41 @@ test('run UI journal: resumed requests preserve sequence and replay boundaries',
   }
 });
 
+test('run UI journal: consequential tool checkpoints stay pending until conversation durability is confirmed', () => {
+  for (const [label, Journal] of [['chrome', RunUiJournalCh], ['firefox', RunUiJournalFx]]) {
+    const journal = new Journal();
+    const snapshot = journal.begin(8, `${label}-tool-checkpoint`, { mode: 'act', kind: 'chat' });
+    assert.equal(snapshot.mode, 'act', `${label}: recovery metadata should retain the originating mode`);
+    assert.equal(snapshot.kind, 'chat', `${label}: recovery metadata should identify fresh chat runs`);
+
+    const call = journal.record(8, snapshot.requestId, 'tool_call', {
+      name: 'click',
+      args: { text: 'Publish' },
+      outcomeUnknown: true,
+    });
+    assert.deepEqual(
+      journal.get(8).pendingToolCall,
+      { name: 'click', seq: call.seq },
+      `${label}: a consequential call must remain visibly pending before execution`,
+    );
+
+    journal.record(8, snapshot.requestId, 'tool_result', {
+      name: 'click',
+      result: { success: true },
+    });
+    assert.ok(
+      journal.get(8).pendingToolCall,
+      `${label}: receiving a tool result alone must not clear the restart guard before conversation persistence`,
+    );
+    journal.settleToolCall(8, snapshot.requestId, 'click');
+    assert.equal(
+      journal.get(8).pendingToolCall,
+      null,
+      `${label}: the guard should clear only after the durable conversation checkpoint`,
+    );
+  }
+});
+
 test('submitted chat durability marker is persisted atomically with the user turn', async () => {
   for (const [label, AgentClass, apiName] of [
     ['chrome', AgentCh, 'chrome'],
@@ -36972,6 +37007,159 @@ test('detached runs resume a persisted non-terminal request after background res
   }
 });
 
+test('detached runs fail closed on uncertain tool outcomes after background restart', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-uncertain-tool-outcome`;
+    const starts = [];
+    await assert.rejects(
+      runDetachedWithReconnect({
+        initialAction: 'chat_start',
+        payload: { tabId: 52, requestId, mode: 'act', text: 'publish once' },
+        start: async (action) => {
+          starts.push(action);
+          return { accepted: true, requestId };
+        },
+        probe: async () => ({
+          running: false,
+          starting: false,
+          submittedTurnDurable: true,
+          runUiDurable: true,
+          runUi: {
+            requestId,
+            status: 'running',
+            pendingToolCall: { name: 'click', seq: 4 },
+            events: [],
+          },
+        }),
+        isConnectionError: () => false,
+        wait: async () => {},
+      }),
+      /outcome of click is uncertain/i,
+      `${label}: an uncommitted page action must never be automatically replayed`,
+    );
+    assert.deepEqual(starts, ['chat_start'], `${label}: recovery must stop before continue_start`);
+  }
+});
+
+test('detached runs surface recorded terminal errors instead of resuming them', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-recorded-terminal-error`;
+    const starts = [];
+    const response = await runDetachedWithReconnect({
+      initialAction: 'chat_start',
+      payload: { tabId: 53, requestId, mode: 'act', text: 'stop on failure' },
+      start: async (action) => {
+        starts.push(action);
+        return { accepted: true, requestId };
+      },
+      probe: async () => ({
+        running: false,
+        starting: false,
+        submittedTurnDurable: true,
+        runUiDurable: true,
+        runUi: {
+          requestId,
+          status: 'running',
+          hadError: true,
+          lastError: 'Provider failed.',
+          events: [{ type: 'error', data: { message: 'Provider failed.' } }],
+        },
+      }),
+      isConnectionError: () => false,
+      wait: async () => {},
+    });
+
+    assert.equal(response.runStatus, 'failed', `${label}: the interrupted error snapshot should become terminal`);
+    assert.equal(response.hadError, true, `${label}: the terminal response should preserve the recorded error`);
+    assert.deepEqual(starts, ['chat_start'], `${label}: a recorded error must not launch continue_start`);
+  }
+});
+
+test('remounted recovery probes before adopting an orphaned run', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-remounted-orphan`;
+    const starts = [];
+    const states = [
+      {
+        running: false,
+        starting: false,
+        submittedTurnDurable: true,
+        runUiDurable: true,
+        runUi: { requestId, status: 'running', kind: 'chat', events: [] },
+      },
+      {
+        running: true,
+        starting: false,
+        runUi: { requestId, status: 'running', kind: 'chat', events: [] },
+      },
+      {
+        running: false,
+        starting: false,
+        runUi: { requestId, status: 'completed', finalContent: 'Adopted answer', events: [] },
+      },
+    ];
+    const response = await runDetachedWithReconnect({
+      initialAction: 'continue_start',
+      payload: { tabId: 54, requestId, mode: 'act' },
+      start: async (action) => {
+        starts.push(action);
+        return { accepted: true, requestId };
+      },
+      probe: async () => states.shift(),
+      isConnectionError: () => false,
+      wait: async () => {},
+      probeFirst: true,
+      requireDurableSubmittedTurn: true,
+    });
+
+    assert.deepEqual(starts, ['continue_start'], `${label}: remount should probe first, then adopt the orphan exactly once`);
+    assert.equal(response.content, 'Adopted answer', `${label}: the remounted monitor should receive terminal output`);
+  }
+});
+
+test('remounted chat recovery fails closed when the submitted turn is not durable', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-remounted-nondurable`;
+    const starts = [];
+    await assert.rejects(
+      runDetachedWithReconnect({
+        initialAction: 'continue_start',
+        payload: { tabId: 55, requestId, mode: 'act' },
+        start: async (action) => {
+          starts.push(action);
+          return { accepted: true, requestId };
+        },
+        probe: async () => ({
+          running: false,
+          starting: false,
+          submittedTurnDurable: false,
+          runUiDurable: true,
+          runUi: { requestId, status: 'running', kind: 'chat', events: [] },
+        }),
+        isConnectionError: () => false,
+        wait: async () => {},
+        probeFirst: true,
+        requireDurableSubmittedTurn: true,
+      }),
+      /submitted turn was not persisted before the sidebar reloaded/i,
+      `${label}: a remount without the original payload must not continue an older conversation`,
+    );
+    assert.deepEqual(starts, [], `${label}: probe-first recovery must fail before starting a continuation`);
+  }
+});
+
 test('fresh chat recovery resubmits the complete payload until its user turn is durable', async () => {
   for (const [label, runDetachedWithReconnect] of [
     ['chrome', runDetachedWithReconnectCh],
@@ -37221,6 +37409,8 @@ test('reconnect protocol is wired through both sidepanels and backgrounds', () =
     assert.match(panel, /sendPlanReviewDecisionWithReconnect\(/, `${label}: plan decisions should survive a lost response channel`);
     assert.match(panel, /showActivity\('Reconnecting…'\)/, `${label}: reconnect attempts should be visible`);
     assert.match(panel, /onState: state => applyActiveRunState\(tabId, state\)/, `${label}: reconnect probes should replay missed UI journal events`);
+    assert.match(panel, /void adoptRestoredRunState\(numericTabId, state\)/, `${label}: remounted sidepanels should adopt orphaned run monitors`);
+    assert.match(panel, /probeFirst: true,[\s\S]*?requireDurableSubmittedTurn:/, `${label}: remount adoption should probe before any safe continuation`);
     assert.match(panel, /if \(state\?\.running \|\| state\?\.starting\)/, `${label}: a reserved detached start should keep the composer and Stop UI in their active state`);
     assert.match(panel, /cancelledRunRecoveryRequestIds/, `${label}: user cancellation should block automatic resume`);
     const stopSection = panel.slice(
@@ -37230,10 +37420,13 @@ test('reconnect protocol is wired through both sidepanels and backgrounds', () =
     assert.match(stopSection, /localRunRequestIds\.get\(Number\(tabId\)\)[\s\S]*?cancelledRunRecoveryRequestIds\.add\(requestId\)[\s\S]*?setTabAbortRequested\(tabId, true\)/, `${label}: Stop should persist request-scoped cancellation before its UI timeout clears`);
     assert.match(background, /case 'chat_start':[\s\S]*?launchDetachedRun\('chat'/, `${label}: background should acknowledge detached chat starts`);
     assert.match(background, /case 'continue_start':[\s\S]*?launchDetachedRun\('continue'/, `${label}: background should acknowledge detached continuation starts`);
-    assert.match(background, /case 'chat':[\s\S]*?await beginContinuationRunUiSnapshot\(tabId, msg\.requestId\)/, `${label}: replayed fresh chats should preserve journal sequence numbers`);
-    assert.match(background, /await beginContinuationRunUiSnapshot\(tabId, msg\.requestId\)/, `${label}: resumed continuations should preserve their journal sequence`);
+    assert.match(background, /case 'chat':[\s\S]*?await beginContinuationRunUiSnapshot\(tabId, msg\.requestId,/, `${label}: replayed fresh chats should preserve journal sequence numbers`);
+    assert.match(background, /await beginContinuationRunUiSnapshot\(tabId, msg\.requestId,/, `${label}: resumed continuations should preserve their journal sequence`);
     assert.match(background, /submittedTurnDurable:?\s*,/, `${label}: run probes should expose whether the submitted chat turn is durable`);
     assert.match(background, /await agent\.hasDurableSubmittedTurn\(tabId, requestedRequestId\)/, `${label}: recovery should verify chat durability against persisted conversation state`);
+    assert.match(background, /beforeConsequentialTool: \(\) => flushRunUiSnapshot/, `${label}: consequential actions should await their pending journal checkpoint`);
+    assert.match(background, /afterConsequentialTool:[\s\S]*?settleToolCall/, `${label}: tool guards should clear only after durable conversation results`);
+    assert.match(background, /runUiDurable:/, `${label}: probes should expose journal persistence failures`);
     assert.match(background, /detachedRequestId: runUi\.requestId/, `${label}: detached chats should bind their persisted user turn to the run request`);
     assert.match(background, /startingRequestId: starting\?\.requestId \|\| null/, `${label}: run probes should expose in-flight start reservations`);
     assert.match(background, /runUi: runUiSnapshotForRequest\(runUiSnapshot, requestedRequestId\)/, `${label}: reconnect probes should not receive another request's journal`);

--- a/test/run.js
+++ b/test/run.js
@@ -36840,6 +36840,91 @@ test('detached runs honor cancellation before retrying an uncertain start', asyn
   }
 });
 
+test('detached runs retry an acknowledged start that never published recoverable state', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-acknowledged-without-state`;
+    const starts = [];
+    const states = [
+      { running: false, starting: false, submittedTurnDurable: false, runUi: null },
+      { running: false, starting: false, submittedTurnDurable: false, runUi: null },
+      {
+        running: false,
+        starting: false,
+        submittedTurnDurable: true,
+        runUi: {
+          requestId,
+          status: 'completed',
+          finalContent: 'Recovered acknowledged prompt',
+          events: [],
+        },
+      },
+    ];
+
+    const response = await runDetachedWithReconnect({
+      initialAction: 'chat_start',
+      payload: { tabId: 49, requestId, mode: 'act', text: 'preserve this accepted prompt' },
+      start: async (action, nextPayload) => {
+        starts.push({ action, payload: nextPayload });
+        return { accepted: true, requestId };
+      },
+      probe: async () => states.shift(),
+      isConnectionError: () => false,
+      wait: async () => {},
+      maxAcknowledgedStartRetries: 1,
+    });
+
+    assert.deepEqual(
+      starts.map(start => start.action),
+      ['chat_start', 'chat_start'],
+      `${label}: an ack without any live, journal, or durable-turn proof should replay the original start once`,
+    );
+    assert.deepEqual(starts[1].payload, starts[0].payload, `${label}: acknowledged-start recovery must preserve the full payload`);
+    assert.equal(response.content, 'Recovered acknowledged prompt', `${label}: replayed start should complete normally`);
+  }
+});
+
+test('detached runs fail closed when plan approval state was lost on restart', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-lost-plan-approval`;
+    const starts = [];
+
+    await assert.rejects(
+      runDetachedWithReconnect({
+        initialAction: 'chat_start',
+        payload: { tabId: 50, requestId, mode: 'act', text: 'wait for plan approval' },
+        start: async (action) => {
+          starts.push(action);
+          return { accepted: true, requestId };
+        },
+        probe: async () => ({
+          running: false,
+          starting: false,
+          pendingPlan: null,
+          submittedTurnDurable: true,
+          runUi: {
+            requestId,
+            status: 'awaiting_plan',
+            pendingPlanId: 'plan-before-restart',
+            events: [],
+          },
+        }),
+        isConnectionError: () => false,
+        wait: async () => {},
+      }),
+      /Plan approval expired after the extension background restarted/i,
+      `${label}: a lost approval waiter must never become an automatic continuation`,
+    );
+
+    assert.deepEqual(starts, ['chat_start'], `${label}: recovery must not send continue_start without approval`);
+  }
+});
+
 test('detached runs resume a persisted non-terminal request after background restart', async () => {
   for (const [label, runDetachedWithReconnect] of [
     ['chrome', runDetachedWithReconnectCh],

--- a/test/run.js
+++ b/test/run.js
@@ -36584,6 +36584,49 @@ test('detached runs reconnect to a live request without starting it twice', asyn
   }
 });
 
+test('detached runs never retry an uncertain start after observing the live request', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-confirmed-uncertain-start`;
+    const starts = [];
+    const states = [
+      {
+        running: true,
+        starting: false,
+        runUi: { requestId, status: 'running', events: [] },
+      },
+      { running: false, starting: false, runUi: null },
+      { running: false, starting: false, runUi: null },
+    ];
+
+    await assert.rejects(
+      runDetachedWithReconnect({
+        initialAction: 'chat_start',
+        payload: { tabId: 46, requestId, mode: 'act', text: 'click the target once' },
+        start: async (action) => {
+          starts.push(action);
+          throw new Error('WebBrain extension connection was lost while sending "chat_start".');
+        },
+        probe: async () => states.shift() || { running: false, starting: false, runUi: null },
+        isConnectionError: error => /connection was lost/i.test(error.message),
+        wait: async () => {},
+        maxMissingStateProbes: 2,
+        maxUncertainStartRetries: 1,
+      }),
+      /acknowledged the run but did not publish recoverable run state/i,
+      `${label}: confirmed delivery should fail closed when all recoverable state disappears`,
+    );
+
+    assert.deepEqual(
+      starts,
+      ['chat_start'],
+      `${label}: observing the live request must permanently disable uncertain-start retries`,
+    );
+  }
+});
+
 test('detached runs resume a persisted non-terminal request after background restart', async () => {
   for (const [label, runDetachedWithReconnect] of [
     ['chrome', runDetachedWithReconnectCh],

--- a/test/run.js
+++ b/test/run.js
@@ -255,6 +255,18 @@ const { RunUiJournal: RunUiJournalCh } = await import(
 const { RunUiJournal: RunUiJournalFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/run-ui-journal.js').replace(/\\/g, '/')
 );
+const {
+  runDetachedWithReconnect: runDetachedWithReconnectCh,
+  sendPlanResponseWithReconnect: sendPlanResponseWithReconnectCh,
+} = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/run-reconnect.js').replace(/\\/g, '/')
+);
+const {
+  runDetachedWithReconnect: runDetachedWithReconnectFx,
+  sendPlanResponseWithReconnect: sendPlanResponseWithReconnectFx,
+} = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/run-reconnect.js').replace(/\\/g, '/')
+);
 const { buildCloudPersistenceRows, createCloudRunController, normalizeCloudBridgeUrl } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/cloud-runs.js').replace(/\\/g, '/')
 );
@@ -10499,7 +10511,7 @@ test('hidden trailing run-capture suffixes wrap normal prompts without entering 
     assert.ok(sendMatch, `${label}: sendMessage missing`);
     const sendBody = sendMatch[0];
     const parseIdx = sendBody.indexOf('parseTrailingRunCaptureDirective(text)');
-    const chatIdx = sendBody.indexOf("sendToBackground('chat'");
+    const chatIdx = sendBody.indexOf("sendRunWithReconnect('chat_start'");
     assert.ok(parseIdx >= 0 && chatIdx > parseIdx, `${label}: capture suffix should be parsed before chat dispatch`);
     assert.match(sendBody, /runCapture: \{[\s\S]*?kind: runCaptureDirective\.kind,[\s\S]*?saveAs: runCaptureDirective\.saveAs/, `${label}: chat dispatch should transfer capture ownership to background`);
     assert.doesNotMatch(sendBody, /startTrailingRunCapture|finishTrailingRunCapture/, `${label}: side panel lifecycle must not own capture start or finalization`);
@@ -13414,7 +13426,7 @@ test('sidepanel preserves stale residual slash-command prompts without hidden ru
       `${label}: aborted sends during history hydration should stop before chat dispatch`,
     );
     const staleReturnIdx = sendBody.indexOf('if (!renderToCurrentTab) {');
-    const sendIdx = sendBody.indexOf("sendToBackground('chat'");
+    const sendIdx = sendBody.indexOf("sendRunWithReconnect('chat_start'");
     assert.notEqual(staleReturnIdx, -1, `${label}: stale-tab residual guard missing`);
     assert.notEqual(sendIdx, -1, `${label}: chat send missing`);
     assert.equal(staleReturnIdx < sendIdx, true, `${label}: stale-tab residual guard must run before chat dispatch`);
@@ -13425,7 +13437,7 @@ test('sidepanel preserves stale residual slash-command prompts without hidden ru
     );
     assert.doesNotMatch(
       sendBody,
-      /sendToBackground\('chat', \{[\s\S]*?tabId: currentTabId/,
+      /sendRunWithReconnect\('chat_start', \{[\s\S]*?tabId: currentTabId/,
       `${label}: chat dispatch should not read currentTabId after slash parsing`,
     );
   }
@@ -13695,9 +13707,9 @@ test('sidepanel continue runs use the initiating tab state', () => {
     const match = panel.match(/async function continueAgent\(options = \{\}\) \{[\s\S]*?\n\}/);
     assert.ok(match, `${label}: continueAgent missing`);
     const body = match[0];
-    assert.match(body, /const tabId = currentTabId;[\s\S]*?const modeForSend = \['ask', 'act', 'dev'\]\.includes\(options\?\.mode\) \? options\.mode : agentMode;[\s\S]*?sendToBackground\('continue', \{[\s\S]*?tabId,[\s\S]*?mode: modeForSend,/, `${label}: Continue should send with the tab and requested-or-current mode captured before awaiting`);
-    assert.doesNotMatch(body, /sendToBackground\('continue', \{[\s\S]*?tabId: currentTabId/, `${label}: Continue should not read currentTabId inside the async send payload`);
-    assert.doesNotMatch(body, /sendToBackground\('continue', \{[\s\S]*?mode: agentMode/, `${label}: Continue should not read agentMode inside the async send payload`);
+    assert.match(body, /const tabId = currentTabId;[\s\S]*?const modeForSend = \['ask', 'act', 'dev'\]\.includes\(options\?\.mode\) \? options\.mode : agentMode;[\s\S]*?sendRunWithReconnect\('continue_start', \{[\s\S]*?tabId,[\s\S]*?mode: modeForSend,/, `${label}: Continue should send with the tab and requested-or-current mode captured before awaiting`);
+    assert.doesNotMatch(body, /sendRunWithReconnect\('continue_start', \{[\s\S]*?tabId: currentTabId/, `${label}: Continue should not read currentTabId inside the async send payload`);
+    assert.doesNotMatch(body, /sendRunWithReconnect\('continue_start', \{[\s\S]*?mode: agentMode/, `${label}: Continue should not read agentMode inside the async send payload`);
     assert.match(body, /await prepareChatHistoryForTurn\(tabId, modeForSend\);[\s\S]*?if \(isTabAbortRequested\(tabId\)\) return false;[\s\S]*?if \(!sameTabId\(currentTabId, tabId\) \|\| !sameTabId\(renderedTabId, tabId\)\) return false;[\s\S]*?assistantEl = addMessage\('assistant', ''\);/, `${label}: Continue should hydrate history, honor aborts, and re-check the initiating tab before rendering`);
     assert.match(body, /let assistantEl = null;[\s\S]*?assistantEl = addMessage\('assistant', ''\);[\s\S]*?currentAssistantEl = assistantEl;[\s\S]*?if \(currentTabId === tabId && res\?\.content && assistantEl\) \{[\s\S]*?addMessageCopyButton\(assistantEl\);/, `${label}: Continue should render only into its captured assistant bubble for the initiating tab`);
     assert.match(body, /if \(currentTabId === tabId && assistantEl\) finalizeSteps\(assistantEl\);[\s\S]*?if \(currentAssistantEl === assistantEl\) currentAssistantEl = null;/, `${label}: Continue should finalize and clear only its captured assistant bubble`);
@@ -36464,6 +36476,17 @@ test('run UI journal: mocked tab switching keeps plans and progress scoped to th
     deliver(gmailTab, gmailRequest, 'plan_resolved', { planId: 'gmail-plan', decision: 'approve' }, 'gmail-run');
     assert.equal(journal.get(gmailTab).status, 'running', `${label}: resolving the plan should make restored copies non-pending`);
     assert.equal(journal.get(gmailTab).events.at(-1).type, 'plan_resolved', `${label}: plan resolution should be journaled for every mounted copy`);
+    assert.deepEqual(
+      journal.get(gmailTab).lastPlanResolution,
+      { planId: 'gmail-plan', decision: 'approve' },
+      `${label}: plan resolution proof should survive event acknowledgement`,
+    );
+    journal.acknowledge(gmailTab, gmailRequest, journal.get(gmailTab).seq);
+    assert.deepEqual(
+      journal.get(gmailTab).lastPlanResolution,
+      { planId: 'gmail-plan', decision: 'approve' },
+      `${label}: reconnect should still prove an approval after replay events are released`,
+    );
   }
 });
 
@@ -36499,6 +36522,228 @@ test('run UI journal: concurrent tabs, bounded replay, terminal snapshots, and s
     remounted.restore(1, persisted.get(1));
     assert.equal(remounted.get(1).finalContent, 'A finished', `${label}: service-worker/panel remount should restore the terminal snapshot`);
   }
+});
+
+test('detached runs reconnect to a live request without starting it twice', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-live-reconnect`;
+    const starts = [];
+    const statuses = [];
+    const replayedStates = [];
+    const states = [
+      {
+        running: true,
+        starting: false,
+        runUi: { requestId, status: 'running', events: [] },
+      },
+      {
+        running: false,
+        starting: false,
+        runUi: {
+          requestId,
+          status: 'completed',
+          finalContent: 'Recovered answer',
+          successfulDone: true,
+          events: [{
+            type: 'tool_result',
+            data: { name: 'done', result: { done: true, outcome: 'success' } },
+          }],
+        },
+      },
+    ];
+    let firstStart = true;
+    const response = await runDetachedWithReconnect({
+      initialAction: 'chat_start',
+      payload: { tabId: 41, requestId, mode: 'act', text: 'inspect the page' },
+      start: async (action) => {
+        starts.push(action);
+        if (firstStart) {
+          firstStart = false;
+          throw new Error('WebBrain extension connection was lost while sending "chat_start".');
+        }
+        return { accepted: true, requestId };
+      },
+      probe: async () => states.shift(),
+      isConnectionError: error => /connection was lost/i.test(error.message),
+      onStatus: status => statuses.push(status.phase),
+      onState: state => replayedStates.push(state?.runUi?.status),
+      wait: async () => {},
+    });
+
+    assert.deepEqual(starts, ['chat_start'], `${label}: uncertain delivery should not duplicate a live run`);
+    assert.equal(response.content, 'Recovered answer', `${label}: terminal content should come from the run journal`);
+    assert.equal(response.reconnected, true, `${label}: response should report reconnection`);
+    assert.equal(response.resumed, false, `${label}: a still-live run should not be resumed`);
+    assert.equal(response.successfulDone, true, `${label}: successful done state should survive journal replay`);
+    assert.ok(statuses.includes('reconnecting'), `${label}: reconnecting status should be visible`);
+    assert.ok(statuses.includes('reconnected'), `${label}: reconnected status should be visible`);
+    assert.deepEqual(replayedStates, ['running', 'completed'], `${label}: missed UI journal states should be replayable after reconnect`);
+  }
+});
+
+test('detached runs resume a persisted non-terminal request after background restart', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-restart-resume`;
+    const starts = [];
+    const statuses = [];
+    const states = [
+      {
+        running: false,
+        starting: false,
+        runUi: { requestId, status: 'running', finalContent: '', events: [] },
+      },
+      {
+        running: true,
+        starting: false,
+        runUi: { requestId, status: 'running', finalContent: '', events: [] },
+      },
+      {
+        running: false,
+        starting: false,
+        runUi: { requestId, status: 'completed', finalContent: 'Resumed answer', events: [] },
+      },
+    ];
+    const response = await runDetachedWithReconnect({
+      initialAction: 'chat_start',
+      payload: { tabId: 42, requestId, mode: 'act', text: 'finish the task' },
+      start: async (action) => {
+        starts.push(action);
+        return { accepted: true, requestId };
+      },
+      probe: async () => states.shift(),
+      isConnectionError: () => false,
+      onStatus: status => statuses.push(status.phase),
+      wait: async () => {},
+    });
+
+    assert.deepEqual(starts, ['chat_start', 'continue_start'], `${label}: stale live state should resume exactly once`);
+    assert.equal(response.content, 'Resumed answer', `${label}: resumed run should publish its terminal content`);
+    assert.equal(response.resumed, true, `${label}: response should report automatic resume`);
+    assert.ok(statuses.includes('resuming'), `${label}: automatic resume should be surfaced`);
+  }
+});
+
+test('detached run recovery honors a user cancellation instead of auto-resuming', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-cancel-recovery`;
+    await assert.rejects(
+      runDetachedWithReconnect({
+        initialAction: 'chat_start',
+        payload: { tabId: 43, requestId, mode: 'act', text: 'do not resume' },
+        start: async () => ({ accepted: true, requestId }),
+        probe: async () => ({
+          running: false,
+          starting: false,
+          runUi: { requestId, status: 'awaiting_plan', events: [] },
+        }),
+        isConnectionError: () => false,
+        shouldResume: () => false,
+        wait: async () => {},
+      }),
+      /recovery was cancelled/i,
+      `${label}: cancelled plan/run should not restart after background loss`,
+    );
+  }
+});
+
+test('plan approval reconnect recovers a lost reply without submitting twice', async () => {
+  for (const [label, sendPlanResponseWithReconnect] of [
+    ['chrome', sendPlanResponseWithReconnectCh],
+    ['firefox', sendPlanResponseWithReconnectFx],
+  ]) {
+    let sends = 0;
+    const statuses = [];
+    const response = await sendPlanResponseWithReconnect({
+      payload: { tabId: 44, planId: 'plan-lost-reply', decision: 'approve' },
+      requestId: `${label}-plan-request`,
+      send: async () => {
+        sends += 1;
+        throw new Error('WebBrain extension connection was lost while sending "plan_response".');
+      },
+      probe: async () => ({
+        running: true,
+        pendingPlan: null,
+        runUi: {
+          requestId: `${label}-plan-request`,
+          status: 'running',
+          lastPlanResolution: { planId: 'plan-lost-reply', decision: 'approve' },
+        },
+      }),
+      isConnectionError: error => /connection was lost/i.test(error.message),
+      onStatus: status => statuses.push(status.phase),
+      wait: async () => {},
+    });
+
+    assert.equal(sends, 1, `${label}: durable approval proof should prevent a duplicate plan decision`);
+    assert.equal(response.matched, true, `${label}: a delivered approval with a lost reply should still succeed`);
+    assert.equal(response.recovered, true, `${label}: recovered approval should be identified`);
+    assert.deepEqual(statuses, ['reconnecting', 'reconnected'], `${label}: approval recovery should be visible`);
+  }
+});
+
+test('plan approval reconnect retries only while the same plan remains pending', async () => {
+  for (const [label, sendPlanResponseWithReconnect] of [
+    ['chrome', sendPlanResponseWithReconnectCh],
+    ['firefox', sendPlanResponseWithReconnectFx],
+  ]) {
+    let sends = 0;
+    const response = await sendPlanResponseWithReconnect({
+      payload: { tabId: 45, planId: 'plan-still-pending', decision: 'approve' },
+      requestId: `${label}-pending-plan-request`,
+      send: async () => {
+        sends += 1;
+        if (sends === 1) {
+          throw new Error('WebBrain extension connection was lost while sending "plan_response".');
+        }
+        return { ok: true, matched: true };
+      },
+      probe: async () => ({
+        running: true,
+        pendingPlan: { planId: 'plan-still-pending' },
+        runUi: {
+          requestId: `${label}-pending-plan-request`,
+          status: 'awaiting_plan',
+          lastPlanResolution: null,
+        },
+      }),
+      isConnectionError: error => /connection was lost/i.test(error.message),
+      wait: async () => {},
+    });
+
+    assert.equal(sends, 2, `${label}: an unresolved live plan should receive one retry`);
+    assert.equal(response.matched, true, `${label}: retry should deliver the pending approval`);
+    assert.equal(response.reconnected, true, `${label}: retried approval should report reconnection`);
+  }
+});
+
+test('reconnect protocol is wired through both sidepanels and backgrounds', () => {
+  for (const [label, prefix] of [['chrome', 'src/chrome'], ['firefox', 'src/firefox']]) {
+    const background = fs.readFileSync(path.join(ROOT, prefix, 'src/background.js'), 'utf8');
+    const panel = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/sidepanel.js'), 'utf8');
+    assert.match(panel, /import \{ runDetachedWithReconnect, sendPlanResponseWithReconnect \} from '\.\.\/run-reconnect\.js';/, `${label}: sidepanel should use the reconnect monitors`);
+    assert.match(panel, /sendRunWithReconnect\('chat_start'/, `${label}: chats should use detached starts`);
+    assert.match(panel, /sendRunWithReconnect\('continue_start'/, `${label}: manual continuations should use detached starts`);
+    assert.match(panel, /sendPlanReviewDecisionWithReconnect\(/, `${label}: plan decisions should survive a lost response channel`);
+    assert.match(panel, /showActivity\('Reconnecting…'\)/, `${label}: reconnect attempts should be visible`);
+    assert.match(panel, /onState: state => applyActiveRunState\(tabId, state\)/, `${label}: reconnect probes should replay missed UI journal events`);
+    assert.match(panel, /cancelledRunRecoveryRequestIds/, `${label}: user cancellation should block automatic resume`);
+    assert.match(background, /case 'chat_start':[\s\S]*?launchDetachedRun\('chat'/, `${label}: background should acknowledge detached chat starts`);
+    assert.match(background, /case 'continue_start':[\s\S]*?launchDetachedRun\('continue'/, `${label}: background should acknowledge detached continuation starts`);
+    assert.match(background, /startingRequestId: starting\?\.requestId \|\| null/, `${label}: run probes should expose in-flight start reservations`);
+    assert.match(background, /RUN_KEEPALIVE_INTERVAL_MS = 20_000/, `${label}: active runs should renew the background lease`);
+    assert.match(background, /releaseRunKeepalive\(\)/, `${label}: completed runs should release their background lease`);
+  }
+  const firefoxManifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'src/firefox/manifest.json'), 'utf8'));
+  assert.equal(firefoxManifest.background.persistent, true, 'firefox: long-running agent background should remain persistent');
 });
 
 test('sidepanel run errors dedupe streamed, returned, and restored copies by tab and request', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -256,12 +256,14 @@ const { RunUiJournal: RunUiJournalFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/run-ui-journal.js').replace(/\\/g, '/')
 );
 const {
+  isBackgroundConnectionError: isBackgroundConnectionErrorCh,
   runDetachedWithReconnect: runDetachedWithReconnectCh,
   sendPlanResponseWithReconnect: sendPlanResponseWithReconnectCh,
 } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/run-reconnect.js').replace(/\\/g, '/')
 );
 const {
+  isBackgroundConnectionError: isBackgroundConnectionErrorFx,
   runDetachedWithReconnect: runDetachedWithReconnectFx,
   sendPlanResponseWithReconnect: sendPlanResponseWithReconnectFx,
 } = await import(
@@ -11771,9 +11773,13 @@ test('sidepanel reports missing background responses without res.content crash',
     ['firefox', 'src/firefox/src/ui/sidepanel.js'],
   ]) {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    const reconnect = fs.readFileSync(
+      path.join(ROOT, panelRel.replace('/ui/sidepanel.js', '/run-reconnect.js')),
+      'utf8',
+    );
     assert.match(panel, /No response from WebBrain background/, `${label}: missing background response should become a clear error`);
     assert.match(panel, /formatBackgroundSendError\(action/, `${label}: runtime disconnects should be rewritten as WebBrain errors`);
-    assert.match(panel, /Receiving end does not exist/, `${label}: Chrome missing-receiver errors should be recognized`);
+    assert.match(reconnect, /Receiving end does not exist/, `${label}: Chrome missing-receiver errors should be recognized`);
     assert.match(panel, /response == null/, `${label}: sendToBackground should reject nullish responses`);
     assert.equal((panel.match(/res\?\.content && (?:currentAssistantEl|assistantEl)/g) || []).length >= 2, true, `${label}: chat and continue should not dereference missing responses`);
     assert.doesNotMatch(panel, /res\.content && (?:currentAssistantEl|assistantEl)/, `${label}: unsafe res.content render guard returned`);
@@ -36698,6 +36704,30 @@ test('detached runs reconnect to a live request without starting it twice', asyn
   }
 });
 
+test('runtime message channel closures are treated as reconnectable background failures', () => {
+  const connectionErrors = [
+    new Error('A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received'),
+    new Error('The message port closed before a response was received.'),
+  ];
+  for (const [label, isBackgroundConnectionError] of [
+    ['chrome', isBackgroundConnectionErrorCh],
+    ['firefox', isBackgroundConnectionErrorFx],
+  ]) {
+    for (const error of connectionErrors) {
+      assert.equal(
+        isBackgroundConnectionError(error),
+        true,
+        `${label}: ${error.message}`,
+      );
+    }
+    assert.equal(
+      isBackgroundConnectionError(new Error('Provider rejected the API key.')),
+      false,
+      `${label}: application failures must not enter the reconnect loop`,
+    );
+  }
+});
+
 test('detached runs never retry an uncertain start after observing the live request', async () => {
   for (const [label, runDetachedWithReconnect] of [
     ['chrome', runDetachedWithReconnectCh],
@@ -37023,7 +37053,7 @@ test('reconnect protocol is wired through both sidepanels and backgrounds', () =
   for (const [label, prefix] of [['chrome', 'src/chrome'], ['firefox', 'src/firefox']]) {
     const background = fs.readFileSync(path.join(ROOT, prefix, 'src/background.js'), 'utf8');
     const panel = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/sidepanel.js'), 'utf8');
-    assert.match(panel, /import \{ runDetachedWithReconnect, sendPlanResponseWithReconnect \} from '\.\.\/run-reconnect\.js';/, `${label}: sidepanel should use the reconnect monitors`);
+    assert.match(panel, /isBackgroundConnectionError,[\s\S]*?runDetachedWithReconnect,[\s\S]*?sendPlanResponseWithReconnect,[\s\S]*?from '\.\.\/run-reconnect\.js';/, `${label}: sidepanel should use the reconnect monitors`);
     assert.match(panel, /sendRunWithReconnect\('chat_start'/, `${label}: chats should use detached starts`);
     assert.match(panel, /sendRunWithReconnect\('continue_start'/, `${label}: manual continuations should use detached starts`);
     assert.match(panel, /sendPlanReviewDecisionWithReconnect\(/, `${label}: plan decisions should survive a lost response channel`);

--- a/test/run.js
+++ b/test/run.js
@@ -36562,6 +36562,63 @@ test('run UI journal: resumed requests preserve sequence and replay boundaries',
   }
 });
 
+test('submitted chat durability marker is persisted atomically with the user turn', async () => {
+  for (const [label, AgentClass, apiName] of [
+    ['chrome', AgentCh, 'chrome'],
+    ['firefox', AgentFx, 'browser'],
+  ]) {
+    const previousApi = globalThis[apiName];
+    const session = {};
+    const writes = [];
+    globalThis[apiName] = {
+      storage: {
+        session: {
+          get: async key => ({ [key]: session[key] }),
+          set: async values => {
+            const cloned = structuredClone(values);
+            writes.push(cloned);
+            Object.assign(session, cloned);
+          },
+          remove: async key => { delete session[key]; },
+        },
+      },
+    };
+    try {
+      const tabId = label === 'chrome' ? 61 : 62;
+      const requestId = `${label}-durable-user-turn`;
+      const first = new AgentClass({});
+      first.conversations.set(tabId, [
+        { role: 'system', content: 'System prompt' },
+        { role: 'user', content: 'Original submitted prompt' },
+      ]);
+      first.conversationModes.set(tabId, 'act');
+      first.conversationIds.set(tabId, `${label}-conversation`);
+
+      await first._persistSubmittedTurn(tabId, requestId);
+
+      assert.equal(writes.length, 1, `${label}: the user turn and durability marker should share one storage write`);
+      const stored = session[`agentConv:${tabId}`];
+      assert.equal(stored.submittedRunRequestId, requestId, `${label}: storage should bind the durable turn to its run request`);
+      assert.equal(stored.messages.at(-1)?.content, 'Original submitted prompt', `${label}: the same write should contain the submitted user turn`);
+
+      const restarted = new AgentClass({});
+      assert.equal(
+        await restarted.hasDurableSubmittedTurn(tabId, requestId),
+        true,
+        `${label}: a restarted background should recognize the persisted submitted turn`,
+      );
+      assert.equal(
+        await restarted.hasDurableSubmittedTurn(tabId, `${requestId}-other`),
+        false,
+        `${label}: durability proof must stay request-scoped`,
+      );
+    } finally {
+      if (previousApi === undefined) delete globalThis[apiName];
+      else globalThis[apiName] = previousApi;
+    }
+  }
+});
+
 test('detached runs reconnect to a live request without starting it twice', async () => {
   for (const [label, runDetachedWithReconnect] of [
     ['chrome', runDetachedWithReconnectCh],
@@ -36677,6 +36734,7 @@ test('detached runs resume a persisted non-terminal request after background res
       {
         running: false,
         starting: false,
+        submittedTurnDurable: true,
         runUi: { requestId, status: 'running', finalContent: '', events: [] },
       },
       {
@@ -36707,6 +36765,73 @@ test('detached runs resume a persisted non-terminal request after background res
     assert.equal(response.content, 'Resumed answer', `${label}: resumed run should publish its terminal content`);
     assert.equal(response.resumed, true, `${label}: response should report automatic resume`);
     assert.ok(statuses.includes('resuming'), `${label}: automatic resume should be surfaced`);
+  }
+});
+
+test('fresh chat recovery resubmits the complete payload until its user turn is durable', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-fresh-chat-recovery`;
+    const payload = {
+      tabId: 47,
+      requestId,
+      text: 'upload and inspect this',
+      mode: 'act',
+      attachments: [{ kind: 'text', name: 'notes.txt', textContent: 'evidence' }],
+      runCapture: { kind: 'screenshot', saveAs: 'proof' },
+      apiMutationsAllowed: true,
+      recommendedAction: { id: 'inspect' },
+      locale: 'tr',
+      intentFailureMessage: 'Plan unavailable.',
+    };
+    const starts = [];
+    const states = [
+      {
+        running: false,
+        starting: false,
+        submittedTurnDurable: false,
+        runUi: { requestId, status: 'running', finalContent: '', events: [] },
+      },
+      {
+        running: true,
+        starting: false,
+        submittedTurnDurable: true,
+        runUi: { requestId, status: 'running', finalContent: '', events: [] },
+      },
+      {
+        running: false,
+        starting: false,
+        submittedTurnDurable: true,
+        runUi: { requestId, status: 'completed', finalContent: 'Recovered original task', events: [] },
+      },
+    ];
+
+    const response = await runDetachedWithReconnect({
+      initialAction: 'chat_start',
+      payload,
+      start: async (action, nextPayload) => {
+        starts.push({ action, payload: nextPayload });
+        return { accepted: true, requestId };
+      },
+      probe: async () => states.shift(),
+      isConnectionError: () => false,
+      wait: async () => {},
+    });
+
+    assert.deepEqual(
+      starts.map(start => start.action),
+      ['chat_start', 'chat_start'],
+      `${label}: a pre-durability restart must replay the original chat instead of continuing an older conversation`,
+    );
+    assert.deepEqual(
+      starts[1].payload,
+      payload,
+      `${label}: recovery must preserve text, attachments, capture options, and per-turn flags`,
+    );
+    assert.equal(response.content, 'Recovered original task', `${label}: replayed fresh chat should complete normally`);
+    assert.equal(response.resumed, true, `${label}: replayed fresh chat should be reported as recovered`);
   }
 });
 
@@ -36853,7 +36978,11 @@ test('reconnect protocol is wired through both sidepanels and backgrounds', () =
     assert.match(panel, /cancelledRunRecoveryRequestIds/, `${label}: user cancellation should block automatic resume`);
     assert.match(background, /case 'chat_start':[\s\S]*?launchDetachedRun\('chat'/, `${label}: background should acknowledge detached chat starts`);
     assert.match(background, /case 'continue_start':[\s\S]*?launchDetachedRun\('continue'/, `${label}: background should acknowledge detached continuation starts`);
+    assert.match(background, /case 'chat':[\s\S]*?await beginContinuationRunUiSnapshot\(tabId, msg\.requestId\)/, `${label}: replayed fresh chats should preserve journal sequence numbers`);
     assert.match(background, /await beginContinuationRunUiSnapshot\(tabId, msg\.requestId\)/, `${label}: resumed continuations should preserve their journal sequence`);
+    assert.match(background, /submittedTurnDurable:?\s*,/, `${label}: run probes should expose whether the submitted chat turn is durable`);
+    assert.match(background, /await agent\.hasDurableSubmittedTurn\(tabId, requestedRequestId\)/, `${label}: recovery should verify chat durability against persisted conversation state`);
+    assert.match(background, /detachedRequestId: runUi\.requestId/, `${label}: detached chats should bind their persisted user turn to the run request`);
     assert.match(background, /startingRequestId: starting\?\.requestId \|\| null/, `${label}: run probes should expose in-flight start reservations`);
     assert.match(background, /detachedRunFailures/, `${label}: detached task failures should remain queryable by request ID`);
     assert.match(background, /detachedError,/, `${label}: run probes should return the original detached task failure`);

--- a/test/run.js
+++ b/test/run.js
@@ -249,10 +249,16 @@ const { renderSkillMarkdown } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/ui/skill-markdown.js').replace(/\\/g, '/')
 );
 
-const { RunUiJournal: RunUiJournalCh } = await import(
+const {
+  RunUiJournal: RunUiJournalCh,
+  runUiSnapshotForRequest: runUiSnapshotForRequestCh,
+} = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/run-ui-journal.js').replace(/\\/g, '/')
 );
-const { RunUiJournal: RunUiJournalFx } = await import(
+const {
+  RunUiJournal: RunUiJournalFx,
+  runUiSnapshotForRequest: runUiSnapshotForRequestFx,
+} = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/run-ui-journal.js').replace(/\\/g, '/')
 );
 const {
@@ -36704,6 +36710,34 @@ test('detached runs reconnect to a live request without starting it twice', asyn
   }
 });
 
+test('run-state probes only expose the snapshot requested by reconnect recovery', () => {
+  const previousSnapshot = {
+    requestId: 'previous-terminal-request',
+    status: 'completed',
+    finalContent: 'Old answer',
+  };
+  for (const [label, runUiSnapshotForRequest] of [
+    ['chrome', runUiSnapshotForRequestCh],
+    ['firefox', runUiSnapshotForRequestFx],
+  ]) {
+    assert.equal(
+      runUiSnapshotForRequest(previousSnapshot, 'new-starting-request'),
+      null,
+      `${label}: a new detached start must not replay the previous request journal`,
+    );
+    assert.equal(
+      runUiSnapshotForRequest(previousSnapshot, previousSnapshot.requestId),
+      previousSnapshot,
+      `${label}: reconnect recovery should receive its matching journal`,
+    );
+    assert.equal(
+      runUiSnapshotForRequest(previousSnapshot),
+      previousSnapshot,
+      `${label}: unscoped sidepanel restore should still receive the tab snapshot`,
+    );
+  }
+});
+
 test('runtime message channel closures are treated as reconnectable background failures', () => {
   const connectionErrors = [
     new Error('A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received'),
@@ -37074,6 +37108,7 @@ test('reconnect protocol is wired through both sidepanels and backgrounds', () =
     assert.match(background, /await agent\.hasDurableSubmittedTurn\(tabId, requestedRequestId\)/, `${label}: recovery should verify chat durability against persisted conversation state`);
     assert.match(background, /detachedRequestId: runUi\.requestId/, `${label}: detached chats should bind their persisted user turn to the run request`);
     assert.match(background, /startingRequestId: starting\?\.requestId \|\| null/, `${label}: run probes should expose in-flight start reservations`);
+    assert.match(background, /runUi: runUiSnapshotForRequest\(runUiSnapshot, requestedRequestId\)/, `${label}: reconnect probes should not receive another request's journal`);
     assert.match(background, /detachedRunFailures/, `${label}: detached task failures should remain queryable by request ID`);
     assert.match(background, /detachedError,/, `${label}: run probes should return the original detached task failure`);
     assert.match(background, /RUN_KEEPALIVE_INTERVAL_MS = 20_000/, `${label}: active runs should renew the background lease`);
@@ -37212,7 +37247,7 @@ test('per-tab run UI protocol is wired into both backgrounds and side panels', (
     assert.match(background, /new RunUiJournal\(/, `${label}: background should own the bounded run journal`);
     assert.match(background, /function assertNoActiveTabRun\(tabId\)/, `${label}: background should prevent duplicate runs within one tab`);
     assert.match(background, /tabId,[\s\S]*?requestId,[\s\S]*?runId:[\s\S]*?seq:/, `${label}: agent updates should carry tab, request, run, and sequence IDs`);
-    assert.match(background, /case 'agent_run_state':[\s\S]*?runUi: await getRunUiSnapshot\(tabId\)/, `${label}: remount state should include the UI journal snapshot`);
+    assert.match(background, /case 'agent_run_state':[\s\S]*?const runUiSnapshot = await getRunUiSnapshot\(tabId\)[\s\S]*?runUi: runUiSnapshotForRequest\(runUiSnapshot, requestedRequestId\)/, `${label}: remount state should include only the requested UI journal snapshot`);
     assert.match(background, /case 'agent_run_ack':[\s\S]*?runUiJournal\.acknowledge/, `${label}: background should accept ordered replay acknowledgements`);
     assert.match(background, /status: snapshot\.status \|\| 'completed'/, `${label}: run_complete should carry explicit terminal status`);
     assert.match(panel, /const processingTabs = new Set\(\);/, `${label}: processing state should be tab scoped`);

--- a/test/run.js
+++ b/test/run.js
@@ -11917,7 +11917,7 @@ test('sidepanel clears shared activity while restoring an idle destination tab',
     assert.notEqual(restoreStart, -1, `${label}: active-run restore helper missing`);
     assert.notEqual(restoreEnd, -1, `${label}: active-run restore helper boundary missing`);
     const restoreBody = panel.slice(restoreStart, restoreEnd);
-    const runningIdx = restoreBody.indexOf('if (state?.running) {');
+    const runningIdx = restoreBody.indexOf('if (state?.running || state?.starting) {');
     const idleIdx = restoreBody.indexOf('} else {', runningIdx);
     const runningBody = restoreBody.slice(runningIdx, idleIdx);
     const idleBody = restoreBody.slice(idleIdx);
@@ -37059,6 +37059,7 @@ test('reconnect protocol is wired through both sidepanels and backgrounds', () =
     assert.match(panel, /sendPlanReviewDecisionWithReconnect\(/, `${label}: plan decisions should survive a lost response channel`);
     assert.match(panel, /showActivity\('Reconnecting…'\)/, `${label}: reconnect attempts should be visible`);
     assert.match(panel, /onState: state => applyActiveRunState\(tabId, state\)/, `${label}: reconnect probes should replay missed UI journal events`);
+    assert.match(panel, /if \(state\?\.running \|\| state\?\.starting\)/, `${label}: a reserved detached start should keep the composer and Stop UI in their active state`);
     assert.match(panel, /cancelledRunRecoveryRequestIds/, `${label}: user cancellation should block automatic resume`);
     const stopSection = panel.slice(
       panel.indexOf('// --- Stop / Abort ---'),

--- a/test/run.js
+++ b/test/run.js
@@ -36741,6 +36741,41 @@ test('detached runs never retry an uncertain start after observing the live requ
   }
 });
 
+test('detached runs honor cancellation before retrying an uncertain start', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-cancel-uncertain-start`;
+    const starts = [];
+    let probes = 0;
+
+    await assert.rejects(
+      runDetachedWithReconnect({
+        initialAction: 'chat_start',
+        payload: { tabId: 48, requestId, mode: 'act', text: 'do not retry after Stop' },
+        start: async (action) => {
+          starts.push(action);
+          throw new Error('WebBrain extension connection was lost while sending "chat_start".');
+        },
+        probe: async () => {
+          probes += 1;
+          return { running: false, starting: false, runUi: null };
+        },
+        isConnectionError: error => /connection was lost/i.test(error.message),
+        shouldResume: () => false,
+        wait: async () => {},
+        maxUncertainStartRetries: 1,
+      }),
+      /recovery was cancelled/i,
+      `${label}: Stop should cancel an uncertain start before any retry is sent`,
+    );
+
+    assert.equal(probes, 2, `${label}: cancellation should be checked at the first retry boundary`);
+    assert.deepEqual(starts, ['chat_start'], `${label}: cancellation must prevent a second start`);
+  }
+});
+
 test('detached runs resume a persisted non-terminal request after background restart', async () => {
   for (const [label, runDetachedWithReconnect] of [
     ['chrome', runDetachedWithReconnectCh],

--- a/test/run.js
+++ b/test/run.js
@@ -35473,6 +35473,7 @@ test('page Stop WebBrain clears stale indicators without stopping recordings', (
     assert.notEqual(handlerStart, -1, `${label}: background Stop handler missing`);
     assert.notEqual(handlerEnd, -1, `${label}: background Stop handler boundary missing`);
     const handlerBody = background.slice(handlerStart, handlerEnd);
+    assert.match(handlerBody, /cancelDetachedRunStart\(tabId\)/, `${label}: page Stop should cancel a reserved detached start`);
     assert.match(handlerBody, /agent\.abort\(tabId\)/, `${label}: active agent runs should still be aborted`);
     assert.match(
       handlerBody,
@@ -37038,6 +37039,48 @@ test('fresh chat recovery resubmits the complete payload until its user turn is 
   }
 });
 
+test('fresh chat recovery never replays after live progress without a durable turn', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-live-progress-without-durable-turn`;
+    const starts = [];
+    const states = [
+      {
+        running: true,
+        starting: false,
+        submittedTurnDurable: false,
+        runUi: { requestId, status: 'running', seq: 3, events: [] },
+      },
+      {
+        running: false,
+        starting: false,
+        submittedTurnDurable: false,
+        runUi: { requestId, status: 'running', seq: 3, events: [] },
+      },
+    ];
+
+    await assert.rejects(
+      runDetachedWithReconnect({
+        initialAction: 'chat_start',
+        payload: { tabId: 51, requestId, mode: 'act', text: 'do this exactly once' },
+        start: async (action) => {
+          starts.push(action);
+          return { accepted: true, requestId };
+        },
+        probe: async () => states.shift(),
+        isConnectionError: () => false,
+        wait: async () => {},
+      }),
+      /avoid duplicate page actions/i,
+      `${label}: live-observed work without a durable turn must fail closed`,
+    );
+
+    assert.deepEqual(starts, ['chat_start'], `${label}: recovery must not replay a chat that already made live progress`);
+  }
+});
+
 test('detached run recovery honors a user cancellation instead of auto-resuming', async () => {
   for (const [label, runDetachedWithReconnect] of [
     ['chrome', runDetachedWithReconnectCh],
@@ -37194,6 +37237,10 @@ test('reconnect protocol is wired through both sidepanels and backgrounds', () =
     assert.match(background, /detachedRequestId: runUi\.requestId/, `${label}: detached chats should bind their persisted user turn to the run request`);
     assert.match(background, /startingRequestId: starting\?\.requestId \|\| null/, `${label}: run probes should expose in-flight start reservations`);
     assert.match(background, /runUi: runUiSnapshotForRequest\(runUiSnapshot, requestedRequestId\)/, `${label}: reconnect probes should not receive another request's journal`);
+    assert.match(background, /const entry = \{ requestId, promise: null, cancelled: false \}/, `${label}: detached starts should retain request-scoped cancellation`);
+    assert.match(background, /assertDetachedRunStartNotCancelled\(tabId, detachedMessage\)/, `${label}: cancelled reservations should not launch queued runs`);
+    assert.match(background, /case 'abort':[\s\S]*?cancelDetachedRunStart\(tabId\)[\s\S]*?agent\.abort\(tabId\)/, `${label}: sidebar Stop should cancel both reserved and active runs`);
+    assert.match(background, /isDetachedStartCancelled: \(\) => isDetachedRunStartCancelled\(tabId, msg\)/, `${label}: cancellation should remain visible through async run setup`);
     assert.match(background, /detachedRunFailures/, `${label}: detached task failures should remain queryable by request ID`);
     assert.match(background, /detachedError,/, `${label}: run probes should return the original detached task failure`);
     assert.match(background, /RUN_KEEPALIVE_INTERVAL_MS = 20_000/, `${label}: active runs should renew the background lease`);
@@ -37508,6 +37555,66 @@ test('planner gate: a stale abort flag does not cancel a fresh task', async () =
 
       assert.equal(abortSeenByGate, false, `${label} stale abort flag should be cleared before the gate`);
       assert.equal(final, 'Fresh task ran.', `${label} fresh task should run, not be cancelled`);
+    }
+  });
+});
+
+test('detached-start cancellation survives setup until before LLM work', async () => {
+  await withPlannerBrowserGlobals(async () => {
+    for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+      const tabId = label === 'chrome' ? 9311 : 9312;
+      const provider = {
+        supportsTools: false,
+        supportsVision: false,
+        promptTier: 'full',
+        contextWindow: 128000,
+        model: 'test-model',
+        name: 'test-provider',
+      };
+      const agent = new AgentClass({
+        getActive: () => provider,
+        getVisionProvider: async () => null,
+      });
+      agent._hydrate = async () => {};
+      agent._manageContext = async () => {};
+      agent._enrichUserMessageWithCurrentPage = async (_tabId, _messages, content) => ({ role: 'user', content });
+      let cancellationChecks = 0;
+
+      const final = await agent.processMessage(
+        tabId,
+        'do not start after Stop',
+        () => {},
+        'act',
+        [],
+        {
+          detachedRequestId: `${label}-cancelled-start`,
+          isDetachedStartCancelled: () => {
+            cancellationChecks += 1;
+            return true;
+          },
+        },
+      );
+
+      assert.equal(final, 'Stopped by user before the run started.', `${label}: cancelled detached start should stop before provider work`);
+      assert.equal(cancellationChecks, 1, `${label}: cancellation should be checked at the final pre-LLM boundary`);
+      assert.equal(agent.activeRunState(tabId).running, false, `${label}: cancelled setup should release active-run state`);
+
+      const continueTabId = tabId + 100;
+      let continueCancellationChecks = 0;
+      const continued = await agent.continueProcessing(
+        continueTabId,
+        () => {},
+        'act',
+        {
+          isDetachedStartCancelled: () => {
+            continueCancellationChecks += 1;
+            return true;
+          },
+        },
+      );
+      assert.equal(continued, 'Stopped by user before the run started.', `${label}: cancelled detached continuation should stop before provider work`);
+      assert.equal(continueCancellationChecks, 1, `${label}: continueProcessing should forward detached cancellation`);
+      assert.equal(agent.activeRunState(continueTabId).running, false, `${label}: cancelled continuation should release active-run state`);
     }
   });
 });

--- a/test/run.js
+++ b/test/run.js
@@ -36655,6 +36655,40 @@ test('detached run recovery honors a user cancellation instead of auto-resuming'
   }
 });
 
+test('detached run recovery preserves background preflight errors', async () => {
+  for (const [label, runDetachedWithReconnect] of [
+    ['chrome', runDetachedWithReconnectCh],
+    ['firefox', runDetachedWithReconnectFx],
+  ]) {
+    const requestId = `${label}-capture-preflight`;
+    let probes = 0;
+    await assert.rejects(
+      runDetachedWithReconnect({
+        initialAction: 'chat_start',
+        payload: { tabId: 44, requestId, mode: 'act', text: 'record this run' },
+        start: async () => ({ accepted: true, requestId }),
+        probe: async () => {
+          probes += 1;
+          return {
+            running: false,
+            starting: false,
+            detachedError: {
+              requestId,
+              message: 'Run capture could not start: microphone permission denied.',
+            },
+            runUi: null,
+          };
+        },
+        isConnectionError: () => false,
+        wait: async () => {},
+      }),
+      /Run capture could not start: microphone permission denied\./,
+      `${label}: detached capture preflight failure should reach the sidebar unchanged`,
+    );
+    assert.equal(probes, 1, `${label}: a reported detached failure should stop recovery immediately`);
+  }
+});
+
 test('plan approval reconnect recovers a lost reply without submitting twice', async () => {
   for (const [label, sendPlanResponseWithReconnect] of [
     ['chrome', sendPlanResponseWithReconnectCh],
@@ -36739,6 +36773,8 @@ test('reconnect protocol is wired through both sidepanels and backgrounds', () =
     assert.match(background, /case 'chat_start':[\s\S]*?launchDetachedRun\('chat'/, `${label}: background should acknowledge detached chat starts`);
     assert.match(background, /case 'continue_start':[\s\S]*?launchDetachedRun\('continue'/, `${label}: background should acknowledge detached continuation starts`);
     assert.match(background, /startingRequestId: starting\?\.requestId \|\| null/, `${label}: run probes should expose in-flight start reservations`);
+    assert.match(background, /detachedRunFailures/, `${label}: detached task failures should remain queryable by request ID`);
+    assert.match(background, /detachedError,/, `${label}: run probes should return the original detached task failure`);
     assert.match(background, /RUN_KEEPALIVE_INTERVAL_MS = 20_000/, `${label}: active runs should renew the background lease`);
     assert.match(background, /releaseRunKeepalive\(\)/, `${label}: completed runs should release their background lease`);
   }

--- a/test/run.js
+++ b/test/run.js
@@ -36524,6 +36524,44 @@ test('run UI journal: concurrent tabs, bounded replay, terminal snapshots, and s
   }
 });
 
+test('run UI journal: resumed requests preserve sequence and replay boundaries', () => {
+  for (const [label, Journal] of [['chrome', RunUiJournalCh], ['firefox', RunUiJournalFx]]) {
+    const journal = new Journal();
+    journal.begin(7, 'resume-request');
+    journal.record(7, 'resume-request', 'thinking', { content: 'Before restart' }, 'run-before');
+    journal.record(7, 'resume-request', 'plan_review', { planId: 'plan-before' }, 'run-before');
+    journal.acknowledge(7, 'resume-request', 1);
+
+    const before = journal.get(7);
+    assert.equal(before.seq, 2, `${label}: fixture should start above sequence zero`);
+    assert.equal(before.ackedSeq, 1, `${label}: fixture should retain an acknowledged replay boundary`);
+
+    const restarted = new Journal();
+    restarted.restore(7, structuredClone(before));
+    const resumed = restarted.resume(7, 'resume-request');
+    assert.ok(resumed, `${label}: matching request should resume its existing journal`);
+    assert.equal(resumed.seq, 2, `${label}: resume must preserve the prior sequence`);
+    assert.equal(resumed.ackedSeq, 1, `${label}: resume must preserve the acknowledged replay boundary`);
+    assert.equal(resumed.truncatedBeforeSeq, 1, `${label}: resume must preserve the compaction boundary`);
+    assert.equal(resumed.status, 'running', `${label}: resumed journal should return to running`);
+    assert.equal(resumed.pendingPlanId, null, `${label}: stale pre-restart plan ownership should be cleared`);
+    assert.deepEqual(
+      resumed.events.map(event => event.seq),
+      [2],
+      `${label}: unacknowledged pre-restart events should remain replayable`,
+    );
+
+    const next = restarted.record(7, 'resume-request', 'thinking', { content: 'After restart' }, 'run-after');
+    assert.equal(next.seq, 3, `${label}: first resumed event should advance beyond the old sequence`);
+    assert.deepEqual(
+      restarted.get(7).events.map(event => event.seq),
+      [2, 3],
+      `${label}: resumed events should not collide with prior replay sequence numbers`,
+    );
+    assert.equal(restarted.resume(7, 'different-request'), null, `${label}: a manual continuation must not reuse another request journal`);
+  }
+});
+
 test('detached runs reconnect to a live request without starting it twice', async () => {
   for (const [label, runDetachedWithReconnect] of [
     ['chrome', runDetachedWithReconnectCh],
@@ -36815,6 +36853,7 @@ test('reconnect protocol is wired through both sidepanels and backgrounds', () =
     assert.match(panel, /cancelledRunRecoveryRequestIds/, `${label}: user cancellation should block automatic resume`);
     assert.match(background, /case 'chat_start':[\s\S]*?launchDetachedRun\('chat'/, `${label}: background should acknowledge detached chat starts`);
     assert.match(background, /case 'continue_start':[\s\S]*?launchDetachedRun\('continue'/, `${label}: background should acknowledge detached continuation starts`);
+    assert.match(background, /await beginContinuationRunUiSnapshot\(tabId, msg\.requestId\)/, `${label}: resumed continuations should preserve their journal sequence`);
     assert.match(background, /startingRequestId: starting\?\.requestId \|\| null/, `${label}: run probes should expose in-flight start reservations`);
     assert.match(background, /detachedRunFailures/, `${label}: detached task failures should remain queryable by request ID`);
     assert.match(background, /detachedError,/, `${label}: run probes should return the original detached task failure`);


### PR DESCRIPTION
## Summary

- start sidebar agent runs through a detached request-ID protocol and poll the persisted run journal for completion
- replay missed UI and plan events after a runtime disconnect, then resume a persisted non-terminal conversation when the background has restarted
- persist the submitted user turn and request identity atomically; if a restart happens earlier, replay the complete original chat payload instead of continuing an older conversation
- preserve the existing journal sequence and replay boundaries when a restarted run resumes with the same request identity
- make plan decisions reconnectable and idempotent so a lost response channel does not reject or duplicate an approval
- preserve detached preflight errors so run-capture failures still trigger the sidebar's prompt and attachment rollback path
- disable uncertain-start retries as soon as the same live request is observed, preventing duplicate page actions after a later state gap
- persist Stop as a request-scoped recovery cancellation and consult it before both journal resume and uncertain-start retry
- treat session-storage quota failures as loss of restart durability rather than a fatal chat error
- keep reserved detached starts in the active UI state so the composer stays locked and Stop remains available
- scope reconnect journal snapshots to the requested run so a new start cannot replay an older terminal run
- fail closed when a restarted background has lost an awaiting-plan approval waiter
- retry an acknowledged start only when no live run, journal, durable turn, or prior live observation proves delivery
- fail closed instead of replaying a non-durable chat after live or journaled progress
- carry Stop cancellation through detached reservation, capture/setup, and the final pre-LLM boundary
- preserve explicit user cancellation, add active-run keepalives, and keep the Firefox background page persistent
- mirror the implementation and regression coverage across Chrome and Firefox

## Root cause

The sidebar held one long-lived runtime message open for the entire agent run. When the extension background context or message channel restarted, the sidebar treated the lost response as terminal even though the run could still be active. Plan approval used another one-shot message, so an approval could reach the background while its response was lost and the UI would incorrectly report failure.

Detached task exceptions also had no recoverable response path after the initial start acknowledgement. In particular, a run-capture preflight failure cleared its UI journal and was reduced to a generic missing-state error before it reached the sidebar's capture-specific recovery logic. An uncertain start also remained retryable after its live request had been observed, which could duplicate the original request if state later disappeared temporarily. Automatic continuation reused the original request identity while resetting its journal sequence, causing resumed events to be discarded by the sidebar's sequence dedupe. A restart could also occur after the run journal was created but before the submitted user turn was durable, so recovery could issue `continue_start` without the original text, attachments, capture options, or per-turn flags. Finally, the Stop UI timeout cleared its tab flag without retaining request-scoped cancellation, uncertain-start retry did not consult that cancellation, and the first durable-turn implementation made storage quota failures fatal to otherwise valid chats.

## User impact

Transient extension/background disconnects now show reconnecting state, recover missed progress, and continue the same run where possible. Resumed progress and final output remain visible because event sequence numbers continue above the pre-restart boundary. If the original user turn was not yet durably recorded, recovery replays the complete request payload; once it is durable, recovery safely continues the existing conversation. Plan approvals are checked against durable journal state before retrying, while Cancel, Change, and Stop decisions do not trigger automatic resume or start retry. Run-capture preflight failures retain their original error and restore the optimistic prompt and attachments for retry. Once a live request confirms uncertain delivery, the original start is never retried. If session storage cannot persist a large conversation, the live chat still runs normally and only cross-restart recovery durability is unavailable.

## Validation

- `node test/run.js`: 1039 passed; 1 pre-existing repository baseline failure remains because package version 25.1.1 does not match the newest CHANGELOG entry 25.0.0
- `npm run test:security`: 60/60 checks passed
- `node --check` on all changed JavaScript files
- Chrome/Firefox reconnect and journal modules are byte-identical
- `git diff --check`