### PR TITLE
Fix sidepanel auto-scroll lag during streaming

### DIFF
--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -6892,9 +6892,29 @@ function hideActivity() {
   hideInspectionBanner();
 }
 
+let scrollToBottomFrame = null;
+
+function pinChatToBottom(container) {
+  // The chat container uses smooth scrolling for user-visible navigation.
+  // During streaming, though, repeatedly assigning scrollTop while that
+  // animation is still running makes the viewport lag behind the growing
+  // conversation. Temporarily bypass smooth behavior for auto-follow.
+  const previousScrollBehavior = container.style.scrollBehavior;
+  container.style.scrollBehavior = 'auto';
+  container.scrollTop = container.scrollHeight;
+  container.style.scrollBehavior = previousScrollBehavior;
+}
+
 function scrollToBottom() {
   const container = document.getElementById('chat-container');
-  container.scrollTop = container.scrollHeight;
+  if (!container) return;
+
+  pinChatToBottom(container);
+  if (scrollToBottomFrame != null) cancelAnimationFrame(scrollToBottomFrame);
+  scrollToBottomFrame = requestAnimationFrame(() => {
+    scrollToBottomFrame = null;
+    if (container.isConnected) pinChatToBottom(container);
+  });
 }
 
 // Debounce math rendering so streaming updates don't re-walk the DOM

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -6534,9 +6534,29 @@ function hideActivity() {
   hideInspectionBanner();
 }
 
+let scrollToBottomFrame = null;
+
+function pinChatToBottom(container) {
+  // The chat container uses smooth scrolling for user-visible navigation.
+  // During streaming, though, repeatedly assigning scrollTop while that
+  // animation is still running makes the viewport lag behind the growing
+  // conversation. Temporarily bypass smooth behavior for auto-follow.
+  const previousScrollBehavior = container.style.scrollBehavior;
+  container.style.scrollBehavior = 'auto';
+  container.scrollTop = container.scrollHeight;
+  container.style.scrollBehavior = previousScrollBehavior;
+}
+
 function scrollToBottom() {
   const container = document.getElementById('chat-container');
-  container.scrollTop = container.scrollHeight;
+  if (!container) return;
+
+  pinChatToBottom(container);
+  if (scrollToBottomFrame != null) cancelAnimationFrame(scrollToBottomFrame);
+  scrollToBottomFrame = requestAnimationFrame(() => {
+    scrollToBottomFrame = null;
+    if (container.isConnected) pinChatToBottom(container);
+  });
 }
 
 // Debounce math rendering so streaming updates don't re-walk the DOM

--- a/test/run.js
+++ b/test/run.js
@@ -14173,6 +14173,25 @@ test('context-menu prompt recovery does not duplicate an in-flight send', async 
   }
 });
 
+test('sidepanel auto-follow bypasses smooth-scroll lag while messages grow', () => {
+  for (const [label, prefix] of [
+    ['chrome', 'src/chrome'],
+    ['firefox', 'src/firefox'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/sidepanel.js'), 'utf8');
+    assert.match(
+      panel,
+      /function pinChatToBottom\(container\) \{[\s\S]*?container\.style\.scrollBehavior = 'auto';[\s\S]*?container\.scrollTop = container\.scrollHeight;[\s\S]*?container\.style\.scrollBehavior = previousScrollBehavior;[\s\S]*?\}/,
+      `${label}: streaming auto-follow should bypass the container's smooth-scroll animation`,
+    );
+    assert.match(
+      panel,
+      /function scrollToBottom\(\) \{[\s\S]*?pinChatToBottom\(container\);[\s\S]*?requestAnimationFrame\(\(\) => \{[\s\S]*?pinChatToBottom\(container\);[\s\S]*?\}\);[\s\S]*?\}/,
+      `${label}: auto-follow should re-pin after the next layout frame`,
+    );
+  }
+});
+
 test('context-menu deferred prompts dispatch one at a time', async () => {
   for (const [label, createHandler] of [
     ['chrome', createContextMenuPromptHandlerCh],


### PR DESCRIPTION
## What changed

- make programmatic sidepanel auto-follow temporarily bypass CSS smooth scrolling
- re-pin the chat to the bottom on the next animation frame to cover layout growth
- mirror the fix across Chrome and Firefox
- add regression coverage for the streaming auto-follow behavior

## Why

The chat container uses smooth scrolling while streaming updates repeatedly assign `scrollTop`. Each new token can retarget the in-progress animation, leaving the viewport behind the newest selection-shortcut turn. That makes a successful request appear not to have started and can prompt the user to submit it again, producing a second similar conversation turn.

## Validation

- Chromium DOM measurement: prior behavior stayed at `0/3980` immediately after auto-scroll; the fixed helper reaches `3980/3980` immediately and after the next frame
- `node test/run.js`: 1015 passed, 1 unrelated pre-existing release-hygiene failure (`package.json` 25.1.1 vs newest CHANGELOG entry 25.0.0)
- `git diff --check`
