### PR TITLE
fix: catch navigation ping-pong loops and keep post-batch screenshots on early interrupts

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -944,11 +944,14 @@ export class Agent {
       && next.pageUrl
       && this._normalizeUrl(previous.pageUrl) !== this._normalizeUrl(next.pageUrl)
     );
-    // Refs, text targets, and coordinates belong to the observed document and
-    // route. Once either changes, old failures cannot describe the new page.
-    // Revisits of a recently seen URL keep their state, or a navigation
-    // ping-pong would launder its loop counters through every tree read.
-    if ((documentChanged || routeChanged) && !this._isRecentNavUrl(tabId, next.pageUrl)) {
+    // A same-route document replacement always invalidates old failures, even
+    // when that URL was visited recently. URL recency only exempts route
+    // changes: a navigation ping-pong must keep its cross-route call buffer
+    // through tree reads so it cannot launder the loop counters on every hop.
+    if (
+      (documentChanged && !routeChanged)
+      || (routeChanged && !this._isRecentNavUrl(tabId, next.pageUrl))
+    ) {
       this._clearLoopState(tabId);
     }
     this._lastAxScopes.set(tabId, next);

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -197,6 +197,9 @@ export class Agent {
     this.loopNudges = new Map();  // tabId -> consecutive-nudge counter
     this.healthyCallsSinceLoop = new Map(); // tabId -> count of clean calls since last nudge
     this.failedActionLoops = new Map(); // tabId -> Map(stable failure scope -> count)
+    // Last few normalized URLs each tab arrived at. Deliberately NOT cleared
+    // by _clearLoopState: it gates those resets, so it must survive them.
+    this.recentNavUrls = new Map(); // tabId -> [normalized URL, ...]
     // A model can walk ref_1, ref_2, … forever while every call looks unique
     // to the exact-argument loop detector. Track that semantic read pattern.
     this.axReadStates = new Map(); // tabId -> { total, suspicious, nextPage, seenPages, warned }
@@ -943,8 +946,34 @@ export class Agent {
     );
     // Refs, text targets, and coordinates belong to the observed document and
     // route. Once either changes, old failures cannot describe the new page.
-    if (documentChanged || routeChanged) this._clearLoopState(tabId);
+    // Revisits of a recently seen URL keep their state, or a navigation
+    // ping-pong would launder its loop counters through every tree read.
+    if ((documentChanged || routeChanged) && !this._isRecentNavUrl(tabId, next.pageUrl)) {
+      this._clearLoopState(tabId);
+    }
     this._lastAxScopes.set(tabId, next);
+  }
+
+  /**
+   * Record that `tabId` arrived at `url` and report whether that URL was
+   * already seen in the last few arrivals. A first visit is page-state
+   * progress and justifies resetting loop counters; a quick revisit is the
+   * signature of a navigation loop and must leave them intact.
+   */
+  _noteNavArrival(tabId, url) {
+    const normalized = this._normalizeUrl(url);
+    if (!normalized) return false;
+    const seen = this.recentNavUrls.get(tabId) || [];
+    const revisited = seen.includes(normalized);
+    seen.push(normalized);
+    if (seen.length > 5) seen.shift();
+    this.recentNavUrls.set(tabId, seen);
+    return revisited;
+  }
+
+  _isRecentNavUrl(tabId, url) {
+    const normalized = this._normalizeUrl(url);
+    return !!normalized && (this.recentNavUrls.get(tabId) || []).includes(normalized);
   }
 
   _checkAccessibilityReadLoop(tabId, name, args, result) {
@@ -1838,8 +1867,12 @@ export class Agent {
   _checkLoop(tabId, toolName, toolArgs, toolResult) {
     // A navigation result is authoritative page-state evidence. Clear before
     // recording this call so same-looking controls on the new page start at
-    // attempt one instead of inheriting an old third-strike counter.
-    if (toolResult?.pageUrlChanged === true) this._clearLoopState(tabId);
+    // attempt one instead of inheriting an old third-strike counter. Arriving
+    // back on a recently seen URL is the exception: a click/go_back ping-pong
+    // would otherwise reset the detector on every hop and never be caught.
+    if (toolResult?.pageUrlChanged === true && !this._noteNavArrival(tabId, toolResult.currentUrl)) {
+      this._clearLoopState(tabId);
+    }
     const { buf, key } = this._recordCall(tabId, toolName, toolArgs, toolResult);
     if (this._isBrowserMutationTool(toolName)) {
       const normalizeFailureScope = value => String(value).slice(0, 320);
@@ -2500,6 +2533,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // executing the original plan on a totally different page").
     const navNotices = []; // accumulated for injection after the loop
     const failedApiMutationLoopKeysThisBatch = new Set();
+    // When this returns true, the caller must `navNotices.length = 0; break;`
+    // (not return): the helper already injected the queued synthetic results
+    // and nav notices, and breaking lets the shared post-batch path flush
+    // state_change/every_step auto-screenshots from earlier calls in the batch.
     const interruptFailedBrowserAction = (toolIndex, triggeringTool) => (
       this._isBrowserMutationTool(triggeringTool)
       && this._interruptToolBatchForFreshTurn(
@@ -2538,7 +2575,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           tool_call_id: tc.id,
           content: JSON.stringify({ success: false, denied: true, error }),
         });
-        if (interruptFailedBrowserAction(toolIndex, fnName)) return { action: 'continue' };
+        if (interruptFailedBrowserAction(toolIndex, fnName)) { navNotices.length = 0; break; }
         continue;
       }
       const parsedArgs = this._parseToolCallArgs(tc);
@@ -2559,7 +2596,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             latencyMs: 0,
           });
         }
-        if (interruptFailedBrowserAction(toolIndex, fnName)) return { action: 'continue' };
+        if (interruptFailedBrowserAction(toolIndex, fnName)) { navNotices.length = 0; break; }
         continue;
       }
       const argRepair = this._repairToolCallArgs(fnName, parsedArgs.args);
@@ -2688,7 +2725,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               content: this._wrapUntrusted(fnName, this._limitToolResult(blockedResult)),
             });
             onUpdate('warning', { message: 'Repeat submission blocked until the invalid form changes.' });
-            if (interruptFailedBrowserAction(toolIndex, fnName)) return { action: 'continue' };
+            if (interruptFailedBrowserAction(toolIndex, fnName)) { navNotices.length = 0; break; }
             continue;
           }
         }
@@ -2722,7 +2759,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               }),
             });
             onUpdate('warning', { message: 'Form submission blocked until the user confirms.' });
-            if (interruptFailedBrowserAction(toolIndex, fnName)) return { action: 'continue' };
+            if (interruptFailedBrowserAction(toolIndex, fnName)) { navNotices.length = 0; break; }
             continue;
           }
           // The submit-specific card is fresher and more precise than the
@@ -2808,7 +2845,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               error: `Cannot run ${fnName}: the target frame/host couldn't be identified, so it can't be permission-checked. Pass a urlFilter naming the iframe's domain (read it first with iframe_read / get_accessibility_tree) and retry.`,
             }),
           });
-          if (interruptFailedBrowserAction(toolIndex, fnName)) return { action: 'continue' };
+          if (interruptFailedBrowserAction(toolIndex, fnName)) { navNotices.length = 0; break; }
           continue;
         }
         if (blocked) {
@@ -2821,7 +2858,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               error: `The user denied permission to ${CAPABILITY_LABEL[blocked.capability]} ${blocked.host}. Do NOT retry this action on that site. Continue with what you can without it, or ask the user how to proceed.`,
             }),
           });
-          if (interruptFailedBrowserAction(toolIndex, fnName)) return { action: 'continue' };
+          if (interruptFailedBrowserAction(toolIndex, fnName)) { navNotices.length = 0; break; }
           continue;
         }
       }
@@ -7680,6 +7717,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this._recentSubmitClicks.delete(tabId);
     this._formValidationBlocks.delete(tabId);
     this._lastAxScopes.delete(tabId);
+    this.recentNavUrls.delete(tabId);
     this.completionInvariants.delete(tabId);
     if (!preserveRunGuard) {
       this._runningTabs.delete(tabId);

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -909,7 +909,7 @@ export class Agent {
     return { method, requestShape, failed };
   }
 
-  _clearDocumentLoopState(tabId) {
+  _clearPageLoopState(tabId) {
     this.failedActionLoops.delete(tabId);
     this.axReadStates.delete(tabId);
     this.noProgressScrolls.delete(tabId);
@@ -929,7 +929,7 @@ export class Agent {
     this.recentCalls.delete(tabId);
     this.loopNudges.delete(tabId);
     this.healthyCallsSinceLoop.delete(tabId);
-    this._clearDocumentLoopState(tabId);
+    this._clearPageLoopState(tabId);
   }
 
   _clearRunLoopState(tabId) {
@@ -956,13 +956,13 @@ export class Agent {
     );
     // A same-route replacement or genuinely fresh route invalidates all loop
     // state. On a recent-route revisit, keep only the cross-route call buffer
-    // and nudge history needed to catch navigation ping-pong; a new document
-    // must still discard stale ref, coordinate, scroll, and failure state.
+    // and nudge history needed to catch navigation ping-pong; the destination
+    // page must still discard stale ref, coordinate, scroll, and failure state.
     const revisitingRoute = routeChanged && this._isRecentNavUrl(tabId, next.pageUrl);
     if ((documentChanged || routeChanged) && !revisitingRoute) {
       this._clearLoopState(tabId);
-    } else if (documentChanged) {
-      this._clearDocumentLoopState(tabId);
+    } else if (revisitingRoute) {
+      this._clearPageLoopState(tabId);
     }
     this._lastAxScopes.set(tabId, next);
   }

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -197,8 +197,9 @@ export class Agent {
     this.loopNudges = new Map();  // tabId -> consecutive-nudge counter
     this.healthyCallsSinceLoop = new Map(); // tabId -> count of clean calls since last nudge
     this.failedActionLoops = new Map(); // tabId -> Map(stable failure scope -> count)
-    // Last few normalized URLs each tab arrived at. Deliberately NOT cleared
-    // by _clearLoopState: it gates those resets, so it must survive them.
+    // Last few normalized URLs each tab arrived at during the active run.
+    // Deliberately NOT cleared by _clearLoopState: it gates those intra-run
+    // resets, so it must survive them until the outer run boundary.
     this.recentNavUrls = new Map(); // tabId -> [normalized URL, ...]
     // A model can walk ref_1, ref_2, … forever while every call looks unique
     // to the exact-argument loop detector. Track that semantic read pattern.
@@ -925,6 +926,11 @@ export class Agent {
         this.failedBulkApiReplayShapes.delete(key);
       }
     }
+  }
+
+  _clearRunLoopState(tabId) {
+    this.recentNavUrls.delete(tabId);
+    this._clearLoopState(tabId);
   }
 
   _rememberAxScope(tabId, documentToken, pageUrl = '') {
@@ -7726,7 +7732,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       this._runningTabs.delete(tabId);
       this.currentRunId.delete(tabId);
     }
-    this._clearLoopState(tabId);
+    this._clearRunLoopState(tabId);
   }
 
   clearConversation(tabId) {
@@ -16124,7 +16130,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       throw new Error('An agent run is already in progress for this tab.');
     }
     this._resetActiveSkillsForRun(tabId, { refreshPrompt: false });
-    this._clearLoopState(tabId);
+    this._clearRunLoopState(tabId);
     if (runOptions?.trustedContinuation !== true) this._continuationExecutionEvidence.delete(tabId);
     this._clickAxCdpFallbacks.delete(tabId);
     const completionRunToken = this._beginCompletionInvariant(tabId);
@@ -16145,7 +16151,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         else this.cloudRunContexts.delete(tabId);
       }
       this._runningTabs.delete(tabId);
-      this._clearLoopState(tabId);
+      this._clearRunLoopState(tabId);
       this._clickAxCdpFallbacks.delete(tabId);
       this._clearCompletionInvariant(tabId, completionRunToken);
     }
@@ -16690,7 +16696,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       throw new Error('An agent run is already in progress for this tab.');
     }
     this._resetActiveSkillsForRun(tabId, { refreshPrompt: false });
-    this._clearLoopState(tabId);
+    this._clearRunLoopState(tabId);
     if (runOptions?.trustedContinuation !== true) this._continuationExecutionEvidence.delete(tabId);
     this._clickAxCdpFallbacks.delete(tabId);
     const completionRunToken = this._beginCompletionInvariant(tabId);
@@ -16711,7 +16717,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         else this.cloudRunContexts.delete(tabId);
       }
       this._runningTabs.delete(tabId);
-      this._clearLoopState(tabId);
+      this._clearRunLoopState(tabId);
       this._clickAxCdpFallbacks.delete(tabId);
       this._clearCompletionInvariant(tabId, completionRunToken);
     }

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -909,10 +909,7 @@ export class Agent {
     return { method, requestShape, failed };
   }
 
-  _clearLoopState(tabId) {
-    this.recentCalls.delete(tabId);
-    this.loopNudges.delete(tabId);
-    this.healthyCallsSinceLoop.delete(tabId);
+  _clearDocumentLoopState(tabId) {
     this.failedActionLoops.delete(tabId);
     this.axReadStates.delete(tabId);
     this.noProgressScrolls.delete(tabId);
@@ -926,6 +923,13 @@ export class Agent {
         this.failedBulkApiReplayShapes.delete(key);
       }
     }
+  }
+
+  _clearLoopState(tabId) {
+    this.recentCalls.delete(tabId);
+    this.loopNudges.delete(tabId);
+    this.healthyCallsSinceLoop.delete(tabId);
+    this._clearDocumentLoopState(tabId);
   }
 
   _clearRunLoopState(tabId) {
@@ -950,15 +954,15 @@ export class Agent {
       && next.pageUrl
       && this._normalizeUrl(previous.pageUrl) !== this._normalizeUrl(next.pageUrl)
     );
-    // A same-route document replacement always invalidates old failures, even
-    // when that URL was visited recently. URL recency only exempts route
-    // changes: a navigation ping-pong must keep its cross-route call buffer
-    // through tree reads so it cannot launder the loop counters on every hop.
-    if (
-      (documentChanged && !routeChanged)
-      || (routeChanged && !this._isRecentNavUrl(tabId, next.pageUrl))
-    ) {
+    // A same-route replacement or genuinely fresh route invalidates all loop
+    // state. On a recent-route revisit, keep only the cross-route call buffer
+    // and nudge history needed to catch navigation ping-pong; a new document
+    // must still discard stale ref, coordinate, scroll, and failure state.
+    const revisitingRoute = routeChanged && this._isRecentNavUrl(tabId, next.pageUrl);
+    if ((documentChanged || routeChanged) && !revisitingRoute) {
       this._clearLoopState(tabId);
+    } else if (documentChanged) {
+      this._clearDocumentLoopState(tabId);
     }
     this._lastAxScopes.set(tabId, next);
   }

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -945,11 +945,14 @@ export class Agent {
       && next.pageUrl
       && this._normalizeUrl(previous.pageUrl) !== this._normalizeUrl(next.pageUrl)
     );
-    // Refs, text targets, and coordinates belong to the observed document and
-    // route. Once either changes, old failures cannot describe the new page.
-    // Revisits of a recently seen URL keep their state, or a navigation
-    // ping-pong would launder its loop counters through every tree read.
-    if ((documentChanged || routeChanged) && !this._isRecentNavUrl(tabId, next.pageUrl)) {
+    // A same-route document replacement always invalidates old failures, even
+    // when that URL was visited recently. URL recency only exempts route
+    // changes: a navigation ping-pong must keep its cross-route call buffer
+    // through tree reads so it cannot launder the loop counters on every hop.
+    if (
+      (documentChanged && !routeChanged)
+      || (routeChanged && !this._isRecentNavUrl(tabId, next.pageUrl))
+    ) {
       this._clearLoopState(tabId);
     }
     this._lastAxScopes.set(tabId, next);

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -161,6 +161,9 @@ export class Agent {
     this.loopNudges = new Map();
     this.healthyCallsSinceLoop = new Map();
     this.failedActionLoops = new Map(); // tabId -> Map(stable failure scope -> count)
+    // Last few normalized URLs each tab arrived at. Deliberately NOT cleared
+    // by _clearLoopState: it gates those resets, so it must survive them.
+    this.recentNavUrls = new Map(); // tabId -> [normalized URL, ...]
     this._lastAxScopes = new Map(); // tabId -> { documentToken, pageUrl }, captured by the latest AX read
     // A model can walk ref_1, ref_2, … forever while every call looks unique
     // to the exact-argument loop detector. Track that semantic read pattern.
@@ -944,8 +947,34 @@ export class Agent {
     );
     // Refs, text targets, and coordinates belong to the observed document and
     // route. Once either changes, old failures cannot describe the new page.
-    if (documentChanged || routeChanged) this._clearLoopState(tabId);
+    // Revisits of a recently seen URL keep their state, or a navigation
+    // ping-pong would launder its loop counters through every tree read.
+    if ((documentChanged || routeChanged) && !this._isRecentNavUrl(tabId, next.pageUrl)) {
+      this._clearLoopState(tabId);
+    }
     this._lastAxScopes.set(tabId, next);
+  }
+
+  /**
+   * Record that `tabId` arrived at `url` and report whether that URL was
+   * already seen in the last few arrivals. A first visit is page-state
+   * progress and justifies resetting loop counters; a quick revisit is the
+   * signature of a navigation loop and must leave them intact.
+   */
+  _noteNavArrival(tabId, url) {
+    const normalized = this._normalizeUrl(url);
+    if (!normalized) return false;
+    const seen = this.recentNavUrls.get(tabId) || [];
+    const revisited = seen.includes(normalized);
+    seen.push(normalized);
+    if (seen.length > 5) seen.shift();
+    this.recentNavUrls.set(tabId, seen);
+    return revisited;
+  }
+
+  _isRecentNavUrl(tabId, url) {
+    const normalized = this._normalizeUrl(url);
+    return !!normalized && (this.recentNavUrls.get(tabId) || []).includes(normalized);
   }
 
   _checkAccessibilityReadLoop(tabId, name, args, result) {
@@ -1664,8 +1693,12 @@ export class Agent {
   _checkLoop(tabId, toolName, toolArgs, toolResult) {
     // A navigation result is authoritative page-state evidence. Clear before
     // recording this call so same-looking controls on the new page start at
-    // attempt one instead of inheriting an old third-strike counter.
-    if (toolResult?.pageUrlChanged === true) this._clearLoopState(tabId);
+    // attempt one instead of inheriting an old third-strike counter. Arriving
+    // back on a recently seen URL is the exception: a click/go_back ping-pong
+    // would otherwise reset the detector on every hop and never be caught.
+    if (toolResult?.pageUrlChanged === true && !this._noteNavArrival(tabId, toolResult.currentUrl)) {
+      this._clearLoopState(tabId);
+    }
     const { buf, key } = this._recordCall(tabId, toolName, toolArgs, toolResult);
     if (this._isBrowserMutationTool(toolName)) {
       const normalizeFailureScope = value => String(value).slice(0, 320);
@@ -2163,6 +2196,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const completionBatchStartState = this.completionInvariants.get(tabId) || null;
     const navNotices = [];
     const failedApiMutationLoopKeysThisBatch = new Set();
+    // When this returns true, the caller must `navNotices.length = 0; break;`
+    // (not return): the helper already injected the queued synthetic results
+    // and nav notices, and breaking lets the shared post-batch path flush
+    // state_change/every_step auto-screenshots from earlier calls in the batch.
     const interruptFailedBrowserAction = (toolIndex, triggeringTool) => (
       this._isBrowserMutationTool(triggeringTool)
       && this._interruptToolBatchForFreshTurn(
@@ -2199,7 +2236,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           tool_call_id: tc.id,
           content: JSON.stringify({ success: false, denied: true, error }),
         });
-        if (interruptFailedBrowserAction(toolIndex, fnName)) return { action: 'continue' };
+        if (interruptFailedBrowserAction(toolIndex, fnName)) { navNotices.length = 0; break; }
         continue;
       }
       const parsedArgs = this._parseToolCallArgs(tc);
@@ -2220,7 +2257,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             latencyMs: 0,
           });
         }
-        if (interruptFailedBrowserAction(toolIndex, fnName)) return { action: 'continue' };
+        if (interruptFailedBrowserAction(toolIndex, fnName)) { navNotices.length = 0; break; }
         continue;
       }
       const argRepair = this._repairToolCallArgs(fnName, parsedArgs.args);
@@ -2327,7 +2364,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               content: this._wrapUntrusted(fnName, this._limitToolResult(blockedResult)),
             });
             onUpdate('warning', { message: 'Repeat submission blocked until the invalid form changes.' });
-            if (interruptFailedBrowserAction(toolIndex, fnName)) return { action: 'continue' };
+            if (interruptFailedBrowserAction(toolIndex, fnName)) { navNotices.length = 0; break; }
             continue;
           }
         }
@@ -2361,7 +2398,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               }),
             });
             onUpdate('warning', { message: 'Form submission blocked until the user confirms.' });
-            if (interruptFailedBrowserAction(toolIndex, fnName)) return { action: 'continue' };
+            if (interruptFailedBrowserAction(toolIndex, fnName)) { navNotices.length = 0; break; }
             continue;
           }
           // The submit-specific card is fresher and more precise than the
@@ -2447,7 +2484,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               error: `Cannot run ${fnName}: the target frame/host couldn't be identified, so it can't be permission-checked. Pass a urlFilter naming the iframe's domain (read it first with iframe_read / get_accessibility_tree) and retry.`,
             }),
           });
-          if (interruptFailedBrowserAction(toolIndex, fnName)) return { action: 'continue' };
+          if (interruptFailedBrowserAction(toolIndex, fnName)) { navNotices.length = 0; break; }
           continue;
         }
         if (blocked) {
@@ -2460,7 +2497,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               error: `The user denied permission to ${CAPABILITY_LABEL[blocked.capability]} ${blocked.host}. Do NOT retry this action on that site. Continue with what you can without it, or ask the user how to proceed.`,
             }),
           });
-          if (interruptFailedBrowserAction(toolIndex, fnName)) return { action: 'continue' };
+          if (interruptFailedBrowserAction(toolIndex, fnName)) { navNotices.length = 0; break; }
           continue;
         }
       }
@@ -6802,6 +6839,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this._recentSubmitClicks.delete(tabId);
     this._formValidationBlocks.delete(tabId);
     this._lastAxScopes.delete(tabId);
+    this.recentNavUrls.delete(tabId);
     this.completionInvariants.delete(tabId);
     if (!preserveRunGuard) {
       this._runningTabs.delete(tabId);

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -161,8 +161,9 @@ export class Agent {
     this.loopNudges = new Map();
     this.healthyCallsSinceLoop = new Map();
     this.failedActionLoops = new Map(); // tabId -> Map(stable failure scope -> count)
-    // Last few normalized URLs each tab arrived at. Deliberately NOT cleared
-    // by _clearLoopState: it gates those resets, so it must survive them.
+    // Last few normalized URLs each tab arrived at during the active run.
+    // Deliberately NOT cleared by _clearLoopState: it gates those intra-run
+    // resets, so it must survive them until the outer run boundary.
     this.recentNavUrls = new Map(); // tabId -> [normalized URL, ...]
     this._lastAxScopes = new Map(); // tabId -> { documentToken, pageUrl }, captured by the latest AX read
     // A model can walk ref_1, ref_2, … forever while every call looks unique
@@ -926,6 +927,11 @@ export class Agent {
         this.failedBulkApiReplayShapes.delete(key);
       }
     }
+  }
+
+  _clearRunLoopState(tabId) {
+    this.recentNavUrls.delete(tabId);
+    this._clearLoopState(tabId);
   }
 
   _rememberAxScope(tabId, documentToken, pageUrl = '') {
@@ -6848,7 +6854,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       this._runningTabs.delete(tabId);
       this.currentRunId.delete(tabId);
     }
-    this._clearLoopState(tabId);
+    this._clearRunLoopState(tabId);
   }
 
   // ─── Scratchpad ──────────────────────────────────────────────────────
@@ -11895,7 +11901,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       throw new Error('An agent run is already in progress for this tab.');
     }
     this._resetActiveSkillsForRun(tabId, { refreshPrompt: false });
-    this._clearLoopState(tabId);
+    this._clearRunLoopState(tabId);
     if (runOptions?.trustedContinuation !== true) this._continuationExecutionEvidence.delete(tabId);
     const completionRunToken = this._beginCompletionInvariant(tabId);
     this._runningTabs.add(tabId);
@@ -11915,7 +11921,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         else this.cloudRunContexts.delete(tabId);
       }
       this._runningTabs.delete(tabId);
-      this._clearLoopState(tabId);
+      this._clearRunLoopState(tabId);
       this._clearCompletionInvariant(tabId, completionRunToken);
     }
   }
@@ -12436,7 +12442,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       throw new Error('An agent run is already in progress for this tab.');
     }
     this._resetActiveSkillsForRun(tabId, { refreshPrompt: false });
-    this._clearLoopState(tabId);
+    this._clearRunLoopState(tabId);
     if (runOptions?.trustedContinuation !== true) this._continuationExecutionEvidence.delete(tabId);
     const completionRunToken = this._beginCompletionInvariant(tabId);
     this._runningTabs.add(tabId);
@@ -12456,7 +12462,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         else this.cloudRunContexts.delete(tabId);
       }
       this._runningTabs.delete(tabId);
-      this._clearLoopState(tabId);
+      this._clearRunLoopState(tabId);
       this._clearCompletionInvariant(tabId, completionRunToken);
     }
   }

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -910,7 +910,7 @@ export class Agent {
     return { method, requestShape, failed };
   }
 
-  _clearDocumentLoopState(tabId) {
+  _clearPageLoopState(tabId) {
     this.failedActionLoops.delete(tabId);
     this.axReadStates.delete(tabId);
     this.noProgressScrolls.delete(tabId);
@@ -930,7 +930,7 @@ export class Agent {
     this.recentCalls.delete(tabId);
     this.loopNudges.delete(tabId);
     this.healthyCallsSinceLoop.delete(tabId);
-    this._clearDocumentLoopState(tabId);
+    this._clearPageLoopState(tabId);
   }
 
   _clearRunLoopState(tabId) {
@@ -957,13 +957,13 @@ export class Agent {
     );
     // A same-route replacement or genuinely fresh route invalidates all loop
     // state. On a recent-route revisit, keep only the cross-route call buffer
-    // and nudge history needed to catch navigation ping-pong; a new document
-    // must still discard stale ref, coordinate, scroll, and failure state.
+    // and nudge history needed to catch navigation ping-pong; the destination
+    // page must still discard stale ref, coordinate, scroll, and failure state.
     const revisitingRoute = routeChanged && this._isRecentNavUrl(tabId, next.pageUrl);
     if ((documentChanged || routeChanged) && !revisitingRoute) {
       this._clearLoopState(tabId);
-    } else if (documentChanged) {
-      this._clearDocumentLoopState(tabId);
+    } else if (revisitingRoute) {
+      this._clearPageLoopState(tabId);
     }
     this._lastAxScopes.set(tabId, next);
   }

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -910,10 +910,7 @@ export class Agent {
     return { method, requestShape, failed };
   }
 
-  _clearLoopState(tabId) {
-    this.recentCalls.delete(tabId);
-    this.loopNudges.delete(tabId);
-    this.healthyCallsSinceLoop.delete(tabId);
+  _clearDocumentLoopState(tabId) {
     this.failedActionLoops.delete(tabId);
     this.axReadStates.delete(tabId);
     this.noProgressScrolls.delete(tabId);
@@ -927,6 +924,13 @@ export class Agent {
         this.failedBulkApiReplayShapes.delete(key);
       }
     }
+  }
+
+  _clearLoopState(tabId) {
+    this.recentCalls.delete(tabId);
+    this.loopNudges.delete(tabId);
+    this.healthyCallsSinceLoop.delete(tabId);
+    this._clearDocumentLoopState(tabId);
   }
 
   _clearRunLoopState(tabId) {
@@ -951,15 +955,15 @@ export class Agent {
       && next.pageUrl
       && this._normalizeUrl(previous.pageUrl) !== this._normalizeUrl(next.pageUrl)
     );
-    // A same-route document replacement always invalidates old failures, even
-    // when that URL was visited recently. URL recency only exempts route
-    // changes: a navigation ping-pong must keep its cross-route call buffer
-    // through tree reads so it cannot launder the loop counters on every hop.
-    if (
-      (documentChanged && !routeChanged)
-      || (routeChanged && !this._isRecentNavUrl(tabId, next.pageUrl))
-    ) {
+    // A same-route replacement or genuinely fresh route invalidates all loop
+    // state. On a recent-route revisit, keep only the cross-route call buffer
+    // and nudge history needed to catch navigation ping-pong; a new document
+    // must still discard stale ref, coordinate, scroll, and failure state.
+    const revisitingRoute = routeChanged && this._isRecentNavUrl(tabId, next.pageUrl);
+    if ((documentChanged || routeChanged) && !revisitingRoute) {
       this._clearLoopState(tabId);
+    } else if (documentChanged) {
+      this._clearDocumentLoopState(tabId);
     }
     this._lastAxScopes.set(tabId, next);
   }

--- a/test/run.js
+++ b/test/run.js
@@ -773,6 +773,24 @@ class LoopDetectorShim {
     this.recentCoordClicks = new Map();
     this.axReadStates = new Map();
     this.noProgressScrolls = new Map();
+    this.recentNavUrls = new Map();
+  }
+  _normalizeUrl(url) {
+    if (!url) return '';
+    try {
+      const u = new URL(url);
+      return u.origin + u.pathname + u.search + u.hash;
+    } catch { return url; }
+  }
+  _noteNavArrival(tabId, url) {
+    const normalized = this._normalizeUrl(url);
+    if (!normalized) return false;
+    const seen = this.recentNavUrls.get(tabId) || [];
+    const revisited = seen.includes(normalized);
+    seen.push(normalized);
+    if (seen.length > 5) seen.shift();
+    this.recentNavUrls.set(tabId, seen);
+    return revisited;
   }
   _checkCoordClickLoop(tabId, x, y) {
     const bx = Math.round(x / 5) * 5;
@@ -861,7 +879,7 @@ class LoopDetectorShim {
     return null;
   }
   _checkLoop(tabId, name, args, result) {
-    if (result?.pageUrlChanged === true) {
+    if (result?.pageUrlChanged === true && !this._noteNavArrival(tabId, result.currentUrl)) {
       this.recentCalls.delete(tabId);
       this.loopNudges.delete(tabId);
       this.healthyCallsSinceLoop.delete(tabId);
@@ -3777,6 +3795,51 @@ test('failed action counters reset on navigation and replacement-page evidence',
     assert.equal(agent.failedActionLoops.has(tab), false, `${label}: fresh route retained old failures`);
     assert.equal(agent._checkLoop(tab, 'click', { text: 'Search' }, failure).kind, 'none');
   }
+});
+
+test('revisiting a recent URL keeps loop state so navigation ping-pong is caught', () => {
+  for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+    const agent = new AgentClass({});
+    const tab = label === 'chrome' ? 336 : 337;
+    const arrive = (url) => ({ success: true, pageUrlChanged: true, currentUrl: url });
+    const listUrl = 'https://example.com/list';
+    const itemUrl = 'https://example.com/item/1';
+
+    // First visits are real progress and reset the detector as before.
+    assert.equal(agent._checkLoop(tab, 'click', { text: 'Item 1' }, arrive(itemUrl)).kind, 'none');
+    assert.equal(agent._checkLoop(tab, 'go_back', {}, arrive(listUrl)).kind, 'none');
+    // From here every hop revisits a recent URL, so the call buffer survives
+    // and the click/go_back oscillation is detected instead of laundering the
+    // loop state through pageUrlChanged on every hop.
+    assert.equal(agent._checkLoop(tab, 'click', { text: 'Item 1' }, arrive(itemUrl)).kind, 'none');
+    assert.equal(agent._checkLoop(tab, 'go_back', {}, arrive(listUrl)).kind, 'none');
+    assert.equal(
+      agent._checkLoop(tab, 'click', { text: 'Item 1' }, arrive(itemUrl)).kind,
+      'nudge',
+      `${label}: navigation ping-pong evaded the oscillation detector`,
+    );
+
+    // Tree reads on those revisited routes must not clear the state either.
+    agent._rememberAxScope(tab, 'doc-list', listUrl);
+    agent._rememberAxScope(tab, 'doc-item', itemUrl);
+    assert.equal(agent.recentCalls.has(tab), true, `${label}: AX scope on a revisited route wiped the call buffer`);
+    assert.equal(agent.loopNudges.get(tab), 1, `${label}: AX scope on a revisited route reset the nudge counter`);
+
+    // A genuinely new URL is still authoritative progress evidence.
+    assert.equal(agent._checkLoop(tab, 'navigate', { url: 'https://example.com/item/2' }, arrive('https://example.com/item/2')).kind, 'none');
+    assert.equal(agent.loopNudges.has(tab), false, `${label}: arriving on a fresh URL no longer resets loop state`);
+    assert.equal(agent.recentCalls.get(tab)?.length, 1, `${label}: fresh-URL arrival should leave only the arriving call in the buffer`);
+  }
+
+  // Shim mirror of the same arrival rule.
+  const shim = new LoopDetectorShim();
+  const tab = 338;
+  const arrive = (url) => ({ success: true, pageUrlChanged: true, currentUrl: url });
+  shim._checkLoop(tab, 'click', { text: 'Next' }, arrive('https://example.com/b'));
+  shim._checkLoop(tab, 'go_back', {}, arrive('https://example.com/a'));
+  shim._checkLoop(tab, 'click', { text: 'Next' }, arrive('https://example.com/b'));
+  shim._checkLoop(tab, 'go_back', {}, arrive('https://example.com/a'));
+  assert.equal(shim._checkLoop(tab, 'click', { text: 'Next' }, arrive('https://example.com/b')).kind, 'nudge');
 });
 
 test('errored vs successful do not collapse together', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -3781,15 +3781,18 @@ test('failed action counters reset on navigation and replacement-page evidence',
   for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
     const agent = new AgentClass({});
     const tab = label === 'chrome' ? 334 : 335;
-    agent._rememberAxScope(tab, 'doc-a', 'https://example.com/search');
+    const searchUrl = 'https://example.com/search';
+    agent._noteNavArrival(tab, searchUrl);
+    agent._rememberAxScope(tab, 'doc-a', searchUrl);
     assert.equal(agent._checkLoop(tab, 'click', { text: 'Search' }, failure).kind, 'none');
     assert.equal(agent._checkLoop(tab, 'click', { text: 'Search' }, failure).kind, 'nudge');
 
-    agent._rememberAxScope(tab, 'doc-b', 'https://example.com/search');
+    agent._rememberAxScope(tab, 'doc-b', searchUrl);
     assert.equal(agent.failedActionLoops.has(tab), false, `${label}: replacement document retained old failures`);
+    assert.equal(agent.recentCalls.has(tab), false, `${label}: recent URL suppressed replacement-document reset`);
     assert.equal(agent._checkLoop(tab, 'click', { text: 'Search' }, failure).kind, 'none');
 
-    agent._rememberAxScope(tab, 'doc-b', 'https://example.com/search');
+    agent._rememberAxScope(tab, 'doc-b', searchUrl);
     assert.equal(agent._checkLoop(tab, 'click', { text: 'Search' }, failure).kind, 'nudge', `${label}: unchanged page scope reset failures`);
     agent._rememberAxScope(tab, 'doc-b', 'https://example.com/results#fresh');
     assert.equal(agent.failedActionLoops.has(tab), false, `${label}: fresh route retained old failures`);

--- a/test/run.js
+++ b/test/run.js
@@ -3822,11 +3822,16 @@ test('revisiting a recent URL keeps loop state so navigation ping-pong is caught
       `${label}: navigation ping-pong evaded the oscillation detector`,
     );
 
-    // Tree reads on those revisited routes must not clear the state either.
+    // Tree reads on those revisited routes keep cross-route loop history, but
+    // a new document must still discard its stale target/failure counters.
+    agent.failedActionLoops.set(tab, new Map([['field-value:ref_1', 2]]));
+    agent.recentCoordClicks.set(tab, [{ key: '10,10', ts: Date.now() }]);
     agent._rememberAxScope(tab, 'doc-list', listUrl);
     agent._rememberAxScope(tab, 'doc-item', itemUrl);
     assert.equal(agent.recentCalls.has(tab), true, `${label}: AX scope on a revisited route wiped the call buffer`);
     assert.equal(agent.loopNudges.get(tab), 1, `${label}: AX scope on a revisited route reset the nudge counter`);
+    assert.equal(agent.failedActionLoops.has(tab), false, `${label}: new document retained failed target counters`);
+    assert.equal(agent.recentCoordClicks.has(tab), false, `${label}: new document retained coordinate history`);
 
     // A genuinely new URL is still authoritative progress evidence.
     assert.equal(agent._checkLoop(tab, 'navigate', { url: 'https://example.com/item/2' }, arrive('https://example.com/item/2')).kind, 'none');

--- a/test/run.js
+++ b/test/run.js
@@ -3845,6 +3845,43 @@ test('revisiting a recent URL keeps loop state so navigation ping-pong is caught
   assert.equal(shim._checkLoop(tab, 'click', { text: 'Next' }, arrive('https://example.com/b')).kind, 'nudge');
 });
 
+test('navigation arrival history survives intra-run resets but clears at run boundaries', () => {
+  const failure = {
+    success: false,
+    failureScope: 'ambiguous-click:search',
+    error: 'Ambiguous text match for "Search"',
+  };
+
+  for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+    const agent = new AgentClass({});
+    const tab = label === 'chrome' ? 339 : 340;
+    const oldRunUrl = 'https://example.com/from-old-run';
+
+    agent._noteNavArrival(tab, oldRunUrl);
+    agent._clearLoopState(tab);
+    assert.equal(agent.recentNavUrls.has(tab), true, `${label}: intra-run reset lost navigation history`);
+
+    agent._clearRunLoopState(tab);
+    assert.equal(agent.recentNavUrls.has(tab), false, `${label}: run boundary retained navigation history`);
+
+    assert.equal(agent._checkLoop(tab, 'click', { text: 'Search' }, failure).kind, 'none');
+    assert.equal(agent._checkLoop(tab, 'click', { text: 'Search' }, failure).kind, 'nudge');
+    assert.equal(agent._checkLoop(tab, 'navigate', { url: oldRunUrl }, {
+      success: true,
+      pageUrlChanged: true,
+      currentUrl: oldRunUrl,
+    }).kind, 'none');
+    assert.equal(agent.failedActionLoops.has(tab), false, `${label}: old-run URL suppressed navigation reset`);
+
+    const source = fs.readFileSync(path.join(ROOT, `src/${label}/src/agent/agent.js`), 'utf8');
+    assert.equal(
+      (source.match(/this\._clearRunLoopState\(tabId\);/g) || []).length,
+      5,
+      `${label}: navigation cleanup is not wired to both run paths and tab cleanup`,
+    );
+  }
+});
+
 test('errored vs successful do not collapse together', () => {
   // Two successes + one failure of the same call should NOT trigger.
   const d = new LoopDetectorShim();

--- a/test/run.js
+++ b/test/run.js
@@ -3823,7 +3823,7 @@ test('revisiting a recent URL keeps loop state so navigation ping-pong is caught
     );
 
     // Tree reads on those revisited routes keep cross-route loop history, but
-    // a new document must still discard its stale target/failure counters.
+    // each destination page must still discard stale target/failure counters.
     agent.failedActionLoops.set(tab, new Map([['field-value:ref_1', 2]]));
     agent.recentCoordClicks.set(tab, [{ key: '10,10', ts: Date.now() }]);
     agent._rememberAxScope(tab, 'doc-list', listUrl);
@@ -3832,6 +3832,14 @@ test('revisiting a recent URL keeps loop state so navigation ping-pong is caught
     assert.equal(agent.loopNudges.get(tab), 1, `${label}: AX scope on a revisited route reset the nudge counter`);
     assert.equal(agent.failedActionLoops.has(tab), false, `${label}: new document retained failed target counters`);
     assert.equal(agent.recentCoordClicks.has(tab), false, `${label}: new document retained coordinate history`);
+
+    agent.failedActionLoops.set(tab, new Map([['field-value:ref_2', 2]]));
+    agent.recentCoordClicks.set(tab, [{ key: '20,20', ts: Date.now() }]);
+    agent._rememberAxScope(tab, 'doc-item', listUrl);
+    assert.equal(agent.recentCalls.has(tab), true, `${label}: same-document route revisit wiped the call buffer`);
+    assert.equal(agent.loopNudges.get(tab), 1, `${label}: same-document route revisit reset the nudge counter`);
+    assert.equal(agent.failedActionLoops.has(tab), false, `${label}: same-document route revisit retained failed target counters`);
+    assert.equal(agent.recentCoordClicks.has(tab), false, `${label}: same-document route revisit retained coordinate history`);
 
     // A genuinely new URL is still authoritative progress evidence.
     assert.equal(agent._checkLoop(tab, 'navigate', { url: 'https://example.com/item/2' }, arrive('https://example.com/item/2')).kind, 'none');


### PR DESCRIPTION
## Summary

Two fixes from a bug scan of the recent loop-detection / batch-interrupt work, mirrored in Chrome and Firefox.

### 1. Navigation ping-pong evaded the loop detector

`_checkLoop` cleared **all** loop state whenever `pageUrlChanged === true`, so a `click → go_back → click` ping-pong reset the detector on every hop and could never be caught — only step/cost caps bounded the run.

Now each tab tracks its last 5 normalized arrival URLs (`recentNavUrls`, deliberately outside `_clearLoopState` since it gates those resets):

- **First visit** to a URL still clears loop state — real progress, unchanged behavior.
- **Revisit** of a recently seen URL keeps the call buffer, so the existing ABAB oscillation detector fires on the ping-pong.
- The same revisit guard applies to `_rememberAxScope`, otherwise interleaved `get_accessibility_tree` reads would launder the counters through the route-change reset.
- Results carrying `pageUrlChanged` without `currentUrl` fall back to the old clear-always behavior, so existing tests/behavior are unaffected.

### 2. Early batch interrupts skipped the post-batch screenshot flush

The six pre-execution failure sites in `_executeToolBatch` (denied permission, unparseable args, blocked/unconfirmed submit, iframe permission) returned `{ action: 'continue' }` directly after `_interruptToolBatchForFreshTurn`, skipping the shared post-batch path. A successful state change made by an earlier call in the same batch then lost its auto-screenshot. They now use the same `navNotices.length = 0; break;` pattern the post-execution fresh-turn path already documents, so `state_change`/`every_step` screenshots still reach the fresh turn.

### Withdrawn during review

A successful coordinate click intentionally does **not** retire `ambiguous-click` counters — the existing test `ambiguous click failure scope survives unrelated actions` asserts this by design, so no change was made there.

## Tests

- `LoopDetectorShim` in `test/run.js` kept in sync with the new arrival rule (per its keep-in-sync contract).
- New regression test covers the real `Agent` classes (Chrome + Firefox) and the shim: ping-pong now nudges, tree reads on revisited routes keep state, and fresh URLs still reset.
- `node test/run.js`: **1088 passed, 0 failed**; injection corpus: **60/60**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)