### PR TITLE
Randomize WebBrain social promotion actions

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2285,7 +2285,7 @@ export class Agent {
   static EXECUTION_APP_STATE_WRITE_TOOLS = new Set(['scratchpad_write', 'progress_update']);
   static DELIVERY_OBSERVATION_TOOLS = new Set(['read_page', 'get_accessibility_tree', 'get_interactive_elements', 'extract_data', 'get_selection', 'scroll', 'wait_for_stable', 'wait_for_element', 'read_pdf', 'fetch_url', 'research_url', 'read_downloaded_file', 'iframe_read', 'get_window_info', 'list_downloads', 'progress_read', 'screenshot', 'get_frames', 'get_shadow_dom', 'shadow_dom_query', 'read_youtube_transcript']);
   static NAV_PRONE_TOOLS = new Set(['click', 'click_ax', 'set_checked', 'navigate', 'go_back', 'go_forward', 'execute_js', 'iframe_click', 'execute_webmcp_tool']);
-  static RECOMMENDED_ACTION_FAST_PATH_IDS = new Set(['download-media', 'tweet-webbrain']);
+  static RECOMMENDED_ACTION_FAST_PATH_IDS = new Set(['download-media', 'tweet-webbrain', 'post-webbrain-linkedin']);
   static RECOMMENDED_ACTION_FIRST_TOOLS = Object.freeze({
     'download-media': new Set(['screenshot']),
     'summarize-page': new Set(['read_page']),
@@ -5696,9 +5696,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (tool !== 'download_public_media') return null;
       if (!this._skillToolForName(tool)) return null;
     }
-    if (id === 'tweet-webbrain' && tool !== 'navigate') return null;
+    if (['tweet-webbrain', 'post-webbrain-linkedin'].includes(id) && tool !== 'navigate') return null;
     const summary = sanitizePlannerText(action.summary || 'Run the selected recommended action.', 500, { collapseWhitespace: true });
-    const stepLimit = id === 'tweet-webbrain' ? 600 : 300;
+    const stepLimit = ['tweet-webbrain', 'post-webbrain-linkedin'].includes(id) ? 600 : 300;
     const steps = Array.isArray(action.steps)
       ? action.steps.map(step => sanitizePlannerText(step, stepLimit, { collapseWhitespace: true })).filter(Boolean).slice(0, 5)
       : [];

--- a/src/chrome/src/ui/locales/ar.js
+++ b/src/chrome/src/ui/locales/ar.js
@@ -461,6 +461,8 @@ export default {
   'sp.recommended.tweet.label': 'انشر عن WebBrain',
   'sp.recommended.tweet.prompt': 'انشر هذا النص كما هو عبر واجهة X المرئية دون تغييره: «{post}» ثم تحقّق من نشره وأبلغ عن رابطه.',
   'sp.recommended.tweet.text': 'تعرّف على WebBrain — وكيل متصفح بالذكاء الاصطناعي مفتوح المصدر يعمل داخل متصفحك. تحدّث مع أي صفحة، وأتمت سير العمل متعدد الخطوات، واستخدم نموذج LLM الخاص بك. مصمم للتوسعة. جرّبه: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'انشر عن WebBrain على LinkedIn',
+  'sp.recommended.linkedin.prompt': 'انشر هذا النص كما هو عبر واجهة LinkedIn المرئية دون تغييره: «{post}» ثم تحقّق من نشره وأبلغ عن رابطه.',
   'sp.review.rating_title': 'هل تستمتع بـ WebBrain؟',
   'sp.review.rating_body': 'اضغط على نجمة — فهذا يساعدنا على معرفة أدائنا.',
   'sp.review.stars_label': 'قيّم WebBrain',

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -136,6 +136,8 @@ export default {
   'sp.recommended.tweet.label': 'Tweet about WebBrain',
   'sp.recommended.tweet.prompt': 'Publish this exact text through the visible X interface without changing it: “{post}” Then verify it was posted and report its URL.',
   'sp.recommended.tweet.text': 'Introducing WebBrain — an open-source AI browser agent that lives in your browser. Chat with any page, automate multi-step workflows, and bring your own LLM. Extensible by design. Try it: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Post about WebBrain',
+  'sp.recommended.linkedin.prompt': 'Publish this exact text through the visible LinkedIn interface without changing it: “{post}” Then verify it was posted and report its URL.',
 
   'sp.review.rating_title': 'Enjoying WebBrain?',
   'sp.review.rating_body': 'Tap a star — it helps us know how we\'re doing.',

--- a/src/chrome/src/ui/locales/es.js
+++ b/src/chrome/src/ui/locales/es.js
@@ -461,6 +461,8 @@ export default {
   'sp.recommended.tweet.label': 'Publicar sobre WebBrain',
   'sp.recommended.tweet.prompt': 'Publica este texto exacto mediante la interfaz visible de X sin modificarlo: «{post}». Después, verifica la publicación e informa de su URL.',
   'sp.recommended.tweet.text': 'Presentamos WebBrain — un agente de navegador con IA y código abierto que vive en tu navegador. Conversa con cualquier página, automatiza flujos de trabajo de varios pasos y usa tu propio LLM. Extensible por diseño. Pruébalo: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Publicar sobre WebBrain en LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Publica este texto exacto mediante la interfaz visible de LinkedIn sin modificarlo: «{post}». Después, verifica la publicación e informa de su URL.',
   'sp.review.rating_title': '¿Te gusta WebBrain?',
   'sp.review.rating_body': 'Toca una estrella: nos ayuda a saber cómo lo estamos haciendo.',
   'sp.review.stars_label': 'Calificar WebBrain',

--- a/src/chrome/src/ui/locales/fr.js
+++ b/src/chrome/src/ui/locales/fr.js
@@ -461,6 +461,8 @@ export default {
   'sp.recommended.tweet.label': 'Publier à propos de WebBrain',
   'sp.recommended.tweet.prompt': 'Publiez ce texte exact dans l’interface visible de X sans le modifier : « {post} » Vérifiez ensuite sa publication et indiquez son URL.',
   'sp.recommended.tweet.text': 'Découvrez WebBrain — un agent de navigateur IA open source intégré à votre navigateur. Discutez avec n’importe quelle page, automatisez des workflows en plusieurs étapes et utilisez votre propre LLM. Extensible par conception. Essayez-le : https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Publier sur WebBrain sur LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Publiez ce texte exact dans l’interface visible de LinkedIn sans le modifier : « {post} » Vérifiez ensuite sa publication et indiquez son URL.',
   'sp.review.rating_title': 'Vous aimez WebBrain ?',
   'sp.review.rating_body': 'Sélectionnez une étoile : cela nous aide à savoir comment nous nous en sortons.',
   'sp.review.stars_label': 'Noter WebBrain',

--- a/src/chrome/src/ui/locales/he.js
+++ b/src/chrome/src/ui/locales/he.js
@@ -128,6 +128,8 @@ export default {
   "sp.recommended.tweet.label": "פרסום על WebBrain",
   "sp.recommended.tweet.prompt": "פרסם את הטקסט הזה בדיוק דרך ממשק X הגלוי, ללא שינויים: „{post}” לאחר מכן ודא שהוא פורסם ודווח על כתובת ה-URL שלו.",
   "sp.recommended.tweet.text": "הכירו את WebBrain — סוכן דפדפן AI בקוד פתוח שפועל בדפדפן שלכם. שוחחו עם כל דף, הפכו תהליכים מרובי שלבים לאוטומטיים והשתמשו ב-LLM משלכם. תוכנן להרחבה. נסו: https://webbrain.one",
+  "sp.recommended.linkedin.label": "פרסום על WebBrain בלינקדאין",
+  "sp.recommended.linkedin.prompt": "פרסם את הטקסט הזה בדיוק דרך ממשק LinkedIn הגלוי, ללא שינויים: „{post}” לאחר מכן ודא שהוא פורסם ודווח על כתובת ה-URL שלו.",
   "sp.review.rating_title": "נהנים מ-WebBrain?",
   "sp.review.rating_body": "בחרו כוכב — כך נדע איך אנחנו מתפקדים.",
   "sp.review.stars_label": "דירוג WebBrain",

--- a/src/chrome/src/ui/locales/id.js
+++ b/src/chrome/src/ui/locales/id.js
@@ -461,6 +461,8 @@ export default {
   'sp.recommended.tweet.label': 'Posting tentang WebBrain',
   'sp.recommended.tweet.prompt': 'Publikasikan teks persis ini melalui antarmuka X yang terlihat tanpa mengubahnya: “{post}” Setelah itu, pastikan postingan terbit dan laporkan URL-nya.',
   'sp.recommended.tweet.text': 'Kenalkan WebBrain — agen browser AI sumber terbuka yang bekerja di browser Anda. Mengobrol dengan halaman apa pun, mengotomatiskan alur kerja bertahap, dan menggunakan LLM pilihan Anda. Dirancang agar dapat diperluas. Coba: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Posting tentang WebBrain di LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Publikasikan teks persis ini melalui antarmuka LinkedIn yang terlihat tanpa mengubahnya: “{post}” Setelah itu, pastikan postingan terbit dan laporkan URL-nya.',
   'sp.review.rating_title': 'Suka dengan WebBrain?',
   'sp.review.rating_body': 'Pilih satu bintang — ini membantu kami mengetahui kinerja kami.',
   'sp.review.stars_label': 'Beri rating WebBrain',

--- a/src/chrome/src/ui/locales/ja.js
+++ b/src/chrome/src/ui/locales/ja.js
@@ -461,6 +461,8 @@ export default {
   'sp.recommended.tweet.label': 'WebBrainについて投稿',
   'sp.recommended.tweet.prompt': '次のテキストを変更せず、表示中のX画面からそのまま投稿してください：「{post}」投稿を確認し、URLを報告してください。',
   'sp.recommended.tweet.text': 'WebBrainをご紹介します。ブラウザで動くオープンソースのAIエージェントです。あらゆるページと対話し、複数ステップの作業を自動化し、お好みのLLMを利用できます。拡張性を重視した設計です。今すぐお試しください：https://webbrain.one',
+  'sp.recommended.linkedin.label': 'LinkedInでWebBrainについて投稿',
+  'sp.recommended.linkedin.prompt': '次の文章を変更せず、表示中のLinkedIn画面からそのまま投稿してください：「{post}」投稿を確認し、URLを報告してください。',
   'sp.review.rating_title': 'WebBrain を気に入っていますか？',
   'sp.review.rating_body': '星を選ぶと、改善の参考になります。',
   'sp.review.stars_label': 'WebBrain を評価',

--- a/src/chrome/src/ui/locales/ko.js
+++ b/src/chrome/src/ui/locales/ko.js
@@ -461,6 +461,8 @@ export default {
   'sp.recommended.tweet.label': 'WebBrain 소개 글 게시',
   'sp.recommended.tweet.prompt': '다음 문구를 수정하지 말고 표시된 X 화면에서 그대로 게시하세요. “{post}” 게시 여부를 확인한 뒤 URL을 알려주세요.',
   'sp.recommended.tweet.text': 'WebBrain을 소개합니다. 브라우저에서 작동하는 오픈 소스 AI 에이전트입니다. 모든 페이지와 대화하고, 여러 단계 작업을 자동화하며, 원하는 LLM을 사용하세요. 확장 가능한 설계. 지금 체험하세요: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'LinkedIn에 WebBrain 소개 글 게시',
+  'sp.recommended.linkedin.prompt': '다음 문구를 수정하지 말고 표시된 LinkedIn 화면에서 그대로 게시하세요. “{post}” 게시 여부를 확인한 뒤 URL을 알려주세요.',
   'sp.review.rating_title': 'WebBrain이 마음에 드시나요?',
   'sp.review.rating_body': '별점을 선택해 주세요. 저희가 얼마나 잘하고 있는지 파악하는 데 도움이 됩니다.',
   'sp.review.stars_label': 'WebBrain 평가',

--- a/src/chrome/src/ui/locales/ms.js
+++ b/src/chrome/src/ui/locales/ms.js
@@ -461,6 +461,8 @@ export default {
   'sp.recommended.tweet.label': 'Siarkan tentang WebBrain',
   'sp.recommended.tweet.prompt': 'Siarkan teks tepat ini melalui antara muka X yang kelihatan tanpa mengubahnya: “{post}” Kemudian sahkan siaran diterbitkan dan laporkan URL-nya.',
   'sp.recommended.tweet.text': 'Kenali WebBrain — ejen pelayar AI sumber terbuka yang berfungsi dalam pelayar anda. Berbual dengan mana-mana halaman, automasikan aliran kerja berbilang langkah, dan gunakan LLM pilihan anda. Direka untuk dikembangkan. Cuba: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Siarkan tentang WebBrain di LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Siarkan teks tepat ini melalui antara muka LinkedIn yang kelihatan tanpa mengubahnya: “{post}” Kemudian sahkan siaran diterbitkan dan laporkan URL-nya.',
   'sp.review.rating_title': 'Suka menggunakan WebBrain?',
   'sp.review.rating_body': 'Pilih satu bintang — ini membantu kami mengetahui prestasi kami.',
   'sp.review.stars_label': 'Nilai WebBrain',

--- a/src/chrome/src/ui/locales/pl.js
+++ b/src/chrome/src/ui/locales/pl.js
@@ -97,6 +97,8 @@ export default {
   'sp.recommended.tweet.label': 'Opublikuj o WebBrain',
   'sp.recommended.tweet.prompt': 'Opublikuj dokładnie ten tekst w widocznym interfejsie X, bez żadnych zmian: „{post}” Następnie sprawdź publikację i podaj jej adres URL.',
   'sp.recommended.tweet.text': 'Poznaj WebBrain — otwartoźródłowego agenta AI działającego w przeglądarce. Rozmawiaj z każdą stroną, automatyzuj wieloetapowe zadania i używaj własnego LLM. Zaprojektowany z myślą o rozszerzaniu. Wypróbuj: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Opublikuj o WebBrain na LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Opublikuj dokładnie ten tekst w widocznym interfejsie LinkedIn, bez żadnych zmian: „{post}” Następnie sprawdź publikację i podaj jej adres URL.',
   'sp.review.rating_title': 'Podoba Ci się WebBrain?',
   'sp.review.rating_body': 'Wybierz gwiazdkę — pomoże nam to ocenić, jak nam idzie.',
   'sp.review.stars_label': 'Oceń WebBrain',

--- a/src/chrome/src/ui/locales/ru.js
+++ b/src/chrome/src/ui/locales/ru.js
@@ -461,6 +461,8 @@ export default {
   'sp.recommended.tweet.label': 'Опубликовать о WebBrain',
   'sp.recommended.tweet.prompt': 'Опубликуйте этот текст без изменений через видимый интерфейс X: «{post}» Затем проверьте публикацию и сообщите её URL.',
   'sp.recommended.tweet.text': 'Представляем WebBrain — браузерного ИИ-агента с открытым кодом, работающего прямо в браузере. Общайтесь с любой страницей, автоматизируйте многошаговые процессы и используйте свою LLM. Создан для расширения. Попробуйте: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Опубликовать о WebBrain в LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Опубликуйте этот текст без изменений через видимый интерфейс LinkedIn: «{post}» Затем проверьте публикацию и сообщите её URL.',
   'sp.review.rating_title': 'Нравится WebBrain?',
   'sp.review.rating_body': 'Выберите звезду — это поможет нам понять, как у нас дела.',
   'sp.review.stars_label': 'Оценить WebBrain',

--- a/src/chrome/src/ui/locales/th.js
+++ b/src/chrome/src/ui/locales/th.js
@@ -461,6 +461,8 @@ export default {
   'sp.recommended.tweet.label': 'โพสต์เกี่ยวกับ WebBrain',
   'sp.recommended.tweet.prompt': 'โพสต์ข้อความนี้ตามต้นฉบับผ่านหน้าจอ X ที่มองเห็นโดยไม่แก้ไข: “{post}” จากนั้นตรวจสอบว่าโพสต์แล้วและรายงาน URL',
   'sp.recommended.tweet.text': 'พบกับ WebBrain — เอเจนต์ AI โอเพนซอร์สในเบราว์เซอร์ สนทนากับทุกหน้า ทำงานหลายขั้นตอนอัตโนมัติ และใช้ LLM ของคุณเอง ออกแบบให้ต่อยอดได้ ลองเลย: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'โพสต์เกี่ยวกับ WebBrain บน LinkedIn',
+  'sp.recommended.linkedin.prompt': 'โพสต์ข้อความนี้ตามต้นฉบับผ่านหน้าจอ LinkedIn ที่มองเห็นโดยไม่แก้ไข: “{post}” จากนั้นตรวจสอบว่าโพสต์แล้วและรายงาน URL',
   'sp.review.rating_title': 'ชอบ WebBrain ไหม',
   'sp.review.rating_body': 'เลือกดาวหนึ่งดวง เพื่อช่วยให้เรารู้ว่าเราทำได้ดีแค่ไหน',
   'sp.review.stars_label': 'ให้คะแนน WebBrain',

--- a/src/chrome/src/ui/locales/tl.js
+++ b/src/chrome/src/ui/locales/tl.js
@@ -461,6 +461,8 @@ export default {
   'sp.recommended.tweet.label': 'Mag-post tungkol sa WebBrain',
   'sp.recommended.tweet.prompt': 'I-post ang eksaktong tekstong ito sa nakikitang X interface nang walang pagbabago: “{post}” Pagkatapos, tiyaking na-post ito at iulat ang URL.',
   'sp.recommended.tweet.text': 'Kilalanin ang WebBrain — isang open-source AI browser agent na nasa browser mo. Makipag-chat sa anumang page, i-automate ang multi-step workflows, at gamitin ang sarili mong LLM. Dinisenyong napapalawak. Subukan: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Mag-post tungkol sa WebBrain sa LinkedIn',
+  'sp.recommended.linkedin.prompt': 'I-post ang eksaktong tekstong ito sa nakikitang LinkedIn interface nang walang pagbabago: “{post}” Pagkatapos, tiyaking na-post ito at iulat ang URL.',
   'sp.review.rating_title': 'Nagugustuhan mo ba ang WebBrain?',
   'sp.review.rating_body': 'Pumili ng bituin — nakakatulong ito para malaman namin kung kumusta kami.',
   'sp.review.stars_label': 'I-rate ang WebBrain',

--- a/src/chrome/src/ui/locales/tr.js
+++ b/src/chrome/src/ui/locales/tr.js
@@ -500,6 +500,8 @@ export default {
   'sp.recommended.tweet.label': 'WebBrain hakkında paylaş',
   'sp.recommended.tweet.prompt': 'Bu metni görünür X arayüzünden hiç değiştirmeden aynen paylaş: “{post}” Ardından paylaşımın yayınlandığını doğrula ve URL’sini bildir.',
   'sp.recommended.tweet.text': 'WebBrain ile tanışın — tarayıcınızda çalışan açık kaynaklı bir yapay zekâ tarayıcı ajanı. Her sayfayla sohbet edin, çok adımlı iş akışlarını otomatikleştirin ve kendi LLM’inizi kullanın. Genişletilebilir olarak tasarlandı. Deneyin: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'WebBrain hakkında LinkedIn’de paylaş',
+  'sp.recommended.linkedin.prompt': 'Bu metni görünür LinkedIn arayüzünden hiç değiştirmeden aynen paylaş: “{post}” Ardından paylaşımın yayınlandığını doğrula ve URL’sini bildir.',
   'sp.review.rating_title': 'WebBrain’den memnun musun?',
   'sp.review.rating_body': 'Bir yıldız seç; nasıl gittiğimizi anlamamıza yardımcı olur.',
   'sp.review.stars_label': 'WebBrain’i değerlendir',

--- a/src/chrome/src/ui/locales/uk.js
+++ b/src/chrome/src/ui/locales/uk.js
@@ -461,6 +461,8 @@ export default {
   'sp.recommended.tweet.label': 'Опублікувати про WebBrain',
   'sp.recommended.tweet.prompt': 'Опублікуйте цей текст без змін через видимий інтерфейс X: «{post}» Потім перевірте публікацію та повідомте її URL.',
   'sp.recommended.tweet.text': 'Представляємо WebBrain — браузерного ШІ-агента з відкритим кодом, що працює у вашому браузері. Спілкуйтеся з будь-якою сторінкою, автоматизуйте багатоетапні процеси та використовуйте власну LLM. Створений для розширення. Спробуйте: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Опублікувати про WebBrain у LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Опублікуйте цей текст без змін через видимий інтерфейс LinkedIn: «{post}» Потім перевірте публікацію та повідомте її URL.',
   'sp.review.rating_title': 'Подобається WebBrain?',
   'sp.review.rating_body': 'Виберіть зірку — це допоможе нам зрозуміти, як у нас справи.',
   'sp.review.stars_label': 'Оцінити WebBrain',

--- a/src/chrome/src/ui/locales/zh.js
+++ b/src/chrome/src/ui/locales/zh.js
@@ -461,6 +461,8 @@ export default {
   'sp.recommended.tweet.label': '发布 WebBrain 介绍',
   'sp.recommended.tweet.prompt': '请通过可见的 X 界面原样发布以下文本，不要修改：“{post}”然后确认已发布并报告帖子网址。',
   'sp.recommended.tweet.text': '认识 WebBrain：一款运行在浏览器中的开源 AI 浏览器智能代理。你可以与任意网页对话、自动执行多步骤工作流，并使用自己的 LLM。专为扩展而设计。立即体验：https://webbrain.one',
+  'sp.recommended.linkedin.label': '在 LinkedIn 发布 WebBrain 介绍',
+  'sp.recommended.linkedin.prompt': '请通过可见的 LinkedIn 界面原样发布以下文本，不要修改：“{post}”然后确认已发布并报告帖子网址。',
   'sp.review.rating_title': '喜欢 WebBrain 吗？',
   'sp.review.rating_body': '点选星级，帮助我们了解做得如何。',
   'sp.review.stars_label': '为 WebBrain 评分',

--- a/src/chrome/src/ui/recommended-actions.js
+++ b/src/chrome/src/ui/recommended-actions.js
@@ -153,6 +153,23 @@ function webbrainTweetRunOptions(postText) {
   };
 }
 
+function webbrainLinkedInRunOptions(postText) {
+  const exactPost = String(postText || '').trim();
+  return {
+    id: 'post-webbrain-linkedin',
+    skipPlanner: true,
+    tool: 'navigate',
+    summary: 'Publish the reviewed localized WebBrain post on LinkedIn exactly as supplied.',
+    steps: [
+      'Open https://www.linkedin.com/feed/ in the current tab through the visible browser UI.',
+      'Select Start a post to open LinkedIn\'s visible composer.',
+      `Enter this exact reviewed text without translating, rewriting, or adding anything: ${JSON.stringify(exactPost)}`,
+      'Publish only after the composer text exactly matches the supplied text.',
+      'Verify the new LinkedIn post appears, then report its URL when available.',
+    ],
+  };
+}
+
 function hasCartOrPriceSignal(pageInfo = {}) {
   const haystack = [
     pageInfo.title,
@@ -243,14 +260,23 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
   const path = pathFromUrl(pageInfo.url || '');
   const actions = [];
   const webbrainPostText = t('sp.recommended.tweet.text');
+  const webbrainPromotionVariant = options.webbrainPromotionVariant === 'linkedin' ? 'linkedin' : 'x';
 
-  addUnique(actions, {
-    id: 'tweet-webbrain',
-    label: t('sp.recommended.tweet.label'),
-    prompt: t('sp.recommended.tweet.prompt', { post: webbrainPostText }),
-    mode: 'act',
-    runOptions: webbrainTweetRunOptions(webbrainPostText),
-  });
+  addUnique(actions, webbrainPromotionVariant === 'linkedin'
+    ? {
+      id: 'post-webbrain-linkedin',
+      label: t('sp.recommended.linkedin.label'),
+      prompt: t('sp.recommended.linkedin.prompt', { post: webbrainPostText }),
+      mode: 'act',
+      runOptions: webbrainLinkedInRunOptions(webbrainPostText),
+    }
+    : {
+      id: 'tweet-webbrain',
+      label: t('sp.recommended.tweet.label'),
+      prompt: t('sp.recommended.tweet.prompt', { post: webbrainPostText }),
+      mode: 'act',
+      runOptions: webbrainTweetRunOptions(webbrainPostText),
+    });
 
   if (MEETING_HOST_RE.test(host)) {
     addUnique(actions, {
@@ -419,7 +445,7 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     });
   }
 
-  if (!actions.some((action) => action.id !== 'tweet-webbrain') && pageInfo.title) {
+  if (!actions.some((action) => !['tweet-webbrain', 'post-webbrain-linkedin'].includes(action.id)) && pageInfo.title) {
     const explainUsesArticleRead = isLongArticle(pageInfo);
     addUnique(actions, {
       id: 'explain-page',

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -521,6 +521,7 @@ const storeReviewFeedbackEl = document.getElementById('store-review-feedback');
 const scheduledJobsEl = document.getElementById('scheduled-jobs');
 const stopBtn = document.getElementById('btn-stop');
 const RECOMMENDED_ACTIONS_COLLAPSED_KEY = 'recommendedActionsCollapsed';
+const WEBBRAIN_PROMOTION_ACTION_IDS = new Set(['tweet-webbrain', 'post-webbrain-linkedin']);
 const PLACEHOLDER_ROTATION_INTERVAL_MS = 10_000;
 const ASK_PLACEHOLDER_KEYS = [
   'sp.input.ask_placeholder',
@@ -923,6 +924,7 @@ let providerSelectionRequestId = 0;
 let providerTestRequestId = 0;
 let selectedProviderId = 'webbrain_cloud';
 let recommendedActionsCollapsed = false;
+let webbrainPromotionHasAnimated = false;
 let slashCommandMatches = [];
 let slashCommandSelectedIndex = 0;
 let busySlashNoticeLastShownAt = 0;
@@ -3386,6 +3388,29 @@ function hideRecommendedActions() {
   recommendedActionsEl.classList.add('hidden');
 }
 
+function createWebbrainPromotionIcon(actionId) {
+  const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  icon.classList.add('recommended-action-icon');
+  icon.setAttribute('viewBox', '0 0 24 24');
+  icon.setAttribute('aria-hidden', 'true');
+  icon.setAttribute('focusable', 'false');
+
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', actionId === 'post-webbrain-linkedin'
+    ? 'M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 1 1 0-4.124 2.062 2.062 0 0 1 0 4.124zM7.119 20.452H3.555V9H7.12v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0z'
+    : 'M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z');
+  icon.appendChild(path);
+  return icon;
+}
+
+function animateWebbrainPromotionOnce() {
+  if (webbrainPromotionHasAnimated || recommendedActionsCollapsed) return;
+  const promotionAction = recommendedActionsListEl?.querySelector('.recommended-action-chip-promotion');
+  if (!promotionAction) return;
+  promotionAction.classList.add('recommended-action-chip-promotion-enter');
+  webbrainPromotionHasAnimated = true;
+}
+
 function updateRecommendedActionsCollapsedState() {
   if (!recommendedActionsEl) return;
   recommendedActionsEl.classList.toggle('collapsed', recommendedActionsCollapsed);
@@ -3403,6 +3428,7 @@ function updateRecommendedActionsCollapsedState() {
 function setRecommendedActionsCollapsed(collapsed, { persist = true } = {}) {
   recommendedActionsCollapsed = Boolean(collapsed);
   updateRecommendedActionsCollapsedState();
+  animateWebbrainPromotionOnce();
   if (persist) {
     void chrome.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: recommendedActionsCollapsed }).catch(() => {});
   }
@@ -3448,7 +3474,8 @@ async function refreshRecommendedActions() {
     const pageInfo = await sendToBackground('get_page_info', { tabId });
     if (requestId !== recommendationsRequestId || currentTabId !== tabId || isProcessing) return;
     const sourceUrl = typeof pageInfo?.url === 'string' ? pageInfo.url : '';
-    const actions = buildRecommendedActions(pageInfo, { max: 4 });
+    const webbrainPromotionVariant = Math.random() < 0.5 ? 'linkedin' : 'x';
+    const actions = buildRecommendedActions(pageInfo, { max: 4, webbrainPromotionVariant });
     recommendedActionsListEl.replaceChildren();
     actions.forEach((action) => {
       const actionForClick = sourceUrl ? { ...action, sourceUrl } : action;
@@ -3456,11 +3483,17 @@ async function refreshRecommendedActions() {
       btn.type = 'button';
       btn.className = 'recommended-action-chip';
       btn.textContent = action.label;
+      btn.dataset.actionId = action.id;
+      if (WEBBRAIN_PROMOTION_ACTION_IDS.has(action.id)) {
+        btn.classList.add('recommended-action-chip-promotion');
+        btn.prepend(createWebbrainPromotionIcon(action.id));
+      }
       btn.dataset.prompt = action.prompt;
       btn.addEventListener('click', () => runRecommendedAction(actionForClick));
       recommendedActionsListEl.appendChild(btn);
     });
     recommendedActionsEl.classList.toggle('hidden', actions.length === 0);
+    animateWebbrainPromotionOnce();
   } catch {
     if (requestId === recommendationsRequestId) hideRecommendedActions();
   }

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -16,6 +16,7 @@
   --accent: #6c63ff;
   --accent-hover: #5a52d5;
   --accent-dim: rgba(108, 99, 255, 0.15);
+  --promotion-action-accent: #4db5f9;
   --success: #4caf50;
   --warning: #ff9800;
   --error: #f44336;
@@ -53,6 +54,7 @@
   --accent: #5b52e8;           /* slightly deepened purple for contrast on cream */
   --accent-hover: #4a42c4;
   --accent-dim: rgba(91, 82, 232, 0.12);
+  --promotion-action-accent: #116f9f;
   --success: #2d8866;
   --warning: #b97a00;
   --error: #c5363c;
@@ -1635,6 +1637,56 @@ body {
 
 .recommended-action-chip:active {
   transform: scale(0.98);
+}
+
+.recommended-action-chip-promotion {
+  align-items: center;
+  display: inline-flex;
+  gap: 6px;
+  border-color: color-mix(in srgb, var(--promotion-action-accent) 48%, var(--border));
+  background: color-mix(in srgb, var(--promotion-action-accent) 13%, var(--bg-secondary));
+  color: var(--text-primary);
+  box-shadow: 0 1px 4px color-mix(in srgb, var(--promotion-action-accent) 14%, transparent);
+}
+
+.recommended-action-chip-promotion:hover {
+  border-color: var(--promotion-action-accent);
+  background: color-mix(in srgb, var(--promotion-action-accent) 20%, var(--bg-secondary));
+  box-shadow: 0 3px 12px color-mix(in srgb, var(--promotion-action-accent) 22%, transparent);
+}
+
+.recommended-action-chip-promotion:focus-visible {
+  outline: 2px solid var(--promotion-action-accent);
+  outline-offset: 2px;
+}
+
+.recommended-action-icon {
+  width: 11px;
+  height: 11px;
+  flex: 0 0 auto;
+  fill: currentColor;
+  color: var(--promotion-action-accent);
+}
+
+.recommended-action-chip-promotion-enter {
+  animation: recommended-promotion-action-glow 850ms cubic-bezier(0.2, 0.75, 0.25, 1);
+}
+
+@keyframes recommended-promotion-action-glow {
+  0%, 100% {
+    box-shadow: 0 1px 4px color-mix(in srgb, var(--promotion-action-accent) 14%, transparent);
+  }
+  45% {
+    box-shadow:
+      0 3px 12px color-mix(in srgb, var(--promotion-action-accent) 24%, transparent),
+      0 0 0 5px color-mix(in srgb, var(--promotion-action-accent) 18%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .recommended-action-chip-promotion-enter {
+    animation: none;
+  }
 }
 
 /* Store review prompt (#208) — sticky card at bottom of chat */

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2101,7 +2101,7 @@ export class Agent {
   static EXECUTION_APP_STATE_WRITE_TOOLS = new Set(['scratchpad_write', 'progress_update']);
   static DELIVERY_OBSERVATION_TOOLS = new Set(['read_page', 'get_accessibility_tree', 'get_interactive_elements', 'extract_data', 'get_selection', 'scroll', 'wait_for_stable', 'wait_for_element', 'read_pdf', 'fetch_url', 'research_url', 'read_downloaded_file', 'iframe_read', 'get_window_info', 'list_downloads', 'progress_read', 'screenshot', 'get_frames', 'get_shadow_dom', 'shadow_dom_query', 'read_youtube_transcript']);
   static NAV_PRONE_TOOLS = new Set(['click', 'click_ax', 'set_checked', 'navigate', 'go_back', 'go_forward', 'execute_js', 'iframe_click']);
-  static RECOMMENDED_ACTION_FAST_PATH_IDS = new Set(['download-media', 'tweet-webbrain']);
+  static RECOMMENDED_ACTION_FAST_PATH_IDS = new Set(['download-media', 'tweet-webbrain', 'post-webbrain-linkedin']);
   static RECOMMENDED_ACTION_FIRST_TOOLS = Object.freeze({
     'download-media': new Set(['screenshot']),
     'summarize-page': new Set(['read_page']),
@@ -4866,9 +4866,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (tool !== 'download_public_media') return null;
       if (!this._skillToolForName(tool)) return null;
     }
-    if (id === 'tweet-webbrain' && tool !== 'navigate') return null;
+    if (['tweet-webbrain', 'post-webbrain-linkedin'].includes(id) && tool !== 'navigate') return null;
     const summary = sanitizePlannerText(action.summary || 'Run the selected recommended action.', 500, { collapseWhitespace: true });
-    const stepLimit = id === 'tweet-webbrain' ? 600 : 300;
+    const stepLimit = ['tweet-webbrain', 'post-webbrain-linkedin'].includes(id) ? 600 : 300;
     const steps = Array.isArray(action.steps)
       ? action.steps.map(step => sanitizePlannerText(step, stepLimit, { collapseWhitespace: true })).filter(Boolean).slice(0, 5)
       : [];

--- a/src/firefox/src/ui/locales/ar.js
+++ b/src/firefox/src/ui/locales/ar.js
@@ -452,6 +452,8 @@ export default {
   'sp.recommended.tweet.label': 'انشر عن WebBrain',
   'sp.recommended.tweet.prompt': 'انشر هذا النص كما هو عبر واجهة X المرئية دون تغييره: «{post}» ثم تحقّق من نشره وأبلغ عن رابطه.',
   'sp.recommended.tweet.text': 'تعرّف على WebBrain — وكيل متصفح بالذكاء الاصطناعي مفتوح المصدر يعمل داخل متصفحك. تحدّث مع أي صفحة، وأتمت سير العمل متعدد الخطوات، واستخدم نموذج LLM الخاص بك. مصمم للتوسعة. جرّبه: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'انشر عن WebBrain على LinkedIn',
+  'sp.recommended.linkedin.prompt': 'انشر هذا النص كما هو عبر واجهة LinkedIn المرئية دون تغييره: «{post}» ثم تحقّق من نشره وأبلغ عن رابطه.',
   'sp.review.rating_title': 'هل تستمتع بـ WebBrain؟',
   'sp.review.rating_body': 'اضغط على نجمة — فهذا يساعدنا على معرفة أدائنا.',
   'sp.review.stars_label': 'قيّم WebBrain',

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -136,6 +136,8 @@ export default {
   'sp.recommended.tweet.label': 'Tweet about WebBrain',
   'sp.recommended.tweet.prompt': 'Publish this exact text through the visible X interface without changing it: “{post}” Then verify it was posted and report its URL.',
   'sp.recommended.tweet.text': 'Introducing WebBrain — an open-source AI browser agent that lives in your browser. Chat with any page, automate multi-step workflows, and bring your own LLM. Extensible by design. Try it: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Post about WebBrain',
+  'sp.recommended.linkedin.prompt': 'Publish this exact text through the visible LinkedIn interface without changing it: “{post}” Then verify it was posted and report its URL.',
 
   'sp.review.rating_title': 'Enjoying WebBrain?',
   'sp.review.rating_body': 'Tap a star — it helps us know how we\'re doing.',

--- a/src/firefox/src/ui/locales/es.js
+++ b/src/firefox/src/ui/locales/es.js
@@ -452,6 +452,8 @@ export default {
   'sp.recommended.tweet.label': 'Publicar sobre WebBrain',
   'sp.recommended.tweet.prompt': 'Publica este texto exacto mediante la interfaz visible de X sin modificarlo: «{post}». Después, verifica la publicación e informa de su URL.',
   'sp.recommended.tweet.text': 'Presentamos WebBrain — un agente de navegador con IA y código abierto que vive en tu navegador. Conversa con cualquier página, automatiza flujos de trabajo de varios pasos y usa tu propio LLM. Extensible por diseño. Pruébalo: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Publicar sobre WebBrain en LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Publica este texto exacto mediante la interfaz visible de LinkedIn sin modificarlo: «{post}». Después, verifica la publicación e informa de su URL.',
   'sp.review.rating_title': '¿Te gusta WebBrain?',
   'sp.review.rating_body': 'Toca una estrella: nos ayuda a saber cómo lo estamos haciendo.',
   'sp.review.stars_label': 'Calificar WebBrain',

--- a/src/firefox/src/ui/locales/fr.js
+++ b/src/firefox/src/ui/locales/fr.js
@@ -452,6 +452,8 @@ export default {
   'sp.recommended.tweet.label': 'Publier à propos de WebBrain',
   'sp.recommended.tweet.prompt': 'Publiez ce texte exact dans l’interface visible de X sans le modifier : « {post} » Vérifiez ensuite sa publication et indiquez son URL.',
   'sp.recommended.tweet.text': 'Découvrez WebBrain — un agent de navigateur IA open source intégré à votre navigateur. Discutez avec n’importe quelle page, automatisez des workflows en plusieurs étapes et utilisez votre propre LLM. Extensible par conception. Essayez-le : https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Publier sur WebBrain sur LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Publiez ce texte exact dans l’interface visible de LinkedIn sans le modifier : « {post} » Vérifiez ensuite sa publication et indiquez son URL.',
   'sp.review.rating_title': 'Vous aimez WebBrain ?',
   'sp.review.rating_body': 'Sélectionnez une étoile : cela nous aide à savoir comment nous nous en sortons.',
   'sp.review.stars_label': 'Noter WebBrain',

--- a/src/firefox/src/ui/locales/he.js
+++ b/src/firefox/src/ui/locales/he.js
@@ -128,6 +128,8 @@ export default {
   "sp.recommended.tweet.label": "פרסום על WebBrain",
   "sp.recommended.tweet.prompt": "פרסם את הטקסט הזה בדיוק דרך ממשק X הגלוי, ללא שינויים: „{post}” לאחר מכן ודא שהוא פורסם ודווח על כתובת ה-URL שלו.",
   "sp.recommended.tweet.text": "הכירו את WebBrain — סוכן דפדפן AI בקוד פתוח שפועל בדפדפן שלכם. שוחחו עם כל דף, הפכו תהליכים מרובי שלבים לאוטומטיים והשתמשו ב-LLM משלכם. תוכנן להרחבה. נסו: https://webbrain.one",
+  "sp.recommended.linkedin.label": "פרסום על WebBrain בלינקדאין",
+  "sp.recommended.linkedin.prompt": "פרסם את הטקסט הזה בדיוק דרך ממשק LinkedIn הגלוי, ללא שינויים: „{post}” לאחר מכן ודא שהוא פורסם ודווח על כתובת ה-URL שלו.",
   "sp.review.rating_title": "נהנים מ-WebBrain?",
   "sp.review.rating_body": "בחרו כוכב — כך נדע איך אנחנו מתפקדים.",
   "sp.review.stars_label": "דירוג WebBrain",

--- a/src/firefox/src/ui/locales/id.js
+++ b/src/firefox/src/ui/locales/id.js
@@ -452,6 +452,8 @@ export default {
   'sp.recommended.tweet.label': 'Posting tentang WebBrain',
   'sp.recommended.tweet.prompt': 'Publikasikan teks persis ini melalui antarmuka X yang terlihat tanpa mengubahnya: “{post}” Setelah itu, pastikan postingan terbit dan laporkan URL-nya.',
   'sp.recommended.tweet.text': 'Kenalkan WebBrain — agen browser AI sumber terbuka yang bekerja di browser Anda. Mengobrol dengan halaman apa pun, mengotomatiskan alur kerja bertahap, dan menggunakan LLM pilihan Anda. Dirancang agar dapat diperluas. Coba: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Posting tentang WebBrain di LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Publikasikan teks persis ini melalui antarmuka LinkedIn yang terlihat tanpa mengubahnya: “{post}” Setelah itu, pastikan postingan terbit dan laporkan URL-nya.',
   'sp.review.rating_title': 'Suka dengan WebBrain?',
   'sp.review.rating_body': 'Pilih satu bintang — ini membantu kami mengetahui kinerja kami.',
   'sp.review.stars_label': 'Beri rating WebBrain',

--- a/src/firefox/src/ui/locales/ja.js
+++ b/src/firefox/src/ui/locales/ja.js
@@ -452,6 +452,8 @@ export default {
   'sp.recommended.tweet.label': 'WebBrainについて投稿',
   'sp.recommended.tweet.prompt': '次のテキストを変更せず、表示中のX画面からそのまま投稿してください：「{post}」投稿を確認し、URLを報告してください。',
   'sp.recommended.tweet.text': 'WebBrainをご紹介します。ブラウザで動くオープンソースのAIエージェントです。あらゆるページと対話し、複数ステップの作業を自動化し、お好みのLLMを利用できます。拡張性を重視した設計です。今すぐお試しください：https://webbrain.one',
+  'sp.recommended.linkedin.label': 'LinkedInでWebBrainについて投稿',
+  'sp.recommended.linkedin.prompt': '次の文章を変更せず、表示中のLinkedIn画面からそのまま投稿してください：「{post}」投稿を確認し、URLを報告してください。',
   'sp.review.rating_title': 'WebBrain を気に入っていますか？',
   'sp.review.rating_body': '星を選ぶと、改善の参考になります。',
   'sp.review.stars_label': 'WebBrain を評価',

--- a/src/firefox/src/ui/locales/ko.js
+++ b/src/firefox/src/ui/locales/ko.js
@@ -452,6 +452,8 @@ export default {
   'sp.recommended.tweet.label': 'WebBrain 소개 글 게시',
   'sp.recommended.tweet.prompt': '다음 문구를 수정하지 말고 표시된 X 화면에서 그대로 게시하세요. “{post}” 게시 여부를 확인한 뒤 URL을 알려주세요.',
   'sp.recommended.tweet.text': 'WebBrain을 소개합니다. 브라우저에서 작동하는 오픈 소스 AI 에이전트입니다. 모든 페이지와 대화하고, 여러 단계 작업을 자동화하며, 원하는 LLM을 사용하세요. 확장 가능한 설계. 지금 체험하세요: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'LinkedIn에 WebBrain 소개 글 게시',
+  'sp.recommended.linkedin.prompt': '다음 문구를 수정하지 말고 표시된 LinkedIn 화면에서 그대로 게시하세요. “{post}” 게시 여부를 확인한 뒤 URL을 알려주세요.',
   'sp.review.rating_title': 'WebBrain이 마음에 드시나요?',
   'sp.review.rating_body': '별점을 선택해 주세요. 저희가 얼마나 잘하고 있는지 파악하는 데 도움이 됩니다.',
   'sp.review.stars_label': 'WebBrain 평가',

--- a/src/firefox/src/ui/locales/ms.js
+++ b/src/firefox/src/ui/locales/ms.js
@@ -452,6 +452,8 @@ export default {
   'sp.recommended.tweet.label': 'Siarkan tentang WebBrain',
   'sp.recommended.tweet.prompt': 'Siarkan teks tepat ini melalui antara muka X yang kelihatan tanpa mengubahnya: “{post}” Kemudian sahkan siaran diterbitkan dan laporkan URL-nya.',
   'sp.recommended.tweet.text': 'Kenali WebBrain — ejen pelayar AI sumber terbuka yang berfungsi dalam pelayar anda. Berbual dengan mana-mana halaman, automasikan aliran kerja berbilang langkah, dan gunakan LLM pilihan anda. Direka untuk dikembangkan. Cuba: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Siarkan tentang WebBrain di LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Siarkan teks tepat ini melalui antara muka LinkedIn yang kelihatan tanpa mengubahnya: “{post}” Kemudian sahkan siaran diterbitkan dan laporkan URL-nya.',
   'sp.review.rating_title': 'Suka menggunakan WebBrain?',
   'sp.review.rating_body': 'Pilih satu bintang — ini membantu kami mengetahui prestasi kami.',
   'sp.review.stars_label': 'Nilai WebBrain',

--- a/src/firefox/src/ui/locales/pl.js
+++ b/src/firefox/src/ui/locales/pl.js
@@ -97,6 +97,8 @@ export default {
   'sp.recommended.tweet.label': 'Opublikuj o WebBrain',
   'sp.recommended.tweet.prompt': 'Opublikuj dokładnie ten tekst w widocznym interfejsie X, bez żadnych zmian: „{post}” Następnie sprawdź publikację i podaj jej adres URL.',
   'sp.recommended.tweet.text': 'Poznaj WebBrain — otwartoźródłowego agenta AI działającego w przeglądarce. Rozmawiaj z każdą stroną, automatyzuj wieloetapowe zadania i używaj własnego LLM. Zaprojektowany z myślą o rozszerzaniu. Wypróbuj: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Opublikuj o WebBrain na LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Opublikuj dokładnie ten tekst w widocznym interfejsie LinkedIn, bez żadnych zmian: „{post}” Następnie sprawdź publikację i podaj jej adres URL.',
   'sp.review.rating_title': 'Podoba Ci się WebBrain?',
   'sp.review.rating_body': 'Wybierz gwiazdkę — pomoże nam to ocenić, jak nam idzie.',
   'sp.review.stars_label': 'Oceń WebBrain',

--- a/src/firefox/src/ui/locales/ru.js
+++ b/src/firefox/src/ui/locales/ru.js
@@ -452,6 +452,8 @@ export default {
   'sp.recommended.tweet.label': 'Опубликовать о WebBrain',
   'sp.recommended.tweet.prompt': 'Опубликуйте этот текст без изменений через видимый интерфейс X: «{post}» Затем проверьте публикацию и сообщите её URL.',
   'sp.recommended.tweet.text': 'Представляем WebBrain — браузерного ИИ-агента с открытым кодом, работающего прямо в браузере. Общайтесь с любой страницей, автоматизируйте многошаговые процессы и используйте свою LLM. Создан для расширения. Попробуйте: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Опубликовать о WebBrain в LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Опубликуйте этот текст без изменений через видимый интерфейс LinkedIn: «{post}» Затем проверьте публикацию и сообщите её URL.',
   'sp.review.rating_title': 'Нравится WebBrain?',
   'sp.review.rating_body': 'Выберите звезду — это поможет нам понять, как у нас дела.',
   'sp.review.stars_label': 'Оценить WebBrain',

--- a/src/firefox/src/ui/locales/th.js
+++ b/src/firefox/src/ui/locales/th.js
@@ -452,6 +452,8 @@ export default {
   'sp.recommended.tweet.label': 'โพสต์เกี่ยวกับ WebBrain',
   'sp.recommended.tweet.prompt': 'โพสต์ข้อความนี้ตามต้นฉบับผ่านหน้าจอ X ที่มองเห็นโดยไม่แก้ไข: “{post}” จากนั้นตรวจสอบว่าโพสต์แล้วและรายงาน URL',
   'sp.recommended.tweet.text': 'พบกับ WebBrain — เอเจนต์ AI โอเพนซอร์สในเบราว์เซอร์ สนทนากับทุกหน้า ทำงานหลายขั้นตอนอัตโนมัติ และใช้ LLM ของคุณเอง ออกแบบให้ต่อยอดได้ ลองเลย: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'โพสต์เกี่ยวกับ WebBrain บน LinkedIn',
+  'sp.recommended.linkedin.prompt': 'โพสต์ข้อความนี้ตามต้นฉบับผ่านหน้าจอ LinkedIn ที่มองเห็นโดยไม่แก้ไข: “{post}” จากนั้นตรวจสอบว่าโพสต์แล้วและรายงาน URL',
   'sp.review.rating_title': 'ชอบ WebBrain ไหม',
   'sp.review.rating_body': 'เลือกดาวหนึ่งดวง เพื่อช่วยให้เรารู้ว่าเราทำได้ดีแค่ไหน',
   'sp.review.stars_label': 'ให้คะแนน WebBrain',

--- a/src/firefox/src/ui/locales/tl.js
+++ b/src/firefox/src/ui/locales/tl.js
@@ -452,6 +452,8 @@ export default {
   'sp.recommended.tweet.label': 'Mag-post tungkol sa WebBrain',
   'sp.recommended.tweet.prompt': 'I-post ang eksaktong tekstong ito sa nakikitang X interface nang walang pagbabago: “{post}” Pagkatapos, tiyaking na-post ito at iulat ang URL.',
   'sp.recommended.tweet.text': 'Kilalanin ang WebBrain — isang open-source AI browser agent na nasa browser mo. Makipag-chat sa anumang page, i-automate ang multi-step workflows, at gamitin ang sarili mong LLM. Dinisenyong napapalawak. Subukan: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Mag-post tungkol sa WebBrain sa LinkedIn',
+  'sp.recommended.linkedin.prompt': 'I-post ang eksaktong tekstong ito sa nakikitang LinkedIn interface nang walang pagbabago: “{post}” Pagkatapos, tiyaking na-post ito at iulat ang URL.',
   'sp.review.rating_title': 'Nagugustuhan mo ba ang WebBrain?',
   'sp.review.rating_body': 'Pumili ng bituin — nakakatulong ito para malaman namin kung kumusta kami.',
   'sp.review.stars_label': 'I-rate ang WebBrain',

--- a/src/firefox/src/ui/locales/tr.js
+++ b/src/firefox/src/ui/locales/tr.js
@@ -491,6 +491,8 @@ export default {
   'sp.recommended.tweet.label': 'WebBrain hakkında paylaş',
   'sp.recommended.tweet.prompt': 'Bu metni görünür X arayüzünden hiç değiştirmeden aynen paylaş: “{post}” Ardından paylaşımın yayınlandığını doğrula ve URL’sini bildir.',
   'sp.recommended.tweet.text': 'WebBrain ile tanışın — tarayıcınızda çalışan açık kaynaklı bir yapay zekâ tarayıcı ajanı. Her sayfayla sohbet edin, çok adımlı iş akışlarını otomatikleştirin ve kendi LLM’inizi kullanın. Genişletilebilir olarak tasarlandı. Deneyin: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'WebBrain hakkında LinkedIn’de paylaş',
+  'sp.recommended.linkedin.prompt': 'Bu metni görünür LinkedIn arayüzünden hiç değiştirmeden aynen paylaş: “{post}” Ardından paylaşımın yayınlandığını doğrula ve URL’sini bildir.',
   'sp.review.rating_title': 'WebBrain’den memnun musun?',
   'sp.review.rating_body': 'Bir yıldız seç; nasıl gittiğimizi anlamamıza yardımcı olur.',
   'sp.review.stars_label': 'WebBrain’i değerlendir',

--- a/src/firefox/src/ui/locales/uk.js
+++ b/src/firefox/src/ui/locales/uk.js
@@ -452,6 +452,8 @@ export default {
   'sp.recommended.tweet.label': 'Опублікувати про WebBrain',
   'sp.recommended.tweet.prompt': 'Опублікуйте цей текст без змін через видимий інтерфейс X: «{post}» Потім перевірте публікацію та повідомте її URL.',
   'sp.recommended.tweet.text': 'Представляємо WebBrain — браузерного ШІ-агента з відкритим кодом, що працює у вашому браузері. Спілкуйтеся з будь-якою сторінкою, автоматизуйте багатоетапні процеси та використовуйте власну LLM. Створений для розширення. Спробуйте: https://webbrain.one',
+  'sp.recommended.linkedin.label': 'Опублікувати про WebBrain у LinkedIn',
+  'sp.recommended.linkedin.prompt': 'Опублікуйте цей текст без змін через видимий інтерфейс LinkedIn: «{post}» Потім перевірте публікацію та повідомте її URL.',
   'sp.review.rating_title': 'Подобається WebBrain?',
   'sp.review.rating_body': 'Виберіть зірку — це допоможе нам зрозуміти, як у нас справи.',
   'sp.review.stars_label': 'Оцінити WebBrain',

--- a/src/firefox/src/ui/locales/zh.js
+++ b/src/firefox/src/ui/locales/zh.js
@@ -452,6 +452,8 @@ export default {
   'sp.recommended.tweet.label': '发布 WebBrain 介绍',
   'sp.recommended.tweet.prompt': '请通过可见的 X 界面原样发布以下文本，不要修改：“{post}”然后确认已发布并报告帖子网址。',
   'sp.recommended.tweet.text': '认识 WebBrain：一款运行在浏览器中的开源 AI 浏览器智能代理。你可以与任意网页对话、自动执行多步骤工作流，并使用自己的 LLM。专为扩展而设计。立即体验：https://webbrain.one',
+  'sp.recommended.linkedin.label': '在 LinkedIn 发布 WebBrain 介绍',
+  'sp.recommended.linkedin.prompt': '请通过可见的 LinkedIn 界面原样发布以下文本，不要修改：“{post}”然后确认已发布并报告帖子网址。',
   'sp.review.rating_title': '喜欢 WebBrain 吗？',
   'sp.review.rating_body': '点选星级，帮助我们了解做得如何。',
   'sp.review.stars_label': '为 WebBrain 评分',

--- a/src/firefox/src/ui/recommended-actions.js
+++ b/src/firefox/src/ui/recommended-actions.js
@@ -152,6 +152,23 @@ function webbrainTweetRunOptions(postText) {
   };
 }
 
+function webbrainLinkedInRunOptions(postText) {
+  const exactPost = String(postText || '').trim();
+  return {
+    id: 'post-webbrain-linkedin',
+    skipPlanner: true,
+    tool: 'navigate',
+    summary: 'Publish the reviewed localized WebBrain post on LinkedIn exactly as supplied.',
+    steps: [
+      'Open https://www.linkedin.com/feed/ in the current tab through the visible browser UI.',
+      'Select Start a post to open LinkedIn\'s visible composer.',
+      `Enter this exact reviewed text without translating, rewriting, or adding anything: ${JSON.stringify(exactPost)}`,
+      'Publish only after the composer text exactly matches the supplied text.',
+      'Verify the new LinkedIn post appears, then report its URL when available.',
+    ],
+  };
+}
+
 function hasCartOrPriceSignal(pageInfo = {}) {
   const haystack = [
     pageInfo.title,
@@ -242,14 +259,23 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
   const path = pathFromUrl(pageInfo.url || '');
   const actions = [];
   const webbrainPostText = t('sp.recommended.tweet.text');
+  const webbrainPromotionVariant = options.webbrainPromotionVariant === 'linkedin' ? 'linkedin' : 'x';
 
-  addUnique(actions, {
-    id: 'tweet-webbrain',
-    label: t('sp.recommended.tweet.label'),
-    prompt: t('sp.recommended.tweet.prompt', { post: webbrainPostText }),
-    mode: 'act',
-    runOptions: webbrainTweetRunOptions(webbrainPostText),
-  });
+  addUnique(actions, webbrainPromotionVariant === 'linkedin'
+    ? {
+      id: 'post-webbrain-linkedin',
+      label: t('sp.recommended.linkedin.label'),
+      prompt: t('sp.recommended.linkedin.prompt', { post: webbrainPostText }),
+      mode: 'act',
+      runOptions: webbrainLinkedInRunOptions(webbrainPostText),
+    }
+    : {
+      id: 'tweet-webbrain',
+      label: t('sp.recommended.tweet.label'),
+      prompt: t('sp.recommended.tweet.prompt', { post: webbrainPostText }),
+      mode: 'act',
+      runOptions: webbrainTweetRunOptions(webbrainPostText),
+    });
 
   if (host === 'github.com' && RELEASES_PATH_RE.test(path)) {
     addUnique(actions, {
@@ -409,7 +435,7 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
     });
   }
 
-  if (!actions.some((action) => action.id !== 'tweet-webbrain') && pageInfo.title) {
+  if (!actions.some((action) => !['tweet-webbrain', 'post-webbrain-linkedin'].includes(action.id)) && pageInfo.title) {
     const explainUsesArticleRead = isLongArticle(pageInfo);
     addUnique(actions, {
       id: 'explain-page',

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -396,6 +396,7 @@ const storeReviewFeedbackEl = document.getElementById('store-review-feedback');
 const scheduledJobsEl = document.getElementById('scheduled-jobs');
 const stopBtn = document.getElementById('btn-stop');
 const RECOMMENDED_ACTIONS_COLLAPSED_KEY = 'recommendedActionsCollapsed';
+const WEBBRAIN_PROMOTION_ACTION_IDS = new Set(['tweet-webbrain', 'post-webbrain-linkedin']);
 const PLACEHOLDER_ROTATION_INTERVAL_MS = 10_000;
 const ASK_PLACEHOLDER_KEYS = [
   'sp.input.ask_placeholder',
@@ -781,6 +782,7 @@ let providerSelectionRequestId = 0;
 let providerTestRequestId = 0;
 let selectedProviderId = 'webbrain_cloud';
 let recommendedActionsCollapsed = false;
+let webbrainPromotionHasAnimated = false;
 let slashCommandMatches = [];
 let slashCommandSelectedIndex = 0;
 let busySlashNoticeLastShownAt = 0;
@@ -3218,6 +3220,29 @@ function hideRecommendedActions() {
   recommendedActionsEl.classList.add('hidden');
 }
 
+function createWebbrainPromotionIcon(actionId) {
+  const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  icon.classList.add('recommended-action-icon');
+  icon.setAttribute('viewBox', '0 0 24 24');
+  icon.setAttribute('aria-hidden', 'true');
+  icon.setAttribute('focusable', 'false');
+
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', actionId === 'post-webbrain-linkedin'
+    ? 'M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 1 1 0-4.124 2.062 2.062 0 0 1 0 4.124zM7.119 20.452H3.555V9H7.12v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0z'
+    : 'M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z');
+  icon.appendChild(path);
+  return icon;
+}
+
+function animateWebbrainPromotionOnce() {
+  if (webbrainPromotionHasAnimated || recommendedActionsCollapsed) return;
+  const promotionAction = recommendedActionsListEl?.querySelector('.recommended-action-chip-promotion');
+  if (!promotionAction) return;
+  promotionAction.classList.add('recommended-action-chip-promotion-enter');
+  webbrainPromotionHasAnimated = true;
+}
+
 function updateRecommendedActionsCollapsedState() {
   if (!recommendedActionsEl) return;
   recommendedActionsEl.classList.toggle('collapsed', recommendedActionsCollapsed);
@@ -3235,6 +3260,7 @@ function updateRecommendedActionsCollapsedState() {
 function setRecommendedActionsCollapsed(collapsed, { persist = true } = {}) {
   recommendedActionsCollapsed = Boolean(collapsed);
   updateRecommendedActionsCollapsedState();
+  animateWebbrainPromotionOnce();
   if (persist) {
     void browser.storage.local.set({ [RECOMMENDED_ACTIONS_COLLAPSED_KEY]: recommendedActionsCollapsed }).catch(() => {});
   }
@@ -3280,7 +3306,8 @@ async function refreshRecommendedActions() {
     const pageInfo = await sendToBackground('get_page_info', { tabId });
     if (requestId !== recommendationsRequestId || currentTabId !== tabId || isProcessing) return;
     const sourceUrl = typeof pageInfo?.url === 'string' ? pageInfo.url : '';
-    const actions = buildRecommendedActions(pageInfo, { max: 4 });
+    const webbrainPromotionVariant = Math.random() < 0.5 ? 'linkedin' : 'x';
+    const actions = buildRecommendedActions(pageInfo, { max: 4, webbrainPromotionVariant });
     recommendedActionsListEl.replaceChildren();
     actions.forEach((action) => {
       const actionForClick = sourceUrl ? { ...action, sourceUrl } : action;
@@ -3288,11 +3315,17 @@ async function refreshRecommendedActions() {
       btn.type = 'button';
       btn.className = 'recommended-action-chip';
       btn.textContent = action.label;
+      btn.dataset.actionId = action.id;
+      if (WEBBRAIN_PROMOTION_ACTION_IDS.has(action.id)) {
+        btn.classList.add('recommended-action-chip-promotion');
+        btn.prepend(createWebbrainPromotionIcon(action.id));
+      }
       btn.dataset.prompt = action.prompt;
       btn.addEventListener('click', () => runRecommendedAction(actionForClick));
       recommendedActionsListEl.appendChild(btn);
     });
     recommendedActionsEl.classList.toggle('hidden', actions.length === 0);
+    animateWebbrainPromotionOnce();
   } catch {
     if (requestId === recommendationsRequestId) hideRecommendedActions();
   }

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -16,6 +16,7 @@
   --accent: #6c63ff;
   --accent-hover: #5a52d5;
   --accent-dim: rgba(108, 99, 255, 0.15);
+  --promotion-action-accent: #4db5f9;
   --success: #4caf50;
   --warning: #ff9800;
   --error: #f44336;
@@ -53,6 +54,7 @@
   --accent: #5b52e8;
   --accent-hover: #4a42c4;
   --accent-dim: rgba(91, 82, 232, 0.12);
+  --promotion-action-accent: #116f9f;
   --success: #2d8866;
   --warning: #b97a00;
   --error: #c5363c;
@@ -1512,6 +1514,56 @@ body {
 
 .recommended-action-chip:active {
   transform: scale(0.98);
+}
+
+.recommended-action-chip-promotion {
+  align-items: center;
+  display: inline-flex;
+  gap: 6px;
+  border-color: color-mix(in srgb, var(--promotion-action-accent) 48%, var(--border));
+  background: color-mix(in srgb, var(--promotion-action-accent) 13%, var(--bg-secondary));
+  color: var(--text-primary);
+  box-shadow: 0 1px 4px color-mix(in srgb, var(--promotion-action-accent) 14%, transparent);
+}
+
+.recommended-action-chip-promotion:hover {
+  border-color: var(--promotion-action-accent);
+  background: color-mix(in srgb, var(--promotion-action-accent) 20%, var(--bg-secondary));
+  box-shadow: 0 3px 12px color-mix(in srgb, var(--promotion-action-accent) 22%, transparent);
+}
+
+.recommended-action-chip-promotion:focus-visible {
+  outline: 2px solid var(--promotion-action-accent);
+  outline-offset: 2px;
+}
+
+.recommended-action-icon {
+  width: 11px;
+  height: 11px;
+  flex: 0 0 auto;
+  fill: currentColor;
+  color: var(--promotion-action-accent);
+}
+
+.recommended-action-chip-promotion-enter {
+  animation: recommended-promotion-action-glow 850ms cubic-bezier(0.2, 0.75, 0.25, 1);
+}
+
+@keyframes recommended-promotion-action-glow {
+  0%, 100% {
+    box-shadow: 0 1px 4px color-mix(in srgb, var(--promotion-action-accent) 14%, transparent);
+  }
+  45% {
+    box-shadow:
+      0 3px 12px color-mix(in srgb, var(--promotion-action-accent) 24%, transparent),
+      0 0 0 5px color-mix(in srgb, var(--promotion-action-accent) 18%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .recommended-action-chip-promotion-enter {
+    animation: none;
+  }
 }
 
 /* Store review prompt (#208) — sticky card at bottom of chat */

--- a/test/run.js
+++ b/test/run.js
@@ -6355,13 +6355,20 @@ test('recommended actions match issue scenarios', () => {
   }
 });
 
-test('Tweet about WebBrain is permanent and carries a ready-to-go plan', () => {
+test('WebBrain promotion has explicit X and LinkedIn variants with ready-to-go plans', () => {
   const exactPost = 'Introducing WebBrain — an open-source AI browser agent that lives in your browser. Chat with any page, automate multi-step workflows, and bring your own LLM. Extensible by design. Try it: https://webbrain.one';
-  const expectedPlanSteps = [
+  const expectedTweetSteps = [
     'Open https://x.com/compose/post in the current tab through the visible browser UI.',
     `Enter this exact reviewed text in the visible X composer without translating, rewriting, or adding anything: ${JSON.stringify(exactPost)}`,
     'Publish only after the composer text exactly matches the supplied text.',
     'Verify the new tweet appears, then report its URL when available.',
+  ];
+  const expectedLinkedInSteps = [
+    'Open https://www.linkedin.com/feed/ in the current tab through the visible browser UI.',
+    'Select Start a post to open LinkedIn\'s visible composer.',
+    `Enter this exact reviewed text without translating, rewriting, or adding anything: ${JSON.stringify(exactPost)}`,
+    'Publish only after the composer text exactly matches the supplied text.',
+    'Verify the new LinkedIn post appears, then report its URL when available.',
   ];
   const pages = [
     {},
@@ -6371,8 +6378,8 @@ test('Tweet about WebBrain is permanent and carries a ready-to-go plan', () => {
 
   for (const buildRecommendedActions of [buildRecommendedActionsCh, buildRecommendedActionsFx]) {
     for (const pageInfo of pages) {
-      const actions = buildRecommendedActions(pageInfo, { max: 1 });
-      const tweet = actions.find((action) => action.id === 'tweet-webbrain');
+      const tweetActions = buildRecommendedActions(pageInfo, { max: 1, webbrainPromotionVariant: 'x' });
+      const tweet = tweetActions.find((action) => action.id === 'tweet-webbrain');
       assert.equal(tweet?.label, 'Tweet about WebBrain');
       assert.equal(tweet?.mode, 'act');
       assert.match(tweet?.prompt || '', /visible X interface[\s\S]*without changing it/);
@@ -6380,15 +6387,71 @@ test('Tweet about WebBrain is permanent and carries a ready-to-go plan', () => {
       assert.equal(tweet?.runOptions?.skipPlanner, true);
       assert.equal(tweet?.runOptions?.tool, 'navigate');
       assert.equal(tweet?.runOptions?.summary, 'Publish the reviewed localized WebBrain post exactly as supplied.');
-      assert.deepEqual(tweet?.runOptions?.steps, expectedPlanSteps);
+      assert.deepEqual(tweet?.runOptions?.steps, expectedTweetSteps);
+
+      const linkedinActions = buildRecommendedActions(pageInfo, { max: 1, webbrainPromotionVariant: 'linkedin' });
+      const linkedin = linkedinActions.find((action) => action.id === 'post-webbrain-linkedin');
+      assert.equal(linkedin?.label, 'Post about WebBrain');
+      assert.equal(linkedin?.mode, 'act');
+      assert.match(linkedin?.prompt || '', /visible LinkedIn interface[\s\S]*without changing it/);
+      assert.ok(linkedin?.prompt?.includes(exactPost), 'LinkedIn prompt should carry the reviewed English post verbatim');
+      assert.equal(linkedin?.runOptions?.skipPlanner, true);
+      assert.equal(linkedin?.runOptions?.tool, 'navigate');
+      assert.equal(linkedin?.runOptions?.summary, 'Publish the reviewed localized WebBrain post on LinkedIn exactly as supplied.');
+      assert.deepEqual(linkedin?.runOptions?.steps, expectedLinkedInSteps);
+      assert.equal(linkedinActions.some((action) => action.id === 'tweet-webbrain'), false, 'one cohort should render only one promotion');
     }
 
-    const fallbackActions = buildRecommendedActions({ url: 'https://example.com/', title: 'Example page' });
-    assert.equal(fallbackActions.some((action) => action.id === 'explain-page'), true, 'permanent action should not suppress the generic page action');
+    for (const webbrainPromotionVariant of ['x', 'linkedin']) {
+      const fallbackActions = buildRecommendedActions(
+        { url: 'https://example.com/', title: 'Example page' },
+        { webbrainPromotionVariant },
+      );
+      assert.equal(fallbackActions.some((action) => action.id === 'explain-page'), true, 'promotion should not suppress the generic page action');
+    }
   }
 });
 
-test('WebBrain tweet copy is reviewed, localized, mirrored, and safely bounded', async () => {
+test('WebBrain promotion chooses a fresh 50/50 variant per display with motion-safe visual treatment', () => {
+  for (const [label, panelRel, cssRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js', 'src/chrome/styles/sidepanel.css'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js', 'src/firefox/styles/sidepanel.css'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    const css = fs.readFileSync(path.join(ROOT, cssRel), 'utf8');
+
+    assert.match(panel, /const webbrainPromotionVariant = Math\.random\(\) < 0\.5 \? 'linkedin' : 'x';/, `${label}: every render should choose from an even split`);
+    assert.doesNotMatch(panel, /WEBBRAIN_PROMOTION_VARIANT_KEY|webbrainPromotionVariantPromise/, `${label}: display choice should not be persisted`);
+    assert.match(panel, /let webbrainPromotionHasAnimated = false;/, `${label}: promotion entrance should have a session-scoped guard`);
+    assert.match(panel, /btn\.dataset\.actionId = action\.id;/, `${label}: recommended actions should expose their stable IDs to CSS`);
+    assert.match(
+      panel,
+      /WEBBRAIN_PROMOTION_ACTION_IDS\.has\(action\.id\)[\s\S]*?recommended-action-chip-promotion[\s\S]*?createWebbrainPromotionIcon\(action\.id\)/,
+      `${label}: both promotion variants should receive their platform icon and treatment`,
+    );
+    assert.match(
+      panel,
+      /function createWebbrainPromotionIcon\(actionId\) \{[\s\S]*?createElementNS\('http:\/\/www\.w3\.org\/2000\/svg', 'svg'\)[\s\S]*?setAttribute\('aria-hidden', 'true'\)[\s\S]*?actionId === 'post-webbrain-linkedin'[\s\S]*?return icon;[\s\S]*?\}/,
+      `${label}: X and LinkedIn icons should be aria-hidden inline SVGs`,
+    );
+    assert.match(
+      panel,
+      /function animateWebbrainPromotionOnce\(\) \{[\s\S]*?webbrainPromotionHasAnimated \|\| recommendedActionsCollapsed[\s\S]*?recommended-action-chip-promotion-enter[\s\S]*?webbrainPromotionHasAnimated = true;[\s\S]*?\}/,
+      `${label}: glow should run once and wait until the action list is expanded`,
+    );
+    assert.match(panel, /buildRecommendedActions\(pageInfo, \{ max: 4, webbrainPromotionVariant \}\)/, `${label}: rendering should use the per-display choice`);
+
+    assert.match(css, /\.recommended-action-chip-promotion \{[\s\S]*?--promotion-action-accent[\s\S]*?background:/, `${label}: both variants should use the dedicated restrained contrast treatment`);
+    assert.match(css, /@keyframes recommended-promotion-action-glow \{/, `${label}: promotion should define its brief glow`);
+    assert.match(
+      css,
+      /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.recommended-action-chip-promotion-enter \{[\s\S]*?animation: none;/,
+      `${label}: promotion glow should respect reduced-motion preferences`,
+    );
+  }
+});
+
+test('WebBrain social promotion copy is reviewed, localized, mirrored, and safely bounded', async () => {
   const localeNames = ['ar', 'en', 'es', 'fr', 'he', 'id', 'ja', 'ko', 'ms', 'pl', 'ru', 'th', 'tl', 'tr', 'uk', 'zh'];
   const transformedUrlLength = 23;
   const conservativeXWeight = (value) => {
@@ -6408,6 +6471,8 @@ test('WebBrain tweet copy is reviewed, localized, mirrored, and safely bounded',
       'sp.recommended.tweet.label',
       'sp.recommended.tweet.prompt',
       'sp.recommended.tweet.text',
+      'sp.recommended.linkedin.label',
+      'sp.recommended.linkedin.prompt',
     ]) {
       assert.equal(typeof chromeLocale[key], 'string', `${locale}: ${key} should be explicit`);
       assert.ok(chromeLocale[key].trim(), `${locale}: ${key} should not be empty`);
@@ -6425,6 +6490,10 @@ test('WebBrain tweet copy is reviewed, localized, mirrored, and safely bounded',
     assert.ok(
       chromeLocale['sp.recommended.tweet.prompt'].includes('{post}'),
       `${locale}: prompt should interpolate the reviewed post`,
+    );
+    assert.ok(
+      chromeLocale['sp.recommended.linkedin.prompt'].includes('{post}'),
+      `${locale}: LinkedIn prompt should interpolate the reviewed post`,
     );
   }
 
@@ -39169,61 +39238,87 @@ test('planner gate: trusted recommended media action skips planner and pins read
   });
 });
 
-test('planner gate: trusted WebBrain tweet action skips planner and pins ready plan', async () => {
+test('planner gate: trusted WebBrain social promotion actions skip planner and pin ready plans', async () => {
   await withPlannerBrowserGlobals(async () => {
     for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
-      const tabId = label === 'chrome' ? 9211 : 9212;
-      const agent = new AgentClass({ getActive: () => ({}) });
-      agent.setPlanBeforeActMode('strict');
-      agent.setPlanReviewSettings({ mode: 'always' });
-      agent.conversations.set(tabId, [{ role: 'system', content: 'system' }]);
-      let plannerCalls = 0;
-      agent._runPlannerGate = async () => {
-        plannerCalls += 1;
-        throw new Error('recommended action fast path should not call planner');
-      };
+      const readyPlans = [
+        {
+          name: 'X',
+          request: 'Publish a concise tweet about WebBrain.',
+          expectedUrl: /https:\/\/x\.com\/compose\/post/,
+          plan: {
+            id: 'tweet-webbrain',
+            skipPlanner: true,
+            tool: 'navigate',
+            summary: 'Publish the reviewed localized WebBrain post exactly as supplied.',
+            steps: [
+              'Open https://x.com/compose/post in the current tab through the visible browser UI.',
+              'Enter this exact reviewed localized text through the visible X composer without rewriting it: "Introducing WebBrain — an open-source AI browser agent that lives in your browser. Chat with any page, automate multi-step workflows, and bring your own LLM. Extensible by design. Try it: https://webbrain.one"',
+              'Verify the new tweet appears and report its URL.',
+            ],
+          },
+        },
+        {
+          name: 'LinkedIn',
+          request: 'Publish a concise LinkedIn post about WebBrain.',
+          expectedUrl: /https:\/\/www\.linkedin\.com\/feed\//,
+          plan: {
+            id: 'post-webbrain-linkedin',
+            skipPlanner: true,
+            tool: 'navigate',
+            summary: 'Publish the reviewed localized WebBrain post on LinkedIn exactly as supplied.',
+            steps: [
+              'Open https://www.linkedin.com/feed/ in the current tab through the visible browser UI.',
+              'Select Start a post and enter this exact reviewed localized text without rewriting it: "Introducing WebBrain — an open-source AI browser agent that lives in your browser. Chat with any page, automate multi-step workflows, and bring your own LLM. Extensible by design. Try it: https://webbrain.one"',
+              'Verify the new LinkedIn post appears and report its URL.',
+            ],
+          },
+        },
+      ];
 
-      const readyPlan = {
-        id: 'tweet-webbrain',
-        skipPlanner: true,
-        tool: 'navigate',
-        summary: 'Publish the reviewed localized WebBrain post exactly as supplied.',
-        steps: [
-          'Open https://x.com/compose/post in the current tab through the visible browser UI.',
-          'Enter this exact reviewed localized text through the visible X composer without rewriting it: "Introducing WebBrain — an open-source AI browser agent that lives in your browser. Chat with any page, automate multi-step workflows, and bring your own LLM. Extensible by design. Try it: https://webbrain.one"',
-          'Verify the new tweet appears and report its URL.',
-        ],
-      };
-      const outcome = await agent._maybeRunPlannerGate(
-        tabId,
-        agent.conversations.get(tabId),
-        { role: 'user', content: 'Publish a concise tweet about WebBrain.' },
-        () => {},
-        'act',
-        null,
-        null,
-        null,
-        { recommendedAction: readyPlan },
-      );
+      for (const [variantIndex, fixture] of readyPlans.entries()) {
+        const tabId = (label === 'chrome' ? 9211 : 9212) + (variantIndex * 10);
+        const agent = new AgentClass({ getActive: () => ({}) });
+        agent.setPlanBeforeActMode('strict');
+        agent.setPlanReviewSettings({ mode: 'always' });
+        agent.conversations.set(tabId, [{ role: 'system', content: 'system' }]);
+        let plannerCalls = 0;
+        agent._runPlannerGate = async () => {
+          plannerCalls += 1;
+          throw new Error('recommended action fast path should not call planner');
+        };
 
-      assert.equal(outcome.proceed, true, `${label} should proceed`);
-      assert.equal(plannerCalls, 0, `${label} should skip the planner call`);
-      const messages = agent.conversations.get(tabId);
-      const idx = agent._findScratchpadIndex(messages);
-      assert.ok(idx >= 0, `${label} should pin the ready tweet plan`);
-      const body = agent._extractScratchpadBody(messages[idx].content);
-      assert.match(body, /\[Approved plan — pinned by recommended action\]/);
-      assert.match(body, /https:\/\/x\.com\/compose\/post/);
-      assert.match(body, /https:\/\/webbrain\.one/);
-      assert.match(body, /Immediate tool[\s\S]*navigate/);
+        const outcome = await agent._maybeRunPlannerGate(
+          tabId,
+          agent.conversations.get(tabId),
+          { role: 'user', content: fixture.request },
+          () => {},
+          'act',
+          null,
+          null,
+          null,
+          { recommendedAction: fixture.plan },
+        );
 
-      assert.equal(
-        agent._recommendedActionFastPathPlan({
-          recommendedAction: { ...readyPlan, tool: 'click_ax' },
-        }),
-        null,
-        `${label} should reject a forged immediate tool for the tweet fast path`,
-      );
+        assert.equal(outcome.proceed, true, `${label} ${fixture.name} should proceed`);
+        assert.equal(plannerCalls, 0, `${label} ${fixture.name} should skip the planner call`);
+        const messages = agent.conversations.get(tabId);
+        const idx = agent._findScratchpadIndex(messages);
+        assert.ok(idx >= 0, `${label} should pin the ready ${fixture.name} plan`);
+        const body = agent._extractScratchpadBody(messages[idx].content);
+        assert.match(body, /\[Approved plan — pinned by recommended action\]/);
+        assert.match(body, fixture.expectedUrl);
+        assert.match(body, /https:\/\/webbrain\.one/);
+        assert.match(body, /Immediate tool[\s\S]*navigate/);
+
+        assert.equal(
+          agent._recommendedActionFastPathPlan({
+            recommendedAction: { ...fixture.plan, tool: 'click_ax' },
+          }),
+          null,
+          `${label} should reject a forged immediate tool for the ${fixture.name} fast path`,
+        );
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

- show exactly one WebBrain social promotion per recommended-actions display, split 50/50 between X and LinkedIn
- add restrained contrast styling, platform icons, and a one-time motion-safe entrance glow
- add a ready-to-run LinkedIn publishing plan and localized labels/prompts in both Chrome and Firefox
- preserve the existing reviewed WebBrain post text for both variants

## Why

This gives the WebBrain promotion more visual attention while distributing displays evenly across X and LinkedIn without changing the approved copy.

## User impact

Users see either “Tweet about WebBrain” or “Post about WebBrain” on each display, with the selected action carrying a concrete publish-and-verify workflow.

## Validation

- `node test/run.js` — 1105 passed, 0 failed
- `npm run test:security` — 60/60 checks passed
- `git diff --check origin/main...HEAD`