### PR TITLE
Fix trusted contenteditable submissions

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15854,6 +15854,9 @@ const ADAPTERS = [
     fullPageCapture: { infiniteScroll: isTwitterInfiniteScrollUrl },
     notes: `
 - The composer is a contenteditable, not a textarea. Character count is enforced client-side at 280 (or higher for Premium).
+- On /compose/post, call wait_for_stable before filling the composer. After typing, re-read the visible accessibility tree and require the Post control to be enabled (no disabled=true) before clicking it.
+- If the exact text is visible but Post remains disabled, keep the composer open and refill the editor with type_text({selector:"[data-testid=\\\"tweetTextarea_0\\\"]", text:"<exact complete post>", clear:true}); this uses the trusted Chrome typing path. Do not dismiss the composer to recover.
+- A click_ax result with verified:false or no observable posting evidence is not proof that the post was published. Keep the composer open and verify a new status URL or matching feed item before reporting success.
 - The timeline is virtualized — tweets scroll out of the DOM. To find a specific tweet, use search, don't scroll.
 - "Reply", "Retweet", "Like" icons are below each tweet; the share menu has "Copy link" for permalinks.
 - Quote tweets vs reposts: the retweet icon opens a menu with both options.`,

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -17349,8 +17349,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       trustedFallbackAttempted: true,
       recoveryRequired: 'fresh_tree',
     };
+    let trustedDispatched = false;
     try {
-      const prepared = await chrome.tabs.sendMessage(tabId, {
+      let prepared = await chrome.tabs.sendMessage(tabId, {
         target: 'content',
         action: 'ax_prepare_field_for_trusted_type',
         params: { ref_id: args.ref_id },
@@ -17363,7 +17364,48 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
 
       await cdpClient.attach(tabId);
-      await cdpClient.sendCommand(tabId, 'Input.insertText', { text: expected });
+      if (prepared.contentEditable && prepared.rect?.w > 0 && prepared.rect?.h > 0) {
+        const x = prepared.rect.x + prepared.rect.w / 2;
+        const y = prepared.rect.y + prepared.rect.h / 2;
+        await cdpClient.sendCommand(tabId, 'Input.dispatchMouseEvent', {
+          type: 'mouseMoved', x, y, button: 'none', buttons: 0,
+        });
+        trustedDispatched = true;
+        await cdpClient.sendCommand(tabId, 'Input.dispatchMouseEvent', {
+          type: 'mousePressed', x, y, button: 'left', buttons: 1, clickCount: 1,
+        });
+        await cdpClient.sendCommand(tabId, 'Input.dispatchMouseEvent', {
+          type: 'mouseReleased', x, y, button: 'left', buttons: 0, clickCount: 1,
+        });
+        // The trusted click collapses the preflight selection. Re-resolve the
+        // same ref and select all once more before Input.insertText replaces
+        // the editor contents.
+        const reselected = await chrome.tabs.sendMessage(tabId, {
+          target: 'content',
+          action: 'ax_prepare_field_for_trusted_type',
+          params: { ref_id: args.ref_id },
+        });
+        if (!reselected?.success) {
+          return {
+            ...failed,
+            dispatched: true,
+            noDispatch: false,
+            error: `${response.error || 'Field verification failed'} Trusted retry focused the editor but could not reselect it: ${reselected?.error || 'unknown preparation failure'}`,
+          };
+        }
+        prepared = reselected;
+      }
+      trustedDispatched = true;
+      if (expected) {
+        await cdpClient.sendCommand(tabId, 'Input.insertText', { text: expected });
+      } else {
+        await cdpClient.sendCommand(tabId, 'Input.dispatchKeyEvent', {
+          type: 'keyDown', key: 'Delete', code: 'Delete', windowsVirtualKeyCode: 46,
+        });
+        await cdpClient.sendCommand(tabId, 'Input.dispatchKeyEvent', {
+          type: 'keyUp', key: 'Delete', code: 'Delete', windowsVirtualKeyCode: 46,
+        });
+      }
       await new Promise(resolve => setTimeout(resolve, 120));
       const verification = await chrome.tabs.sendMessage(tabId, {
         target: 'content',
@@ -17383,6 +17425,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const recovered = {
         ...response,
         success: true,
+        dispatched: true,
+        trusted: true,
         verified: true,
         method: `${toolName}_cdp_fallback`,
         fallbackAttempted: true,
@@ -17390,8 +17434,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         fieldMeta: verification.fieldMeta || prepared.fieldMeta || response.fieldMeta,
       };
       delete recovered.error;
+      delete recovered.noDispatch;
       delete recovered.actual;
       delete recovered.actualRedacted;
+      delete recovered.trustedTypeRequired;
       delete recovered.recoveryRequired;
       delete recovered.failureScope;
       delete recovered.retryable;
@@ -17420,6 +17466,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     } catch (error) {
       return {
         ...failed,
+        ...(trustedDispatched ? { dispatched: true, noDispatch: false } : {}),
         error: `${response.error || 'Field verification failed'} Trusted Chrome retry failed: ${error?.message || String(error)}`,
       };
     }

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -17415,6 +17415,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (!verification?.success || verification.verified !== true) {
         return {
           ...failed,
+          dispatched: true,
+          noDispatch: false,
           verified: false,
           ...(verification?.fieldMeta ? { fieldMeta: verification.fieldMeta } : {}),
           ...(Object.prototype.hasOwnProperty.call(verification || {}, 'actual') ? { actual: verification.actual } : {}),

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -564,6 +564,18 @@
     const ph = el.getAttribute('placeholder');
     if (ph) line += ' placeholder="' + ph + '"';
 
+    // Disabled submit/action state is a blocker the model must see before it
+    // tries to activate a control. In particular, React editors can contain
+    // visually correct DOM text while their application state still leaves
+    // the associated Post/Send button aria-disabled.
+    let disabled = false;
+    try {
+      disabled = !!el.disabled
+        || el.getAttribute('aria-disabled') === 'true'
+        || el.matches(':disabled');
+    } catch {}
+    if (disabled) line += ' disabled=true';
+
     // Checkbox/radio state is an action-critical value, not decorative
     // metadata. Without it the model has to infer state from a focus ring or
     // screenshot and can accidentally toggle a control back off.

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -3519,6 +3519,7 @@
       return {
         tag,
         type: fieldType,
+        contentEditable: !!el.isContentEditable,
         name: el.getAttribute ? el.getAttribute('name') : null,
         id: elId,
         autocomplete: el.getAttribute ? el.getAttribute('autocomplete') : null,
@@ -3672,6 +3673,18 @@
               ? ' Nearest existing refs: ' + suggestions.map(s => `${s.ref} (${s.role}${s.name ? ' "' + s.name + '"' : ''})`).join(', ') + '.'
               : '';
             return failure(`ref_id ${ref_id} not found.${formatNote} The element may have been removed or the page replaced.${hint} Re-read the accessibility tree to get fresh ids — do NOT guess ref numbers or invent placeholders.`, { suggestions });
+          }
+          const disabledOwner = el.closest?.('button:disabled,input:disabled,select:disabled,textarea:disabled,[aria-disabled="true"]');
+          if (disabledOwner) {
+            return failure(
+              `ref_id ${ref_id} is disabled and cannot be activated. Re-read the page after correcting the form or editor state; do not treat this click as submitted.`,
+              {
+                ref_id,
+                disabled: true,
+                nativeDisabled: !!disabledOwner.disabled,
+                ariaDisabled: disabledOwner.getAttribute?.('aria-disabled') === 'true',
+              },
+            );
           }
           try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
           try { el.focus({ preventScroll: true }); } catch {}
@@ -4160,23 +4173,20 @@
           let method = '';
           let selectExpected = null;
           if (el.isContentEditable) {
-            dispatched = true;
             previous = _editableTextValue(el);
-            if (clear) {
-              try {
-                const sel = window.getSelection();
-                const r = document.createRange();
-                r.selectNodeContents(el);
-                sel.removeAllRanges();
-                sel.addRange(r);
-                document.execCommand('delete');
-              } catch {}
-            }
-            try { document.execCommand('insertText', false, text); } catch {
-              el.textContent = (clear ? '' : previous) + text;
-              el.dispatchEvent(new Event('input', { bubbles: true }));
-            }
-            method = 'type_ax_contenteditable';
+            return failure(
+              'Contenteditable fields require trusted browser typing. Attempting one ref-bound Chrome typing pass.',
+              {
+                method: 'type_ax_contenteditable_trusted',
+                ref_id,
+                rect: typeRect,
+                verified: false,
+                fieldMeta,
+                fallbackAttempted: false,
+                trustedTypeRequired: true,
+                _expectedValue: (clear ? '' : previous) + text,
+              },
+            );
           } else if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT') {
             // Guard against non-typeable INPUT subtypes. These all share the
             // INPUT tagName so without this check a confused model calling
@@ -4341,25 +4351,25 @@
           } else if (!el.isContentEditable && el.tagName !== 'TEXTAREA' && el.tagName !== 'INPUT') {
             return failure(`ref_id ${ref_id} is not a text field (tag=${el.tagName}). set_field works on input/textarea/contenteditable only.`);
           }
+          const fieldMeta = _fieldMeta(el);
           let prevValue = '';
-          dispatched = true;
           if (el.isContentEditable) {
             prevValue = _editableTextValue(el);
-            if (clear) {
-              try {
-                const sel = window.getSelection();
-                const r = document.createRange();
-                r.selectNodeContents(el);
-                sel.removeAllRanges();
-                sel.addRange(r);
-                document.execCommand('delete');
-              } catch {}
-            }
-            try { document.execCommand('insertText', false, text); } catch {
-              el.textContent = (clear ? '' : prevValue) + text;
-              el.dispatchEvent(new Event('input', { bubbles: true }));
-            }
+            return failure(
+              'Contenteditable fields require trusted browser typing. Attempting one ref-bound Chrome typing pass.',
+              {
+                method: 'set_field_contenteditable_trusted',
+                ref_id,
+                rect,
+                verified: false,
+                fieldMeta,
+                fallbackAttempted: false,
+                trustedTypeRequired: true,
+                _expectedValue: (clear ? '' : prevValue) + text,
+              },
+            );
           } else {
+            dispatched = true;
             prevValue = el.value || '';
             const proto = el.tagName === 'TEXTAREA'
               ? window.HTMLTextAreaElement.prototype
@@ -4381,7 +4391,6 @@
               { ref_id, verified: false, recoveryRequired: 'fresh_tree', failureScope: `field-value:${ref_id}`, retryable: false },
             );
           }
-          const fieldMeta = _fieldMeta(el);
           const actual = el.isContentEditable ? _editableTextValue(el) : (el.value || '');
           const verified = _setFieldValueMatches(actual, prevValue, text, clear, el.isContentEditable);
           const fallbackAttempted = false;
@@ -4494,7 +4503,20 @@
           const isCombobox = role === 'combobox'
             || !!(el.getAttribute && el.getAttribute('aria-autocomplete'))
             || (el.getAttribute && el.getAttribute('aria-expanded') === 'true');
-          return { success: true, ref_id, fieldMeta: _fieldMeta(el), isCombobox };
+          const rect = el.getBoundingClientRect();
+          return {
+            success: true,
+            ref_id,
+            fieldMeta: _fieldMeta(el),
+            isCombobox,
+            contentEditable: !!el.isContentEditable,
+            rect: {
+              x: Math.round(rect.x),
+              y: Math.round(rect.y),
+              w: Math.round(rect.width),
+              h: Math.round(rect.height),
+            },
+          };
         } catch (error) {
           return { success: false, error: error && error.message || String(error) };
         }

--- a/src/chrome/src/ui/recommended-actions.js
+++ b/src/chrome/src/ui/recommended-actions.js
@@ -146,8 +146,10 @@ function webbrainTweetRunOptions(postText) {
     summary: 'Publish the reviewed localized WebBrain post exactly as supplied.',
     steps: [
       'Open https://x.com/compose/post in the current tab through the visible browser UI.',
+      'Wait for the visible X composer to become stable before entering text.',
       `Enter this exact reviewed text in the visible X composer without translating, rewriting, or adding anything: ${JSON.stringify(exactPost)}`,
-      'Publish only after the composer text exactly matches the supplied text.',
+      'Publish only after the composer text exactly matches the supplied text and the Post control is enabled. If it remains disabled, keep the composer open and refill it through the trusted typing path.',
+      'Treat an unverified or no-progress Post click as not submitted; keep the composer open and recover instead of dismissing it.',
       'Verify the new tweet appears, then report its URL when available.',
     ],
   };

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15853,6 +15853,9 @@ const ADAPTERS = [
     fullPageCapture: { infiniteScroll: isTwitterInfiniteScrollUrl },
     notes: `
 - The composer is a contenteditable, not a textarea. Character count is enforced client-side at 280 (or higher for Premium).
+- On /compose/post, call wait_for_stable before filling the composer. After typing, re-read the visible accessibility tree and require the Post control to be enabled (no disabled=true) before clicking it.
+- If the exact text is visible but Post remains disabled, keep the composer open and refill the editor with type_text({selector:"[data-testid=\\\"tweetTextarea_0\\\"]", text:"<exact complete post>", clear:true}). Do not dismiss the composer to recover.
+- A click_ax result with verified:false or no observable posting evidence is not proof that the post was published. Keep the composer open and verify a new status URL or matching feed item before reporting success.
 - The timeline is virtualized — tweets scroll out of the DOM. To find a specific tweet, use search, don't scroll.
 - "Reply", "Retweet", "Like" icons are below each tweet; the share menu has "Copy link" for permalinks.
 - Quote tweets vs reposts: the retweet icon opens a menu with both options.`,

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -564,6 +564,18 @@
     const ph = el.getAttribute('placeholder');
     if (ph) line += ' placeholder="' + ph + '"';
 
+    // Disabled submit/action state is a blocker the model must see before it
+    // tries to activate a control. In particular, React editors can contain
+    // visually correct DOM text while their application state still leaves
+    // the associated Post/Send button aria-disabled.
+    let disabled = false;
+    try {
+      disabled = !!el.disabled
+        || el.getAttribute('aria-disabled') === 'true'
+        || el.matches(':disabled');
+    } catch {}
+    if (disabled) line += ' disabled=true';
+
     // Checkbox/radio state is an action-critical value, not decorative
     // metadata. Without it the model has to infer state from a focus ring or
     // screenshot and can accidentally toggle a control back off.

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -2837,6 +2837,7 @@
       return {
         tag,
         type: fieldType,
+        contentEditable: !!el.isContentEditable,
         name: el.getAttribute ? el.getAttribute('name') : null,
         id: elId,
         autocomplete: el.getAttribute ? el.getAttribute('autocomplete') : null,
@@ -3057,6 +3058,18 @@
               ? ' Nearest existing refs: ' + suggestions.map(s => `${s.ref} (${s.role}${s.name ? ' "' + s.name + '"' : ''})`).join(', ') + '.'
               : '';
             return failure(`ref_id ${ref_id} not found.${formatNote} The element may have been removed or the page replaced.${hint} Re-read the accessibility tree to get fresh ids — do NOT guess ref numbers or invent placeholders.`, { suggestions });
+          }
+          const disabledOwner = el.closest?.('button:disabled,input:disabled,select:disabled,textarea:disabled,[aria-disabled="true"]');
+          if (disabledOwner) {
+            return failure(
+              `ref_id ${ref_id} is disabled and cannot be activated. Re-read the page after correcting the form or editor state; do not treat this click as submitted.`,
+              {
+                ref_id,
+                disabled: true,
+                nativeDisabled: !!disabledOwner.disabled,
+                ariaDisabled: disabledOwner.getAttribute?.('aria-disabled') === 'true',
+              },
+            );
           }
           const tag = el.tagName ? el.tagName.toLowerCase() : '';
           const inputType = tag === 'input' ? String(el.type || '').toLowerCase() : '';

--- a/src/firefox/src/ui/recommended-actions.js
+++ b/src/firefox/src/ui/recommended-actions.js
@@ -145,8 +145,10 @@ function webbrainTweetRunOptions(postText) {
     summary: 'Publish the reviewed localized WebBrain post exactly as supplied.',
     steps: [
       'Open https://x.com/compose/post in the current tab through the visible browser UI.',
+      'Wait for the visible X composer to become stable before entering text.',
       `Enter this exact reviewed text in the visible X composer without translating, rewriting, or adding anything: ${JSON.stringify(exactPost)}`,
-      'Publish only after the composer text exactly matches the supplied text.',
+      'Publish only after the composer text exactly matches the supplied text and the Post control is enabled. If it remains disabled, keep the composer open and refill it through the trusted typing path.',
+      'Treat an unverified or no-progress Post click as not submitted; keep the composer open and recover instead of dismissing it.',
       'Verify the new tweet appears, then report its URL when available.',
     ],
   };

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -1549,6 +1549,27 @@ for (const browserKind of ['chrome', 'firefox']) {
     }
   });
 
+  test(`click_ax (${browserKind}): disabled controls are visible and rejected before dispatch`, async (page) => {
+    await setupContentFixture(page, 'trusted-click-fallback.html', browserKind);
+    const tree = await call(page, 'get_accessibility_tree', { filter: 'all', maxDepth: 10, maxChars: 30000 });
+    const content = String(tree?.pageContent || '');
+    for (const label of ['Disabled native action', 'Disabled ARIA action']) {
+      const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const match = content.match(new RegExp(`button "${escaped}" \\[(ref_\\d+)\\][^\\n]*disabled=true`));
+      if (!match) throw new Error(`expected disabled state for ${label} in AX tree: ${content}`);
+      const result = await call(page, 'click_ax', { ref_id: match[1] });
+      if (
+        result?.success !== false
+        || result.disabled !== true
+        || result.dispatched !== false
+        || result.noDispatch !== true
+        || result.fallbackAttempted !== false
+      ) {
+        throw new Error(`disabled ${label} should fail before dispatch: ${JSON.stringify(result)}`);
+      }
+    }
+  });
+
   test(`input tools (${browserKind}): invalid targets and keys are explicit pre-dispatch failures`, async (page) => {
     await setupContentFixture(page, 'trusted-click-fallback.html', browserKind);
     const calls = [
@@ -1869,6 +1890,86 @@ for (const browserKind of ['chrome', 'firefox']) {
     }
   });
 }
+
+test('set_field (chrome): trusted contenteditable input updates framework state and enables submit', async (page) => {
+  await setup(page, 'trusted-click-fallback.html');
+  const tree = await call(page, 'get_accessibility_tree', { filter: 'all', maxDepth: 10, maxChars: 30000 });
+  const content = String(tree?.pageContent || '');
+  const editorMatch = content.match(/textbox "Framework post text" \[(ref_\d+)\]/);
+  if (!editorMatch || !/button "Framework Post" \[(ref_\d+)\][^\n]*disabled=true/.test(content)) {
+    throw new Error(`expected empty framework editor and disabled submit: ${content}`);
+  }
+
+  const preflight = await call(page, 'set_field', {
+    ref_id: editorMatch[1],
+    text: 'Trusted framework post',
+    clear: true,
+  });
+  if (
+    preflight?.success !== false
+    || preflight.trustedTypeRequired !== true
+    || preflight.dispatched !== false
+    || preflight.noDispatch !== true
+  ) {
+    throw new Error(`contenteditable set_field should route to trusted typing before DOM mutation: ${JSON.stringify(preflight)}`);
+  }
+
+  const before = await page.evaluate(() => ({
+    text: document.getElementById('framework-editor').innerText,
+    disabled: document.getElementById('framework-post').getAttribute('aria-disabled'),
+    events: window.__frameworkInputEvents,
+  }));
+  if (before.text || before.disabled !== 'true' || before.events.length !== 0) {
+    throw new Error(`contenteditable preflight mutated framework state: ${JSON.stringify(before)}`);
+  }
+
+  const originalChrome = globalThis.chrome;
+  const originals = {
+    attach: cdpClient.attach,
+    sendCommand: cdpClient.sendCommand,
+  };
+  const session = await page.context().newCDPSession(page);
+  globalThis.chrome = {
+    tabs: {
+      async sendMessage(_tabId, message) {
+        return call(page, message.action, message.params || {});
+      },
+    },
+  };
+  try {
+    cdpClient.attach = async () => ({ tabId: 42, attached: true });
+    cdpClient.sendCommand = async (_tabId, method, params) => session.send(method, params);
+    const agent = new Agent({});
+    const result = await agent._maybeFallbackFieldWithCdp(
+      42,
+      'set_field',
+      { ref_id: editorMatch[1], text: 'Trusted framework post', clear: true },
+      preflight,
+    );
+    const after = await page.evaluate(() => ({
+      text: document.getElementById('framework-editor').innerText,
+      disabled: document.getElementById('framework-post').getAttribute('aria-disabled'),
+      events: window.__frameworkInputEvents,
+    }));
+    if (
+      result?.success !== true
+      || result.trusted !== true
+      || result.verified !== true
+      || result.dispatched !== true
+      || after.text !== 'Trusted framework post'
+      || after.disabled !== 'false'
+      || after.events.length !== 1
+      || after.events[0].trusted !== true
+    ) {
+      throw new Error(`trusted contenteditable path did not update framework state: ${JSON.stringify({ result, after })}`);
+    }
+  } finally {
+    cdpClient.attach = originals.attach;
+    cdpClient.sendCommand = originals.sendCommand;
+    if (originalChrome === undefined) delete globalThis.chrome;
+    else globalThis.chrome = originalChrome;
+  }
+});
 
 test('click_ax: Agent.executeTool keeps synthetic-first behavior and uses trusted CDP only for an ignored generic row', async (page) => {
   await setup(page, 'trusted-click-fallback.html');

--- a/test/fixtures/trusted-click-fallback.html
+++ b/test/fixtures/trusted-click-fallback.html
@@ -130,6 +130,8 @@
     <input type="text" aria-label="Nested input action">
   </div>
   <button id="native-button" type="button">Native button</button>
+  <button id="disabled-native-button" type="button" disabled>Disabled native action</button>
+  <button id="disabled-aria-button" type="button" aria-disabled="true">Disabled ARIA action</button>
   <details id="native-details" class="row">
     <summary id="native-summary">Native disclosure</summary>
     <div>Native disclosure content</div>
@@ -144,6 +146,10 @@
   <input id="native-input" type="text" value="Native input" aria-label="Native input">
   <select id="native-select" aria-label="Native select"><option>Native select</option></select>
   <div id="editable-row" class="row" role="textbox" aria-label="Editable row" contenteditable="true">Editable row</div>
+  <section id="framework-composer">
+    <div id="framework-editor" role="textbox" aria-label="Framework post text" contenteditable="true"></div>
+    <button id="framework-post" type="button" aria-disabled="true">Framework Post</button>
+  </section>
   <div id="download-row" class="row" role="listitem" data-download tabindex="0">Export report</div>
   <form>
     <div id="form-row" class="row" role="listitem" tabindex="0">Form row</div>
@@ -178,6 +184,13 @@
     window.__trustedClickEvents = [];
     window.__syntheticClickEvents = [];
     window.__trustedCheckboxEvents = [];
+    window.__frameworkInputEvents = [];
+    document.getElementById('framework-editor').addEventListener('input', (event) => {
+      window.__frameworkInputEvents.push({ trusted: event.isTrusted, text: event.currentTarget.innerText });
+      if (event.isTrusted && event.currentTarget.innerText.trim()) {
+        document.getElementById('framework-post').setAttribute('aria-disabled', 'false');
+      }
+    });
     document.getElementById('trusted-firefox-checkbox').addEventListener('click', (event) => {
       window.__trustedCheckboxEvents.push({ trusted: event.isTrusted, checked: event.currentTarget.checked });
       if (!event.isTrusted) event.preventDefault();

--- a/test/run.js
+++ b/test/run.js
@@ -31659,8 +31659,30 @@ test('Chrome controlled-field fallback recovers exactly once and never submits a
     );
 
     commands.length = 0;
-    contentEditable = false;
     verified = false;
+    const failedEditor = await agent._maybeFallbackFieldWithCdp(
+      42,
+      'set_field',
+      { ref_id: 'ref_editor', text: 'exact post', submit: false },
+      {
+        success: false,
+        verified: false,
+        dispatched: false,
+        noDispatch: true,
+        trustedTypeRequired: true,
+        error: 'contenteditable requires trusted typing',
+        _expectedValue: 'exact post',
+      },
+    );
+    assert.equal(failedEditor.success, false);
+    assert.equal(failedEditor.verified, false);
+    assert.equal(failedEditor.dispatched, true, 'a failed readback must preserve the trusted input dispatch');
+    assert.equal(failedEditor.noDispatch, false, 'trusted contenteditable input must not remain retry-safe');
+    assert.equal(failedEditor.recoveryRequired, 'fresh_tree');
+    assert.equal(commands.filter(command => command.method === 'Input.insertText').length, 1, 'only one trusted editor retry is allowed');
+
+    commands.length = 0;
+    contentEditable = false;
     const failed = await agent._maybeFallbackFieldWithCdp(
       42,
       'set_field',

--- a/test/run.js
+++ b/test/run.js
@@ -2363,6 +2363,14 @@ test('matches google search across TLDs and includes udm=14, without hijacking o
 test('matches twitter.com and x.com', () => {
   assert.equal(getActiveAdapter('https://twitter.com/elonmusk')?.name, 'twitter');
   assert.equal(getActiveAdapter('https://x.com/elonmusk')?.name, 'twitter');
+  for (const getAdapter of [getActiveAdapter, getActiveAdapterFx]) {
+    const notes = getAdapter('https://x.com/compose/post')?.notes || '';
+    assert.match(notes, /wait_for_stable/);
+    assert.match(notes, /disabled=true/);
+    assert.match(notes, /selector:"\[data-testid=\\"tweetTextarea_0\\"\]"/);
+    assert.match(notes, /verified:false/);
+    assert.match(notes, /keep the composer open/i);
+  }
 });
 
 test('matches youtube video URLs and includes transcript guidance', () => {
@@ -6835,8 +6843,10 @@ test('WebBrain promotion has explicit X and LinkedIn variants with ready-to-go p
   const exactPost = 'Introducing WebBrain — an open-source AI browser agent that lives in your browser. Chat with any page, automate multi-step workflows, and bring your own LLM. Extensible by design. Try it: https://webbrain.one';
   const expectedTweetSteps = [
     'Open https://x.com/compose/post in the current tab through the visible browser UI.',
+    'Wait for the visible X composer to become stable before entering text.',
     `Enter this exact reviewed text in the visible X composer without translating, rewriting, or adding anything: ${JSON.stringify(exactPost)}`,
-    'Publish only after the composer text exactly matches the supplied text.',
+    'Publish only after the composer text exactly matches the supplied text and the Post control is enabled. If it remains disabled, keep the composer open and refill it through the trusted typing path.',
+    'Treat an unverified or no-progress Post click as not submitted; keep the composer open and recover instead of dismissing it.',
     'Verify the new tweet appears, then report its URL when available.',
   ];
   const expectedLinkedInSteps = [
@@ -31534,6 +31544,15 @@ test('Chrome controlled-field fallback is ref-bound, trusted, verified, and subm
   assert.match(agent, /verification\.verified !== true[\s\S]*if \(toolName === 'set_field' && args\?\.submit === true\)/, 'chrome: submit must remain after trusted verification');
   assert.match(content, /'ax_prepare_field_for_trusted_type'[\s\S]*window\.__wb_ax_lookup\(ref_id\)[\s\S]*el\.select\(\)/, 'chrome: trusted retry must focus and select the ref-bound field');
   assert.match(content, /'ax_verify_field_value'[\s\S]*_setFieldValueMatches\(actual, '', expected, true/, 'chrome: trusted retry must use exact settled verification');
+  for (const toolName of ['type_ax', 'set_field']) {
+    const branchStart = content.indexOf(`'${toolName}': async () => {`);
+    const branchEnd = toolName === 'type_ax'
+      ? content.indexOf("'set_field': async () => {", branchStart)
+      : content.indexOf("'ax_prepare_field_for_trusted_type':", branchStart);
+    const branch = content.slice(branchStart, branchEnd);
+    assert.match(branch, /el\.isContentEditable[\s\S]*trustedTypeRequired: true[\s\S]*_expectedValue/, `chrome: ${toolName} contenteditables must route through trusted typing`);
+    assert.doesNotMatch(branch, /document\.execCommand\('insertText'/, `chrome: ${toolName} must not accept synthetic contenteditable DOM text as verified input`);
+  }
 });
 
 test('Chrome controlled-field fallback recovers exactly once and never submits a mismatch', async () => {
@@ -31545,11 +31564,20 @@ test('Chrome controlled-field fallback recovers exactly once and never submits a
   try {
     const commands = [];
     let verified = true;
+    let contentEditable = false;
+    let prepareCalls = 0;
     globalThis.chrome = {
       tabs: {
         async sendMessage(_tabId, message) {
           if (message.action === 'ax_prepare_field_for_trusted_type') {
-            return { success: true, fieldMeta: { type: 'text' }, isCombobox: false };
+            prepareCalls += 1;
+            return {
+              success: true,
+              fieldMeta: { type: contentEditable ? 'div' : 'text', contentEditable },
+              isCombobox: false,
+              contentEditable,
+              ...(contentEditable ? { rect: { x: 10, y: 20, w: 300, h: 80 } } : {}),
+            };
           }
           if (message.action === 'ax_verify_field_value') {
             return {
@@ -31597,6 +31625,41 @@ test('Chrome controlled-field fallback recovers exactly once and never submits a
     );
 
     commands.length = 0;
+    contentEditable = true;
+    prepareCalls = 0;
+    const recoveredEditor = await agent._maybeFallbackFieldWithCdp(
+      42,
+      'set_field',
+      { ref_id: 'ref_editor', text: 'exact post', submit: false },
+      {
+        success: false,
+        verified: false,
+        dispatched: false,
+        noDispatch: true,
+        trustedTypeRequired: true,
+        error: 'contenteditable requires trusted typing',
+        _expectedValue: 'exact post',
+      },
+    );
+    assert.equal(recoveredEditor.success, true);
+    assert.equal(recoveredEditor.trusted, true);
+    assert.equal(recoveredEditor.dispatched, true);
+    assert.equal(recoveredEditor.noDispatch, undefined);
+    assert.equal(recoveredEditor.trustedTypeRequired, undefined);
+    assert.equal(prepareCalls, 2, 'contenteditable trusted focus must be followed by ref-bound reselection');
+    assert.deepEqual(
+      commands.map(command => command.method),
+      [
+        'Input.dispatchMouseEvent',
+        'Input.dispatchMouseEvent',
+        'Input.dispatchMouseEvent',
+        'Input.insertText',
+      ],
+      'contenteditable recovery must use trusted focus followed by trusted text insertion',
+    );
+
+    commands.length = 0;
+    contentEditable = false;
     verified = false;
     const failed = await agent._maybeFallbackFieldWithCdp(
       42,


### PR DESCRIPTION
## Summary

- route Chrome contenteditable writes through trusted CDP input so framework state updates with the visible DOM
- expose disabled controls in the accessibility tree and fail closed before clicking them
- harden the X adapter and recommended post action to wait for an enabled Post button, recover with trusted typing, and verify actual navigation/feed progress
- mirror disabled-state handling in Firefox and add focused regression coverage

## Root cause

The X composer is a contenteditable element backed by framework state. The previous field tools could mutate visible `innerText` synthetically and accept that DOM readback even when X still considered the composer empty. The Post button therefore stayed disabled, while `click_ax` attempted a synthetic click and returned an unverified success.

## Validation

- `npm run test:fixtures` — pass
- `npm run test:security` — 60/60 pass
- syntax checks and `git diff --check` — pass
- `node test/run.js` — 1222 pass, 1 pre-existing repository release-history failure (`package.json` is 25.7.3 while the newest `CHANGELOG.md` entry on `main` is 25.7.0)
