### PR TITLE
Remove Chrome Web Store release from available skills

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15710,8 +15710,7 @@ const ADAPTERS = [
     matches: (url) => /^https:\/\/chrome\.google\.com\/webstore\/devconsole(?:[/?#]|$)/i.test(url),
     notes: `
 - This dashboard is a Chrome-protected page. Extension DOM, accessibility-tree, script-injection, and debugger tools cannot access it. Never retry those tools here.
-- If the enabled skill catalog contains \`chrome-web-store-release\`, load it and use \`chrome_web_store_status\`, \`chrome_web_store_upload\`, and \`chrome_web_store_publish\` instead of dashboard controls.
-- If that skill is not enabled, ask the user to enable "Chrome Web Store release" in Settings → Skills and configure OAuth, publisher/item IDs, and a release ZIP. Continue manually if they do not want API access.
+- Continue manually in the dashboard; no packaged release skill is available.
 - A screenshot may provide read-only visual context once, but it cannot make dashboard controls interactive or verify an API mutation.`,
   },
   {

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -4034,7 +4034,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // <untrusted_page_content> box and is read as an instruction, not data.
       let resultContent = this._wrapUntrusted(fnName, this._limitToolResult(toolResult));
       if (toolResult?.errorCode === 'chrome_protected_page') {
-        resultContent += '\n[TRUSTED RUNTIME ROUTING: Chrome blocks extension DOM/debugger access on this dashboard. Do not call another DOM, accessibility, wait, script, iframe, WebMCP, or upload_file tool here. If chrome-web-store-release is enabled and visible in the skill catalog, load it and use its chrome_web_store_* tools. Otherwise ask the user to enable/configure that packaged skill or continue manually.]';
+        resultContent += '\n[TRUSTED RUNTIME ROUTING: Chrome blocks extension DOM/debugger access on this dashboard. Do not call another DOM, accessibility, wait, script, iframe, WebMCP, or upload_file tool here. Continue manually in the dashboard.]';
         onUpdate('warning', { message: 'Chrome-protected dashboard detected; DOM automation is unavailable.' });
       }
       if (nytimesPageGateFallback) {

--- a/src/chrome/src/agent/skills.js
+++ b/src/chrome/src/agent/skills.js
@@ -46,11 +46,6 @@ export const PACKAGED_SKILL_SOURCES = Object.freeze([
     name: 'Open Library',
     path: 'skills/open-library-books.md',
   }),
-  Object.freeze({
-    id: 'chrome-web-store-release',
-    name: 'Chrome Web Store release',
-    path: 'skills/chrome-web-store-release.md',
-  }),
 ]);
 export const DEFAULT_SKILL_SOURCES = Object.freeze(
   PACKAGED_SKILL_SOURCES.filter((source) => [

--- a/src/chrome/src/agent/skills.js
+++ b/src/chrome/src/agent/skills.js
@@ -64,6 +64,17 @@ function cleanSingleLine(value) {
   return cleanText(value).replace(/\s+/g, ' ');
 }
 
+export function removeRetiredPackagedSkills(value) {
+  const skills = Array.isArray(value) ? value : [];
+  // Match the retired packaged provenance exactly so a user-authored skill
+  // that happens to reuse the old id remains intact.
+  return skills.filter((skill) => !(
+    skill?.id === 'chrome-web-store-release'
+    && skill?.sourceType === 'built-in'
+    && cleanSingleLine(skill?.sourceUrl || skill?.path) === 'skills/chrome-web-store-release.md'
+  ));
+}
+
 function stableId(value, index) {
   const raw = cleanSingleLine(value);
   return /^[a-zA-Z0-9_-]{1,80}$/.test(raw) ? raw : `skill_${index + 1}`;

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -9,6 +9,7 @@ import {
   PACKAGED_SKILL_SOURCES,
   normalizeCustomSkills,
   normalizeDefaultSkillRemovalIds,
+  removeRetiredPackagedSkills,
   refreshBuiltInSkillRecord,
 } from './agent/skills.js';
 import { ScheduledJobManager } from './agent/scheduler.js';
@@ -668,7 +669,18 @@ async function loadCustomSkills() {
     DEFAULT_SKILLS_SEEDED_STORAGE_KEY,
     'enableAllPackagedSkills',
   ]);
-  let skills = normalizeCustomSkills(stored[CUSTOM_SKILLS_STORAGE_KEY]);
+  const storedSkills = Array.isArray(stored[CUSTOM_SKILLS_STORAGE_KEY])
+    ? stored[CUSTOM_SKILLS_STORAGE_KEY]
+    : [];
+  const retainedSkills = removeRetiredPackagedSkills(storedSkills);
+  let skills = normalizeCustomSkills(retainedSkills);
+  if (retainedSkills.length !== storedSkills.length) {
+    try {
+      await chrome.storage.local.set({ [CUSTOM_SKILLS_STORAGE_KEY]: skills });
+    } catch (error) {
+      console.warn('[WebBrain] Retired packaged skills could not be removed', error);
+    }
+  }
   const removedDefaultIds = new Set(normalizeDefaultSkillRemovalIds(stored[DEFAULT_SKILLS_REMOVED_STORAGE_KEY]));
   try {
     const existingIds = new Set(skills.map((skill) => skill.id));
@@ -891,7 +903,16 @@ chrome.storage.onChanged.addListener((changes) => {
     });
   }
   if (changes[CUSTOM_SKILLS_STORAGE_KEY]) {
-    agent.customSkills = normalizeCustomSkills(changes[CUSTOM_SKILLS_STORAGE_KEY].newValue);
+    const storedSkills = Array.isArray(changes[CUSTOM_SKILLS_STORAGE_KEY].newValue)
+      ? changes[CUSTOM_SKILLS_STORAGE_KEY].newValue
+      : [];
+    const retainedSkills = removeRetiredPackagedSkills(storedSkills);
+    agent.customSkills = normalizeCustomSkills(retainedSkills);
+    if (retainedSkills.length !== storedSkills.length) {
+      chrome.storage.local.set({ [CUSTOM_SKILLS_STORAGE_KEY]: agent.customSkills }).catch((error) => {
+        console.warn('[WebBrain] Retired packaged skills could not be removed', error);
+      });
+    }
     refreshPrompts = true;
   }
   if (changes.captchaSolverEnabled) {

--- a/src/chrome/src/chrome-protected-pages.js
+++ b/src/chrome/src/chrome-protected-pages.js
@@ -36,13 +36,7 @@ export function chromeProtectedPageFailure(url, toolName = '') {
     nonRetryableScope: `chrome-protected-page:${protectedPage}`,
     protectedPage,
     url: String(url || ''),
-    recoverySkill: 'chrome-web-store-release',
-    recoveryTools: [
-      'chrome_web_store_status',
-      'chrome_web_store_upload',
-      'chrome_web_store_publish',
-    ],
-    error: `${name} cannot access the Chrome Web Store Developer Dashboard because Chrome blocks extension content scripts and debugger attachment on this protected page. Do not retry this or another DOM tool. If the Chrome Web Store release skill is enabled, load it and use its trusted tools; otherwise ask the user to enable it in Settings → Skills. A screenshot may be used once for read-only visual context, but cannot make dashboard controls interactive.`,
-    stopMessage: 'Stopped: Chrome protects the Chrome Web Store Developer Dashboard from extension DOM access. Repeating DOM reads, waits, clicks, typing, script injection, or debugger-based fallbacks cannot work. Use the enabled Chrome Web Store release skill or continue manually.',
+    error: `${name} cannot access the Chrome Web Store Developer Dashboard because Chrome blocks extension content scripts and debugger attachment on this protected page. Do not retry this or another DOM tool. Continue manually in the dashboard. A screenshot may be used once for read-only visual context, but cannot make dashboard controls interactive.`,
+    stopMessage: 'Stopped: Chrome protects the Chrome Web Store Developer Dashboard from extension DOM access. Repeating DOM reads, waits, clicks, typing, script injection, or debugger-based fallbacks cannot work. Continue manually in the dashboard.',
   };
 }

--- a/src/chrome/src/ui/settings.html
+++ b/src/chrome/src/ui/settings.html
@@ -1736,42 +1736,6 @@
       <div id="skills-list"></div>
     </div>
 
-    <div class="provider-card" id="chrome-web-store-release-card" hidden>
-      <div class="setting-label" style="margin-bottom:6px;" data-i18n="st.skills.cws.heading"></div>
-      <div class="setting-desc" style="margin-bottom:14px;" data-i18n-html="st.skills.cws.desc_html"></div>
-      <div class="field">
-        <label for="chrome-web-store-publisher-id" data-i18n="st.skills.cws.publisher_id"></label>
-        <input type="text" id="chrome-web-store-publisher-id" autocomplete="off">
-      </div>
-      <div class="field">
-        <label for="chrome-web-store-item-id" data-i18n="st.skills.cws.item_id"></label>
-        <input type="text" id="chrome-web-store-item-id" autocomplete="off" maxlength="32">
-      </div>
-      <div class="field">
-        <label for="chrome-web-store-oauth-client-id" data-i18n="st.skills.cws.oauth_client_id"></label>
-        <input type="text" id="chrome-web-store-oauth-client-id" autocomplete="off">
-      </div>
-      <div class="field">
-        <label for="chrome-web-store-oauth-client-secret" data-i18n="st.skills.cws.oauth_client_secret"></label>
-        <input type="password" id="chrome-web-store-oauth-client-secret" autocomplete="off">
-      </div>
-      <div class="setting-desc" style="margin:-4px 0 12px;" data-i18n="st.skills.cws.redirect_help"></div>
-      <div class="btn-row">
-        <button class="btn-secondary" id="btn-save-chrome-web-store" data-i18n="st.skills.cws.save"></button>
-        <button class="btn-primary" id="btn-connect-chrome-web-store" data-i18n="st.skills.cws.connect"></button>
-        <button class="btn-secondary" id="btn-signout-chrome-web-store" data-i18n="st.skills.cws.signout"></button>
-      </div>
-      <div class="field" style="margin-top:16px;">
-        <label for="chrome-web-store-package" data-i18n="st.skills.cws.package"></label>
-        <input type="file" id="chrome-web-store-package" accept=".zip,application/zip">
-        <div class="setting-desc" id="chrome-web-store-package-status"></div>
-      </div>
-      <div class="btn-row">
-        <button class="btn-secondary" id="btn-clear-chrome-web-store-package" data-i18n="st.skills.cws.clear_package"></button>
-      </div>
-      <div class="test-result" id="chrome-web-store-result"></div>
-    </div>
-
     <div class="info-box" data-i18n-html="st.skills.security_html"></div>
 
     <dialog class="skill-preview-dialog" id="skill-preview-dialog" aria-labelledby="skill-preview-title">

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -37,13 +37,6 @@ import {
   normalizeDownloadDirectory,
 } from '../download-directory.js';
 import {
-  CHROME_WEB_STORE_CONFIG_KEY,
-  CHROME_WEB_STORE_MAX_PACKAGE_BYTES,
-  CHROME_WEB_STORE_PACKAGE_KEY,
-  CHROME_WEB_STORE_SKILL_ID,
-  normalizeChromeWebStoreConfig,
-} from '../chrome-web-store-release.js';
-import {
   providerIconHtml,
   providerIconUrl,
   PROVIDER_SHORT_LABELS,
@@ -113,19 +106,6 @@ const skillPreviewSource = document.getElementById('skill-preview-source');
 const skillPreviewRendered = document.getElementById('skill-preview-rendered');
 const skillPreviewRaw = document.getElementById('skill-preview-raw');
 const skillPreviewViewButtons = document.querySelectorAll('[data-skill-preview-view]');
-const chromeWebStoreCard = document.getElementById('chrome-web-store-release-card');
-const chromeWebStorePublisherId = document.getElementById('chrome-web-store-publisher-id');
-const chromeWebStoreItemId = document.getElementById('chrome-web-store-item-id');
-const chromeWebStoreOauthClientId = document.getElementById('chrome-web-store-oauth-client-id');
-const chromeWebStoreOauthClientSecret = document.getElementById('chrome-web-store-oauth-client-secret');
-const chromeWebStorePackage = document.getElementById('chrome-web-store-package');
-const chromeWebStorePackageStatus = document.getElementById('chrome-web-store-package-status');
-const chromeWebStoreResult = document.getElementById('chrome-web-store-result');
-const btnSaveChromeWebStore = document.getElementById('btn-save-chrome-web-store');
-const btnConnectChromeWebStore = document.getElementById('btn-connect-chrome-web-store');
-const btnSignoutChromeWebStore = document.getElementById('btn-signout-chrome-web-store');
-const btnClearChromeWebStorePackage = document.getElementById('btn-clear-chrome-web-store-package');
-
 // Transcription service (Whisper-compatible) — same shape as the vision
 // override but routes to /v1/audio/transcriptions instead of /v1/chat/completions.
 const transcriptionBaseUrlInput = document.getElementById('transcription-base-url');
@@ -829,11 +809,6 @@ function renderPackagedSkills() {
 function renderSkills() {
   if (!skillsList) return;
   renderPackagedSkills();
-  const chromeWebStoreEnabled = customSkills.some((skill) => (
-    skill.id === CHROME_WEB_STORE_SKILL_ID && skill.sourceType === 'built-in'
-  ));
-  if (chromeWebStoreCard) chromeWebStoreCard.hidden = !chromeWebStoreEnabled;
-  if (chromeWebStoreEnabled) void loadChromeWebStoreSettings();
   if (customSkills.length === 0) {
     skillsList.innerHTML = `<div class="setting-desc">${escapeHtml(t('st.skills.empty'))}</div>`;
     return;
@@ -871,85 +846,6 @@ function renderSkills() {
       flashSkillsResult('ok', t('st.skills.removed'));
     });
   });
-}
-
-function showChromeWebStoreResult(kind, message) {
-  if (!chromeWebStoreResult) return;
-  chromeWebStoreResult.className = `test-result show ${kind}`;
-  chromeWebStoreResult.textContent = message;
-}
-
-function chromeWebStoreConfigFromForm() {
-  return normalizeChromeWebStoreConfig({
-    publisherId: chromeWebStorePublisherId?.value,
-    itemId: chromeWebStoreItemId?.value,
-    oauthClientId: chromeWebStoreOauthClientId?.value,
-    oauthClientSecret: chromeWebStoreOauthClientSecret?.value,
-  });
-}
-
-async function saveChromeWebStoreConfig({ flash = true } = {}) {
-  const config = chromeWebStoreConfigFromForm();
-  await chrome.storage.local.set({ [CHROME_WEB_STORE_CONFIG_KEY]: config });
-  if (flash) showChromeWebStoreResult('ok', t('st.skills.cws.saved'));
-  return config;
-}
-
-async function loadChromeWebStoreSettings() {
-  if (!chromeWebStoreCard || chromeWebStoreCard.hidden) return;
-  const stored = await chrome.storage.local.get([CHROME_WEB_STORE_CONFIG_KEY, CHROME_WEB_STORE_PACKAGE_KEY]);
-  const config = normalizeChromeWebStoreConfig(stored[CHROME_WEB_STORE_CONFIG_KEY]);
-  if (chromeWebStorePublisherId) chromeWebStorePublisherId.value = config.publisherId;
-  if (chromeWebStoreItemId) chromeWebStoreItemId.value = config.itemId;
-  if (chromeWebStoreOauthClientId) chromeWebStoreOauthClientId.value = config.oauthClientId;
-  if (chromeWebStoreOauthClientSecret) chromeWebStoreOauthClientSecret.value = config.oauthClientSecret;
-  const pkg = stored[CHROME_WEB_STORE_PACKAGE_KEY];
-  if (chromeWebStorePackageStatus) {
-    chromeWebStorePackageStatus.textContent = pkg?.name
-      ? t('st.skills.cws.package_selected', { name: pkg.name, size: Math.ceil((Number(pkg.size) || 0) / 1024) })
-      : t('st.skills.cws.package_empty');
-  }
-  const oauth = await sendToBackground('chrome_web_store_oauth_status').catch(() => ({ signedIn: false }));
-  showChromeWebStoreResult(oauth.signedIn ? 'ok' : 'warn', oauth.signedIn
-    ? t('st.skills.cws.connected')
-    : t('st.skills.cws.disconnected'));
-}
-
-function bytesToBase64(bytes) {
-  let binary = '';
-  const chunkSize = 0x8000;
-  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
-    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
-  }
-  return btoa(binary);
-}
-
-async function selectChromeWebStorePackage(file) {
-  if (!file) return;
-  if (!/\.zip$/i.test(file.name)) throw new Error(t('st.skills.cws.package_zip_only'));
-  if (file.size <= 0 || file.size > CHROME_WEB_STORE_MAX_PACKAGE_BYTES) {
-    throw new Error(t('st.skills.cws.package_too_large'));
-  }
-  const bytes = new Uint8Array(await file.arrayBuffer());
-  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
-  const sha256 = [...digest].map((value) => value.toString(16).padStart(2, '0')).join('');
-  await chrome.storage.local.set({
-    [CHROME_WEB_STORE_PACKAGE_KEY]: {
-      name: file.name,
-      size: file.size,
-      lastModified: file.lastModified,
-      sha256,
-      base64: bytesToBase64(bytes),
-      selectedAt: Date.now(),
-    },
-  });
-  if (chromeWebStorePackageStatus) {
-    chromeWebStorePackageStatus.textContent = t('st.skills.cws.package_selected', {
-      name: file.name,
-      size: Math.ceil(file.size / 1024),
-    });
-  }
-  showChromeWebStoreResult('ok', t('st.skills.cws.package_ready'));
 }
 
 async function addCustomSkill(record, opts = {}) {
@@ -1064,41 +960,6 @@ btnClearSkillForm?.addEventListener('click', () => {
   if (skillUrlInput) skillUrlInput.value = '';
   if (skillTextArea) skillTextArea.value = '';
   flashSkillsResult('ok', t('st.skills.form_cleared'));
-});
-
-btnSaveChromeWebStore?.addEventListener('click', () => {
-  saveChromeWebStoreConfig().catch((error) => showChromeWebStoreResult('fail', error.message));
-});
-btnConnectChromeWebStore?.addEventListener('click', async () => {
-  btnConnectChromeWebStore.disabled = true;
-  try {
-    const config = await saveChromeWebStoreConfig({ flash: false });
-    const result = await sendToBackground('chrome_web_store_oauth_start', { config });
-    if (!result.ok) throw new Error(result.error || t('st.skills.cws.connect_failed'));
-    showChromeWebStoreResult('ok', t('st.skills.cws.connected'));
-  } catch (error) {
-    showChromeWebStoreResult('fail', error.message);
-  } finally {
-    btnConnectChromeWebStore.disabled = false;
-  }
-});
-btnSignoutChromeWebStore?.addEventListener('click', async () => {
-  const result = await sendToBackground('chrome_web_store_oauth_signout').catch((error) => ({ ok: false, error: error.message }));
-  showChromeWebStoreResult(result.ok ? 'ok' : 'fail', result.ok ? t('st.skills.cws.signed_out') : result.error);
-});
-chromeWebStorePackage?.addEventListener('change', async () => {
-  try {
-    await selectChromeWebStorePackage(chromeWebStorePackage.files?.[0]);
-  } catch (error) {
-    showChromeWebStoreResult('fail', error.message);
-  } finally {
-    chromeWebStorePackage.value = '';
-  }
-});
-btnClearChromeWebStorePackage?.addEventListener('click', async () => {
-  await chrome.storage.local.remove(CHROME_WEB_STORE_PACKAGE_KEY);
-  if (chromeWebStorePackageStatus) chromeWebStorePackageStatus.textContent = t('st.skills.cws.package_empty');
-  showChromeWebStoreResult('ok', t('st.skills.cws.package_cleared'));
 });
 
 if (globalThis.chrome?.storage?.onChanged) {

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -17,6 +17,7 @@ import {
   normalizeCustomSkills,
   normalizeDefaultSkillRemovalIds,
   readSkillImportText,
+  removeRetiredPackagedSkills,
 } from '../agent/skills.js';
 import {
   USER_MEMORY_AUTO_CAPTURE_KEY,
@@ -758,7 +759,7 @@ skillPreviewViewButtons.forEach((button) => {
 async function loadCustomSkills() {
   if (!skillsList) return;
   const stored = await chrome.storage.local.get(CUSTOM_SKILLS_STORAGE_KEY);
-  customSkills = normalizeCustomSkills(stored[CUSTOM_SKILLS_STORAGE_KEY]);
+  customSkills = normalizeCustomSkills(removeRetiredPackagedSkills(stored[CUSTOM_SKILLS_STORAGE_KEY]));
   renderSkills();
 }
 
@@ -965,7 +966,7 @@ btnClearSkillForm?.addEventListener('click', () => {
 if (globalThis.chrome?.storage?.onChanged) {
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area !== 'local' || !changes[CUSTOM_SKILLS_STORAGE_KEY]) return;
-    customSkills = normalizeCustomSkills(changes[CUSTOM_SKILLS_STORAGE_KEY].newValue);
+    customSkills = normalizeCustomSkills(removeRetiredPackagedSkills(changes[CUSTOM_SKILLS_STORAGE_KEY].newValue));
     renderSkills();
   });
 }

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15710,8 +15710,7 @@ const ADAPTERS = [
     matches: (url) => /^https:\/\/chrome\.google\.com\/webstore\/devconsole(?:[/?#]|$)/i.test(url),
     notes: `
 - This dashboard does not support reliable extension DOM automation. Do not retry DOM or accessibility tools here.
-- If the enabled skill catalog contains \`chrome-web-store-release\`, load it and use \`chrome_web_store_status\`, \`chrome_web_store_upload\`, and \`chrome_web_store_publish\` instead of dashboard controls.
-- If that skill is not enabled, ask the user to enable "Chrome Web Store release" in Settings → Skills and configure OAuth, publisher/item IDs, and a release ZIP. Continue manually if they do not want API access.`,
+- Continue manually in the dashboard; no packaged release skill is available.`,
   },
   {
     name: 'github',

--- a/src/firefox/src/agent/skills.js
+++ b/src/firefox/src/agent/skills.js
@@ -46,11 +46,6 @@ export const PACKAGED_SKILL_SOURCES = Object.freeze([
     name: 'Open Library',
     path: 'skills/open-library-books.md',
   }),
-  Object.freeze({
-    id: 'chrome-web-store-release',
-    name: 'Chrome Web Store release',
-    path: 'skills/chrome-web-store-release.md',
-  }),
 ]);
 export const DEFAULT_SKILL_SOURCES = Object.freeze(
   PACKAGED_SKILL_SOURCES.filter((source) => [

--- a/src/firefox/src/agent/skills.js
+++ b/src/firefox/src/agent/skills.js
@@ -64,6 +64,17 @@ function cleanSingleLine(value) {
   return cleanText(value).replace(/\s+/g, ' ');
 }
 
+export function removeRetiredPackagedSkills(value) {
+  const skills = Array.isArray(value) ? value : [];
+  // Match the retired packaged provenance exactly so a user-authored skill
+  // that happens to reuse the old id remains intact.
+  return skills.filter((skill) => !(
+    skill?.id === 'chrome-web-store-release'
+    && skill?.sourceType === 'built-in'
+    && cleanSingleLine(skill?.sourceUrl || skill?.path) === 'skills/chrome-web-store-release.md'
+  ));
+}
+
 function stableId(value, index) {
   const raw = cleanSingleLine(value);
   return /^[a-zA-Z0-9_-]{1,80}$/.test(raw) ? raw : `skill_${index + 1}`;

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -9,6 +9,7 @@ import {
   PACKAGED_SKILL_SOURCES,
   normalizeCustomSkills,
   normalizeDefaultSkillRemovalIds,
+  removeRetiredPackagedSkills,
   refreshBuiltInSkillRecord,
 } from './agent/skills.js';
 import { ScheduledJobManager } from './agent/scheduler.js';
@@ -643,7 +644,18 @@ async function loadCustomSkills() {
     DEFAULT_SKILLS_SEEDED_STORAGE_KEY,
     'enableAllPackagedSkills',
   ]);
-  let skills = normalizeCustomSkills(stored[CUSTOM_SKILLS_STORAGE_KEY]);
+  const storedSkills = Array.isArray(stored[CUSTOM_SKILLS_STORAGE_KEY])
+    ? stored[CUSTOM_SKILLS_STORAGE_KEY]
+    : [];
+  const retainedSkills = removeRetiredPackagedSkills(storedSkills);
+  let skills = normalizeCustomSkills(retainedSkills);
+  if (retainedSkills.length !== storedSkills.length) {
+    try {
+      await browser.storage.local.set({ [CUSTOM_SKILLS_STORAGE_KEY]: skills });
+    } catch (error) {
+      console.warn('[WebBrain] Retired packaged skills could not be removed', error);
+    }
+  }
   const removedDefaultIds = new Set(normalizeDefaultSkillRemovalIds(stored[DEFAULT_SKILLS_REMOVED_STORAGE_KEY]));
   try {
     const existingIds = new Set(skills.map((skill) => skill.id));
@@ -846,7 +858,16 @@ browser.storage.onChanged.addListener((changes) => {
     });
   }
   if (changes[CUSTOM_SKILLS_STORAGE_KEY]) {
-    agent.customSkills = normalizeCustomSkills(changes[CUSTOM_SKILLS_STORAGE_KEY].newValue);
+    const storedSkills = Array.isArray(changes[CUSTOM_SKILLS_STORAGE_KEY].newValue)
+      ? changes[CUSTOM_SKILLS_STORAGE_KEY].newValue
+      : [];
+    const retainedSkills = removeRetiredPackagedSkills(storedSkills);
+    agent.customSkills = normalizeCustomSkills(retainedSkills);
+    if (retainedSkills.length !== storedSkills.length) {
+      browser.storage.local.set({ [CUSTOM_SKILLS_STORAGE_KEY]: agent.customSkills }).catch((error) => {
+        console.warn('[WebBrain] Retired packaged skills could not be removed', error);
+      });
+    }
     refreshPrompts = true;
   }
   if (changes.captchaSolverEnabled) {

--- a/src/firefox/src/ui/settings.html
+++ b/src/firefox/src/ui/settings.html
@@ -1717,28 +1717,6 @@
       <div id="skills-list"></div>
     </div>
 
-    <div class="provider-card" id="chrome-web-store-release-card" hidden>
-      <div class="setting-label" style="margin-bottom:6px;" data-i18n="st.skills.cws.heading"></div>
-      <div class="setting-desc" style="margin-bottom:14px;" data-i18n-html="st.skills.cws.desc_html"></div>
-      <div class="field"><label for="chrome-web-store-publisher-id" data-i18n="st.skills.cws.publisher_id"></label><input type="text" id="chrome-web-store-publisher-id" autocomplete="off"></div>
-      <div class="field"><label for="chrome-web-store-item-id" data-i18n="st.skills.cws.item_id"></label><input type="text" id="chrome-web-store-item-id" autocomplete="off" maxlength="32"></div>
-      <div class="field"><label for="chrome-web-store-oauth-client-id" data-i18n="st.skills.cws.oauth_client_id"></label><input type="text" id="chrome-web-store-oauth-client-id" autocomplete="off"></div>
-      <div class="field"><label for="chrome-web-store-oauth-client-secret" data-i18n="st.skills.cws.oauth_client_secret"></label><input type="password" id="chrome-web-store-oauth-client-secret" autocomplete="off"></div>
-      <div class="setting-desc" style="margin:-4px 0 12px;" data-i18n="st.skills.cws.redirect_help"></div>
-      <div class="btn-row">
-        <button class="btn-secondary" id="btn-save-chrome-web-store" data-i18n="st.skills.cws.save"></button>
-        <button class="btn-primary" id="btn-connect-chrome-web-store" data-i18n="st.skills.cws.connect"></button>
-        <button class="btn-secondary" id="btn-signout-chrome-web-store" data-i18n="st.skills.cws.signout"></button>
-      </div>
-      <div class="field" style="margin-top:16px;">
-        <label for="chrome-web-store-package" data-i18n="st.skills.cws.package"></label>
-        <input type="file" id="chrome-web-store-package" accept=".zip,application/zip">
-        <div class="setting-desc" id="chrome-web-store-package-status"></div>
-      </div>
-      <div class="btn-row"><button class="btn-secondary" id="btn-clear-chrome-web-store-package" data-i18n="st.skills.cws.clear_package"></button></div>
-      <div class="test-result" id="chrome-web-store-result"></div>
-    </div>
-
     <div class="info-box" data-i18n-html="st.skills.security_html"></div>
 
     <dialog class="skill-preview-dialog" id="skill-preview-dialog" aria-labelledby="skill-preview-title">

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -17,6 +17,7 @@ import {
   normalizeCustomSkills,
   normalizeDefaultSkillRemovalIds,
   readSkillImportText,
+  removeRetiredPackagedSkills,
 } from '../agent/skills.js';
 import {
   USER_MEMORY_AUTO_CAPTURE_KEY,
@@ -741,7 +742,7 @@ skillPreviewViewButtons.forEach((button) => {
 async function loadCustomSkills() {
   if (!skillsList) return;
   const stored = await browser.storage.local.get(CUSTOM_SKILLS_STORAGE_KEY);
-  customSkills = normalizeCustomSkills(stored[CUSTOM_SKILLS_STORAGE_KEY]);
+  customSkills = normalizeCustomSkills(removeRetiredPackagedSkills(stored[CUSTOM_SKILLS_STORAGE_KEY]));
   renderSkills();
 }
 
@@ -948,7 +949,7 @@ btnClearSkillForm?.addEventListener('click', () => {
 if (globalThis.browser?.storage?.onChanged) {
   browser.storage.onChanged.addListener((changes, area) => {
     if (area !== 'local' || !changes[CUSTOM_SKILLS_STORAGE_KEY]) return;
-    customSkills = normalizeCustomSkills(changes[CUSTOM_SKILLS_STORAGE_KEY].newValue);
+    customSkills = normalizeCustomSkills(removeRetiredPackagedSkills(changes[CUSTOM_SKILLS_STORAGE_KEY].newValue));
     renderSkills();
   });
 }

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -37,13 +37,6 @@ import {
   normalizeDownloadDirectory,
 } from '../download-directory.js';
 import {
-  CHROME_WEB_STORE_CONFIG_KEY,
-  CHROME_WEB_STORE_MAX_PACKAGE_BYTES,
-  CHROME_WEB_STORE_PACKAGE_KEY,
-  CHROME_WEB_STORE_SKILL_ID,
-  normalizeChromeWebStoreConfig,
-} from '../chrome-web-store-release.js';
-import {
   providerIconHtml,
   providerIconUrl,
   PROVIDER_SHORT_LABELS,
@@ -112,18 +105,6 @@ const skillPreviewSource = document.getElementById('skill-preview-source');
 const skillPreviewRendered = document.getElementById('skill-preview-rendered');
 const skillPreviewRaw = document.getElementById('skill-preview-raw');
 const skillPreviewViewButtons = document.querySelectorAll('[data-skill-preview-view]');
-const chromeWebStoreCard = document.getElementById('chrome-web-store-release-card');
-const chromeWebStorePublisherId = document.getElementById('chrome-web-store-publisher-id');
-const chromeWebStoreItemId = document.getElementById('chrome-web-store-item-id');
-const chromeWebStoreOauthClientId = document.getElementById('chrome-web-store-oauth-client-id');
-const chromeWebStoreOauthClientSecret = document.getElementById('chrome-web-store-oauth-client-secret');
-const chromeWebStorePackage = document.getElementById('chrome-web-store-package');
-const chromeWebStorePackageStatus = document.getElementById('chrome-web-store-package-status');
-const chromeWebStoreResult = document.getElementById('chrome-web-store-result');
-const btnSaveChromeWebStore = document.getElementById('btn-save-chrome-web-store');
-const btnConnectChromeWebStore = document.getElementById('btn-connect-chrome-web-store');
-const btnSignoutChromeWebStore = document.getElementById('btn-signout-chrome-web-store');
-const btnClearChromeWebStorePackage = document.getElementById('btn-clear-chrome-web-store-package');
 const btnTestVision = document.getElementById('btn-test-vision');
 const btnClearVision = document.getElementById('btn-clear-vision');
 const visionTestResult = document.getElementById('test-vision');
@@ -811,11 +792,6 @@ function renderPackagedSkills() {
 function renderSkills() {
   if (!skillsList) return;
   renderPackagedSkills();
-  const chromeWebStoreEnabled = customSkills.some((skill) => (
-    skill.id === CHROME_WEB_STORE_SKILL_ID && skill.sourceType === 'built-in'
-  ));
-  if (chromeWebStoreCard) chromeWebStoreCard.hidden = !chromeWebStoreEnabled;
-  if (chromeWebStoreEnabled) void loadChromeWebStoreSettings();
   if (customSkills.length === 0) {
     skillsList.innerHTML = `<div class="setting-desc">${escapeHtml(t('st.skills.empty'))}</div>`;
     return;
@@ -853,65 +829,6 @@ function renderSkills() {
       flashSkillsResult('ok', t('st.skills.removed'));
     });
   });
-}
-
-function showChromeWebStoreResult(kind, message) {
-  if (!chromeWebStoreResult) return;
-  chromeWebStoreResult.className = `test-result show ${kind}`;
-  chromeWebStoreResult.textContent = message;
-}
-
-function chromeWebStoreConfigFromForm() {
-  return normalizeChromeWebStoreConfig({
-    publisherId: chromeWebStorePublisherId?.value,
-    itemId: chromeWebStoreItemId?.value,
-    oauthClientId: chromeWebStoreOauthClientId?.value,
-    oauthClientSecret: chromeWebStoreOauthClientSecret?.value,
-  });
-}
-
-async function saveChromeWebStoreConfig({ flash = true } = {}) {
-  const config = chromeWebStoreConfigFromForm();
-  await browser.storage.local.set({ [CHROME_WEB_STORE_CONFIG_KEY]: config });
-  if (flash) showChromeWebStoreResult('ok', t('st.skills.cws.saved'));
-  return config;
-}
-
-async function loadChromeWebStoreSettings() {
-  if (!chromeWebStoreCard || chromeWebStoreCard.hidden) return;
-  const stored = await browser.storage.local.get([CHROME_WEB_STORE_CONFIG_KEY, CHROME_WEB_STORE_PACKAGE_KEY]);
-  const config = normalizeChromeWebStoreConfig(stored[CHROME_WEB_STORE_CONFIG_KEY]);
-  if (chromeWebStorePublisherId) chromeWebStorePublisherId.value = config.publisherId;
-  if (chromeWebStoreItemId) chromeWebStoreItemId.value = config.itemId;
-  if (chromeWebStoreOauthClientId) chromeWebStoreOauthClientId.value = config.oauthClientId;
-  if (chromeWebStoreOauthClientSecret) chromeWebStoreOauthClientSecret.value = config.oauthClientSecret;
-  const pkg = stored[CHROME_WEB_STORE_PACKAGE_KEY];
-  if (chromeWebStorePackageStatus) {
-    chromeWebStorePackageStatus.textContent = pkg?.name
-      ? t('st.skills.cws.package_selected', { name: pkg.name, size: Math.ceil((Number(pkg.size) || 0) / 1024) })
-      : t('st.skills.cws.package_empty');
-  }
-  const oauth = await sendToBackground('chrome_web_store_oauth_status').catch(() => ({ signedIn: false }));
-  showChromeWebStoreResult(oauth.signedIn ? 'ok' : 'warn', oauth.signedIn ? t('st.skills.cws.connected') : t('st.skills.cws.disconnected'));
-}
-
-function bytesToBase64(bytes) {
-  let binary = '';
-  const chunkSize = 0x8000;
-  for (let offset = 0; offset < bytes.length; offset += chunkSize) binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
-  return btoa(binary);
-}
-
-async function selectChromeWebStorePackage(file) {
-  if (!file) return;
-  if (!/\.zip$/i.test(file.name)) throw new Error(t('st.skills.cws.package_zip_only'));
-  if (file.size <= 0 || file.size > CHROME_WEB_STORE_MAX_PACKAGE_BYTES) throw new Error(t('st.skills.cws.package_too_large'));
-  const bytes = new Uint8Array(await file.arrayBuffer());
-  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
-  const sha256 = [...digest].map((value) => value.toString(16).padStart(2, '0')).join('');
-  await browser.storage.local.set({ [CHROME_WEB_STORE_PACKAGE_KEY]: { name: file.name, size: file.size, lastModified: file.lastModified, sha256, base64: bytesToBase64(bytes), selectedAt: Date.now() } });
-  if (chromeWebStorePackageStatus) chromeWebStorePackageStatus.textContent = t('st.skills.cws.package_selected', { name: file.name, size: Math.ceil(file.size / 1024) });
-  showChromeWebStoreResult('ok', t('st.skills.cws.package_ready'));
 }
 
 async function addCustomSkill(record, opts = {}) {
@@ -1026,34 +943,6 @@ btnClearSkillForm?.addEventListener('click', () => {
   if (skillUrlInput) skillUrlInput.value = '';
   if (skillTextArea) skillTextArea.value = '';
   flashSkillsResult('ok', t('st.skills.form_cleared'));
-});
-
-btnSaveChromeWebStore?.addEventListener('click', () => {
-  saveChromeWebStoreConfig().catch((error) => showChromeWebStoreResult('fail', error.message));
-});
-btnConnectChromeWebStore?.addEventListener('click', async () => {
-  btnConnectChromeWebStore.disabled = true;
-  try {
-    const config = await saveChromeWebStoreConfig({ flash: false });
-    const result = await sendToBackground('chrome_web_store_oauth_start', { config });
-    if (!result.ok) throw new Error(result.error || t('st.skills.cws.connect_failed'));
-    showChromeWebStoreResult('ok', t('st.skills.cws.connected'));
-  } catch (error) { showChromeWebStoreResult('fail', error.message); }
-  finally { btnConnectChromeWebStore.disabled = false; }
-});
-btnSignoutChromeWebStore?.addEventListener('click', async () => {
-  const result = await sendToBackground('chrome_web_store_oauth_signout').catch((error) => ({ ok: false, error: error.message }));
-  showChromeWebStoreResult(result.ok ? 'ok' : 'fail', result.ok ? t('st.skills.cws.signed_out') : result.error);
-});
-chromeWebStorePackage?.addEventListener('change', async () => {
-  try { await selectChromeWebStorePackage(chromeWebStorePackage.files?.[0]); }
-  catch (error) { showChromeWebStoreResult('fail', error.message); }
-  finally { chromeWebStorePackage.value = ''; }
-});
-btnClearChromeWebStorePackage?.addEventListener('click', async () => {
-  await browser.storage.local.remove(CHROME_WEB_STORE_PACKAGE_KEY);
-  if (chromeWebStorePackageStatus) chromeWebStorePackageStatus.textContent = t('st.skills.cws.package_empty');
-  showChromeWebStoreResult('ok', t('st.skills.cws.package_cleared'));
 });
 
 if (globalThis.browser?.storage?.onChanged) {

--- a/test/run.js
+++ b/test/run.js
@@ -11338,7 +11338,6 @@ test('every bundled skill declares its canonical semantic intents', () => {
     'open-meteo-weather': ['current_weather', 'weather_forecast', 'location_forecast'],
     'open-library-books': ['book_search', 'book_metadata', 'isbn_lookup', 'author_lookup'],
     'temporary-file-share-litterbox': ['temporary_file_share', 'public_upload_link', 'expiring_file_upload'],
-    'chrome-web-store-release': ['chrome-web-store-release', 'extension-publish'],
   };
   for (const [label, prefix, sources, normalizeSkills] of [
     ['chrome', 'src/chrome', PACKAGED_SKILL_SOURCES_CH, normalizeCustomSkillsCh],
@@ -42863,7 +42862,6 @@ test('settings exposes custom skills tab and packaged skills resource directory'
     'temporary-file-share-litterbox',
     'open-meteo-weather',
     'open-library-books',
-    'chrome-web-store-release',
   ]);
   assert.deepEqual(PACKAGED_SKILL_SOURCES_FX.map((skill) => skill.id), [
     'freeskillz-xyz',
@@ -42872,7 +42870,6 @@ test('settings exposes custom skills tab and packaged skills resource directory'
     'temporary-file-share-litterbox',
     'open-meteo-weather',
     'open-library-books',
-    'chrome-web-store-release',
   ]);
   assert.deepEqual(DEFAULT_SKILL_SOURCES_CH.map((skill) => skill.id), [
     'freeskillz-xyz',
@@ -42882,8 +42879,8 @@ test('settings exposes custom skills tab and packaged skills resource directory'
     'freeskillz-xyz',
     'otp-verification-code-helper',
   ]);
-  assert.equal(DEFAULT_SKILL_SOURCES_CH.some((skill) => skill.id === 'chrome-web-store-release'), false, 'chrome: release skill must be disabled by default');
-  assert.equal(DEFAULT_SKILL_SOURCES_FX.some((skill) => skill.id === 'chrome-web-store-release'), false, 'firefox: release skill must be disabled by default');
+  assert.equal(PACKAGED_SKILL_SOURCES_CH.some((skill) => skill.id === 'chrome-web-store-release'), false, 'chrome: release workflow must not appear in available packaged skills');
+  assert.equal(PACKAGED_SKILL_SOURCES_FX.some((skill) => skill.id === 'chrome-web-store-release'), false, 'firefox: release workflow must not appear in available packaged skills');
 
   const privacyPolicy = fs.readFileSync(path.join(ROOT, 'web/privacy.html'), 'utf8');
   const privacyDataFlow = fs.readFileSync(path.join(ROOT, 'docs/privacy-and-data-flow.md'), 'utf8');

--- a/test/run.js
+++ b/test/run.js
@@ -704,6 +704,7 @@ const {
   fetchSkillImportResponse: fetchSkillImportResponseCh,
   normalizeCustomSkills: normalizeCustomSkillsCh,
   normalizeDefaultSkillRemovalIds: normalizeDefaultSkillRemovalIdsCh,
+  removeRetiredPackagedSkills: removeRetiredPackagedSkillsCh,
   refreshBuiltInSkillRecord: refreshBuiltInSkillRecordCh,
   readSkillImportText: readSkillImportTextCh,
   buildCustomSkillsPrompt: buildCustomSkillsPromptCh,
@@ -727,6 +728,7 @@ const {
   fetchSkillImportResponse: fetchSkillImportResponseFx,
   normalizeCustomSkills: normalizeCustomSkillsFx,
   normalizeDefaultSkillRemovalIds: normalizeDefaultSkillRemovalIdsFx,
+  removeRetiredPackagedSkills: removeRetiredPackagedSkillsFx,
   refreshBuiltInSkillRecord: refreshBuiltInSkillRecordFx,
   readSkillImportText: readSkillImportTextFx,
   buildCustomSkillsPrompt: buildCustomSkillsPromptFx,
@@ -11750,6 +11752,41 @@ test('default skill removal ids are normalized in both builds', () => {
       `${label}: default removal ids should dedupe and reject unsafe values`,
     );
     assert.deepEqual(normalizeIds(null), [], `${label}: invalid removal storage should normalize to empty`);
+  }
+});
+
+test('retired packaged Chrome Web Store release records are purged in both builds', () => {
+  for (const [label, prefix, removeRetired] of [
+    ['chrome', 'src/chrome', removeRetiredPackagedSkillsCh],
+    ['firefox', 'src/firefox', removeRetiredPackagedSkillsFx],
+  ]) {
+    const retired = packagedChromeWebStoreRecord(prefix);
+    const legacyPathRecord = { ...retired, sourceUrl: '', path: retired.sourceUrl };
+    const userSkill = {
+      ...retired,
+      sourceType: 'text',
+      sourceUrl: '',
+      content: '# My Chrome Web Store release notes',
+    };
+    const unrelated = packagedFreeSkillzRecord(prefix);
+
+    assert.deepEqual(
+      removeRetired([retired, legacyPathRecord, userSkill, unrelated]),
+      [userSkill, unrelated],
+      `${label}: only exact retired built-in release records should be removed`,
+    );
+    assert.deepEqual(removeRetired(null), [], `${label}: invalid stored skills should migrate to an empty list`);
+
+    const background = fs.readFileSync(path.join(ROOT, prefix, 'src/background.js'), 'utf8');
+    const settings = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/settings.js'), 'utf8');
+    assert.ok(
+      (background.match(/removeRetiredPackagedSkills\(/g)?.length || 0) >= 2,
+      `${label}: startup and live background updates should purge retired records`,
+    );
+    assert.ok(
+      (settings.match(/removeRetiredPackagedSkills\(/g)?.length || 0) >= 2,
+      `${label}: initial and live settings views should hide retired records`,
+    );
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -42500,8 +42500,17 @@ test('Chrome Web Store release uses an always-on protected-page guard and opt-in
   assert.equal(failure.errorCode, 'chrome_protected_page');
   assert.equal(failure.nonRetryable, true);
   assert.equal(failure.dispatched, false);
-  assert.equal(failure.recoverySkill, 'chrome-web-store-release');
+  assert.equal(failure.recoverySkill, undefined);
   assert.match(failure.error, /Do not retry/i);
+  assert.match(failure.error, /Continue manually/i);
+  assert.doesNotMatch(failure.error, /enable.*Chrome Web Store release|Settings → Skills/i);
+  const chromeAgentRoutingSource = fs.readFileSync(path.join(ROOT, 'src/chrome/src/agent/agent.js'), 'utf8');
+  assert.doesNotMatch(chromeAgentRoutingSource, /ask the user to enable\/configure that packaged skill/i, 'chrome: runtime warning must not route users to a removed packaged skill');
+  for (const file of ['src/chrome/src/agent/adapters.js', 'src/firefox/src/agent/adapters.js']) {
+    const adapterSource = fs.readFileSync(path.join(ROOT, file), 'utf8');
+    assert.doesNotMatch(adapterSource, /ask the user to enable "Chrome Web Store release"/i, `${file}: adapter must not route users to a removed packaged skill`);
+    assert.match(adapterSource, /Continue manually in the dashboard; no packaged release skill is available/i, `${file}: adapter should provide an available fallback`);
+  }
   for (const toolName of ['wait_for_stable', 'get_accessibility_tree', 'read_page', 'click_ax', 'upload_file', 'download_resource_from_page', 'execute_js', 'get_frames']) {
     assert.equal(isChromeProtectedPageDomTool(toolName), true, `chrome: ${toolName} should be stopped before protected-page dispatch`);
   }
@@ -42741,10 +42750,13 @@ test('Chrome Web Store release uses an always-on protected-page guard and opt-in
 
   const adapter = getActiveAdapter(dashboard);
   assert.equal(adapter?.name, 'chrome-web-store-developer');
-  assert.match(adapter?.notes || '', /chrome_web_store_status/);
+  assert.doesNotMatch(adapter?.notes || '', /chrome_web_store_status|Settings → Skills/);
+  assert.match(adapter?.notes || '', /Continue manually in the dashboard/);
   assert.equal(getActiveAdapter('https://chrome.google.com/webstore/devconsole?authuser=1')?.name, 'chrome-web-store-developer');
   assert.equal(getActiveAdapterFx(dashboard)?.name, 'chrome-web-store-developer');
   assert.equal(getActiveAdapterFx('https://chrome.google.com/webstore/devconsole#drafts')?.name, 'chrome-web-store-developer');
+  assert.doesNotMatch(getActiveAdapterFx(dashboard)?.notes || '', /chrome_web_store_status|Settings → Skills/);
+  assert.match(getActiveAdapterFx(dashboard)?.notes || '', /Continue manually in the dashboard/);
 
   const chromeAgentSource = fs.readFileSync(path.join(ROOT, 'src/chrome/src/agent/agent.js'), 'utf8');
   const guardIndex = chromeAgentSource.indexOf('const protectedPageFailure = await this._chromeProtectedPageFailure(tabId, fnName);');
@@ -42755,6 +42767,7 @@ test('Chrome Web Store release uses an always-on protected-page guard and opt-in
     'chrome: protected-page guard must run before WebMCP preparation and tool dispatch',
   );
   assert.match(chromeAgentSource, /TRUSTED RUNTIME ROUTING: Chrome blocks extension DOM\/debugger access/, 'chrome: protected-page recovery should remain outside the untrusted page-content wrapper');
+  assert.doesNotMatch(chromeAgentSource, /ask the user to enable\/configure that packaged skill/i, 'chrome: protected-page recovery must not route users to a removed packaged skill');
 });
 
 test('Chrome Web Store upload forces a fresh status turn before any batched publish', async () => {
@@ -42941,8 +42954,8 @@ test('settings exposes custom skills tab and packaged skills resource directory'
     assert.match(html, /id="skill-url"/, `${label}: URL skill input missing`);
     assert.match(html, /id="skill-text"/, `${label}: raw skill textarea missing`);
     assert.match(html, /id="packaged-skills-list"/, `${label}: available packaged skills list missing`);
-    assert.match(html, /id="chrome-web-store-release-card" hidden/, `${label}: release setup should be hidden until the skill is enabled`);
-    assert.match(html, /id="chrome-web-store-package"[^>]*accept="\.zip,application\/zip"/, `${label}: release ZIP picker missing`);
+    assert.doesNotMatch(html, /id="chrome-web-store-release-card"/, `${label}: removed release skill must not leave an orphaned setup card`);
+    assert.doesNotMatch(html, /id="chrome-web-store-package"/, `${label}: removed release skill must not leave an orphaned ZIP picker`);
     assert.match(html, /id="skill-preview-dialog"/, `${label}: skill content preview dialog missing`);
     assert.match(html, /id="skill-preview-rendered"[^>]*tabindex="0"/, `${label}: rendered skill preview should be keyboard-scrollable`);
     assert.match(html, /id="skill-preview-raw"[^>]*tabindex="0"[^>]*hidden/, `${label}: raw skill preview should be available but hidden by default`);
@@ -42975,15 +42988,14 @@ test('settings exposes custom skills tab and packaged skills resource directory'
     assert.match(settingsJs, /installedDefault/, `${label}: reinstalling a default should clear its removal tombstone`);
     assert.match(settingsJs, /st\.skills\.source\.built_in/, `${label}: settings should label packaged skills`);
     assert.match(settingsJs, /skill\.tools/, `${label}: settings should show exposed skill tools`);
-    assert.match(settingsJs, /CHROME_WEB_STORE_PACKAGE_KEY/, `${label}: release package should use dedicated local storage`);
-    assert.match(settingsJs, /crypto\.subtle\.digest\('SHA-256'/, `${label}: release package should record a local integrity digest`);
+    assert.doesNotMatch(settingsJs, /CHROME_WEB_STORE_(?:CONFIG|PACKAGE|SKILL)/, `${label}: removed release setup must not leave UI storage wiring`);
+    assert.doesNotMatch(settingsJs, /chrome_web_store_oauth_/, `${label}: removed release setup must not leave UI OAuth handlers`);
     const skillIdFunction = settingsJs.slice(
       settingsJs.indexOf('function makeSkillId()'),
       settingsJs.indexOf('function showSkillsResult'),
     );
     assert.match(skillIdFunction, /crypto\.randomUUID\(\)/, `${label}: imported skill IDs should use secure randomness`);
     assert.doesNotMatch(skillIdFunction, /Math\.random\(/, `${label}: imported skill IDs must not use insecure randomness`);
-    assert.match(background, /chrome_web_store_oauth_start/, `${label}: release OAuth should run in the durable background context`);
     assert.match(englishLocale, /small catalog sends only each eligible skill\\'s ID, name, summary, and optional semantic intents/, `${label}: settings should explain the semantic skill catalog`);
     assert.match(englishLocale, /full instructions and compatible <code>webbrain-tools<\/code> are exposed only after/i, `${label}: settings should explain on-demand skill loading`);
     assert.match(englishLocale, /Compact does not load skills/, `${label}: settings should explain Compact skill isolation`);


### PR DESCRIPTION
## Summary

- remove the Chrome Web Store release workflow from the packaged skill catalog in Chrome and Firefox
- update bundled-skill expectations for both browser builds
- add regression assertions that the workflow cannot appear under Available packaged skills

## Why

The release workflow was registered in `PACKAGED_SKILL_SOURCES`, which surfaced a standalone publishing tool alongside chat-integrated skills. Removing that registration keeps the available skill surface focused without changing the dormant release implementation.

## Validation

- `git diff --check`
- `node test/run.js` — 1,226 passed; 1 unrelated existing failure because package version `25.7.7` is ahead of the newest changelog entry `25.7.6`