### PR TITLE
Fix find_text selection verification

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1328,9 +1328,22 @@ export class Agent {
     const x = Number.isFinite(pageX) ? pageX : viewportX;
     const y = Number.isFinite(pageY) ? pageY : viewportY;
     if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) return '';
-    return [x, y, width, height]
+    let selectionIdentity = 'document';
+    if (result.selectionSource === 'text_control') {
+      const selectionStart = result.selectionStart;
+      const selectionEnd = result.selectionEnd;
+      if (
+        !Number.isInteger(selectionStart)
+        || !Number.isInteger(selectionEnd)
+        || selectionStart < 0
+        || selectionEnd <= selectionStart
+      ) return '';
+      selectionIdentity = `text_control:${selectionStart}:${selectionEnd}`;
+    }
+    const rectIdentity = [x, y, width, height]
       .map(value => Math.round(value * 2) / 2)
       .join(',');
+    return `${selectionIdentity}|${rectIdentity}`;
   }
 
   _noteHealthyLoopCall(tabId) {

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1317,7 +1317,7 @@ export class Agent {
   }
 
   _findTextMatchLoopIdentity(result) {
-    if (result?.success !== true || !result?.rect || typeof result.rect !== 'object') return '';
+    if (result?.success !== true || result?.verified === false || !result?.rect || typeof result.rect !== 'object') return '';
     const rect = result.rect;
     const pageX = typeof rect.pageX === 'number' ? rect.pageX : NaN;
     const pageY = typeof rect.pageY === 'number' ? rect.pageY : NaN;
@@ -1327,7 +1327,7 @@ export class Agent {
     const height = typeof rect.height === 'number' ? rect.height : NaN;
     const x = Number.isFinite(pageX) ? pageX : viewportX;
     const y = Number.isFinite(pageY) ? pageY : viewportY;
-    if (![x, y, width, height].every(Number.isFinite)) return '';
+    if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) return '';
     return [x, y, width, height]
       .map(value => Math.round(value * 2) / 2)
       .join(',');
@@ -10836,6 +10836,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (result == null || result?.done) return false;
     if (typeof result !== 'object') return true;
     if (result.success === false
+        || result.verified === false
+        || result.inconclusive
         || result.denied
         || result.cancelled
         || result.skipped

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -10836,8 +10836,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (result == null || result?.done) return false;
     if (typeof result !== 'object') return true;
     if (result.success === false
-        || result.verified === false
-        || result.inconclusive
         || result.denied
         || result.cancelled
         || result.skipped
@@ -10891,9 +10889,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       && this.constructor.EXECUTION_APP_STATE_TOOLS.has(name);
     const requiredScheduleSucceeded = state?.requiredSchedulingTool === name
       && this._isSuccessfulSchedulingEvidence(result);
+    // find_text is observational: verified:false means it did not prove a
+    // visible selection. Keep this tool-specific because mutations such as
+    // upload_file may dispatch successfully, return verified:false, and rely
+    // on the completion invariant's required follow-up page observation.
+    const unverifiedFindText = name === 'find_text'
+      && (result?.found !== true || result?.verified !== true || result?.inconclusive === true);
     if (!state?.enabled
         || name === 'done'
         || (this.constructor.EXECUTION_META_TOOLS.has(name) && !requestedAppStateTool)
+        || unverifiedFindText
         || (!this._isSuccessfulExecutionEvidence(result) && !requiredScheduleSucceeded)) return;
     state.successfulTaskToolCalls += 1;
     if (requiredScheduleSucceeded) state.successfulRequiredSchedulingToolCalls += 1;

--- a/src/chrome/src/agent/planner.js
+++ b/src/chrome/src/agent/planner.js
@@ -67,7 +67,7 @@ Rules:
   memory: scratchpad_write, progress_update, progress_read
   schedule: schedule_task (future/recurring work the user explicitly asked for), schedule_resume (pause CURRENT run blocked on external event)
   finish: done
-- press_keys supports only unmodified Escape, Tab, Enter, and arrow keys. Never plan Ctrl/Cmd/Alt/Shift combinations or browser UI shortcuts. To locate and highlight literal page text, plan find_text instead of Ctrl/Cmd+F.
+- press_keys supports only unmodified Escape, Tab, Enter, and arrow keys. Never plan Ctrl/Cmd/Alt/Shift combinations or browser UI shortcuts. To select one literal page-text match, plan find_text instead of Ctrl/Cmd+F. Each find_text call replaces the previous selection and does not open browser Find UI; never plan sequential calls as simultaneous highlights.
 - For repeated same-kind UI mutations (for example following many users), plan visible UI first with bounded batches, verification, progress_update, and wait_for_stable pacing; do not plan one huge same-shape click/tool batch.
 - Do not invent a prerequisite to discover a raw identifier (email address, account ID, username, or similar) when the target UI provides a name-based contact/entity picker and the user already supplied a human-readable name. Plan to use the picker first. Inspect surrounding pages or messages for the raw identifier only if the picker fails, returns multiple ambiguous matches, or the user explicitly asked for the identifier itself.
 - Set confidence from 0.0 to 1.0 for how clear and safe this plan is. Use 0.90+ only when the task, page state, and next steps are straightforward; use lower scores for ambiguity, destructive changes, payments, credentials, bulk mutations, or uncertain page state.
@@ -124,7 +124,7 @@ Rules:
 - schedule_task supports one-shot times and fixed-minute intervals only. Calendar/cron recurrence such as monthly is unsupported: classify it as clarify, explain the limitation in localized.summary, and ask for a one-shot time or fixed interval. Never convert calendar recurrence into an approximate interval.
 - Canonical summary, steps, and risks must be English. localized fields must use the requested wbLocale.
 - For execute, keep the compact plan to 1–4 steps. For plan_only, provide 2–8 useful steps. For respond and clarify, steps may be empty.
-- press_keys supports only unmodified Escape, Tab, Enter, and arrow keys. Never plan modifier combinations or browser UI shortcuts; use find_text to locate and highlight page text instead of Ctrl/Cmd+F.
+- press_keys supports only unmodified Escape, Tab, Enter, and arrow keys. Never plan modifier combinations or browser UI shortcuts; use find_text to select one page-text match instead of Ctrl/Cmd+F. Each call replaces the previous selection and cannot create simultaneous highlights or browser Find UI.
 - Do not invent URLs, credentials, tool names, or facts.`;
 
 export function normalizePlannerLocale(value) {

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -298,7 +298,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'press_keys',
-      description: 'Press one unmodified keyboard key. Supports only Escape, Tab, Enter, ArrowUp, ArrowDown, ArrowLeft, and ArrowRight. Ctrl/Cmd/Alt/Shift combinations and browser shortcuts such as Ctrl+F are not supported. Use find_text to locate and highlight page text.',
+      description: 'Press one unmodified keyboard key. Supports only Escape, Tab, Enter, ArrowUp, ArrowDown, ArrowLeft, and ArrowRight. Ctrl/Cmd/Alt/Shift combinations and browser shortcuts such as Ctrl+F are not supported. Use find_text to select one page-text match.',
       parameters: {
         type: 'object',
         properties: {
@@ -512,7 +512,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'find_text',
-      description: 'Find and select/highlight the next occurrence of literal text in the current page. Use this instead of Ctrl+F or Cmd+F; press_keys cannot send modifier combinations or open browser UI. Repeating the same search advances to the next match.',
+      description: 'Find and select the next occurrence of literal text in the current page. Use this instead of Ctrl+F or Cmd+F; press_keys cannot send modifier combinations. Repeating the same search advances to the next match. Each call replaces the previous page selection, so only the current match remains selected. This tool does not open the browser Find UI. Never claim that sequential find_text calls leave multiple terms highlighted.',
       parameters: {
         type: 'object',
         properties: {
@@ -1432,7 +1432,7 @@ Available tools:
 - schedule_resume: Durably pause this current task and resume it later in the same tab/conversation. Terminal tool; use only for external waits.
 - schedule_task: Create a one-shot or fixed-minute-interval task only when the user explicitly asks for future scheduled work. It does not support calendar/cron recurrence; never approximate monthly recurrence. Prefer URL targets for repeatable automations; current_tab is strict and fails if the tab changes.
 - get_selection: Get highlighted text
-- find_text: Find and select/highlight literal page text. Use this instead of Ctrl/Cmd+F.
+- find_text: Select one literal page-text match instead of Ctrl/Cmd+F. Each call replaces the previous selection; it does not open browser Find UI or keep multiple terms highlighted.
 - press_keys: Press only unmodified Escape/Tab/Enter/arrows. Modifier combinations and browser shortcuts are unsupported.
 - new_tab: Open a background reference tab; the current run stays on its original tab
 - clarify: Pause and ask the user a question. Use ONLY for material ambiguity that you cannot resolve by reading the page (e.g. "my API key" on a site with multiple plugins that each have one). Unanswered clarifies auto-select options[0] after the timeout (default 60s) with source=timeout (not high-risk approval); Settings Instant yields source=auto (intentional auto-approve — continue). Put the safe/default first. Do NOT use to confirm correct actions; do NOT call before every step. Budget 1-2 per run, max.
@@ -1704,7 +1704,7 @@ TOOLS — use ONLY these:
 - click({text}): Click by visible text. Fallback when no ref_id.
 - type_text({text}): Type into the focused element. Click the field first.
 - get_selection: Read highlighted text.
-- find_text({text}): Locate and highlight literal page text instead of using Ctrl/Cmd+F.
+- find_text({text}): Select one literal page-text match instead of Ctrl/Cmd+F. Each call replaces the previous selection; no browser Find UI or simultaneous highlights.
 - press_keys({key}): Press one supported unmodified key. Ctrl/Cmd/Alt/Shift combinations and browser shortcuts are unavailable.
 - navigate({url}): Go to a URL.
 - new_tab({url}): Open a URL in a background tab for user reference. It does not activate or retarget the current run, so never use it as a site-permission workaround.
@@ -1774,7 +1774,7 @@ TOOLS — use only these:
 - click_ax({ref_id}) / set_checked({ref_id, checked}) / type_ax({ref_id, text}) / set_field({ref_id, text, submit}): act on nodes by ref_id. set_field is preferred for text fields; set_checked is required for native checkboxes.
 - read_page: prose fallback for long articles. get_window_info: inspect browser window/viewport size. scroll, navigate({url}), go_back()/go_forward(): walk the run tab's history. new_tab({url}) only opens a background reference tab and never retargets the run.
 - get_interactive_elements: legacy indexed element list (use when the tree misses elements). click({text}) / type_text({text}) / press_keys({key}): legacy fallbacks. press_keys supports only unmodified Escape/Tab/Enter/arrows, never Ctrl/Cmd/Alt/Shift combinations or browser shortcuts.
-- extract_data: tables/headings/images/links. get_selection: read highlighted text. find_text({text}): locate and highlight literal page text instead of Ctrl/Cmd+F. read_pdf: read a PDF.
+- extract_data: tables/headings/images/links. get_selection: read highlighted text. find_text({text}): select one literal page-text match; each call replaces the previous selection and never creates simultaneous highlights or browser Find UI. read_pdf: read a PDF.
 - wait_for_element({selector}) / wait_for_stable({quietMs}): wait for an element / for the page to go quiet after an action.
 - schedule_resume({after_seconds|run_at, reason, resume_instruction}): terminal durable pause for this current task.
 - schedule_task({title, prompt, schedule, target, mode}): create one-shot or fixed-minute-interval future work only when explicitly requested by the user. Calendar/cron recurrence is unsupported and must not be approximated. Prefer target.type:"url" for monitors/repeatable automations; use current_tab only for exact current-tab state.

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -1849,9 +1849,10 @@
       const matchCase = params?.matchCase === true;
       const backwards = params?.backwards === true;
       const wrap = params?.wrap !== false;
-      // Match browser Find semantics across the whole document, including
-      // embedded frames. Without searchInFrames, find_text falsely reports a
-      // miss for text that Ctrl/Cmd+F would find inside an iframe.
+      // Match browser Find semantics across the whole page, including frames.
+      // When the active match moves into a frame, the top document can retain
+      // an older selection; frame focus keeps that stale range from verifying
+      // the current hit.
       const found = window.find(text, matchCase, backwards, wrap, false, true, false);
       if (!found) {
         return {
@@ -1863,11 +1864,56 @@
           error: `find_text: "${text}" was not found on the current page. Re-read the page or try a shorter literal phrase.`,
         };
       }
+      const activeElement = window.document?.activeElement;
+      const activeElementTag = String(activeElement?.tagName || '').toUpperCase();
+      const inputType = String(activeElement?.type || 'text').toLowerCase();
+      const isTextControl = activeElementTag === 'TEXTAREA'
+        || (activeElementTag === 'INPUT' && ['text', 'search', 'url', 'tel', 'email'].includes(inputType));
+      const normalizedQuery = text.normalize('NFC');
+      const matchesQuery = (value) => {
+        const normalizedValue = String(value || '').normalize('NFC');
+        return matchCase
+          ? normalizedValue === normalizedQuery
+          : normalizedValue.toLowerCase() === normalizedQuery.toLowerCase();
+      };
+      const hasVisibleBounds = (candidate) => !!candidate
+        && [candidate.x, candidate.y, candidate.width, candidate.height].every(Number.isFinite)
+        && candidate.width > 0
+        && candidate.height > 0;
       const selection = window.getSelection?.();
-      const selectedText = String(selection?.toString?.() || '');
+      const documentSelectedText = String(selection?.toString?.() || '');
+      const documentBounds = selection?.rangeCount
+        ? selection.getRangeAt(0).getBoundingClientRect()
+        : undefined;
+      let controlSelectedText = '';
+      let controlBounds;
+      const controlSelectionStart = activeElement?.selectionStart;
+      const controlSelectionEnd = activeElement?.selectionEnd;
+      if (
+        isTextControl
+        && Number.isInteger(controlSelectionStart)
+        && Number.isInteger(controlSelectionEnd)
+        && controlSelectionStart >= 0
+        && controlSelectionEnd > controlSelectionStart
+      ) {
+        controlSelectedText = String(activeElement.value || '').slice(controlSelectionStart, controlSelectionEnd);
+        controlBounds = activeElement.getBoundingClientRect?.();
+      }
+      const documentMatchesQuery = matchesQuery(documentSelectedText);
+      const controlMatchesQuery = matchesQuery(controlSelectedText);
+      let selectedText = documentSelectedText;
+      let selectionSource = 'document';
+      let bounds = documentBounds;
+      if (documentMatchesQuery && hasVisibleBounds(documentBounds)) {
+        // Keep the page selection. A focused field can retain an unrelated
+        // selection while window.find advances to a normal document match.
+      } else if (controlMatchesQuery && hasVisibleBounds(controlBounds)) {
+        selectedText = controlSelectedText;
+        bounds = controlBounds;
+        selectionSource = 'text_control';
+      }
       let rect;
-      if (selection?.rangeCount) {
-        const bounds = selection.getRangeAt(0).getBoundingClientRect();
+      if (bounds) {
         const scrollX = Number.isFinite(Number(window.scrollX)) ? Number(window.scrollX) : 0;
         const scrollY = Number.isFinite(Number(window.scrollY)) ? Number(window.scrollY) : 0;
         rect = {
@@ -1883,12 +1929,16 @@
         && [rect.x, rect.y, rect.pageX, rect.pageY, rect.width, rect.height].every(Number.isFinite)
         && rect.width > 0
         && rect.height > 0;
-      const normalizedSelectedText = selectedText.normalize('NFC');
-      const normalizedQuery = text.normalize('NFC');
-      const selectionMatchesQuery = matchCase
-        ? normalizedSelectedText === normalizedQuery
-        : normalizedSelectedText.toLowerCase() === normalizedQuery.toLowerCase();
-      const verified = selectionMatchesQuery && hasVisibleRect;
+      const selectionMatchesQuery = matchesQuery(selectedText);
+      const selectionInFrame = activeElementTag === 'IFRAME' || activeElementTag === 'FRAME';
+      const hasSelectionIdentity = selectionSource !== 'text_control'
+        || (
+          Number.isInteger(controlSelectionStart)
+          && Number.isInteger(controlSelectionEnd)
+          && controlSelectionStart >= 0
+          && controlSelectionEnd > controlSelectionStart
+        );
+      const verified = selectionMatchesQuery && hasVisibleRect && hasSelectionIdentity && !selectionInFrame;
       return {
         success: true,
         found: true,
@@ -1896,13 +1946,18 @@
         query: text,
         selectedText,
         selectionMatchesQuery,
-        selectionScope: 'current_match_only',
-        replacesPreviousSelection: true,
+        selectionSource,
+        selectionInFrame,
+        selectionScope: selectionInFrame ? 'frame_match_unverified' : 'current_match_only',
+        ...(selectionSource === 'text_control'
+          ? { selectionStart: controlSelectionStart, selectionEnd: controlSelectionEnd }
+          : {}),
+        replacesPreviousSelection: !selectionInFrame,
         browserFindUiOpened: false,
         ...(rect ? { rect } : {}),
         warning: verified
           ? 'Only this match is selected. This call replaced any previous page selection, and it did not open the browser Find UI. Do not claim earlier find_text matches remain highlighted.'
-          : 'window.find reported a match, but WebBrain could not verify a visible selection in the top document (for example, the match may be inside a frame). Do not claim it is visibly highlighted. Only one current selection is supported, and the browser Find UI was not opened.',
+          : 'window.find reported a match, but WebBrain could not verify a visible current selection in the top document (for example, the active match may be inside a frame while an older top-document selection remains). Do not claim it is visibly highlighted. The browser Find UI was not opened.',
       };
     } catch (error) {
       return { success: false, found: false, dispatched: false, noDispatch: true, error: `find_text failed: ${error.message || error}` };

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -1879,12 +1879,30 @@
           height: bounds.height,
         };
       }
+      const hasVisibleRect = !!rect
+        && [rect.x, rect.y, rect.pageX, rect.pageY, rect.width, rect.height].every(Number.isFinite)
+        && rect.width > 0
+        && rect.height > 0;
+      const normalizedSelectedText = selectedText.normalize('NFC');
+      const normalizedQuery = text.normalize('NFC');
+      const selectionMatchesQuery = matchCase
+        ? normalizedSelectedText === normalizedQuery
+        : normalizedSelectedText.toLowerCase() === normalizedQuery.toLowerCase();
+      const verified = selectionMatchesQuery && hasVisibleRect;
       return {
         success: true,
         found: true,
+        verified,
         query: text,
         selectedText,
+        selectionMatchesQuery,
+        selectionScope: 'current_match_only',
+        replacesPreviousSelection: true,
+        browserFindUiOpened: false,
         ...(rect ? { rect } : {}),
+        warning: verified
+          ? 'Only this match is selected. This call replaced any previous page selection, and it did not open the browser Find UI. Do not claim earlier find_text matches remain highlighted.'
+          : 'window.find reported a match, but WebBrain could not verify a visible selection in the top document (for example, the match may be inside a frame). Do not claim it is visibly highlighted. Only one current selection is supported, and the browser Find UI was not opened.',
       };
     } catch (error) {
       return { success: false, found: false, dispatched: false, noDispatch: true, error: `find_text failed: ${error.message || error}` };

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1356,9 +1356,22 @@ export class Agent {
     const x = Number.isFinite(pageX) ? pageX : viewportX;
     const y = Number.isFinite(pageY) ? pageY : viewportY;
     if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) return '';
-    return [x, y, width, height]
+    let selectionIdentity = 'document';
+    if (result.selectionSource === 'text_control') {
+      const selectionStart = result.selectionStart;
+      const selectionEnd = result.selectionEnd;
+      if (
+        !Number.isInteger(selectionStart)
+        || !Number.isInteger(selectionEnd)
+        || selectionStart < 0
+        || selectionEnd <= selectionStart
+      ) return '';
+      selectionIdentity = `text_control:${selectionStart}:${selectionEnd}`;
+    }
+    const rectIdentity = [x, y, width, height]
       .map(value => Math.round(value * 2) / 2)
       .join(',');
+    return `${selectionIdentity}|${rectIdentity}`;
   }
 
   _noteHealthyLoopCall(tabId) {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1345,7 +1345,7 @@ export class Agent {
   }
 
   _findTextMatchLoopIdentity(result) {
-    if (result?.success !== true || !result?.rect || typeof result.rect !== 'object') return '';
+    if (result?.success !== true || result?.verified === false || !result?.rect || typeof result.rect !== 'object') return '';
     const rect = result.rect;
     const pageX = typeof rect.pageX === 'number' ? rect.pageX : NaN;
     const pageY = typeof rect.pageY === 'number' ? rect.pageY : NaN;
@@ -1355,7 +1355,7 @@ export class Agent {
     const height = typeof rect.height === 'number' ? rect.height : NaN;
     const x = Number.isFinite(pageX) ? pageX : viewportX;
     const y = Number.isFinite(pageY) ? pageY : viewportY;
-    if (![x, y, width, height].every(Number.isFinite)) return '';
+    if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) return '';
     return [x, y, width, height]
       .map(value => Math.round(value * 2) / 2)
       .join(',');
@@ -9668,6 +9668,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (result == null || result?.done) return false;
     if (typeof result !== 'object') return true;
     if (result.success === false
+        || result.verified === false
+        || result.inconclusive
         || result.denied
         || result.cancelled
         || result.skipped

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -9668,8 +9668,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (result == null || result?.done) return false;
     if (typeof result !== 'object') return true;
     if (result.success === false
-        || result.verified === false
-        || result.inconclusive
         || result.denied
         || result.cancelled
         || result.skipped
@@ -9723,9 +9721,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       && this.constructor.EXECUTION_APP_STATE_TOOLS.has(name);
     const requiredScheduleSucceeded = state?.requiredSchedulingTool === name
       && this._isSuccessfulSchedulingEvidence(result);
+    // find_text is observational: verified:false means it did not prove a
+    // visible selection. Keep this tool-specific because mutations such as
+    // upload_file may dispatch successfully, return verified:false, and rely
+    // on the completion invariant's required follow-up page observation.
+    const unverifiedFindText = name === 'find_text'
+      && (result?.found !== true || result?.verified !== true || result?.inconclusive === true);
     if (!state?.enabled
         || name === 'done'
         || (this.constructor.EXECUTION_META_TOOLS.has(name) && !requestedAppStateTool)
+        || unverifiedFindText
         || (!this._isSuccessfulExecutionEvidence(result) && !requiredScheduleSucceeded)) return;
     state.successfulTaskToolCalls += 1;
     if (requiredScheduleSucceeded) state.successfulRequiredSchedulingToolCalls += 1;

--- a/src/firefox/src/agent/planner.js
+++ b/src/firefox/src/agent/planner.js
@@ -67,7 +67,7 @@ Rules:
   memory: scratchpad_write, progress_update, progress_read
   schedule: schedule_task (future/recurring work the user explicitly asked for), schedule_resume (pause CURRENT run blocked on external event)
   finish: done
-- press_keys supports only unmodified Escape, Tab, Enter, and arrow keys. Never plan Ctrl/Cmd/Alt/Shift combinations or browser UI shortcuts. To locate and highlight literal page text, plan find_text instead of Ctrl/Cmd+F.
+- press_keys supports only unmodified Escape, Tab, Enter, and arrow keys. Never plan Ctrl/Cmd/Alt/Shift combinations or browser UI shortcuts. To select one literal page-text match, plan find_text instead of Ctrl/Cmd+F. Each find_text call replaces the previous selection and does not open browser Find UI; never plan sequential calls as simultaneous highlights.
 - For repeated same-kind UI mutations (for example following many users), plan visible UI first with bounded batches, verification, progress_update, and wait_for_stable pacing; do not plan one huge same-shape click/tool batch.
 - Do not invent a prerequisite to discover a raw identifier (email address, account ID, username, or similar) when the target UI provides a name-based contact/entity picker and the user already supplied a human-readable name. Plan to use the picker first. Inspect surrounding pages or messages for the raw identifier only if the picker fails, returns multiple ambiguous matches, or the user explicitly asked for the identifier itself.
 - Set confidence from 0.0 to 1.0 for how clear and safe this plan is. Use 0.90+ only when the task, page state, and next steps are straightforward; use lower scores for ambiguity, destructive changes, payments, credentials, bulk mutations, or uncertain page state.
@@ -124,7 +124,7 @@ Rules:
 - schedule_task supports one-shot times and fixed-minute intervals only. Calendar/cron recurrence such as monthly is unsupported: classify it as clarify, explain the limitation in localized.summary, and ask for a one-shot time or fixed interval. Never convert calendar recurrence into an approximate interval.
 - Canonical summary, steps, and risks must be English. localized fields must use the requested wbLocale.
 - For execute, keep the compact plan to 1–4 steps. For plan_only, provide 2–8 useful steps. For respond and clarify, steps may be empty.
-- press_keys supports only unmodified Escape, Tab, Enter, and arrow keys. Never plan modifier combinations or browser UI shortcuts; use find_text to locate and highlight page text instead of Ctrl/Cmd+F.
+- press_keys supports only unmodified Escape, Tab, Enter, and arrow keys. Never plan modifier combinations or browser UI shortcuts; use find_text to select one page-text match instead of Ctrl/Cmd+F. Each call replaces the previous selection and cannot create simultaneous highlights or browser Find UI.
 - Do not invent URLs, credentials, tool names, or facts.`;
 
 export function normalizePlannerLocale(value) {

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -298,7 +298,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'press_keys',
-      description: 'Press one unmodified keyboard key. Supports only Escape, Tab, Enter, ArrowUp, ArrowDown, ArrowLeft, and ArrowRight. Ctrl/Cmd/Alt/Shift combinations and browser shortcuts such as Ctrl+F are not supported. Use find_text to locate and highlight page text. Firefox dispatches synthetic events, so native controls may not react on every site.',
+      description: 'Press one unmodified keyboard key. Supports only Escape, Tab, Enter, ArrowUp, ArrowDown, ArrowLeft, and ArrowRight. Ctrl/Cmd/Alt/Shift combinations and browser shortcuts such as Ctrl+F are not supported. Use find_text to select one page-text match. Firefox dispatches synthetic events, so native controls may not react on every site.',
       parameters: {
         type: 'object',
         properties: {
@@ -512,7 +512,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'find_text',
-      description: 'Find and select/highlight the next occurrence of literal text in the current page. Use this instead of Ctrl+F or Cmd+F; press_keys cannot send modifier combinations or open browser UI. Repeating the same search advances to the next match.',
+      description: 'Find and select the next occurrence of literal text in the current page. Use this instead of Ctrl+F or Cmd+F; press_keys cannot send modifier combinations. Repeating the same search advances to the next match. Each call replaces the previous page selection, so only the current match remains selected. This tool does not open the browser Find UI. Never claim that sequential find_text calls leave multiple terms highlighted.',
       parameters: {
         type: 'object',
         properties: {
@@ -1184,7 +1184,7 @@ TOOLS - use only these:
 - click({text}): Click by visible text. Fallback when no ref_id works.
 - type_text({text}): Type into the focused element. Click the field first.
 - get_selection: Read highlighted text.
-- find_text({text}): Locate and highlight literal page text instead of using Ctrl/Cmd+F.
+- find_text({text}): Select one literal page-text match instead of Ctrl/Cmd+F. Each call replaces the previous selection; no browser Find UI or simultaneous highlights.
 - press_keys({key}): Press one supported unmodified key. Ctrl/Cmd/Alt/Shift combinations and browser shortcuts are unavailable.
 - navigate({url}): Go to a URL.
 - new_tab({url}): Open a URL in a background tab for user reference. It does not activate or retarget the current run, so never use it as a site-permission workaround.
@@ -1303,7 +1303,7 @@ Available tools:
 - schedule_resume: Durably pause this current task and resume it later in the same tab/conversation. Terminal tool; use only for external waits.
 - schedule_task: Create a one-shot or fixed-minute-interval task only when the user explicitly asks for future scheduled work. It does not support calendar/cron recurrence; never approximate monthly recurrence. Prefer URL targets for repeatable automations; current_tab is strict and fails if the tab changes.
 - get_selection: Get highlighted text
-- find_text: Find and select/highlight literal page text. Use this instead of Ctrl/Cmd+F.
+- find_text: Select one literal page-text match instead of Ctrl/Cmd+F. Each call replaces the previous selection; it does not open browser Find UI or keep multiple terms highlighted.
 - press_keys: Press only unmodified Escape/Tab/Enter/arrows. Modifier combinations and browser shortcuts are unsupported.
 - new_tab: Open a background reference tab; the current run stays on its original tab
 - clarify: Pause and ask the user a question. Use ONLY for material ambiguity that you cannot resolve by reading the page (e.g. "my API key" on a site with multiple plugins that each have one). Unanswered clarifies auto-select options[0] after the timeout (default 60s) with source=timeout (not high-risk approval); Settings Instant yields source=auto (intentional auto-approve — continue). Put the safe/default first. Do NOT use to confirm correct actions; do NOT call before every step. Budget 1-2 per run, max.
@@ -1529,7 +1529,7 @@ TOOLS — use only these:
 - click_ax({ref_id}) / set_checked({ref_id, checked}) / type_ax({ref_id, text}) / set_field({ref_id, text, submit}): act on nodes by ref_id. set_field is preferred for text fields; set_checked is required for native checkboxes.
 - read_page: prose fallback for long articles. get_window_info: inspect browser window/viewport size. scroll, navigate({url}), go_back()/go_forward(): walk the run tab's history. new_tab({url}) only opens a background reference tab and never retargets the run.
 - get_interactive_elements: legacy indexed element list (use when the tree misses elements). click({text}) / type_text({text}) / press_keys({key}): legacy fallbacks. press_keys supports only unmodified Escape/Tab/Enter/arrows, never Ctrl/Cmd/Alt/Shift combinations or browser shortcuts.
-- extract_data: tables/headings/images/links. get_selection: read highlighted text. find_text({text}): locate and highlight literal page text instead of Ctrl/Cmd+F. read_pdf: read a PDF.
+- extract_data: tables/headings/images/links. get_selection: read highlighted text. find_text({text}): select one literal page-text match; each call replaces the previous selection and never creates simultaneous highlights or browser Find UI. read_pdf: read a PDF.
 - wait_for_element({selector}) / wait_for_stable({quietMs}): wait for an element / for the page to go quiet after an action.
 - schedule_resume({after_seconds|run_at, reason, resume_instruction}): terminal durable pause for this current task.
 - schedule_task({title, prompt, schedule, target, mode}): create one-shot or fixed-minute-interval future work only when explicitly requested by the user. Calendar/cron recurrence is unsupported and must not be approximated. Prefer target.type:"url" for monitors/repeatable automations; use current_tab only for exact current-tab state.

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -2073,12 +2073,30 @@
           height: bounds.height,
         };
       }
+      const hasVisibleRect = !!rect
+        && [rect.x, rect.y, rect.pageX, rect.pageY, rect.width, rect.height].every(Number.isFinite)
+        && rect.width > 0
+        && rect.height > 0;
+      const normalizedSelectedText = selectedText.normalize('NFC');
+      const normalizedQuery = text.normalize('NFC');
+      const selectionMatchesQuery = matchCase
+        ? normalizedSelectedText === normalizedQuery
+        : normalizedSelectedText.toLowerCase() === normalizedQuery.toLowerCase();
+      const verified = selectionMatchesQuery && hasVisibleRect;
       return {
         success: true,
         found: true,
+        verified,
         query: text,
         selectedText,
+        selectionMatchesQuery,
+        selectionScope: 'current_match_only',
+        replacesPreviousSelection: true,
+        browserFindUiOpened: false,
         ...(rect ? { rect } : {}),
+        warning: verified
+          ? 'Only this match is selected. This call replaced any previous page selection, and it did not open the browser Find UI. Do not claim earlier find_text matches remain highlighted.'
+          : 'window.find reported a match, but WebBrain could not verify a visible selection in the top document (for example, the match may be inside a frame). Do not claim it is visibly highlighted. Only one current selection is supported, and the browser Find UI was not opened.',
       };
     } catch (error) {
       return { success: false, found: false, dispatched: false, noDispatch: true, error: `find_text failed: ${error.message || error}` };

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -2043,9 +2043,10 @@
       const matchCase = params?.matchCase === true;
       const backwards = params?.backwards === true;
       const wrap = params?.wrap !== false;
-      // Match browser Find semantics across the whole document, including
-      // embedded frames. Without searchInFrames, find_text falsely reports a
-      // miss for text that Ctrl/Cmd+F would find inside an iframe.
+      // Match browser Find semantics across the whole page, including frames.
+      // When the active match moves into a frame, the top document can retain
+      // an older selection; frame focus keeps that stale range from verifying
+      // the current hit.
       const found = window.find(text, matchCase, backwards, wrap, false, true, false);
       if (!found) {
         return {
@@ -2057,11 +2058,56 @@
           error: `find_text: "${text}" was not found on the current page. Re-read the page or try a shorter literal phrase.`,
         };
       }
+      const activeElement = window.document?.activeElement;
+      const activeElementTag = String(activeElement?.tagName || '').toUpperCase();
+      const inputType = String(activeElement?.type || 'text').toLowerCase();
+      const isTextControl = activeElementTag === 'TEXTAREA'
+        || (activeElementTag === 'INPUT' && ['text', 'search', 'url', 'tel', 'email'].includes(inputType));
+      const normalizedQuery = text.normalize('NFC');
+      const matchesQuery = (value) => {
+        const normalizedValue = String(value || '').normalize('NFC');
+        return matchCase
+          ? normalizedValue === normalizedQuery
+          : normalizedValue.toLowerCase() === normalizedQuery.toLowerCase();
+      };
+      const hasVisibleBounds = (candidate) => !!candidate
+        && [candidate.x, candidate.y, candidate.width, candidate.height].every(Number.isFinite)
+        && candidate.width > 0
+        && candidate.height > 0;
       const selection = window.getSelection?.();
-      const selectedText = String(selection?.toString?.() || '');
+      const documentSelectedText = String(selection?.toString?.() || '');
+      const documentBounds = selection?.rangeCount
+        ? selection.getRangeAt(0).getBoundingClientRect()
+        : undefined;
+      let controlSelectedText = '';
+      let controlBounds;
+      const controlSelectionStart = activeElement?.selectionStart;
+      const controlSelectionEnd = activeElement?.selectionEnd;
+      if (
+        isTextControl
+        && Number.isInteger(controlSelectionStart)
+        && Number.isInteger(controlSelectionEnd)
+        && controlSelectionStart >= 0
+        && controlSelectionEnd > controlSelectionStart
+      ) {
+        controlSelectedText = String(activeElement.value || '').slice(controlSelectionStart, controlSelectionEnd);
+        controlBounds = activeElement.getBoundingClientRect?.();
+      }
+      const documentMatchesQuery = matchesQuery(documentSelectedText);
+      const controlMatchesQuery = matchesQuery(controlSelectedText);
+      let selectedText = documentSelectedText;
+      let selectionSource = 'document';
+      let bounds = documentBounds;
+      if (documentMatchesQuery && hasVisibleBounds(documentBounds)) {
+        // Keep the page selection. A focused field can retain an unrelated
+        // selection while window.find advances to a normal document match.
+      } else if (controlMatchesQuery && hasVisibleBounds(controlBounds)) {
+        selectedText = controlSelectedText;
+        bounds = controlBounds;
+        selectionSource = 'text_control';
+      }
       let rect;
-      if (selection?.rangeCount) {
-        const bounds = selection.getRangeAt(0).getBoundingClientRect();
+      if (bounds) {
         const scrollX = Number.isFinite(Number(window.scrollX)) ? Number(window.scrollX) : 0;
         const scrollY = Number.isFinite(Number(window.scrollY)) ? Number(window.scrollY) : 0;
         rect = {
@@ -2077,12 +2123,16 @@
         && [rect.x, rect.y, rect.pageX, rect.pageY, rect.width, rect.height].every(Number.isFinite)
         && rect.width > 0
         && rect.height > 0;
-      const normalizedSelectedText = selectedText.normalize('NFC');
-      const normalizedQuery = text.normalize('NFC');
-      const selectionMatchesQuery = matchCase
-        ? normalizedSelectedText === normalizedQuery
-        : normalizedSelectedText.toLowerCase() === normalizedQuery.toLowerCase();
-      const verified = selectionMatchesQuery && hasVisibleRect;
+      const selectionMatchesQuery = matchesQuery(selectedText);
+      const selectionInFrame = activeElementTag === 'IFRAME' || activeElementTag === 'FRAME';
+      const hasSelectionIdentity = selectionSource !== 'text_control'
+        || (
+          Number.isInteger(controlSelectionStart)
+          && Number.isInteger(controlSelectionEnd)
+          && controlSelectionStart >= 0
+          && controlSelectionEnd > controlSelectionStart
+        );
+      const verified = selectionMatchesQuery && hasVisibleRect && hasSelectionIdentity && !selectionInFrame;
       return {
         success: true,
         found: true,
@@ -2090,13 +2140,18 @@
         query: text,
         selectedText,
         selectionMatchesQuery,
-        selectionScope: 'current_match_only',
-        replacesPreviousSelection: true,
+        selectionSource,
+        selectionInFrame,
+        selectionScope: selectionInFrame ? 'frame_match_unverified' : 'current_match_only',
+        ...(selectionSource === 'text_control'
+          ? { selectionStart: controlSelectionStart, selectionEnd: controlSelectionEnd }
+          : {}),
+        replacesPreviousSelection: !selectionInFrame,
         browserFindUiOpened: false,
         ...(rect ? { rect } : {}),
         warning: verified
           ? 'Only this match is selected. This call replaced any previous page selection, and it did not open the browser Find UI. Do not claim earlier find_text matches remain highlighted.'
-          : 'window.find reported a match, but WebBrain could not verify a visible selection in the top document (for example, the match may be inside a frame). Do not claim it is visibly highlighted. Only one current selection is supported, and the browser Find UI was not opened.',
+          : 'window.find reported a match, but WebBrain could not verify a visible current selection in the top document (for example, the active match may be inside a frame while an older top-document selection remains). Do not claim it is visibly highlighted. The browser Find UI was not opened.',
       };
     } catch (error) {
       return { success: false, found: false, dispatched: false, noDispatch: true, error: `find_text failed: ${error.message || error}` };

--- a/test/run.js
+++ b/test/run.js
@@ -860,7 +860,7 @@ class LoopDetectorShim {
     return false;
   }
   _findTextMatchLoopIdentity(result) {
-    if (result?.success !== true || !result?.rect || typeof result.rect !== 'object') return '';
+    if (result?.success !== true || result?.verified === false || !result?.rect || typeof result.rect !== 'object') return '';
     const rect = result.rect;
     const pageX = typeof rect.pageX === 'number' ? rect.pageX : NaN;
     const pageY = typeof rect.pageY === 'number' ? rect.pageY : NaN;
@@ -870,7 +870,7 @@ class LoopDetectorShim {
     const height = typeof rect.height === 'number' ? rect.height : NaN;
     const x = Number.isFinite(pageX) ? pageX : viewportX;
     const y = Number.isFinite(pageY) ? pageY : viewportY;
-    if (![x, y, width, height].every(Number.isFinite)) return '';
+    if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) return '';
     return [x, y, width, height]
       .map(value => Math.round(value * 2) / 2)
       .join(',');
@@ -3717,6 +3717,7 @@ test('find_text loop detection follows match progress in both browser agents', (
   const match = pageY => ({
     success: true,
     found: true,
+    verified: true,
     rect: { x: 10, y: 20, pageX: 110, pageY, width: 30, height: 12 },
   });
 
@@ -3755,9 +3756,14 @@ test('find_text loop detection follows match progress in both browser agents', (
     const framedTab = `${label}-framed`;
     for (let index = 0; index < 4; index += 1) {
       assert.equal(
-        framed._checkLoop(framedTab, 'find_text', args, { success: true, found: true }).kind,
+        framed._checkLoop(framedTab, 'find_text', args, {
+          success: true,
+          found: true,
+          verified: false,
+          rect: { x: 0, y: 0, pageX: 0, pageY: 0, width: 0, height: 0 },
+        }).kind,
         'none',
-        `${label}: a successful frame match without a top-document rect was blocked`,
+        `${label}: an unverified frame match without a visible top-document range was blocked`,
       );
     }
 
@@ -9122,6 +9128,9 @@ test('getToolsForMode: find_text replaces unsupported modifier shortcuts', () =>
     assert.deepEqual(findText.function.parameters.required, ['text']);
     assert.equal(findText.function.parameters.properties.text.maxLength, 500);
     assert.match(findText.function.description, /instead of Ctrl\+F or Cmd\+F/i);
+    assert.match(findText.function.description, /Each call replaces the previous page selection/i);
+    assert.match(findText.function.description, /does not open the browser Find UI/i);
+    assert.match(findText.function.description, /Never claim.*sequential find_text calls.*multiple terms highlighted/i);
 
     const pressKeys = fullTools.find(t => t.function.name === 'press_keys');
     assert.deepEqual(pressKeys.function.parameters.properties.key.enum, [
@@ -9129,6 +9138,14 @@ test('getToolsForMode: find_text replaces unsupported modifier shortcuts', () =>
     ]);
     assert.match(pressKeys.function.description, /Ctrl\/Cmd\/Alt\/Shift combinations.*not supported/i);
     assert.doesNotMatch(pressKeys.function.parameters.properties.key.enum.join(' '), /Control|Meta|Alt|Shift|KeyF/);
+
+    const prompts = label === 'chrome'
+      ? [SYSTEM_PROMPT_ACT_CH, SYSTEM_PROMPT_ACT_MID_CH, SYSTEM_PROMPT_ACT_COMPACT_CH]
+      : [SYSTEM_PROMPT_ACT_FX, SYSTEM_PROMPT_ACT_MID_FX, SYSTEM_PROMPT_ACT_COMPACT_FX];
+    for (const prompt of prompts) {
+      assert.match(prompt, /find_text[\s\S]{0,180}replaces the previous selection/i, `${label}: Act prompt omitted single-selection semantics`);
+      assert.match(prompt, /find_text[\s\S]{0,220}(?:browser Find UI|simultaneous highlights)/i, `${label}: Act prompt omitted browser UI/multi-highlight limitation`);
+    }
   }
   assert.equal(UNTRUSTED_CONTENT_TOOLS_CH.has('find_text'), true, 'chrome: selected page text must stay inside the untrusted boundary');
   assert.equal(UNTRUSTED_CONTENT_TOOLS.has('find_text'), true, 'firefox: selected page text must stay inside the untrusted boundary');
@@ -33161,12 +33178,47 @@ test('find_text uses page search and returns selected match evidence in both bro
     assert.deepEqual(Array.from(findArgs), ['Needle', true, true, false, false, true, false], `${label}: window.find should include embedded frames while honoring the finite schema`);
     assert.equal(result.success, true);
     assert.equal(result.found, true);
+    assert.equal(result.verified, true);
     assert.equal(result.selectedText, 'Needle');
+    assert.equal(result.selectionMatchesQuery, true);
+    assert.equal(result.selectionScope, 'current_match_only');
+    assert.equal(result.replacesPreviousSelection, true);
+    assert.equal(result.browserFindUiOpened, false);
+    assert.match(result.warning, /Only this match is selected/);
+    assert.match(result.warning, /replaced any previous page selection/);
+    assert.match(result.warning, /did not open the browser Find UI/);
     assert.deepEqual(
       { ...result.rect },
       { x: 10, y: 20, pageX: 110, pageY: 220, width: 30, height: 12 },
       `${label}: find_text should return stable page coordinates for loop identity`,
     );
+    window.getSelection = () => ({
+      rangeCount: 1,
+      toString: () => '',
+      getRangeAt: () => ({
+        getBoundingClientRect: () => ({ x: 0, y: 0, width: 0, height: 0 }),
+      }),
+    });
+    const unverified = findText({ text: 'framed match' });
+    assert.equal(unverified.success, true, `${label}: window.find frame matches should remain explicit matches`);
+    assert.equal(unverified.found, true);
+    assert.equal(unverified.verified, false, `${label}: empty zero-sized selections must not be verified`);
+    assert.equal(unverified.selectionMatchesQuery, false);
+    assert.equal(unverified.replacesPreviousSelection, true);
+    assert.equal(unverified.browserFindUiOpened, false);
+    assert.match(unverified.warning, /could not verify a visible selection in the top document/i);
+    assert.match(unverified.warning, /Do not claim it is visibly highlighted/i);
+    window.getSelection = () => ({
+      rangeCount: 1,
+      toString: () => 'stale previous selection',
+      getRangeAt: () => ({
+        getBoundingClientRect: () => ({ x: 10, y: 20, width: 30, height: 12 }),
+      }),
+    });
+    const staleSelection = findText({ text: 'framed match' });
+    assert.equal(staleSelection.success, true);
+    assert.equal(staleSelection.selectionMatchesQuery, false);
+    assert.equal(staleSelection.verified, false, `${label}: a visible stale top-document selection must not verify a frame match`);
     window.find = () => false;
     const missing = findText({ text: 'absent phrase' });
     assert.equal(missing.success, false, `${label}: a missing match should not count as successful task evidence`);
@@ -37587,7 +37639,7 @@ test('streamed runs preserve consequential evidence for a trusted continuation',
   }
 });
 
-test('execution evidence ignores failed, denied, skipped, blocked, and unknown outcomes', () => {
+test('execution evidence ignores failed, unverified, inconclusive, denied, skipped, blocked, and unknown outcomes', () => {
   for (const [index, AgentClass] of [AgentCh, AgentFx].entries()) {
     const agent = new AgentClass({});
     const tabId = 8614 + index;
@@ -37625,6 +37677,8 @@ test('execution evidence ignores failed, denied, skipped, blocked, and unknown o
     }
     for (const result of [
       { success: false },
+      { success: true, verified: false },
+      { success: true, inconclusive: true },
       { denied: true },
       { skipped: true },
       { blocked: true },
@@ -37645,6 +37699,36 @@ test('execution evidence ignores failed, denied, skipped, blocked, and unknown o
 
     agent._markPlanExecutionToolCall(tabId, 'navigate', { success: true }, { consequential: true });
     assert.equal(agent._executionEvidenceSatisfied(state), true, `${AgentClass.name}: successful navigation evidence was not counted`);
+
+    const findTabId = 8620 + index;
+    const findState = agent._startPlanExecutionGuard(findTabId, 'act', {
+      requestKind: 'execute',
+      requiresStateChange: false,
+    });
+    agent._markPlanExecutionToolCall(findTabId, 'find_text', {
+      success: true,
+      found: true,
+      verified: false,
+      selectedText: '',
+      rect: { x: 0, y: 0, pageX: 0, pageY: 0, width: 0, height: 0 },
+    });
+    assert.equal(
+      agent._executionEvidenceSatisfied(findState),
+      false,
+      `${AgentClass.name}: an unverified find_text match counted as completed read-only work`,
+    );
+    agent._markPlanExecutionToolCall(findTabId, 'find_text', {
+      success: true,
+      found: true,
+      verified: true,
+      selectedText: 'Needle',
+      rect: { x: 10, y: 20, pageX: 10, pageY: 20, width: 30, height: 12 },
+    });
+    assert.equal(
+      agent._executionEvidenceSatisfied(findState),
+      true,
+      `${AgentClass.name}: a verified find_text selection did not count as completed read-only work`,
+    );
   }
 });
 
@@ -42939,6 +43023,8 @@ test('planner: prompt treats page context as untrusted data', () => {
   assert.match(PLANNER_SYSTEM_PROMPT, /interact:[^\n]*find_text/);
   assert.match(PLANNER_SYSTEM_PROMPT, /Never plan Ctrl\/Cmd\/Alt\/Shift combinations or browser UI shortcuts/);
   assert.match(PLANNER_SYSTEM_PROMPT, /plan find_text instead of Ctrl\/Cmd\+F/);
+  assert.match(PLANNER_SYSTEM_PROMPT, /Each find_text call replaces the previous selection/);
+  assert.match(PLANNER_SYSTEM_PROMPT, /never plan sequential calls as simultaneous highlights/);
   assert.match(PLANNER_SYSTEM_PROMPT, /attached JSON\/TXT\/CSV text file content/);
   assert.match(PLANNER_SYSTEM_PROMPT, /brief neutral scratchpad_notes/);
   assert.match(PLANNER_SYSTEM_PROMPT, /Do not plan to copy the full file/);
@@ -42954,7 +43040,9 @@ test('planner: prompt treats page context as untrusted data', () => {
   assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /lacks usable timing or cadence.*clarify/i);
   assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /Calendar\/cron recurrence.*unsupported/i);
   assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /Never convert calendar recurrence/i);
-  assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /use find_text to locate and highlight page text instead of Ctrl\/Cmd\+F/);
+  assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /use find_text to select one page-text match instead of Ctrl\/Cmd\+F/);
+  assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /Each call replaces the previous selection/);
+  assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /cannot create simultaneous highlights or browser Find UI/);
   assert.match(PLANNER_SYSTEM_PROMPT_FX, /lacks usable timing or cadence.*clarify/i);
   assert.match(PLANNER_INTENT_SYSTEM_PROMPT_FX, /Calendar\/cron recurrence.*unsupported/i);
   assert.match(PLANNER_INTENT_SYSTEM_PROMPT_FX, /"use_progress_ledger": boolean/);

--- a/test/run.js
+++ b/test/run.js
@@ -871,9 +871,22 @@ class LoopDetectorShim {
     const x = Number.isFinite(pageX) ? pageX : viewportX;
     const y = Number.isFinite(pageY) ? pageY : viewportY;
     if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) return '';
-    return [x, y, width, height]
+    let selectionIdentity = 'document';
+    if (result.selectionSource === 'text_control') {
+      const selectionStart = result.selectionStart;
+      const selectionEnd = result.selectionEnd;
+      if (
+        !Number.isInteger(selectionStart)
+        || !Number.isInteger(selectionEnd)
+        || selectionStart < 0
+        || selectionEnd <= selectionStart
+      ) return '';
+      selectionIdentity = `text_control:${selectionStart}:${selectionEnd}`;
+    }
+    const rectIdentity = [x, y, width, height]
       .map(value => Math.round(value * 2) / 2)
       .join(',');
+    return `${selectionIdentity}|${rectIdentity}`;
   }
   _noteHealthyLoopCall(tabId) {
     const healthy = (this.healthyCallsSinceLoop.get(tabId) || 0) + 1;
@@ -3750,6 +3763,37 @@ test('find_text loop detection follows match progress in both browser agents', (
       stuck._checkLoop(stuckTab, 'find_text', args, match(220)).kind,
       'nudge',
       `${label}: a truly unchanged match position should remain loop-detectable`,
+    );
+
+    const controlMatch = (selectionStart, selectionEnd) => ({
+      ...match(220),
+      selectionSource: 'text_control',
+      selectionStart,
+      selectionEnd,
+    });
+    const advancingControl = new Detector({});
+    const advancingControlTab = `${label}-advancing-control`;
+    for (const [selectionStart, selectionEnd] of [[0, 6], [12, 18], [24, 30]]) {
+      assert.equal(
+        advancingControl._checkLoop(
+          advancingControlTab,
+          'find_text',
+          args,
+          controlMatch(selectionStart, selectionEnd),
+        ).kind,
+        'none',
+        `${label}: advancing matches inside one text control were treated as a repeated call`,
+      );
+    }
+
+    const stuckControl = new Detector({});
+    const stuckControlTab = `${label}-stuck-control`;
+    assert.equal(stuckControl._checkLoop(stuckControlTab, 'find_text', args, controlMatch(12, 18)).kind, 'none');
+    assert.equal(stuckControl._checkLoop(stuckControlTab, 'find_text', args, controlMatch(12, 18)).kind, 'none');
+    assert.equal(
+      stuckControl._checkLoop(stuckControlTab, 'find_text', args, controlMatch(12, 18)).kind,
+      'nudge',
+      `${label}: an unchanged text-control range should remain loop-detectable`,
     );
 
     const framed = new Detector({});
@@ -33157,12 +33201,13 @@ test('find_text uses page search and returns selected match evidence in both bro
     const end = content.indexOf('\n\n  /**\n   * Press supported keyboard keys.', start);
     assert.ok(start >= 0 && end > start, `${label}: find_text should remain independently testable`);
 
-    let findArgs;
+    let findCalls = [];
     const window = {
       scrollX: 100,
       scrollY: 200,
+      document: { activeElement: { tagName: 'BODY' } },
       find: (...args) => {
-        findArgs = args;
+        findCalls.push(args);
         return true;
       },
       getSelection: () => ({
@@ -33175,12 +33220,18 @@ test('find_text uses page search and returns selected match evidence in both bro
     };
     const findText = vm.runInNewContext(`(${content.slice(start, end)})`, { window });
     const result = findText({ text: '  Needle  ', matchCase: true, backwards: true, wrap: false });
-    assert.deepEqual(Array.from(findArgs), ['Needle', true, true, false, false, true, false], `${label}: window.find should include embedded frames while honoring the finite schema`);
+    assert.deepEqual(
+      findCalls.map(args => Array.from(args)),
+      [['Needle', true, true, false, false, true, false]],
+      `${label}: find_text should search frames while honoring the finite schema`,
+    );
     assert.equal(result.success, true);
     assert.equal(result.found, true);
     assert.equal(result.verified, true);
     assert.equal(result.selectedText, 'Needle');
     assert.equal(result.selectionMatchesQuery, true);
+    assert.equal(result.selectionSource, 'document');
+    assert.equal(result.selectionInFrame, false);
     assert.equal(result.selectionScope, 'current_match_only');
     assert.equal(result.replacesPreviousSelection, true);
     assert.equal(result.browserFindUiOpened, false);
@@ -33192,6 +33243,8 @@ test('find_text uses page search and returns selected match evidence in both bro
       { x: 10, y: 20, pageX: 110, pageY: 220, width: 30, height: 12 },
       `${label}: find_text should return stable page coordinates for loop identity`,
     );
+    findCalls = [];
+    window.document.activeElement = { tagName: 'IFRAME' };
     window.getSelection = () => ({
       rangeCount: 1,
       toString: () => '',
@@ -33204,9 +33257,15 @@ test('find_text uses page search and returns selected match evidence in both bro
     assert.equal(unverified.found, true);
     assert.equal(unverified.verified, false, `${label}: empty zero-sized selections must not be verified`);
     assert.equal(unverified.selectionMatchesQuery, false);
-    assert.equal(unverified.replacesPreviousSelection, true);
+    assert.equal(unverified.selectionInFrame, true);
+    assert.deepEqual(
+      findCalls.map(args => Array.from(args)),
+      [['framed match', false, false, true, false, true, false]],
+      `${label}: frame-aware search should remain the primary next-occurrence search`,
+    );
+    assert.equal(unverified.replacesPreviousSelection, false);
     assert.equal(unverified.browserFindUiOpened, false);
-    assert.match(unverified.warning, /could not verify a visible selection in the top document/i);
+    assert.match(unverified.warning, /could not verify a visible current selection in the top document/i);
     assert.match(unverified.warning, /Do not claim it is visibly highlighted/i);
     window.getSelection = () => ({
       rangeCount: 1,
@@ -33218,7 +33277,90 @@ test('find_text uses page search and returns selected match evidence in both bro
     const staleSelection = findText({ text: 'framed match' });
     assert.equal(staleSelection.success, true);
     assert.equal(staleSelection.selectionMatchesQuery, false);
+    assert.equal(staleSelection.selectionInFrame, true);
     assert.equal(staleSelection.verified, false, `${label}: a visible stale top-document selection must not verify a frame match`);
+    window.getSelection = () => ({
+      rangeCount: 1,
+      toString: () => 'Needle',
+      getRangeAt: () => ({
+        getBoundingClientRect: () => ({ x: 10, y: 20, width: 30, height: 12 }),
+      }),
+    });
+    const staleMatchingSelection = findText({ text: 'Needle', matchCase: true, wrap: false });
+    assert.equal(staleMatchingSelection.success, true);
+    assert.equal(staleMatchingSelection.selectionMatchesQuery, true);
+    assert.equal(staleMatchingSelection.selectionInFrame, true);
+    assert.equal(
+      staleMatchingSelection.verified,
+      false,
+      `${label}: a same-query top selection left unchanged by a frame match must not be verified as the current hit`,
+    );
+    assert.match(staleMatchingSelection.warning, /older top-document selection remains/i);
+    window.document.activeElement = { tagName: 'BODY' };
+    const repeatedTopSelection = findText({ text: 'Needle', matchCase: true });
+    assert.equal(repeatedTopSelection.selectionInFrame, false);
+    assert.equal(
+      repeatedTopSelection.verified,
+      true,
+      `${label}: an unchanged visible selection should remain verifiable when this call finds it in the top document`,
+    );
+    window.document.activeElement = {
+      tagName: 'TEXTAREA',
+      value: 'Before Needle after',
+      selectionStart: 7,
+      selectionEnd: 13,
+      getBoundingClientRect: () => ({ x: 15, y: 25, width: 160, height: 60 }),
+    };
+    window.getSelection = () => ({ rangeCount: 0, toString: () => '' });
+    const textControlSelection = findText({ text: 'Needle', matchCase: true });
+    assert.equal(textControlSelection.verified, true, `${label}: an active textarea selection was not verified`);
+    assert.equal(textControlSelection.selectedText, 'Needle');
+    assert.equal(textControlSelection.selectionSource, 'text_control');
+    assert.equal(textControlSelection.selectionStart, 7);
+    assert.equal(textControlSelection.selectionEnd, 13);
+    assert.deepEqual(
+      { ...textControlSelection.rect },
+      { x: 15, y: 25, pageX: 115, pageY: 225, width: 160, height: 60 },
+      `${label}: text-control verification should return stable control bounds`,
+    );
+    window.document.activeElement = {
+      tagName: 'TEXTAREA',
+      value: 'stale field value',
+      selectionStart: 0,
+      selectionEnd: 5,
+      getBoundingClientRect: () => ({ x: 15, y: 25, width: 160, height: 60 }),
+    };
+    window.getSelection = () => ({
+      rangeCount: 1,
+      toString: () => 'Needle',
+      getRangeAt: () => ({
+        getBoundingClientRect: () => ({ x: 40, y: 50, width: 45, height: 12 }),
+      }),
+    });
+    const documentOverStaleControl = findText({ text: 'Needle', matchCase: true });
+    assert.equal(documentOverStaleControl.verified, true, `${label}: a document match should not be hidden by a stale focused-field selection`);
+    assert.equal(documentOverStaleControl.selectedText, 'Needle');
+    assert.equal(documentOverStaleControl.selectionSource, 'document');
+    assert.equal('selectionStart' in documentOverStaleControl, false);
+    assert.equal('selectionEnd' in documentOverStaleControl, false);
+    assert.deepEqual(
+      { ...documentOverStaleControl.rect },
+      { x: 40, y: 50, pageX: 140, pageY: 250, width: 45, height: 12 },
+      `${label}: document selection bounds should win over stale focused-field bounds`,
+    );
+    window.document.activeElement = {
+      tagName: 'INPUT',
+      type: 'password',
+      value: 'Secret Needle',
+      selectionStart: 7,
+      selectionEnd: 13,
+      getBoundingClientRect: () => ({ x: 15, y: 25, width: 160, height: 30 }),
+    };
+    window.getSelection = () => ({ rangeCount: 0, toString: () => '' });
+    const passwordSelection = findText({ text: 'Needle', matchCase: true });
+    assert.equal(passwordSelection.verified, false, `${label}: password-field text must not be exposed as verified selection evidence`);
+    assert.equal(passwordSelection.selectedText, '');
+    assert.equal(passwordSelection.selectionSource, 'document');
     window.find = () => false;
     const missing = findText({ text: 'absent phrase' });
     assert.equal(missing.success, false, `${label}: a missing match should not count as successful task evidence`);

--- a/test/run.js
+++ b/test/run.js
@@ -37639,7 +37639,7 @@ test('streamed runs preserve consequential evidence for a trusted continuation',
   }
 });
 
-test('execution evidence ignores failed, unverified, inconclusive, denied, skipped, blocked, and unknown outcomes', () => {
+test('execution evidence ignores failed, denied, skipped, blocked, and unknown outcomes', () => {
   for (const [index, AgentClass] of [AgentCh, AgentFx].entries()) {
     const agent = new AgentClass({});
     const tabId = 8614 + index;
@@ -37677,8 +37677,6 @@ test('execution evidence ignores failed, unverified, inconclusive, denied, skipp
     }
     for (const result of [
       { success: false },
-      { success: true, verified: false },
-      { success: true, inconclusive: true },
       { denied: true },
       { skipped: true },
       { blocked: true },
@@ -37728,6 +37726,23 @@ test('execution evidence ignores failed, unverified, inconclusive, denied, skipp
       agent._executionEvidenceSatisfied(findState),
       true,
       `${AgentClass.name}: a verified find_text selection did not count as completed read-only work`,
+    );
+
+    const uploadTabId = 8624 + index;
+    const uploadState = agent._startPlanExecutionGuard(uploadTabId, 'act', {
+      requestKind: 'execute',
+      requiresStateChange: true,
+    });
+    agent._markPlanExecutionToolCall(uploadTabId, 'upload_file', {
+      success: true,
+      verified: false,
+      file: '/tmp/attachment.txt',
+      note: 'The async uploader consumed the file; verify the attachment on the page.',
+    }, { consequential: true });
+    assert.equal(
+      agent._executionEvidenceSatisfied(uploadState),
+      true,
+      `${AgentClass.name}: a dispatched upload pending page verification lost its mutation evidence`,
     );
   }
 });


### PR DESCRIPTION
## Summary

- make `find_text` distinguish a reported match from a verified rendered selection
- expose the single-selection contract in structured results: each call replaces the previous page selection and never opens browser Find UI
- update full, mid, compact, and planner guidance so sequential searches are not reported as simultaneous highlights
- prevent `verified:false` and inconclusive tool results from satisfying execution evidence
- keep Chrome and Firefox behavior mirrored and add regression coverage

## Root cause

A July 23 trace asked WebBrain to highlight several pasta types. The agent called `find_text` repeatedly, then claimed all matches remained highlighted and that the browser find bar showed matches. In reality, `window.find()` replaces the current page selection on every call and does not open browser chrome. The old runtime also returned `success:true` solely from `window.find()`, even when `selectedText` was empty and the selection rectangle was zero-sized.

## User impact

A verified result now requires selected text that matches the query plus a positive-size rendered range. Frame-only or otherwise unobservable matches remain explicit `found:true` results but carry `verified:false` and cannot count as completed execution evidence. The agent is told consistently that only the current match stays selected, so multi-term requests are reported with the real limitation instead of a false persistent-highlight claim.

## Validation

- `git diff --check`
- syntax checks for all changed JavaScript files
- Chrome/Firefox planner and `findText` parity checks
- `npm test` — 1230/1230 Node tests and 60/60 injection-corpus checks passed
- `npm run test:security` — 60/60 passed