### PR TITLE
Trace interactive Ask streaming lifecycle

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1174,7 +1174,7 @@ export class Agent {
     const rawMessage = String(error?.message || error || 'Streaming request failed.');
     const message = rawMessage
       .replace(/\b(Bearer)\s+[^\s,;]+/gi, '$1 [redacted]')
-      .replace(/((?:api[_ -]?key|access[_ -]?token|token|secret|password)\s*[:=]\s*)["']?[^\s,"';]+/gi, '$1[redacted]')
+      .replace(/((?:^|[^a-zA-Z0-9_])["']?(?:api[_ -]?key|access[_ -]?token|token|secret|password)["']?\s*[:=]\s*)(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;}\]]+)/gi, '$1[redacted]')
       .replace(/([?&](?:api[_-]?key|access[_-]?token|token|key)=)[^&\s]+/gi, '$1[redacted]')
       .replace(/\b(?:sk-(?:or-v1-)?|gsk_|xai-)[a-zA-Z0-9_-]{12,}\b/g, '[redacted]')
       .slice(0, 500);

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -18426,6 +18426,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let runId = null;
     let finalResponse = '';
     let _traceStatus = 'done'; // updated on early exits
+    let askStreamingTraceWrite = Promise.resolve();
+    let shouldOrderInteractiveAskTrace = false;
+    const queueAskStreamingTraceWrite = (write) => {
+      askStreamingTraceWrite = askStreamingTraceWrite
+        .then(write)
+        .catch(() => {});
+      return askStreamingTraceWrite;
+    };
 
     if (mode === 'dev' && provider.promptTier === 'compact') {
       const msg = this._devModeBlockedMessage(provider);
@@ -18537,17 +18545,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let compressionPlaceholderRecoveryAttempted = false;
     let askStreamingDisabledForRun = false;
 
-    // Keep trace persistence ordered without putting IndexedDB on the LLM
-    // request path. The recorder is diagnostic-only and must never delay a
-    // stream, fallback, or completed response.
-    let askStreamingTraceWrite = Promise.resolve();
+    // Keep trace persistence ordered without putting IndexedDB on the token
+    // delivery path. Once generation settles, later response/finalization
+    // writes flush this queue so lifecycle events cannot arrive afterward.
+    shouldOrderInteractiveAskTrace = mode === 'ask' && runOptions?.interactiveChat === true;
     const recordAskStreaming = (payload) => {
       const traceRunId = runId;
       const traceStep = steps;
       if (!traceRunId) return;
-      askStreamingTraceWrite = askStreamingTraceWrite
-        .then(() => trace.recordStreaming(traceRunId, traceStep, payload))
-        .catch(() => {});
+      queueAskStreamingTraceWrite(
+        () => trace.recordStreaming(traceRunId, traceStep, payload),
+      );
     };
 
     const chatMainTurn = async (chatMessages, chatOptions, requestContext) => {
@@ -18707,7 +18715,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         const chatOpts = { tools: useTools ? tools : undefined, temperature: plannerTemperature, maxTokens: 4096 };
         const prunedMessages = this._pruneOldImages(messages, provider);
         this._logDebug({ type: 'llm_request', step: steps, provider: provider.constructor.name, messages: prunedMessages, options: chatOpts });
-        if (runId) trace.recordLLMRequest(runId, steps, { providerClass: provider.constructor.name, model: provider.model, messageCount: prunedMessages.length, toolsCount: (chatOpts.tools || []).length });
+        if (runId) {
+          const writeRequestTrace = () => trace.recordLLMRequest(runId, steps, {
+            providerClass: provider.constructor.name,
+            model: provider.model,
+            messageCount: prunedMessages.length,
+            toolsCount: (chatOpts.tools || []).length,
+          });
+          if (shouldOrderInteractiveAskTrace) queueAskStreamingTraceWrite(writeRequestTrace);
+          else writeRequestTrace();
+        }
         const _llmStart = Date.now();
         result = await chatMainTurn(prunedMessages, chatOpts, { tabId, generationName: 'main' });
         if (result?.usage?.prompt_tokens) {
@@ -18718,7 +18735,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }
         const _llmLatency = Date.now() - _llmStart;
         this._logDebug({ type: 'llm_response', step: steps, content: result.content, toolCalls: result.toolCalls });
-        if (runId) trace.recordLLMResponse(runId, steps, { content: result.content, toolCalls: result.toolCalls, usage: result.usage, latencyMs: _llmLatency, model: provider.model });
+        if (runId) {
+          const writeResponseTrace = () => trace.recordLLMResponse(runId, steps, {
+            content: result.content,
+            toolCalls: result.toolCalls,
+            usage: result.usage,
+            latencyMs: _llmLatency,
+            model: provider.model,
+          });
+          if (shouldOrderInteractiveAskTrace) await queueAskStreamingTraceWrite(writeResponseTrace);
+          else writeResponseTrace();
+        }
       } catch (e) {
         this._logDebug({ type: 'llm_error', step: steps, error: e.message });
         if (this._isCostAllowanceError(e)) {
@@ -19012,10 +19039,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const message = error?.message || String(error);
       _traceStatus = 'error';
       finalResponse = `Error: ${message}`;
-      if (runId) trace.recordError(runId, null, 'agent', message);
+      if (runId) {
+        const writeErrorTrace = () => trace.recordError(runId, null, 'agent', message);
+        if (shouldOrderInteractiveAskTrace) await queueAskStreamingTraceWrite(writeErrorTrace);
+        else writeErrorTrace();
+      }
       throw error;
     } finally {
       this.currentCostState.delete(tabId);
+      await askStreamingTraceWrite;
       this._endTraceRun(tabId, runId, _traceStatus, finalResponse);
     }
   }

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1135,17 +1135,58 @@ export class Agent {
     };
   }
 
-  _shouldStreamInteractiveAsk(provider, mode, runOptions = {}, disabledForRun = false) {
+  _interactiveAskStreamingDecision(provider, mode, runOptions = {}, disabledForRun = false) {
     const streamingEnabled = runOptions?.askStreamingEnabled
       ?? runOptions?.openaiAskStreamingEnabled;
-    return mode === 'ask'
-      && runOptions?.interactiveChat === true
-      && streamingEnabled !== false
-      && runOptions?.trustedContinuation !== true
-      && runOptions?.cloudRun !== true
-      && disabledForRun !== true
-      && typeof provider?.chatStream === 'function'
-      && provider?._supportsInteractiveAskStreaming?.() === true;
+    if (mode !== 'ask') return { eligible: false, reason: 'mode_not_ask' };
+    if (runOptions?.interactiveChat !== true) return { eligible: false, reason: 'not_interactive_chat' };
+    if (streamingEnabled === false) return { eligible: false, reason: 'disabled_in_settings' };
+    if (runOptions?.trustedContinuation === true) return { eligible: false, reason: 'trusted_continuation' };
+    if (runOptions?.cloudRun === true) return { eligible: false, reason: 'cloud_run' };
+    if (disabledForRun === true) return { eligible: false, reason: 'disabled_after_fallback' };
+    if (typeof provider?.chatStream !== 'function') return { eligible: false, reason: 'provider_missing_chat_stream' };
+    try {
+      if (provider?._supportsInteractiveAskStreaming?.() !== true) {
+        return { eligible: false, reason: 'provider_not_supported' };
+      }
+    } catch {
+      return { eligible: false, reason: 'provider_capability_check_failed' };
+    }
+    return { eligible: true, reason: 'eligible' };
+  }
+
+  _shouldStreamInteractiveAsk(provider, mode, runOptions = {}, disabledForRun = false) {
+    return this._interactiveAskStreamingDecision(provider, mode, runOptions, disabledForRun).eligible;
+  }
+
+  _interactiveAskStreamingProtocol(provider) {
+    try {
+      if (typeof provider?._usesResponsesApi === 'function') {
+        return provider._usesResponsesApi() === true ? 'responses' : 'chat_completions';
+      }
+      return 'provider_native';
+    } catch {
+      return 'unknown';
+    }
+  }
+
+  _interactiveAskStreamingFailure(error) {
+    const rawMessage = String(error?.message || error || 'Streaming request failed.');
+    const message = rawMessage
+      .replace(/\b(Bearer)\s+[^\s,;]+/gi, '$1 [redacted]')
+      .replace(/((?:api[_ -]?key|access[_ -]?token|token|secret|password)\s*[:=]\s*)["']?[^\s,"';]+/gi, '$1[redacted]')
+      .replace(/([?&](?:api[_-]?key|access[_-]?token|token|key)=)[^&\s]+/gi, '$1[redacted]')
+      .replace(/\b(?:sk-(?:or-v1-)?|gsk_|xai-)[a-zA-Z0-9_-]{12,}\b/g, '[redacted]')
+      .slice(0, 500);
+    const rawCode = error?.incompleteReason || error?.code || '';
+    const errorCode = String(rawCode).replace(/[^a-zA-Z0-9_.-]/g, '_').slice(0, 80);
+    let reason = 'stream_error';
+    if (this._isCostAllowanceError(error)) reason = 'cost_limit';
+    else if (errorCode === 'missing_response_completed' || /before (?:its )?terminal event/i.test(rawMessage)) {
+      reason = 'missing_terminal_event';
+    } else if (this._shouldFallbackAskStream(error)) reason = 'transport_error';
+    else if (error?.isAskStreamTerminalError === true) reason = 'provider_stream_error';
+    return { reason, errorCode: errorCode || null, message };
   }
 
   // Backward-compatible aliases for integrations/tests that used the original
@@ -18496,13 +18537,35 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let compressionPlaceholderRecoveryAttempted = false;
     let askStreamingDisabledForRun = false;
 
+    // Keep trace persistence ordered without putting IndexedDB on the LLM
+    // request path. The recorder is diagnostic-only and must never delay a
+    // stream, fallback, or completed response.
+    let askStreamingTraceWrite = Promise.resolve();
+    const recordAskStreaming = (payload) => {
+      const traceRunId = runId;
+      const traceStep = steps;
+      if (!traceRunId) return;
+      askStreamingTraceWrite = askStreamingTraceWrite
+        .then(() => trace.recordStreaming(traceRunId, traceStep, payload))
+        .catch(() => {});
+    };
+
     const chatMainTurn = async (chatMessages, chatOptions, requestContext) => {
-      if (!this._shouldStreamInteractiveAsk(
+      const decision = this._interactiveAskStreamingDecision(
         provider,
         mode,
         runOptions,
         askStreamingDisabledForRun,
-      )) {
+      );
+      const protocol = this._interactiveAskStreamingProtocol(provider);
+      if (!decision.eligible) {
+        if (mode === 'ask' && runOptions?.interactiveChat === true) {
+          recordAskStreaming({
+            status: 'skipped',
+            reason: decision.reason,
+            protocol,
+          });
+        }
         return this._chatWithCostAllowance(
           provider,
           chatMessages,
@@ -18512,9 +18575,24 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         );
       }
 
+      let firstDeltaMs = null;
+      let textDeltaCount = 0;
+      let textChars = 0;
       let emittedText = false;
+      recordAskStreaming({
+        status: 'attempted',
+        reason: decision.reason,
+        protocol,
+      });
+      const streamStartedAt = Date.now();
+      const streamMetrics = () => ({
+        durationMs: Date.now() - streamStartedAt,
+        firstDeltaMs,
+        textDeltaCount,
+        textChars,
+      });
       try {
-        return await this._chatStreamWithCostAllowance(
+        const result = await this._chatStreamWithCostAllowance(
           provider,
           chatMessages,
           chatOptions,
@@ -18522,13 +18600,31 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           requestContext,
           (delta) => {
             emittedText = true;
+            if (firstDeltaMs == null) firstDeltaMs = Date.now() - streamStartedAt;
+            textDeltaCount += 1;
+            textChars += delta.length;
             onUpdate('text_delta', { content: delta });
           },
         );
+        recordAskStreaming({
+          status: 'completed',
+          reason: 'terminal_event_received',
+          protocol,
+          ...streamMetrics(),
+          toolCallCount: Array.isArray(result?.toolCalls) ? result.toolCalls.length : 0,
+        });
+        return result;
       } catch (error) {
+        const fallbackSafe = this._shouldFallbackAskStream(error);
+        recordAskStreaming({
+          status: fallbackSafe ? 'fallback' : 'failed',
+          protocol,
+          ...streamMetrics(),
+          ...this._interactiveAskStreamingFailure(error),
+        });
         if (this._isCostAllowanceError(error)) throw error;
         if (emittedText) onUpdate('text', { content: '', replace: true });
-        if (!this._shouldFallbackAskStream(error)) throw error;
+        if (!fallbackSafe) throw error;
         askStreamingDisabledForRun = true;
         onUpdate('warning', {
           code: 'ask_stream_fallback',

--- a/src/chrome/src/agent/trace-export.js
+++ b/src/chrome/src/agent/trace-export.js
@@ -7,10 +7,11 @@
  * the right source for a tool chain; `this.conversations` is not (it is compacted,
  * enriched, and wrapped — see the closed PR #348 review).
  *
- * This renders the TOOL CHAIN: user/assistant/planner prose, tool calls (name,
- * args, result), and errors — in order. Screenshot / note / vision_sub_call events
- * are recorded but deliberately not rendered; the file says so in its footer, so it
- * never claims to be a complete record. The complete record is the Traces-page JSON.
+ * This renders the TOOL CHAIN: user/assistant/planner prose, streaming lifecycle
+ * metadata, tool calls (name, args, result), and errors — in order. Screenshot /
+ * note / vision_sub_call events are recorded but deliberately not rendered; the
+ * file says so in its footer, so it never claims to be a complete record. The
+ * complete record is the Traces-page JSON.
  *
  * Pure and browser-neutral → unit-tested in test/run.js without a DOM or IndexedDB.
  *
@@ -82,6 +83,22 @@ function renderResult(result) {
   return { text: truncate(oneLine(s), RESULT_LIMIT), failed };
 }
 
+function renderStreaming(data) {
+  const d = data || {};
+  const details = [
+    oneLine(d.protocol),
+    oneLine(d.reason),
+    d.errorCode ? `code ${oneLine(d.errorCode)}` : '',
+    Number.isFinite(d.textDeltaCount) ? `${d.textDeltaCount} text delta${d.textDeltaCount === 1 ? '' : 's'}` : '',
+    Number.isFinite(d.textChars) ? `${d.textChars} chars` : '',
+    Number.isFinite(d.firstDeltaMs) ? `first delta ${d.firstDeltaMs} ms` : '',
+    Number.isFinite(d.durationMs) ? `${d.durationMs} ms total` : '',
+    Number.isFinite(d.toolCallCount) ? `${d.toolCallCount} tool call${d.toolCallCount === 1 ? '' : 's'}` : '',
+  ].filter(Boolean);
+  const message = oneLine(d.message);
+  return `- 🌊 Ask stream ${oneLine(d.status || 'event')}${details.length ? ` · ${details.join(' · ')}` : ''}${message ? `: ${message}` : ''}\n`;
+}
+
 function exportedRunStatus(run, events = []) {
   const status = oneLine(run?.status || '');
   const sawLoopError = events.some(ev => ev?.kind === 'error' && ev?.data?.phase === 'loop');
@@ -137,6 +154,8 @@ export function tracesToMarkdown(runsWithEvents, {
         toolCount += 1;
         const { text, failed } = renderResult(d.result);
         md += `- 🔧 \`${d.name || 'tool'}\`(${stringifyArgs(d.args)}) → ${failed ? '✗ ' : ''}${text}\n`;
+      } else if (ev.kind === 'streaming') {
+        md += renderStreaming(d);
       } else if (ev.kind === 'error') {
         md += `- ⚠️ error${d.phase ? ` (${d.phase})` : ''}: ${oneLine(d.message || '')}\n`;
       }

--- a/src/chrome/src/trace/recorder.js
+++ b/src/chrome/src/trace/recorder.js
@@ -249,6 +249,15 @@ export function recordError(runId, step, phase, message) {
 }
 
 /**
+ * Record the lifecycle of an interactive Ask streaming attempt without
+ * persisting token contents. Payloads contain only decision/outcome codes,
+ * protocol, aggregate counts, timing, and a redacted error summary.
+ */
+export function recordStreaming(runId, step, payload = {}) {
+  return _appendEvent(runId, 'streaming', { step, ...payload });
+}
+
+/**
  * Record a vision sub-call: the agent asked a dedicated vision model to
  * describe a screenshot so the main planning model receives text instead
  * of pixels. Captured for debugging and quality inspection — description

--- a/src/chrome/src/ui/traces.html
+++ b/src/chrome/src/ui/traces.html
@@ -276,6 +276,7 @@
     }
     .event.llm_request { opacity: 0.55; }
     .event.llm_response { border-left: 3px solid var(--accent); }
+    .event.streaming { border-left: 3px solid #22d3ee; }
     .event.tool { border-left: 3px solid #3fa7d6; }
     .event.screenshot { border-left: 3px solid #a78bfa; padding: 8px; }
     .event.error { border-left: 3px solid var(--error); color: var(--error); }

--- a/src/chrome/src/ui/traces.js
+++ b/src/chrome/src/ui/traces.js
@@ -348,6 +348,26 @@ function renderEvent(ev, shotCache, compact, objectUrls = new Set()) {
           ${src ? `<img src="${escapeAttr(src)}" alt="${escapeAttr(caption)}" loading="lazy">` : `<span class="latency">${escapeHtml(t('tr.event.screenshot_missing'))}</span>`}
         </div>`;
     }
+    case 'streaming': {
+      const d = ev.data || {};
+      const details = [
+        d.protocol,
+        d.reason,
+        d.errorCode ? `#${d.errorCode}` : '',
+        Number.isFinite(d.textDeltaCount) ? `Δ × ${d.textDeltaCount}` : '',
+        Number.isFinite(d.textChars) ? t('st.skills.item.chars', { count: d.textChars }) : '',
+        Number.isFinite(d.firstDeltaMs) ? `TTFT ${d.firstDeltaMs} ms` : '',
+        Number.isFinite(d.durationMs) ? `${t('tr.duration.label')}: ${d.durationMs} ms` : '',
+        Number.isFinite(d.toolCallCount) ? `🔧 × ${d.toolCallCount}` : '',
+      ].filter(Boolean).join(' · ');
+      const message = d.message ? `<div class="content-text">${escapeHtml(d.message)}</div>` : '';
+      return `
+        <div class="event streaming">
+          <div class="event-head"><span class="kind">🌊 ${escapeHtml(t('st.display.openai_ask_streaming.label'))}: ${escapeHtml(d.status || '?')}</span>${stepBadge}<span class="latency">${ts}</span></div>
+          ${details ? `<div class="tool-args">${escapeHtml(details)}</div>` : ''}
+          ${message}
+        </div>`;
+    }
     case 'error': {
       return `
         <div class="event error">

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1212,7 +1212,7 @@ export class Agent {
     const rawMessage = String(error?.message || error || 'Streaming request failed.');
     const message = rawMessage
       .replace(/\b(Bearer)\s+[^\s,;]+/gi, '$1 [redacted]')
-      .replace(/((?:api[_ -]?key|access[_ -]?token|token|secret|password)\s*[:=]\s*)["']?[^\s,"';]+/gi, '$1[redacted]')
+      .replace(/((?:^|[^a-zA-Z0-9_])["']?(?:api[_ -]?key|access[_ -]?token|token|secret|password)["']?\s*[:=]\s*)(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;}\]]+)/gi, '$1[redacted]')
       .replace(/([?&](?:api[_-]?key|access[_-]?token|token|key)=)[^&\s]+/gi, '$1[redacted]')
       .replace(/\b(?:sk-(?:or-v1-)?|gsk_|xai-)[a-zA-Z0-9_-]{12,}\b/g, '[redacted]')
       .slice(0, 500);

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -13709,6 +13709,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let runId = null;
     let finalResponse = '';
     let _traceStatus = 'done';
+    let askStreamingTraceWrite = Promise.resolve();
+    let shouldOrderInteractiveAskTrace = false;
+    const queueAskStreamingTraceWrite = (write) => {
+      askStreamingTraceWrite = askStreamingTraceWrite
+        .then(write)
+        .catch(() => {});
+      return askStreamingTraceWrite;
+    };
 
     if (mode === 'dev' && provider.promptTier === 'compact') {
       const msg = this._devModeBlockedMessage(provider);
@@ -13811,17 +13819,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let compressionPlaceholderRecoveryAttempted = false;
     let askStreamingDisabledForRun = false;
 
-    // Keep trace persistence ordered without putting IndexedDB on the LLM
-    // request path. The recorder is diagnostic-only and must never delay a
-    // stream, fallback, or completed response.
-    let askStreamingTraceWrite = Promise.resolve();
+    // Keep trace persistence ordered without putting IndexedDB on the token
+    // delivery path. Once generation settles, later response/finalization
+    // writes flush this queue so lifecycle events cannot arrive afterward.
+    shouldOrderInteractiveAskTrace = mode === 'ask' && runOptions?.interactiveChat === true;
     const recordAskStreaming = (payload) => {
       const traceRunId = runId;
       const traceStep = steps;
       if (!traceRunId) return;
-      askStreamingTraceWrite = askStreamingTraceWrite
-        .then(() => trace.recordStreaming(traceRunId, traceStep, payload))
-        .catch(() => {});
+      queueAskStreamingTraceWrite(
+        () => trace.recordStreaming(traceRunId, traceStep, payload),
+      );
     };
 
     const chatMainTurn = async (chatMessages, chatOptions, requestContext) => {
@@ -13977,7 +13985,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         const prunedMessages = this._pruneOldImages(messages, provider);
         this._logDebug({ type: 'llm_request', step: steps, provider: provider.constructor.name, messages: prunedMessages, options: chatOpts });
         const _llmStart = Date.now();
-        if (runId) { try { await trace.recordLLMRequest(runId, steps, { providerClass: provider.constructor.name, model: provider.model, messageCount: prunedMessages.length, toolsCount: (chatOpts.tools || []).length }); } catch {} }
+        if (runId) {
+          const writeRequestTrace = () => trace.recordLLMRequest(runId, steps, {
+            providerClass: provider.constructor.name,
+            model: provider.model,
+            messageCount: prunedMessages.length,
+            toolsCount: (chatOpts.tools || []).length,
+          });
+          try {
+            if (shouldOrderInteractiveAskTrace) queueAskStreamingTraceWrite(writeRequestTrace);
+            else await writeRequestTrace();
+          } catch {}
+        }
         result = await chatMainTurn(prunedMessages, chatOpts, { tabId, generationName: 'main' });
         if (result?.usage?.prompt_tokens) {
           this._lastInputTokens.set(tabId, result.usage.prompt_tokens);
@@ -13985,7 +14004,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           // _manageContext can add only the growth since (see its delta logic).
           this._lastEstCharsAtReport.set(tabId, this._estimateContextChars(messages));
         }
-        if (runId) { try { await trace.recordLLMResponse(runId, steps, { content: result.content, toolCalls: result.toolCalls, usage: result.usage, latencyMs: Date.now() - _llmStart, model: provider.model }); } catch {} }
+        if (runId) {
+          const writeResponseTrace = () => trace.recordLLMResponse(runId, steps, {
+            content: result.content,
+            toolCalls: result.toolCalls,
+            usage: result.usage,
+            latencyMs: Date.now() - _llmStart,
+            model: provider.model,
+          });
+          try {
+            if (shouldOrderInteractiveAskTrace) await queueAskStreamingTraceWrite(writeResponseTrace);
+            else await writeResponseTrace();
+          } catch {}
+        }
         this._logDebug({ type: 'llm_response', step: steps, content: result.content, toolCalls: result.toolCalls });
       } catch (e) {
         this._logDebug({ type: 'llm_error', step: steps, error: e.message });
@@ -14271,9 +14302,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const message = error?.message || String(error);
       _traceStatus = 'error';
       finalResponse = `Error: ${message}`;
-      if (runId) trace.recordError(runId, null, 'agent', message);
+      if (runId) {
+        const writeErrorTrace = () => trace.recordError(runId, null, 'agent', message);
+        if (shouldOrderInteractiveAskTrace) await queueAskStreamingTraceWrite(writeErrorTrace);
+        else writeErrorTrace();
+      }
       throw error;
     } finally {
+      await askStreamingTraceWrite;
       this._endTraceRun(tabId, runId, _traceStatus, finalResponse);
     }
   }

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1173,17 +1173,58 @@ export class Agent {
     };
   }
 
-  _shouldStreamInteractiveAsk(provider, mode, runOptions = {}, disabledForRun = false) {
+  _interactiveAskStreamingDecision(provider, mode, runOptions = {}, disabledForRun = false) {
     const streamingEnabled = runOptions?.askStreamingEnabled
       ?? runOptions?.openaiAskStreamingEnabled;
-    return mode === 'ask'
-      && runOptions?.interactiveChat === true
-      && streamingEnabled !== false
-      && runOptions?.trustedContinuation !== true
-      && runOptions?.cloudRun !== true
-      && disabledForRun !== true
-      && typeof provider?.chatStream === 'function'
-      && provider?._supportsInteractiveAskStreaming?.() === true;
+    if (mode !== 'ask') return { eligible: false, reason: 'mode_not_ask' };
+    if (runOptions?.interactiveChat !== true) return { eligible: false, reason: 'not_interactive_chat' };
+    if (streamingEnabled === false) return { eligible: false, reason: 'disabled_in_settings' };
+    if (runOptions?.trustedContinuation === true) return { eligible: false, reason: 'trusted_continuation' };
+    if (runOptions?.cloudRun === true) return { eligible: false, reason: 'cloud_run' };
+    if (disabledForRun === true) return { eligible: false, reason: 'disabled_after_fallback' };
+    if (typeof provider?.chatStream !== 'function') return { eligible: false, reason: 'provider_missing_chat_stream' };
+    try {
+      if (provider?._supportsInteractiveAskStreaming?.() !== true) {
+        return { eligible: false, reason: 'provider_not_supported' };
+      }
+    } catch {
+      return { eligible: false, reason: 'provider_capability_check_failed' };
+    }
+    return { eligible: true, reason: 'eligible' };
+  }
+
+  _shouldStreamInteractiveAsk(provider, mode, runOptions = {}, disabledForRun = false) {
+    return this._interactiveAskStreamingDecision(provider, mode, runOptions, disabledForRun).eligible;
+  }
+
+  _interactiveAskStreamingProtocol(provider) {
+    try {
+      if (typeof provider?._usesResponsesApi === 'function') {
+        return provider._usesResponsesApi() === true ? 'responses' : 'chat_completions';
+      }
+      return 'provider_native';
+    } catch {
+      return 'unknown';
+    }
+  }
+
+  _interactiveAskStreamingFailure(error) {
+    const rawMessage = String(error?.message || error || 'Streaming request failed.');
+    const message = rawMessage
+      .replace(/\b(Bearer)\s+[^\s,;]+/gi, '$1 [redacted]')
+      .replace(/((?:api[_ -]?key|access[_ -]?token|token|secret|password)\s*[:=]\s*)["']?[^\s,"';]+/gi, '$1[redacted]')
+      .replace(/([?&](?:api[_-]?key|access[_-]?token|token|key)=)[^&\s]+/gi, '$1[redacted]')
+      .replace(/\b(?:sk-(?:or-v1-)?|gsk_|xai-)[a-zA-Z0-9_-]{12,}\b/g, '[redacted]')
+      .slice(0, 500);
+    const rawCode = error?.incompleteReason || error?.code || '';
+    const errorCode = String(rawCode).replace(/[^a-zA-Z0-9_.-]/g, '_').slice(0, 80);
+    let reason = 'stream_error';
+    if (this._isCostAllowanceError(error)) reason = 'cost_limit';
+    else if (errorCode === 'missing_response_completed' || /before (?:its )?terminal event/i.test(rawMessage)) {
+      reason = 'missing_terminal_event';
+    } else if (this._shouldFallbackAskStream(error)) reason = 'transport_error';
+    else if (error?.isAskStreamTerminalError === true) reason = 'provider_stream_error';
+    return { reason, errorCode: errorCode || null, message };
   }
 
   // Backward-compatible aliases for integrations/tests that used the original
@@ -13770,13 +13811,35 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let compressionPlaceholderRecoveryAttempted = false;
     let askStreamingDisabledForRun = false;
 
+    // Keep trace persistence ordered without putting IndexedDB on the LLM
+    // request path. The recorder is diagnostic-only and must never delay a
+    // stream, fallback, or completed response.
+    let askStreamingTraceWrite = Promise.resolve();
+    const recordAskStreaming = (payload) => {
+      const traceRunId = runId;
+      const traceStep = steps;
+      if (!traceRunId) return;
+      askStreamingTraceWrite = askStreamingTraceWrite
+        .then(() => trace.recordStreaming(traceRunId, traceStep, payload))
+        .catch(() => {});
+    };
+
     const chatMainTurn = async (chatMessages, chatOptions, requestContext) => {
-      if (!this._shouldStreamInteractiveAsk(
+      const decision = this._interactiveAskStreamingDecision(
         provider,
         mode,
         runOptions,
         askStreamingDisabledForRun,
-      )) {
+      );
+      const protocol = this._interactiveAskStreamingProtocol(provider);
+      if (!decision.eligible) {
+        if (mode === 'ask' && runOptions?.interactiveChat === true) {
+          recordAskStreaming({
+            status: 'skipped',
+            reason: decision.reason,
+            protocol,
+          });
+        }
         return this._chatWithCostAllowance(
           provider,
           chatMessages,
@@ -13786,9 +13849,24 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         );
       }
 
+      let firstDeltaMs = null;
+      let textDeltaCount = 0;
+      let textChars = 0;
       let emittedText = false;
+      recordAskStreaming({
+        status: 'attempted',
+        reason: decision.reason,
+        protocol,
+      });
+      const streamStartedAt = Date.now();
+      const streamMetrics = () => ({
+        durationMs: Date.now() - streamStartedAt,
+        firstDeltaMs,
+        textDeltaCount,
+        textChars,
+      });
       try {
-        return await this._chatStreamWithCostAllowance(
+        const result = await this._chatStreamWithCostAllowance(
           provider,
           chatMessages,
           chatOptions,
@@ -13796,13 +13874,31 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           requestContext,
           (delta) => {
             emittedText = true;
+            if (firstDeltaMs == null) firstDeltaMs = Date.now() - streamStartedAt;
+            textDeltaCount += 1;
+            textChars += delta.length;
             onUpdate('text_delta', { content: delta });
           },
         );
+        recordAskStreaming({
+          status: 'completed',
+          reason: 'terminal_event_received',
+          protocol,
+          ...streamMetrics(),
+          toolCallCount: Array.isArray(result?.toolCalls) ? result.toolCalls.length : 0,
+        });
+        return result;
       } catch (error) {
+        const fallbackSafe = this._shouldFallbackAskStream(error);
+        recordAskStreaming({
+          status: fallbackSafe ? 'fallback' : 'failed',
+          protocol,
+          ...streamMetrics(),
+          ...this._interactiveAskStreamingFailure(error),
+        });
         if (this._isCostAllowanceError(error)) throw error;
         if (emittedText) onUpdate('text', { content: '', replace: true });
-        if (!this._shouldFallbackAskStream(error)) throw error;
+        if (!fallbackSafe) throw error;
         askStreamingDisabledForRun = true;
         onUpdate('warning', {
           code: 'ask_stream_fallback',

--- a/src/firefox/src/agent/trace-export.js
+++ b/src/firefox/src/agent/trace-export.js
@@ -7,10 +7,11 @@
  * the right source for a tool chain; `this.conversations` is not (it is compacted,
  * enriched, and wrapped — see the closed PR #348 review).
  *
- * This renders the TOOL CHAIN: user/assistant/planner prose, tool calls (name,
- * args, result), and errors — in order. Screenshot / note / vision_sub_call events
- * are recorded but deliberately not rendered; the file says so in its footer, so it
- * never claims to be a complete record. The complete record is the Traces-page JSON.
+ * This renders the TOOL CHAIN: user/assistant/planner prose, streaming lifecycle
+ * metadata, tool calls (name, args, result), and errors — in order. Screenshot /
+ * note / vision_sub_call events are recorded but deliberately not rendered; the
+ * file says so in its footer, so it never claims to be a complete record. The
+ * complete record is the Traces-page JSON.
  *
  * Pure and browser-neutral → unit-tested in test/run.js without a DOM or IndexedDB.
  *
@@ -82,6 +83,22 @@ function renderResult(result) {
   return { text: truncate(oneLine(s), RESULT_LIMIT), failed };
 }
 
+function renderStreaming(data) {
+  const d = data || {};
+  const details = [
+    oneLine(d.protocol),
+    oneLine(d.reason),
+    d.errorCode ? `code ${oneLine(d.errorCode)}` : '',
+    Number.isFinite(d.textDeltaCount) ? `${d.textDeltaCount} text delta${d.textDeltaCount === 1 ? '' : 's'}` : '',
+    Number.isFinite(d.textChars) ? `${d.textChars} chars` : '',
+    Number.isFinite(d.firstDeltaMs) ? `first delta ${d.firstDeltaMs} ms` : '',
+    Number.isFinite(d.durationMs) ? `${d.durationMs} ms total` : '',
+    Number.isFinite(d.toolCallCount) ? `${d.toolCallCount} tool call${d.toolCallCount === 1 ? '' : 's'}` : '',
+  ].filter(Boolean);
+  const message = oneLine(d.message);
+  return `- 🌊 Ask stream ${oneLine(d.status || 'event')}${details.length ? ` · ${details.join(' · ')}` : ''}${message ? `: ${message}` : ''}\n`;
+}
+
 function exportedRunStatus(run, events = []) {
   const status = oneLine(run?.status || '');
   const sawLoopError = events.some(ev => ev?.kind === 'error' && ev?.data?.phase === 'loop');
@@ -137,6 +154,8 @@ export function tracesToMarkdown(runsWithEvents, {
         toolCount += 1;
         const { text, failed } = renderResult(d.result);
         md += `- 🔧 \`${d.name || 'tool'}\`(${stringifyArgs(d.args)}) → ${failed ? '✗ ' : ''}${text}\n`;
+      } else if (ev.kind === 'streaming') {
+        md += renderStreaming(d);
       } else if (ev.kind === 'error') {
         md += `- ⚠️ error${d.phase ? ` (${d.phase})` : ''}: ${oneLine(d.message || '')}\n`;
       }

--- a/src/firefox/src/trace/recorder.js
+++ b/src/firefox/src/trace/recorder.js
@@ -232,6 +232,15 @@ export function recordError(runId, step, phase, message) {
 }
 
 /**
+ * Record the lifecycle of an interactive Ask streaming attempt without
+ * persisting token contents. Payloads contain only decision/outcome codes,
+ * protocol, aggregate counts, timing, and a redacted error summary.
+ */
+export function recordStreaming(runId, step, payload = {}) {
+  return _appendEvent(runId, 'streaming', { step, ...payload });
+}
+
+/**
  * Record a vision sub-call: the agent asked a dedicated vision model to
  * describe a screenshot so the main planning model receives text instead
  * of pixels. Captured for debugging and quality inspection — description

--- a/src/firefox/src/ui/traces.html
+++ b/src/firefox/src/ui/traces.html
@@ -276,6 +276,7 @@
     }
     .event.llm_request { opacity: 0.55; }
     .event.llm_response { border-left: 3px solid var(--accent); }
+    .event.streaming { border-left: 3px solid #22d3ee; }
     .event.tool { border-left: 3px solid #3fa7d6; }
     .event.screenshot { border-left: 3px solid #a78bfa; padding: 8px; }
     .event.error { border-left: 3px solid var(--error); color: var(--error); }

--- a/src/firefox/src/ui/traces.js
+++ b/src/firefox/src/ui/traces.js
@@ -348,6 +348,26 @@ function renderEvent(ev, shotCache, compact, objectUrls = new Set()) {
           ${src ? `<img src="${escapeAttr(src)}" alt="${escapeAttr(caption)}" loading="lazy">` : `<span class="latency">${escapeHtml(t('tr.event.screenshot_missing'))}</span>`}
         </div>`;
     }
+    case 'streaming': {
+      const d = ev.data || {};
+      const details = [
+        d.protocol,
+        d.reason,
+        d.errorCode ? `#${d.errorCode}` : '',
+        Number.isFinite(d.textDeltaCount) ? `Δ × ${d.textDeltaCount}` : '',
+        Number.isFinite(d.textChars) ? t('st.skills.item.chars', { count: d.textChars }) : '',
+        Number.isFinite(d.firstDeltaMs) ? `TTFT ${d.firstDeltaMs} ms` : '',
+        Number.isFinite(d.durationMs) ? `${t('tr.duration.label')}: ${d.durationMs} ms` : '',
+        Number.isFinite(d.toolCallCount) ? `🔧 × ${d.toolCallCount}` : '',
+      ].filter(Boolean).join(' · ');
+      const message = d.message ? `<div class="content-text">${escapeHtml(d.message)}</div>` : '';
+      return `
+        <div class="event streaming">
+          <div class="event-head"><span class="kind">🌊 ${escapeHtml(t('st.display.openai_ask_streaming.label'))}: ${escapeHtml(d.status || '?')}</span>${stepBadge}<span class="latency">${ts}</span></div>
+          ${details ? `<div class="tool-args">${escapeHtml(details)}</div>` : ''}
+          ${message}
+        </div>`;
+    }
     case 'error': {
       return `
         <div class="event error">

--- a/test/run.js
+++ b/test/run.js
@@ -3132,6 +3132,60 @@ test('trace export: chrome and firefox serializers are identical', () => {
   assert.equal(tracesToMarkdownFx(TRACE_RUNS).markdown, tracesToMarkdown(TRACE_RUNS).markdown);
 });
 
+test('trace export: renders Ask streaming decisions and aggregate lifecycle metrics', () => {
+  const streamingRun = [{
+    run: { runId: 'streaming', userMessage: 'Explain this page', model: 'test', status: 'done' },
+    events: [
+      {
+        runId: 'streaming',
+        seq: 0,
+        kind: 'streaming',
+        data: { step: 1, status: 'attempted', reason: 'eligible', protocol: 'chat_completions' },
+      },
+      {
+        runId: 'streaming',
+        seq: 1,
+        kind: 'streaming',
+        data: {
+          step: 1,
+          status: 'completed',
+          reason: 'terminal_event_received',
+          protocol: 'chat_completions',
+          textDeltaCount: 7,
+          textChars: 128,
+          firstDeltaMs: 42,
+          durationMs: 310,
+          toolCallCount: 0,
+        },
+      },
+      {
+        runId: 'streaming',
+        seq: 2,
+        kind: 'streaming',
+        data: {
+          step: 2,
+          status: 'fallback',
+          reason: 'missing_terminal_event',
+          protocol: 'responses',
+          errorCode: 'missing_response_completed',
+          textDeltaCount: 2,
+          textChars: 18,
+          firstDeltaMs: 50,
+          durationMs: 200,
+          message: 'Responses stream incomplete (missing_response_completed).',
+        },
+      },
+    ],
+  }];
+  for (const [label, serialize] of [['chrome', tracesToMarkdown], ['firefox', tracesToMarkdownFx]]) {
+    const { markdown, toolCount } = serialize(streamingRun);
+    assert.equal(toolCount, 0, `${label}: lifecycle events must not count as tools`);
+    assert.match(markdown, /Ask stream attempted · chat_completions · eligible/, `${label}: attempt missing`);
+    assert.match(markdown, /Ask stream completed · chat_completions · terminal_event_received · 7 text deltas · 128 chars · first delta 42 ms · 310 ms total · 0 tool calls/, `${label}: completion metrics missing`);
+    assert.match(markdown, /Ask stream fallback · responses · missing_terminal_event · code missing_response_completed · 2 text deltas/, `${label}: fallback reason missing`);
+  }
+});
+
 test('/export --traces is wired in both side panels and backgrounds', () => {
   for (const [label, panelRel, bgRel] of [
     ['chrome', 'src/chrome/src/ui/sidepanel.js', 'src/chrome/src/background.js'],
@@ -27418,6 +27472,41 @@ test('Ask streaming eligibility is limited to interactive runs with a capable pr
     assert.equal(agent._shouldStreamInteractiveAsk(streamingProvider, 'ask', interactive, true), false, `${label}: per-run circuit breaker must disable streaming`);
     assert.equal(agent._shouldStreamInteractiveAsk({ ...streamingProvider, _supportsInteractiveAskStreaming: () => false }, 'ask', interactive), false, `${label}: unsupported providers must stay non-streaming`);
     assert.equal(agent._shouldStreamInteractiveAsk(streamingProvider, 'ask', { interactiveChat: true, openaiAskStreamingEnabled: false }), false, `${label}: legacy kill-switch payloads remain supported`);
+
+    assert.equal(agent._interactiveAskStreamingDecision(streamingProvider, 'act', interactive).reason, 'mode_not_ask', `${label}: mode decision should be traceable`);
+    assert.equal(agent._interactiveAskStreamingDecision(streamingProvider, 'ask', {}).reason, 'not_interactive_chat', `${label}: scheduled decision should be traceable`);
+    assert.equal(agent._interactiveAskStreamingDecision(streamingProvider, 'ask', { ...interactive, askStreamingEnabled: false }).reason, 'disabled_in_settings', `${label}: setting decision should be traceable`);
+    assert.equal(agent._interactiveAskStreamingDecision(streamingProvider, 'ask', interactive, true).reason, 'disabled_after_fallback', `${label}: circuit-breaker decision should be traceable`);
+    assert.equal(agent._interactiveAskStreamingDecision({ ...streamingProvider, _supportsInteractiveAskStreaming: () => false }, 'ask', interactive).reason, 'provider_not_supported', `${label}: provider decision should be traceable`);
+    assert.equal(agent._interactiveAskStreamingDecision(streamingProvider, 'ask', interactive).reason, 'eligible', `${label}: eligible decision should be traceable`);
+    assert.equal(agent._interactiveAskStreamingProtocol(streamingProvider), 'provider_native', `${label}: native provider protocol should not be mislabeled`);
+    assert.equal(agent._interactiveAskStreamingProtocol({ _usesResponsesApi: () => false }), 'chat_completions', `${label}: compatible provider protocol should be traceable`);
+    assert.equal(agent._interactiveAskStreamingProtocol({ _usesResponsesApi: () => true }), 'responses', `${label}: Responses protocol should be traceable`);
+
+    const transportError = new Error('failed with Authorization: Bearer secret-token, api_key=secret-key, and sk-or-v1-anothersecretkey');
+    transportError.isAskStreamFallbackSafe = true;
+    const failure = agent._interactiveAskStreamingFailure(transportError);
+    assert.equal(failure.reason, 'transport_error', `${label}: fallback reason should be classified`);
+    assert.doesNotMatch(failure.message, /secret-token|secret-key|anothersecretkey/, `${label}: trace error must redact secrets`);
+    assert.match(failure.message, /\[redacted\]/, `${label}: trace error should retain a redaction marker`);
+  }
+});
+
+test('Ask streaming lifecycle tracing is wired through recorder, agent, and Traces UI', () => {
+  for (const browser of ['chrome', 'firefox']) {
+    const agentSource = fs.readFileSync(path.join(ROOT, `src/${browser}/src/agent/agent.js`), 'utf8');
+    const recorderSource = fs.readFileSync(path.join(ROOT, `src/${browser}/src/trace/recorder.js`), 'utf8');
+    const tracesSource = fs.readFileSync(path.join(ROOT, `src/${browser}/src/ui/traces.js`), 'utf8');
+    const tracesHtml = fs.readFileSync(path.join(ROOT, `src/${browser}/src/ui/traces.html`), 'utf8');
+
+    assert.match(recorderSource, /export function recordStreaming\([\s\S]*?_appendEvent\(runId, 'streaming'/, `${browser}: recorder event missing`);
+    assert.match(agentSource, /let askStreamingTraceWrite = Promise\.resolve\(\)[\s\S]*?\.then\(\(\) => trace\.recordStreaming\(traceRunId, traceStep, payload\)\)/, `${browser}: ordered background recorder queue missing`);
+    assert.doesNotMatch(agentSource, /const recordAskStreaming = async/, `${browser}: trace writes must stay off the streaming request path`);
+    assert.match(agentSource, /status: 'attempted'[\s\S]*?\}\);\s*const streamStartedAt = Date\.now\(\)/, `${browser}: stream timing should start after the trace event is queued`);
+    assert.match(agentSource, /status: 'attempted'[\s\S]*?status: 'completed'[\s\S]*?status: fallbackSafe \? 'fallback' : 'failed'/, `${browser}: lifecycle outcomes missing`);
+    assert.match(tracesSource, /case 'streaming':[\s\S]*?t\('st\.display\.openai_ask_streaming\.label'\)/, `${browser}: localized Traces UI renderer missing`);
+    assert.doesNotMatch(tracesSource, /Ask stream:|text delta|first delta|ms total|tool call/, `${browser}: streaming trace copy should not be hard-coded in English`);
+    assert.match(tracesHtml, /\.event\.streaming \{ border-left:/, `${browser}: Traces UI styling missing`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -27500,10 +27500,13 @@ test('Ask streaming lifecycle tracing is wired through recorder, agent, and Trac
     const tracesHtml = fs.readFileSync(path.join(ROOT, `src/${browser}/src/ui/traces.html`), 'utf8');
 
     assert.match(recorderSource, /export function recordStreaming\([\s\S]*?_appendEvent\(runId, 'streaming'/, `${browser}: recorder event missing`);
-    assert.match(agentSource, /let askStreamingTraceWrite = Promise\.resolve\(\)[\s\S]*?\.then\(\(\) => trace\.recordStreaming\(traceRunId, traceStep, payload\)\)/, `${browser}: ordered background recorder queue missing`);
+    assert.match(agentSource, /let askStreamingTraceWrite = Promise\.resolve\(\)[\s\S]*?const queueAskStreamingTraceWrite = \(write\) => \{[\s\S]*?\.then\(write\)[\s\S]*?queueAskStreamingTraceWrite\(\s*\(\) => trace\.recordStreaming\(traceRunId, traceStep, payload\)/, `${browser}: ordered background recorder queue missing`);
     assert.doesNotMatch(agentSource, /const recordAskStreaming = async/, `${browser}: trace writes must stay off the streaming request path`);
     assert.match(agentSource, /status: 'attempted'[\s\S]*?\}\);\s*const streamStartedAt = Date\.now\(\)/, `${browser}: stream timing should start after the trace event is queued`);
     assert.match(agentSource, /status: 'attempted'[\s\S]*?status: 'completed'[\s\S]*?status: fallbackSafe \? 'fallback' : 'failed'/, `${browser}: lifecycle outcomes missing`);
+    assert.match(agentSource, /if \(shouldOrderInteractiveAskTrace\) queueAskStreamingTraceWrite\(writeRequestTrace\)/, `${browser}: request trace must lead the streaming lifecycle queue`);
+    assert.match(agentSource, /if \(shouldOrderInteractiveAskTrace\) await queueAskStreamingTraceWrite\(writeResponseTrace\)/, `${browser}: response trace must flush after streaming lifecycle events`);
+    assert.match(agentSource, /finally \{[\s\S]{0,120}?await askStreamingTraceWrite;\s*this\._endTraceRun/, `${browser}: run finalization must wait for streaming lifecycle traces`);
     assert.match(tracesSource, /case 'streaming':[\s\S]*?t\('st\.display\.openai_ask_streaming\.label'\)/, `${browser}: localized Traces UI renderer missing`);
     assert.doesNotMatch(tracesSource, /Ask stream:|text delta|first delta|ms total|tool call/, `${browser}: streaming trace copy should not be hard-coded in English`);
     assert.match(tracesHtml, /\.event\.streaming \{ border-left:/, `${browser}: Traces UI styling missing`);

--- a/test/run.js
+++ b/test/run.js
@@ -27483,11 +27483,11 @@ test('Ask streaming eligibility is limited to interactive runs with a capable pr
     assert.equal(agent._interactiveAskStreamingProtocol({ _usesResponsesApi: () => false }), 'chat_completions', `${label}: compatible provider protocol should be traceable`);
     assert.equal(agent._interactiveAskStreamingProtocol({ _usesResponsesApi: () => true }), 'responses', `${label}: Responses protocol should be traceable`);
 
-    const transportError = new Error('failed with Authorization: Bearer secret-token, api_key=secret-key, and sk-or-v1-anothersecretkey');
+    const transportError = new Error('failed with Authorization: Bearer secret-token, api_key=secret-key, {"api_key":"json-secret","password":"quoted-secret"}, and sk-or-v1-anothersecretkey');
     transportError.isAskStreamFallbackSafe = true;
     const failure = agent._interactiveAskStreamingFailure(transportError);
     assert.equal(failure.reason, 'transport_error', `${label}: fallback reason should be classified`);
-    assert.doesNotMatch(failure.message, /secret-token|secret-key|anothersecretkey/, `${label}: trace error must redact secrets`);
+    assert.doesNotMatch(failure.message, /secret-token|secret-key|json-secret|quoted-secret|anothersecretkey/, `${label}: trace error must redact secrets`);
     assert.match(failure.message, /\[redacted\]/, `${label}: trace error should retain a redaction marker`);
   }
 });


### PR DESCRIPTION
## Summary
- record interactive Ask streaming decisions and outcomes in durable traces
- show protocol, TTFT, aggregate delta metrics, and redacted fallback/failure details in the Traces UI and `/export --traces`
- keep trace writes ordered but off the LLM request path, with mirrored Chrome/Firefox behavior

## Why
Existing traces could confirm the provider and final LLM response but could not prove whether WebBrain attempted streaming, completed it, silently fell back, or skipped it.

## Impact
Future vLLM, OpenRouter, OpenAI, and other supported-provider traces expose the streaming lifecycle without storing token contents or delaying generation.

## Validation
- `npm test` (1,255 tests; 60/60 security checks)
- syntax checks for every changed JavaScript module
- `git diff --check`