### PR TITLE
fix(agent): support reCAPTCHA Enterprise and invisible URL parameter detection in CapSolver

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -14315,7 +14315,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
         // Detect when the model didn't pre-specify a captcha type. Image-
         // to-text is a special case that needs an explicit imageBase64.
-        let { type, websiteKey, isInvisible, pageAction, minScore, imageBase64 } = args || {};
+        let { type, websiteKey, isInvisible, isEnterprise, pageAction, minScore, imageBase64 } = args || {};
         if (!type) {
           const detected = await detectCaptcha(tabId);
           if (!detected) {
@@ -14324,6 +14324,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           type = detected.type;
           if (!websiteKey) websiteKey = detected.websiteKey;
           if (isInvisible == null && detected.isInvisible != null) isInvisible = detected.isInvisible;
+          if (isEnterprise == null && detected.isEnterprise != null) isEnterprise = detected.isEnterprise;
           if (!pageAction && detected.pageAction) pageAction = detected.pageAction;
         }
 
@@ -14341,6 +14342,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           websiteURL,
           websiteKey,
           ...(isInvisible != null ? { isInvisible } : {}),
+          ...(isEnterprise != null ? { isEnterprise } : {}),
           ...(pageAction ? { pageAction } : {}),
           ...(minScore ? { minScore } : {}),
           ...(imageBase64 ? { body: imageBase64 } : {}),

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -28,7 +28,7 @@ import {
 } from './pdf-tools.js';
 import * as trace from '../trace/recorder.js';
 import { tracesToMarkdown } from './trace-export.js';
-import { solveCaptcha, detectCaptcha, injectToken } from './captcha-solver.js';
+import { solveCaptcha, detectCaptcha, injectToken, captchaParamError } from './captcha-solver.js';
 import { getRecordingStateFresh as recorderStateFresh } from '../recorder/host.js';
 import { Capability, CAPABILITY_LABEL, capabilitiesFor, requiredHosts, frameHostMatches, isNetworkMutation, normalizeHost, PermissionManager, UNTRUSTED_CONTENT_TOOLS } from './permission-gate.js';
 import {
@@ -14316,30 +14316,24 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         // Detect when the model didn't pre-specify a captcha type. Image-
         // to-text is a special case that needs an explicit imageBase64.
         let { type, websiteKey, isInvisible, isEnterprise, pageAction, minScore, imageBase64 } = args || {};
+        // Detection notes explain *why* a field is missing (e.g. a v3 widget
+        // that never exposed its action name). Carry it into the failure so
+        // the model gets the remedy, not just the rejection.
+        let detectionNote = null;
         if (!type) {
           const detected = await detectCaptcha(tabId);
           if (!detected) {
             return noDispatchFailure('No CAPTCHA detected on the page. If the captcha lives inside a cross-origin iframe or uses a non-standard widget, pass `type` and `websiteKey` explicitly.');
           }
           type = detected.type;
+          detectionNote = detected.note || null;
           if (!websiteKey) websiteKey = detected.websiteKey;
           if (isInvisible == null && detected.isInvisible != null) isInvisible = detected.isInvisible;
           if (isEnterprise == null && detected.isEnterprise != null) isEnterprise = detected.isEnterprise;
           if (!pageAction && detected.pageAction) pageAction = detected.pageAction;
         }
 
-        if (type === 'image_to_text') {
-          if (!imageBase64) {
-            return noDispatchFailure('solve_captcha: image_to_text requires `imageBase64`.');
-          }
-        } else if (!websiteKey) {
-          return noDispatchFailure(`solve_captcha: ${type} requires a websiteKey (data-sitekey). Auto-detection didn't find one — pass it explicitly.`);
-        } else if ((type === 'recaptcha_v3' || type === 'recaptchav3' || type === 'recaptcha_v3_enterprise') && !pageAction) {
-          return noDispatchFailure(`solve_captcha: ${type} requires a \`pageAction\` (e.g. "login", "submit"). Auto-detection found a v3 sitekey but no action name — pass \`pageAction\` explicitly.`);
-        }
-
-        dispatched = true;
-        const result = await solveCaptcha(apiKey, {
+        const params = {
           type,
           websiteURL,
           websiteKey,
@@ -14348,7 +14342,25 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           ...(pageAction ? { pageAction } : {}),
           ...(minScore ? { minScore } : {}),
           ...(imageBase64 ? { body: imageBase64 } : {}),
-        });
+        };
+
+        if (type === 'image_to_text') {
+          if (!imageBase64) {
+            return noDispatchFailure('solve_captcha: image_to_text requires `imageBase64`.');
+          }
+        } else if (!websiteKey) {
+          return noDispatchFailure(`solve_captcha: ${type} requires a websiteKey (data-sitekey). Auto-detection didn't find one — pass it explicitly.`);
+        }
+        // Everything CapSolver would reject on argument grounds is checked
+        // here, before `dispatched` flips — a bad argument must not be
+        // reported as an external side effect that already happened.
+        const paramError = captchaParamError(params);
+        if (paramError) {
+          return noDispatchFailure(detectionNote ? `${paramError} ${detectionNote}` : paramError);
+        }
+
+        dispatched = true;
+        const result = await solveCaptcha(apiKey, params);
 
         // For non-image types, push the token into the page response field
         // unless the caller explicitly opted out.

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -14334,6 +14334,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           }
         } else if (!websiteKey) {
           return noDispatchFailure(`solve_captcha: ${type} requires a websiteKey (data-sitekey). Auto-detection didn't find one — pass it explicitly.`);
+        } else if ((type === 'recaptcha_v3' || type === 'recaptchav3' || type === 'recaptcha_v3_enterprise') && !pageAction) {
+          return noDispatchFailure(`solve_captcha: ${type} requires a \`pageAction\` (e.g. "login", "submit"). Auto-detection found a v3 sitekey but no action name — pass \`pageAction\` explicitly.`);
         }
 
         dispatched = true;

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -114,11 +114,15 @@ function buildTask({ type, websiteURL, websiteKey, ...rest }) {
     };
   }
   if (t === 'recaptcha_v3' || t === 'recaptchav3' || t === 'recaptcha_v3_enterprise') {
+    const pageAction = rest.pageAction || rest.action;
+    if (!pageAction) {
+      throw new Error(`solve_captcha: ${type} requires a pageAction (e.g. "login", "submit").`);
+    }
     return {
       type: isEnterprise ? 'ReCaptchaV3EnterpriseTaskProxyLess' : 'ReCaptchaV3TaskProxyLess',
       websiteURL,
       websiteKey,
-      pageAction: rest.pageAction || rest.action || 'verify',
+      pageAction,
       ...(rest.minScore ? { minScore: rest.minScore } : {}),
       ...(rest.enterprisePayload ? { enterprisePayload: rest.enterprisePayload } : {}),
     };
@@ -249,8 +253,10 @@ function detectCaptchaInPage() {
           recap.getAttribute('data-sitekey-type') === 'enterprise' ||
           recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
           d.querySelector('script[src*="recaptcha/enterprise"]') != null;
+        const version = recap.getAttribute('data-version') || (recap.classList.contains('g-recaptcha-v3') ? 'v3' : null);
+        const isV3 = version === 'v3';
         return {
-          type: action ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
+          type: isV3 ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
           websiteKey: sitekey,
           isInvisible,
           isEnterprise,

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -6,11 +6,12 @@
 //   POST /getTaskResult  → { status: "ready"|"processing", solution? }
 //   POST /getBalance     → { balance, packages }
 //
-// Coverage today: reCAPTCHA v2 (checkbox/invisible), reCAPTCHA v3, hCaptcha,
-// Cloudflare Turnstile, plain image-to-text. Other types CapSolver supports
-// (FunCaptcha, AWS WAF, GeeTest, datadome) are not auto-detected here yet —
-// the agent can still drive them by passing an explicit `type` to
-// solve_captcha and the right `taskTypeOverride`.
+// Coverage today: reCAPTCHA v2 (checkbox/invisible), reCAPTCHA v3, both of
+// those in their Enterprise flavour, hCaptcha, Cloudflare Turnstile, plain
+// image-to-text. Other types CapSolver supports (FunCaptcha, AWS WAF,
+// GeeTest, datadome) are not auto-detected here yet — the agent can still
+// drive them by passing an explicit `type` to solve_captcha and the right
+// `taskTypeOverride`.
 
 const API_BASE = 'https://api.capsolver.com';
 const POLL_INTERVAL_MS = 2500;
@@ -36,28 +37,35 @@ async function postJson(path, body) {
 
 // Wrap a CapSolver error response in a friendlier message.
 //
-// CapSolver returns several different error codes when it refuses a sitekey
-// it considers a public TEST/DEMO key (Google's recaptcha demo, the
-// hcaptcha.com demo, etc.). Two we've actually hit in the wild:
+// Two failure classes look nearly identical on the wire but need opposite
+// responses from the model, so we key off the *description* rather than the
+// error code — CapSolver reuses ERROR_INVALID_TASK_DATA and
+// ERROR_WRONG_CAPTCHA_TYPE for both:
 //
-//   ERROR_WRONG_CAPTCHA_TYPE  ("wrong captcha type")
-//   ERROR_INVALID_TASK_DATA   ("We don't support this service.")
+//   1. Refused sitekey. CapSolver won't farm public TEST/DEMO keys (Google's
+//      recaptcha demo, hcaptcha.com/demo) because no genuine token would come
+//      back. Description reads like "We don't support this service." The fix
+//      is to try the flow on a real production site.
+//   2. Bad task configuration. Description reads like "Invalid input: check
+//      captcha type or parameters" — you get this when the task type doesn't
+//      match the widget, e.g. a plain ReCaptchaV2TaskProxyLess against an
+//      Enterprise sitekey. The fix is to correct `type`/`isEnterprise`.
 //
-// Both translate, in practice, to "this is a public test sitekey, real
-// captcha solvers won't farm it because no genuine token would come back".
-// The vendor-side description on its own is opaque, so we tack on a one-
-// liner pointing the model (and the user, via the trace) at the real
-// remedy: try on a production site.
+// Blaming (2) on a demo key is actively harmful: the model gives up and moves
+// to another site instead of retrying with the right task type. Match the
+// demo phrasing narrowly for the same reason — an earlier bare /test/ matched
+// the "test" inside "latest" and mislabelled ordinary parameter errors.
+const CAPSOLVER_TASK_CONFIG_RE = /invalid input|check captcha type|wrong captcha type/i;
+const CAPSOLVER_DEMO_KEY_RE = /\btest\s*(?:site\s*)?key\b|\bdemo\b|unsupported|don['’]?t[\s_]support|not[\s_]support/i;
+
 function capsolverError(prefix, body) {
   const desc = body.errorDescription || body.errorCode || 'unknown error';
-  const code = String(body.errorCode || '');
-  const looksLikeDemoRejection =
-    (code === 'ERROR_WRONG_CAPTCHA_TYPE' ||
-    code === 'ERROR_INVALID_TASK_DATA' ||
-    /don['’]?t support|not support|unsupported/i.test(desc)) &&
-    !/invalid input|check captcha type/i.test(desc) &&
-    /test|demo|unsupported|don['’]?t support|not support/i.test(desc);
-  if (looksLikeDemoRejection) {
+  if (CAPSOLVER_TASK_CONFIG_RE.test(desc)) {
+    return new Error(
+      `${prefix}: ${desc}. CapSolver rejected the task configuration, not the sitekey — most often the task type doesn't match the widget (a plain reCAPTCHA task against an Enterprise sitekey, or a v2 task against a v3 key). Re-check the detected type and pass \`type\` / \`isEnterprise\` explicitly.`
+    );
+  }
+  if (CAPSOLVER_DEMO_KEY_RE.test(desc)) {
     return new Error(
       `${prefix}: ${desc}. This usually means CapSolver refused the sitekey — most often because it is a public TEST/DEMO key (Google's recaptcha demo, hcaptcha.com/demo, etc.) that no captcha-solving service will farm. Try the same flow on a real production site.`
     );
@@ -99,11 +107,43 @@ async function pollTaskResult(apiKey, taskId, { timeoutMs = POLL_TIMEOUT_MS } = 
 }
 
 // ─── Task builders ─────────────────────────────────────────────────────
+//
+// Each builder takes the params the agent / detector gathered from the page
+// and returns the task object CapSolver's createTask endpoint expects. We
+// default to the "proxyless" task types so the user doesn't need to BYO
+// proxy — that's the simplest path and what virtually every reCAPTCHA /
+// hCaptcha / Turnstile setup actually needs.
+//
+// `enterprisePayload` is accepted but deliberately absent from the
+// solve_captcha schema (same as on the hCaptcha branch): it carries the
+// site-specific `s` token some Enterprise deployments require, which a model
+// has no way to obtain from the page. It stays here so callers that do have
+// one can pass it through.
+
+// Type aliases the model or the detector may hand us. Kept as sets rather
+// than inline `||` chains so buildTask and captchaParamError below can't
+// drift apart on which spellings count as v3.
+const RECAPTCHA_V2_TYPES = new Set(['recaptcha_v2', 'recaptchav2', 'recaptcha_v2_enterprise', 'recaptcha_enterprise']);
+const RECAPTCHA_V3_TYPES = new Set(['recaptcha_v3', 'recaptchav3', 'recaptcha_v3_enterprise']);
+
+// Validate the params CapSolver would reject before we spend a request on
+// them. Exported so agent.js can run it *before* it flags the tool call as
+// dispatched — a missing pageAction is a local argument error, not an
+// external side effect. Returns an error string, or null when the params
+// are usable.
+export function captchaParamError(params) {
+  const t = String(params?.type || '').toLowerCase();
+  if (!t) return 'solve_captcha: type is required.';
+  if (RECAPTCHA_V3_TYPES.has(t) && !(params.pageAction || params.action)) {
+    return `solve_captcha: ${params.type} requires a \`pageAction\` (e.g. "login", "submit"). reCAPTCHA v3 scores the action name, so CapSolver cannot mint a usable token without it — pass \`pageAction\` explicitly.`;
+  }
+  return null;
+}
 
 function buildTask({ type, websiteURL, websiteKey, ...rest }) {
   const t = String(type || '').toLowerCase();
   const isEnterprise = !!rest.isEnterprise || t.includes('enterprise');
-  if (t === 'recaptcha_v2' || t === 'recaptchav2' || t === 'recaptcha_v2_enterprise' || t === 'recaptcha_enterprise') {
+  if (RECAPTCHA_V2_TYPES.has(t)) {
     return {
       type: isEnterprise ? 'ReCaptchaV2EnterpriseTaskProxyLess' : 'ReCaptchaV2TaskProxyLess',
       websiteURL,
@@ -113,11 +153,8 @@ function buildTask({ type, websiteURL, websiteKey, ...rest }) {
       ...(rest.userAgent ? { userAgent: rest.userAgent } : {}),
     };
   }
-  if (t === 'recaptcha_v3' || t === 'recaptchav3' || t === 'recaptcha_v3_enterprise') {
+  if (RECAPTCHA_V3_TYPES.has(t)) {
     const pageAction = rest.pageAction || rest.action;
-    if (!pageAction) {
-      throw new Error(`solve_captcha: ${type} requires a pageAction (e.g. "login", "submit").`);
-    }
     return {
       type: isEnterprise ? 'ReCaptchaV3EnterpriseTaskProxyLess' : 'ReCaptchaV3TaskProxyLess',
       websiteURL,
@@ -160,7 +197,10 @@ function buildTask({ type, websiteURL, websiteKey, ...rest }) {
 // type. The DOM convention is well-documented for the ones we auto-handle.
 function solutionFor(type, solution) {
   const t = String(type || '').toLowerCase();
-  if (t.startsWith('recaptcha') || t === 'recaptcha_v2' || t === 'recaptchav2' || t === 'recaptcha_v3' || t === 'recaptchav3') {
+  // Covers every reCAPTCHA spelling — v2/v3, snake or camel, Enterprise or
+  // not. They all return the token under the same solution key and inject
+  // into the same field.
+  if (t.startsWith('recaptcha')) {
     return { token: solution.gRecaptchaResponse, fieldName: 'g-recaptcha-response' };
   }
   if (t === 'hcaptcha') {
@@ -181,7 +221,8 @@ function solutionFor(type, solution) {
 
 export async function solveCaptcha(apiKey, params) {
   if (!apiKey) throw new Error('No CapSolver API key configured.');
-  if (!params?.type) throw new Error('solve_captcha: type is required.');
+  const paramError = captchaParamError(params);
+  if (paramError) throw new Error(paramError);
   const task = buildTask(params);
   const taskId = await createTask(apiKey, task);
   const solution = await pollTaskResult(apiKey, taskId);
@@ -201,6 +242,22 @@ export async function solveCaptcha(apiKey, params) {
 // page's light DOM, even if its UI lives inside a same-origin iframe.
 
 function detectCaptchaInPage() {
+  // Helpers are declared inside the function, not at module scope: this whole
+  // body is serialised into the page world by chrome.scripting.executeScript,
+  // so it cannot close over anything outside itself.
+  const V3_NO_ACTION_NOTE = 'reCAPTCHA v3 detected, but the page never exposed an action name. solve_captcha needs pageAction — read it from the grecaptcha.execute(...) call in the site JS, or infer it from the form (login, submit, checkout).';
+
+  // reCAPTCHA v3 puts the action name in the loader script's query string.
+  // Parse it with URL so percent-encoded action names come back decoded.
+  const getUrlAction = (urlStr) => {
+    try {
+      const u = new URL(urlStr, 'https://dummy.host');
+      const act = u.searchParams.get('action') || u.searchParams.get('pageAction') || u.searchParams.get('page_action');
+      return act ? act.trim() : null;
+    } catch {}
+    return null;
+  };
+
   // Helper: visit same-origin iframes too, since reCAPTCHA on many sites
   // is rendered inside a same-origin wrapper. Cross-origin frames are
   // skipped (their .contentDocument throws on access).
@@ -241,7 +298,10 @@ function detectCaptchaInPage() {
         return { type: 'turnstile', websiteKey: sitekey };
       }
     }
-    // reCAPTCHA v2/v3 / Enterprise host elements
+    // reCAPTCHA v2/v3, classic or Enterprise. `.g-recaptcha` is the documented
+    // host class; `data-recaptcha-sitekey` is a wrapper convention several
+    // form libraries use. Both are reCAPTCHA-specific, so this still doesn't
+    // grab a bare `data-sitekey` belonging to another provider.
     const recap = d.querySelector('.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey], [data-recaptcha-sitekey]');
     if (recap) {
       const sitekey = recap.getAttribute('data-sitekey') || recap.getAttribute('data-recaptcha-sitekey');
@@ -249,20 +309,48 @@ function detectCaptchaInPage() {
         const size = recap.getAttribute('data-size');
         const isInvisible = size === 'invisible';
         const action = recap.getAttribute('data-action') || recap.getAttribute('data-recaptcha-action') || null;
-        const hasClassicScript = d.querySelector('script[src*="recaptcha/api.js"]') != null;
-        const hasEnterpriseScript = d.querySelector('script[src*="recaptcha/enterprise"]') != null;
+        // Script tags decide both version and edition. Look in the parent
+        // document too: when the widget lives in a same-origin iframe the
+        // loader tag usually stays in the top document.
+        const scriptSrcs = [];
+        for (const doc of (d === document ? [d] : [d, document])) {
+          for (const s of doc.querySelectorAll('script[src]')) {
+            try { if (s.src) scriptSrcs.push(s.src); } catch {}
+          }
+        }
+        const hasClassicScript = scriptSrcs.some(s => s.includes('recaptcha/api.js'));
+        const hasEnterpriseScript = scriptSrcs.some(s => s.includes('recaptcha/enterprise'));
+        // data-enterprise / data-sitekey-type aren't Google attributes — they
+        // are wrapper-library conventions (django-recaptcha, some Rails and
+        // Vue helpers). Cheap to check, so we take them as hints before
+        // falling back to which loader script the page pulled in.
         const isEnterprise = recap.getAttribute('data-enterprise') === 'true' ||
           recap.getAttribute('data-sitekey-type') === 'enterprise' ||
           recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
           (!hasClassicScript && hasEnterpriseScript);
+        // Version, in order of reliability:
+        //   1. an explicit wrapper-set data-version / .g-recaptcha-v3 marker
+        //   2. a `render=<sitekey>` loader script — the v3 signature; v2 loads
+        //      the script bare or with render=explicit
+        //   3. data-action with no data-size=invisible
+        // (3) alone is not enough in either direction: v2 invisible widgets
+        // carry data-action too, and some v3 wrappers copy data-size onto
+        // their host div. Without (2) both of those land on the wrong task
+        // type and CapSolver rejects the key.
         const version = recap.getAttribute('data-version') || (recap.classList.contains('g-recaptcha-v3') ? 'v3' : null);
-        const isV3 = version === 'v3' || (!!action && !isInvisible);
+        const renderScript = scriptSrcs.find(s =>
+          /recaptcha\/(api|enterprise)\.js/i.test(s) && s.includes(`render=${sitekey}`)) || null;
+        const isV3 = version === 'v3' || !!renderScript || (!!action && !isInvisible);
+        // v3 needs an action name to solve. Fall back to the loader script's
+        // ?action= when the host element doesn't carry one, and say so
+        // explicitly when neither does — solve_captcha refuses v3 without it.
+        const pageAction = action || (isV3 && renderScript ? getUrlAction(renderScript) : null);
         return {
           type: isV3 ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
           websiteKey: sitekey,
           isInvisible,
           isEnterprise,
-          ...(action ? { pageAction: action } : {}),
+          ...(pageAction ? { pageAction } : (isV3 ? { note: V3_NO_ACTION_NOTE } : {})),
         };
       }
     }
@@ -286,15 +374,25 @@ function detectCaptchaInPage() {
   // Turnstile) or `?k=` (reCAPTCHA) query parameter. iframe.src and
   // script.src are readable across origins from the parent page, so we
   // can scrape them even when the widget renders cross-origin.
-  const getUrlAction = (urlStr) => {
-    try {
-      const u = new URL(urlStr, 'https://dummy.host');
-      const act = u.searchParams.get('action') || u.searchParams.get('pageAction') || u.searchParams.get('page_action');
-      return act ? act.trim() : null;
-    } catch {}
+  // hCaptcha and Turnstile expose the same `?sitekey=` in either tag, so one
+  // matcher serves both passes below.
+  const nonRecaptchaFromUrl = (url) => {
+    if (/hcaptcha\.com/i.test(url)) {
+      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
+      if (m) return { type: 'hcaptcha', websiteKey: m[1], detectedVia: 'url' };
+    }
+    if (/challenges\.cloudflare\.com\/turnstile/i.test(url)) {
+      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
+      if (m) return { type: 'turnstile', websiteKey: m[1], detectedVia: 'url' };
+    }
     return null;
   };
 
+  // Split by tag type because reCAPTCHA needs both halves to classify a
+  // widget: the anchor iframe carries the sitekey, the loader script carries
+  // the version and action. Iframes are scanned first — a rendered anchor
+  // frame is a stronger signal that the widget is actually on this page than
+  // a script tag, which may just be a loader the page never used.
   const iframeUrls = [];
   const scriptUrls = [];
   for (const el of document.querySelectorAll('iframe[src], script[src]')) {
@@ -306,20 +404,17 @@ function detectCaptchaInPage() {
     } catch {}
   }
   for (const url of iframeUrls) {
-    if (/hcaptcha\.com/i.test(url)) {
-      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) return { type: 'hcaptcha', websiteKey: m[1], detectedVia: 'url' };
-    }
-    if (/challenges\.cloudflare\.com\/turnstile/i.test(url)) {
-      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) return { type: 'turnstile', websiteKey: m[1], detectedVia: 'url' };
-    }
+    const other = nonRecaptchaFromUrl(url);
+    if (other) return other;
     if (/recaptcha\/(api2|enterprise)\/anchor/i.test(url)) {
       const m = url.match(/[?&#]k=([a-zA-Z0-9_-]{6,})/);
       if (m) {
         const sitekey = m[1];
         const isEnterprise = /recaptcha\/enterprise/i.test(url);
         const isInvisible = /[?&#]size=invisible/i.test(url);
+        // v3 renders an anchor frame too (the badge), and it always carries
+        // size=invisible — so the frame alone can't tell v3 from an invisible
+        // v2. A loader script rendering this exact sitekey settles it.
         const matchingV3Script = scriptUrls.find(s => s.includes(`render=${sitekey}`));
         if (matchingV3Script) {
           const pageAction = getUrlAction(matchingV3Script);
@@ -327,7 +422,7 @@ function detectCaptchaInPage() {
             type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
             websiteKey: sitekey,
             isEnterprise,
-            ...(pageAction ? { pageAction } : {}),
+            ...(pageAction ? { pageAction } : { note: V3_NO_ACTION_NOTE }),
             detectedVia: 'url',
           };
         }
@@ -342,16 +437,12 @@ function detectCaptchaInPage() {
     }
   }
   for (const url of scriptUrls) {
-    if (/hcaptcha\.com/i.test(url)) {
-      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) return { type: 'hcaptcha', websiteKey: m[1], detectedVia: 'url' };
-    }
-    if (/challenges\.cloudflare\.com\/turnstile/i.test(url)) {
-      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) return { type: 'turnstile', websiteKey: m[1], detectedVia: 'url' };
-    }
+    const other = nonRecaptchaFromUrl(url);
+    if (other) return other;
     if (/recaptcha\/(api\.js|enterprise\.js)/i.test(url)) {
       const m = url.match(/[?&#]render=([a-zA-Z0-9_-]{6,})/);
+      // render=explicit means the page renders a v2 widget by hand later —
+      // it is not a sitekey.
       if (m && m[1] !== 'explicit') {
         const isEnterprise = /enterprise/i.test(url);
         const pageAction = getUrlAction(url);
@@ -359,9 +450,8 @@ function detectCaptchaInPage() {
           type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
           websiteKey: m[1],
           isEnterprise,
-          ...(pageAction ? { pageAction } : {}),
+          ...(pageAction ? { pageAction } : { note: V3_NO_ACTION_NOTE }),
           detectedVia: 'url',
-          note: !pageAction ? 'reCAPTCHA v3 detected via script render tag without pageAction. Pass pageAction explicitly if the target site validates specific action names.' : undefined,
         };
       }
     }

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -284,26 +284,25 @@ function detectCaptchaInPage() {
   // Turnstile) or `?k=` (reCAPTCHA) query parameter. iframe.src and
   // script.src are readable across origins from the parent page, so we
   // can scrape them even when the widget renders cross-origin.
-  const urlCandidates = [];
+  const iframeUrls = [];
+  const scriptUrls = [];
   for (const el of document.querySelectorAll('iframe[src], script[src]')) {
-    try { if (el.src) urlCandidates.push(el.src); } catch {}
+    try {
+      if (el.src) {
+        if (el.tagName.toLowerCase() === 'iframe') iframeUrls.push(el.src);
+        else scriptUrls.push(el.src);
+      }
+    } catch {}
   }
-  for (const url of urlCandidates) {
-    // hCaptcha
+  for (const url of iframeUrls) {
     if (/hcaptcha\.com/i.test(url)) {
       const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) {
-        return { type: 'hcaptcha', websiteKey: m[1], detectedVia: 'url' };
-      }
+      if (m) return { type: 'hcaptcha', websiteKey: m[1], detectedVia: 'url' };
     }
-    // Cloudflare Turnstile
     if (/challenges\.cloudflare\.com\/turnstile/i.test(url)) {
       const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) {
-        return { type: 'turnstile', websiteKey: m[1], detectedVia: 'url' };
-      }
+      if (m) return { type: 'turnstile', websiteKey: m[1], detectedVia: 'url' };
     }
-    // reCAPTCHA v2 / Enterprise anchor
     if (/recaptcha\/(api2|enterprise)\/anchor/i.test(url)) {
       const m = url.match(/[?&#]k=([a-zA-Z0-9_-]{6,})/);
       if (m) {
@@ -318,7 +317,16 @@ function detectCaptchaInPage() {
         };
       }
     }
-    // reCAPTCHA api.js / enterprise.js render parameter (v3 or Enterprise)
+  }
+  for (const url of scriptUrls) {
+    if (/hcaptcha\.com/i.test(url)) {
+      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
+      if (m) return { type: 'hcaptcha', websiteKey: m[1], detectedVia: 'url' };
+    }
+    if (/challenges\.cloudflare\.com\/turnstile/i.test(url)) {
+      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
+      if (m) return { type: 'turnstile', websiteKey: m[1], detectedVia: 'url' };
+    }
     if (/recaptcha\/(api\.js|enterprise\.js)/i.test(url)) {
       const m = url.match(/[?&#]render=([a-zA-Z0-9_-]{6,})/);
       if (m && m[1] !== 'explicit') {

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -254,7 +254,7 @@ function detectCaptchaInPage() {
           recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
           d.querySelector('script[src*="recaptcha/enterprise"]') != null;
         const version = recap.getAttribute('data-version') || (recap.classList.contains('g-recaptcha-v3') ? 'v3' : null);
-        const isV3 = version === 'v3';
+        const isV3 = version === 'v3' || (!!action && !isInvisible);
         return {
           type: isV3 ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
           websiteKey: sitekey,

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -52,9 +52,11 @@ function capsolverError(prefix, body) {
   const desc = body.errorDescription || body.errorCode || 'unknown error';
   const code = String(body.errorCode || '');
   const looksLikeDemoRejection =
-    code === 'ERROR_WRONG_CAPTCHA_TYPE' ||
+    (code === 'ERROR_WRONG_CAPTCHA_TYPE' ||
     code === 'ERROR_INVALID_TASK_DATA' ||
-    /don['’]?t support|not support|unsupported/i.test(desc);
+    /don['’]?t support|not support|unsupported/i.test(desc)) &&
+    !/invalid input|check captcha type/i.test(desc) &&
+    /test|demo|unsupported|don['’]?t support|not support/i.test(desc);
   if (looksLikeDemoRejection) {
     return new Error(
       `${prefix}: ${desc}. This usually means CapSolver refused the sitekey — most often because it is a public TEST/DEMO key (Google's recaptcha demo, hcaptcha.com/demo, etc.) that no captcha-solving service will farm. Try the same flow on a real production site.`
@@ -97,31 +99,28 @@ async function pollTaskResult(apiKey, taskId, { timeoutMs = POLL_TIMEOUT_MS } = 
 }
 
 // ─── Task builders ─────────────────────────────────────────────────────
-//
-// Each builder takes the params the agent / detector gathered from the page
-// and returns the task object CapSolver's createTask endpoint expects. We
-// default to the "proxyless" task types so the user doesn't need to BYO
-// proxy — that's the simplest path and what virtually every reCAPTCHA /
-// hCaptcha / Turnstile setup actually needs.
 
 function buildTask({ type, websiteURL, websiteKey, ...rest }) {
   const t = String(type || '').toLowerCase();
-  if (t === 'recaptcha_v2' || t === 'recaptchav2') {
+  const isEnterprise = !!rest.isEnterprise || t.includes('enterprise');
+  if (t === 'recaptcha_v2' || t === 'recaptchav2' || t === 'recaptcha_v2_enterprise' || t === 'recaptcha_enterprise') {
     return {
-      type: 'ReCaptchaV2TaskProxyLess',
+      type: isEnterprise ? 'ReCaptchaV2EnterpriseTaskProxyLess' : 'ReCaptchaV2TaskProxyLess',
       websiteURL,
       websiteKey,
       ...(rest.isInvisible != null ? { isInvisible: !!rest.isInvisible } : {}),
+      ...(rest.enterprisePayload ? { enterprisePayload: rest.enterprisePayload } : {}),
       ...(rest.userAgent ? { userAgent: rest.userAgent } : {}),
     };
   }
-  if (t === 'recaptcha_v3' || t === 'recaptchav3') {
+  if (t === 'recaptcha_v3' || t === 'recaptchav3' || t === 'recaptcha_v3_enterprise') {
     return {
-      type: 'ReCaptchaV3TaskProxyLess',
+      type: isEnterprise ? 'ReCaptchaV3EnterpriseTaskProxyLess' : 'ReCaptchaV3TaskProxyLess',
       websiteURL,
       websiteKey,
       pageAction: rest.pageAction || rest.action || 'verify',
       ...(rest.minScore ? { minScore: rest.minScore } : {}),
+      ...(rest.enterprisePayload ? { enterprisePayload: rest.enterprisePayload } : {}),
     };
   }
   if (t === 'hcaptcha') {
@@ -238,21 +237,20 @@ function detectCaptchaInPage() {
         return { type: 'turnstile', websiteKey: sitekey };
       }
     }
-    // reCAPTCHA v2/v3. Match only on reCAPTCHA-specific markers — the
-    // `.g-recaptcha` class or `id="g-recaptcha-..."` — so we don't
-    // accidentally grab any `data-sitekey` element from another widget.
-    const recap = d.querySelector('.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey]');
+    // reCAPTCHA v2/v3 / Enterprise host elements
+    const recap = d.querySelector('.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey], [data-recaptcha-sitekey]');
     if (recap) {
-      const sitekey = recap.getAttribute('data-sitekey');
+      const sitekey = recap.getAttribute('data-sitekey') || recap.getAttribute('data-recaptcha-sitekey');
       if (sitekey) {
         const size = recap.getAttribute('data-size');
         const isInvisible = size === 'invisible';
-        // v3 widgets typically carry data-action; v2 doesn't.
         const action = recap.getAttribute('data-action') || null;
+        const isEnterprise = recap.getAttribute('data-enterprise') === 'true' || d.querySelector('script[src*="recaptcha/enterprise"]') != null;
         return {
-          type: action ? 'recaptcha_v3' : 'recaptcha_v2',
+          type: action ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
           websiteKey: sitekey,
           isInvisible,
+          isEnterprise,
           ...(action ? { pageAction: action } : {}),
         };
       }
@@ -296,14 +294,32 @@ function detectCaptchaInPage() {
         return { type: 'turnstile', websiteKey: m[1], detectedVia: 'url' };
       }
     }
-    // reCAPTCHA v2 — the anchor iframe carries the sitekey in `k=` and
-    // visible (checkbox) widgets are the only kind that produce this URL
-    // pattern (v3 is invisible and would have surfaced via the DOM scan
-    // above if a host element existed).
+    // reCAPTCHA v2 / Enterprise anchor
     if (/recaptcha\/(api2|enterprise)\/anchor/i.test(url)) {
       const m = url.match(/[?&#]k=([a-zA-Z0-9_-]{6,})/);
       if (m) {
-        return { type: 'recaptcha_v2', websiteKey: m[1], detectedVia: 'url' };
+        const isEnterprise = /recaptcha\/enterprise/i.test(url);
+        const isInvisible = /[?&#]size=invisible/i.test(url);
+        return {
+          type: isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2',
+          websiteKey: m[1],
+          isInvisible,
+          isEnterprise,
+          detectedVia: 'url',
+        };
+      }
+    }
+    // reCAPTCHA api.js / enterprise.js render parameter (v3 or Enterprise)
+    if (/recaptcha\/(api\.js|enterprise\.js)/i.test(url)) {
+      const m = url.match(/[?&#]render=([a-zA-Z0-9_-]{6,})/);
+      if (m && m[1] !== 'explicit') {
+        const isEnterprise = /enterprise/i.test(url);
+        return {
+          type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
+          websiteKey: m[1],
+          isEnterprise,
+          detectedVia: 'url',
+        };
       }
     }
   }

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -245,7 +245,9 @@ function detectCaptchaInPage() {
         const size = recap.getAttribute('data-size');
         const isInvisible = size === 'invisible';
         const action = recap.getAttribute('data-action') || null;
-        const isEnterprise = recap.getAttribute('data-enterprise') === 'true' || d.querySelector('script[src*="recaptcha/enterprise"]') != null;
+        const isEnterprise = recap.getAttribute('data-enterprise') === 'true' ||
+          recap.getAttribute('data-sitekey-type') === 'enterprise' ||
+          recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null;
         return {
           type: action ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
           websiteKey: sitekey,

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -156,7 +156,7 @@ function buildTask({ type, websiteURL, websiteKey, ...rest }) {
 // type. The DOM convention is well-documented for the ones we auto-handle.
 function solutionFor(type, solution) {
   const t = String(type || '').toLowerCase();
-  if (t === 'recaptcha_v2' || t === 'recaptchav2' || t === 'recaptcha_v3' || t === 'recaptchav3') {
+  if (t.startsWith('recaptcha') || t === 'recaptcha_v2' || t === 'recaptchav2' || t === 'recaptcha_v3' || t === 'recaptchav3') {
     return { token: solution.gRecaptchaResponse, fieldName: 'g-recaptcha-response' };
   }
   if (t === 'hcaptcha') {
@@ -244,7 +244,7 @@ function detectCaptchaInPage() {
       if (sitekey) {
         const size = recap.getAttribute('data-size');
         const isInvisible = size === 'invisible';
-        const action = recap.getAttribute('data-action') || d.querySelector('[data-action]')?.getAttribute('data-action') || null;
+        const action = recap.getAttribute('data-action') || recap.getAttribute('data-recaptcha-action') || null;
         const isEnterprise = recap.getAttribute('data-enterprise') === 'true' ||
           recap.getAttribute('data-sitekey-type') === 'enterprise' ||
           recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
@@ -318,7 +318,7 @@ function detectCaptchaInPage() {
       if (m && m[1] !== 'explicit') {
         const isEnterprise = /enterprise/i.test(url);
         const actionMatch = url.match(/[?&#](action|pageAction)=([a-zA-Z0-9_-]+)/i);
-        const pageAction = actionMatch ? actionMatch[2] : (document.querySelector('[data-action]')?.getAttribute('data-action') || null);
+        const pageAction = actionMatch ? actionMatch[2] : null;
         return {
           type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
           websiteKey: m[1],

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -249,10 +249,12 @@ function detectCaptchaInPage() {
         const size = recap.getAttribute('data-size');
         const isInvisible = size === 'invisible';
         const action = recap.getAttribute('data-action') || recap.getAttribute('data-recaptcha-action') || null;
+        const hasClassicScript = d.querySelector('script[src*="recaptcha/api.js"]') != null;
+        const hasEnterpriseScript = d.querySelector('script[src*="recaptcha/enterprise"]') != null;
         const isEnterprise = recap.getAttribute('data-enterprise') === 'true' ||
           recap.getAttribute('data-sitekey-type') === 'enterprise' ||
           recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
-          d.querySelector('script[src*="recaptcha/enterprise"]') != null;
+          (!hasClassicScript && hasEnterpriseScript);
         const version = recap.getAttribute('data-version') || (recap.classList.contains('g-recaptcha-v3') ? 'v3' : null);
         const isV3 = version === 'v3' || (!!action && !isInvisible);
         return {
@@ -306,11 +308,24 @@ function detectCaptchaInPage() {
     if (/recaptcha\/(api2|enterprise)\/anchor/i.test(url)) {
       const m = url.match(/[?&#]k=([a-zA-Z0-9_-]{6,})/);
       if (m) {
+        const sitekey = m[1];
         const isEnterprise = /recaptcha\/enterprise/i.test(url);
         const isInvisible = /[?&#]size=invisible/i.test(url);
+        const matchingV3Script = scriptUrls.find(s => s.includes(`render=${sitekey}`));
+        if (matchingV3Script) {
+          const actionMatch = matchingV3Script.match(/[?&#](action|pageAction)=([a-zA-Z0-9_-]+)/i);
+          const pageAction = actionMatch ? actionMatch[2] : null;
+          return {
+            type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
+            websiteKey: sitekey,
+            isEnterprise,
+            ...(pageAction ? { pageAction } : {}),
+            detectedVia: 'url',
+          };
+        }
         return {
           type: isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2',
-          websiteKey: m[1],
+          websiteKey: sitekey,
           isInvisible,
           isEnterprise,
           detectedVia: 'url',

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -244,10 +244,11 @@ function detectCaptchaInPage() {
       if (sitekey) {
         const size = recap.getAttribute('data-size');
         const isInvisible = size === 'invisible';
-        const action = recap.getAttribute('data-action') || null;
+        const action = recap.getAttribute('data-action') || d.querySelector('[data-action]')?.getAttribute('data-action') || null;
         const isEnterprise = recap.getAttribute('data-enterprise') === 'true' ||
           recap.getAttribute('data-sitekey-type') === 'enterprise' ||
-          recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null;
+          recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
+          d.querySelector('script[src*="recaptcha/enterprise"]') != null;
         return {
           type: action ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
           websiteKey: sitekey,
@@ -316,11 +317,15 @@ function detectCaptchaInPage() {
       const m = url.match(/[?&#]render=([a-zA-Z0-9_-]{6,})/);
       if (m && m[1] !== 'explicit') {
         const isEnterprise = /enterprise/i.test(url);
+        const actionMatch = url.match(/[?&#](action|pageAction)=([a-zA-Z0-9_-]+)/i);
+        const pageAction = actionMatch ? actionMatch[2] : (document.querySelector('[data-action]')?.getAttribute('data-action') || null);
         return {
           type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
           websiteKey: m[1],
           isEnterprise,
+          ...(pageAction ? { pageAction } : {}),
           detectedVia: 'url',
+          note: !pageAction ? 'reCAPTCHA v3 detected via script render tag without pageAction. Pass pageAction explicitly if the target site validates specific action names.' : undefined,
         };
       }
     }

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -286,6 +286,15 @@ function detectCaptchaInPage() {
   // Turnstile) or `?k=` (reCAPTCHA) query parameter. iframe.src and
   // script.src are readable across origins from the parent page, so we
   // can scrape them even when the widget renders cross-origin.
+  const getUrlAction = (urlStr) => {
+    try {
+      const u = new URL(urlStr, 'https://dummy.host');
+      const act = u.searchParams.get('action') || u.searchParams.get('pageAction') || u.searchParams.get('page_action');
+      return act ? act.trim() : null;
+    } catch {}
+    return null;
+  };
+
   const iframeUrls = [];
   const scriptUrls = [];
   for (const el of document.querySelectorAll('iframe[src], script[src]')) {
@@ -313,8 +322,7 @@ function detectCaptchaInPage() {
         const isInvisible = /[?&#]size=invisible/i.test(url);
         const matchingV3Script = scriptUrls.find(s => s.includes(`render=${sitekey}`));
         if (matchingV3Script) {
-          const actionMatch = matchingV3Script.match(/[?&#](action|pageAction)=([a-zA-Z0-9_-]+)/i);
-          const pageAction = actionMatch ? actionMatch[2] : null;
+          const pageAction = getUrlAction(matchingV3Script);
           return {
             type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
             websiteKey: sitekey,
@@ -346,8 +354,7 @@ function detectCaptchaInPage() {
       const m = url.match(/[?&#]render=([a-zA-Z0-9_-]{6,})/);
       if (m && m[1] !== 'explicit') {
         const isEnterprise = /enterprise/i.test(url);
-        const actionMatch = url.match(/[?&#](action|pageAction)=([a-zA-Z0-9_-]+)/i);
-        const pageAction = actionMatch ? actionMatch[2] : null;
+        const pageAction = getUrlAction(url);
         return {
           type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
           websiteKey: m[1],

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -1066,7 +1066,7 @@ export const AGENT_TOOLS = [
           websiteKey: { type: 'string', description: 'Site key from the captcha widget\'s data-sitekey attribute. Auto-detected when omitted.' },
           isInvisible: { type: 'boolean', description: 'reCAPTCHA v2 / hCaptcha only — true when the widget uses invisible mode (no visible checkbox). Auto-detected when omitted.' },
           isEnterprise: { type: 'boolean', description: 'reCAPTCHA v2/v3 only — true when the widget uses Google reCAPTCHA Enterprise. Auto-detected when omitted.' },
-          pageAction: { type: 'string', description: 'reCAPTCHA v3 only — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action when present.' },
+          pageAction: { type: 'string', description: 'Required for reCAPTCHA v3 — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action or the loader script when present; pass it explicitly if detection reports it missing.' },
           minScore: { type: 'number', description: 'reCAPTCHA v3 only — minimum score requested (0.3 is the usual lower bound, 0.7+ is hard).' },
           imageBase64: { type: 'string', description: 'image_to_text only — base64-encoded image bytes (no data: prefix).' },
           inject: { type: 'boolean', description: 'After solving, inject the token into the page\'s response field (textarea[name=g-recaptcha-response] etc.) and fire the widget\'s callback. Default true. Set false to get just the token back.' },

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -1060,11 +1060,12 @@ export const AGENT_TOOLS = [
         properties: {
           type: {
             type: 'string',
-            enum: ['recaptcha_v2', 'recaptcha_v3', 'hcaptcha', 'turnstile', 'image_to_text'],
+            enum: ['recaptcha_v2', 'recaptcha_v3', 'recaptcha_v2_enterprise', 'recaptcha_v3_enterprise', 'hcaptcha', 'turnstile', 'image_to_text'],
             description: 'CAPTCHA type. Omit to auto-detect from the page DOM.',
           },
           websiteKey: { type: 'string', description: 'Site key from the captcha widget\'s data-sitekey attribute. Auto-detected when omitted.' },
           isInvisible: { type: 'boolean', description: 'reCAPTCHA v2 / hCaptcha only — true when the widget uses invisible mode (no visible checkbox). Auto-detected when omitted.' },
+          isEnterprise: { type: 'boolean', description: 'reCAPTCHA v2/v3 only — true when the widget uses Google reCAPTCHA Enterprise. Auto-detected when omitted.' },
           pageAction: { type: 'string', description: 'reCAPTCHA v3 only — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action when present.' },
           minScore: { type: 'number', description: 'reCAPTCHA v3 only — minimum score requested (0.3 is the usual lower bound, 0.7+ is hard).' },
           imageBase64: { type: 'string', description: 'image_to_text only — base64-encoded image bytes (no data: prefix).' },

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -12567,6 +12567,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           }
         } else if (!websiteKey) {
           return noDispatchFailure(`solve_captcha: ${type} requires a websiteKey (data-sitekey). Auto-detection didn't find one — pass it explicitly.`);
+        } else if ((type === 'recaptcha_v3' || type === 'recaptchav3' || type === 'recaptcha_v3_enterprise') && !pageAction) {
+          return noDispatchFailure(`solve_captcha: ${type} requires a \`pageAction\` (e.g. "login", "submit"). Auto-detection found a v3 sitekey but no action name — pass \`pageAction\` explicitly.`);
         }
 
         dispatched = true;

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -30,7 +30,7 @@ import {
 } from './pdf-tools.js';
 import * as trace from '../trace/recorder.js';
 import { tracesToMarkdown } from './trace-export.js';
-import { solveCaptcha, detectCaptcha, injectToken } from './captcha-solver.js';
+import { solveCaptcha, detectCaptcha, injectToken, captchaParamError } from './captcha-solver.js';
 import { Capability, CAPABILITY_LABEL, capabilitiesFor, requiredHosts, frameHostMatches, isNetworkMutation, normalizeHost, PermissionManager, UNTRUSTED_CONTENT_TOOLS } from './permission-gate.js';
 import {
   buildPlannerMessages,
@@ -12549,30 +12549,24 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         } catch {}
 
         let { type, websiteKey, isInvisible, isEnterprise, pageAction, minScore, imageBase64 } = args || {};
+        // Detection notes explain *why* a field is missing (e.g. a v3 widget
+        // that never exposed its action name). Carry it into the failure so
+        // the model gets the remedy, not just the rejection.
+        let detectionNote = null;
         if (!type) {
           const detected = await detectCaptcha(tabId);
           if (!detected) {
             return noDispatchFailure('No CAPTCHA detected on the page. If the captcha lives inside a cross-origin iframe or uses a non-standard widget, pass `type` and `websiteKey` explicitly.');
           }
           type = detected.type;
+          detectionNote = detected.note || null;
           if (!websiteKey) websiteKey = detected.websiteKey;
           if (isInvisible == null && detected.isInvisible != null) isInvisible = detected.isInvisible;
           if (isEnterprise == null && detected.isEnterprise != null) isEnterprise = detected.isEnterprise;
           if (!pageAction && detected.pageAction) pageAction = detected.pageAction;
         }
 
-        if (type === 'image_to_text') {
-          if (!imageBase64) {
-            return noDispatchFailure('solve_captcha: image_to_text requires `imageBase64`.');
-          }
-        } else if (!websiteKey) {
-          return noDispatchFailure(`solve_captcha: ${type} requires a websiteKey (data-sitekey). Auto-detection didn't find one — pass it explicitly.`);
-        } else if ((type === 'recaptcha_v3' || type === 'recaptchav3' || type === 'recaptcha_v3_enterprise') && !pageAction) {
-          return noDispatchFailure(`solve_captcha: ${type} requires a \`pageAction\` (e.g. "login", "submit"). Auto-detection found a v3 sitekey but no action name — pass \`pageAction\` explicitly.`);
-        }
-
-        dispatched = true;
-        const result = await solveCaptcha(apiKey, {
+        const params = {
           type,
           websiteURL,
           websiteKey,
@@ -12581,7 +12575,25 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           ...(pageAction ? { pageAction } : {}),
           ...(minScore ? { minScore } : {}),
           ...(imageBase64 ? { body: imageBase64 } : {}),
-        });
+        };
+
+        if (type === 'image_to_text') {
+          if (!imageBase64) {
+            return noDispatchFailure('solve_captcha: image_to_text requires `imageBase64`.');
+          }
+        } else if (!websiteKey) {
+          return noDispatchFailure(`solve_captcha: ${type} requires a websiteKey (data-sitekey). Auto-detection didn't find one — pass it explicitly.`);
+        }
+        // Everything CapSolver would reject on argument grounds is checked
+        // here, before `dispatched` flips — a bad argument must not be
+        // reported as an external side effect that already happened.
+        const paramError = captchaParamError(params);
+        if (paramError) {
+          return noDispatchFailure(detectionNote ? `${paramError} ${detectionNote}` : paramError);
+        }
+
+        dispatched = true;
+        const result = await solveCaptcha(apiKey, params);
 
         const wantInject = args?.inject !== false && type !== 'image_to_text';
         let injection = null;

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -12548,7 +12548,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           websiteURL = tab?.url || '';
         } catch {}
 
-        let { type, websiteKey, isInvisible, pageAction, minScore, imageBase64 } = args || {};
+        let { type, websiteKey, isInvisible, isEnterprise, pageAction, minScore, imageBase64 } = args || {};
         if (!type) {
           const detected = await detectCaptcha(tabId);
           if (!detected) {
@@ -12557,6 +12557,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           type = detected.type;
           if (!websiteKey) websiteKey = detected.websiteKey;
           if (isInvisible == null && detected.isInvisible != null) isInvisible = detected.isInvisible;
+          if (isEnterprise == null && detected.isEnterprise != null) isEnterprise = detected.isEnterprise;
           if (!pageAction && detected.pageAction) pageAction = detected.pageAction;
         }
 
@@ -12574,6 +12575,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           websiteURL,
           websiteKey,
           ...(isInvisible != null ? { isInvisible } : {}),
+          ...(isEnterprise != null ? { isEnterprise } : {}),
           ...(pageAction ? { pageAction } : {}),
           ...(minScore ? { minScore } : {}),
           ...(imageBase64 ? { body: imageBase64 } : {}),

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -31,21 +31,22 @@ async function postJson(path, body) {
 }
 
 // Wrap a CapSolver error response in a friendlier message. See the chrome
-// build's captcha-solver.js for the full rationale — short version:
-// ERROR_WRONG_CAPTCHA_TYPE and ERROR_INVALID_TASK_DATA ("We don't support
-// this service") are the codes CapSolver returns for public TEST/DEMO
-// sitekeys (Google's recaptcha demo, hcaptcha.com/demo). Tack on a hint so
-// the agent and the user know to try a production site.
+// build's captcha-solver.js for the full rationale — short version: CapSolver
+// reuses the same error codes for "I refuse this public TEST/DEMO sitekey"
+// and "your task configuration is wrong", so we key off the description and
+// give each its own remedy. Matching the demo phrasing loosely is a bug: a
+// bare /test/ matches the "test" inside "latest".
+const CAPSOLVER_TASK_CONFIG_RE = /invalid input|check captcha type|wrong captcha type/i;
+const CAPSOLVER_DEMO_KEY_RE = /\btest\s*(?:site\s*)?key\b|\bdemo\b|unsupported|don['’]?t[\s_]support|not[\s_]support/i;
+
 function capsolverError(prefix, body) {
   const desc = body.errorDescription || body.errorCode || 'unknown error';
-  const code = String(body.errorCode || '');
-  const looksLikeDemoRejection =
-    (code === 'ERROR_WRONG_CAPTCHA_TYPE' ||
-    code === 'ERROR_INVALID_TASK_DATA' ||
-    /don['’]?t support|not support|unsupported/i.test(desc)) &&
-    !/invalid input|check captcha type/i.test(desc) &&
-    /test|demo|unsupported|don['’]?t support|not support/i.test(desc);
-  if (looksLikeDemoRejection) {
+  if (CAPSOLVER_TASK_CONFIG_RE.test(desc)) {
+    return new Error(
+      `${prefix}: ${desc}. CapSolver rejected the task configuration, not the sitekey — most often the task type doesn't match the widget (a plain reCAPTCHA task against an Enterprise sitekey, or a v2 task against a v3 key). Re-check the detected type and pass \`type\` / \`isEnterprise\` explicitly.`
+    );
+  }
+  if (CAPSOLVER_DEMO_KEY_RE.test(desc)) {
     return new Error(
       `${prefix}: ${desc}. This usually means CapSolver refused the sitekey — most often because it is a public TEST/DEMO key (Google's recaptcha demo, hcaptcha.com/demo, etc.) that no captcha-solving service will farm. Try the same flow on a real production site.`
     );
@@ -86,10 +87,36 @@ async function pollTaskResult(apiKey, taskId, { timeoutMs = POLL_TIMEOUT_MS } = 
   throw new Error(`CapSolver: timed out after ${Math.round(timeoutMs / 1000)}s waiting for solution.`);
 }
 
+// We default to the "proxyless" task types so the user doesn't need to BYO
+// proxy. `enterprisePayload` is accepted but deliberately absent from the
+// solve_captcha schema (same as on the hCaptcha branch): it carries the
+// site-specific `s` token some Enterprise deployments require, which a model
+// has no way to obtain from the page.
+
+// Type aliases the model or the detector may hand us. Kept as sets rather
+// than inline `||` chains so buildTask and captchaParamError below can't
+// drift apart on which spellings count as v3.
+const RECAPTCHA_V2_TYPES = new Set(['recaptcha_v2', 'recaptchav2', 'recaptcha_v2_enterprise', 'recaptcha_enterprise']);
+const RECAPTCHA_V3_TYPES = new Set(['recaptcha_v3', 'recaptchav3', 'recaptcha_v3_enterprise']);
+
+// Validate the params CapSolver would reject before we spend a request on
+// them. Exported so agent.js can run it *before* it flags the tool call as
+// dispatched — a missing pageAction is a local argument error, not an
+// external side effect. Returns an error string, or null when the params
+// are usable.
+export function captchaParamError(params) {
+  const t = String(params?.type || '').toLowerCase();
+  if (!t) return 'solve_captcha: type is required.';
+  if (RECAPTCHA_V3_TYPES.has(t) && !(params.pageAction || params.action)) {
+    return `solve_captcha: ${params.type} requires a \`pageAction\` (e.g. "login", "submit"). reCAPTCHA v3 scores the action name, so CapSolver cannot mint a usable token without it — pass \`pageAction\` explicitly.`;
+  }
+  return null;
+}
+
 function buildTask({ type, websiteURL, websiteKey, ...rest }) {
   const t = String(type || '').toLowerCase();
   const isEnterprise = !!rest.isEnterprise || t.includes('enterprise');
-  if (t === 'recaptcha_v2' || t === 'recaptchav2' || t === 'recaptcha_v2_enterprise' || t === 'recaptcha_enterprise') {
+  if (RECAPTCHA_V2_TYPES.has(t)) {
     return {
       type: isEnterprise ? 'ReCaptchaV2EnterpriseTaskProxyLess' : 'ReCaptchaV2TaskProxyLess',
       websiteURL,
@@ -99,11 +126,8 @@ function buildTask({ type, websiteURL, websiteKey, ...rest }) {
       ...(rest.userAgent ? { userAgent: rest.userAgent } : {}),
     };
   }
-  if (t === 'recaptcha_v3' || t === 'recaptchav3' || t === 'recaptcha_v3_enterprise') {
+  if (RECAPTCHA_V3_TYPES.has(t)) {
     const pageAction = rest.pageAction || rest.action;
-    if (!pageAction) {
-      throw new Error(`solve_captcha: ${type} requires a pageAction (e.g. "login", "submit").`);
-    }
     return {
       type: isEnterprise ? 'ReCaptchaV3EnterpriseTaskProxyLess' : 'ReCaptchaV3TaskProxyLess',
       websiteURL,
@@ -144,7 +168,9 @@ function buildTask({ type, websiteURL, websiteKey, ...rest }) {
 
 function solutionFor(type, solution) {
   const t = String(type || '').toLowerCase();
-  if (t.startsWith('recaptcha') || t === 'recaptcha_v2' || t === 'recaptchav2' || t === 'recaptcha_v3' || t === 'recaptchav3') {
+  // Covers every reCAPTCHA spelling — v2/v3, snake or camel, Enterprise or
+  // not. They all return the token under the same solution key.
+  if (t.startsWith('recaptcha')) {
     return { token: solution.gRecaptchaResponse, fieldName: 'g-recaptcha-response' };
   }
   if (t === 'hcaptcha') {
@@ -161,7 +187,8 @@ function solutionFor(type, solution) {
 
 export async function solveCaptcha(apiKey, params) {
   if (!apiKey) throw new Error('No CapSolver API key configured.');
-  if (!params?.type) throw new Error('solve_captcha: type is required.');
+  const paramError = captchaParamError(params);
+  if (paramError) throw new Error(paramError);
   const task = buildTask(params);
   const taskId = await createTask(apiKey, task);
   const solution = await pollTaskResult(apiKey, taskId);
@@ -172,11 +199,28 @@ export async function solveCaptcha(apiKey, params) {
 // ─── Page-side helpers (Firefox MV2 executeScript with code string) ──
 
 const DETECT_CODE = `(() => {
+  const V3_NO_ACTION_NOTE = 'reCAPTCHA v3 detected, but the page never exposed an action name. solve_captcha needs pageAction — read it from the grecaptcha.execute(...) call in the site JS, or infer it from the form (login, submit, checkout).';
+
+  // reCAPTCHA v3 puts the action name in the loader script's query string.
+  // Parse it with URL so percent-encoded action names come back decoded.
+  const getUrlAction = (urlStr) => {
+    try {
+      const u = new URL(urlStr, 'https://dummy.host');
+      const act = u.searchParams.get('action') || u.searchParams.get('pageAction') || u.searchParams.get('page_action');
+      return act ? act.trim() : null;
+    } catch (_) {}
+    return null;
+  };
+
   const docs = [document];
   for (const f of document.querySelectorAll('iframe')) {
-    try { if (f.contentDocument) docs.push(f.contentDocument); } catch {}
+    try { if (f.contentDocument) docs.push(f.contentDocument); } catch (_) {}
   }
   for (const d of docs) {
+    // Order matters: check provider-specific widgets BEFORE the generic
+    // reCAPTCHA fallback. Turnstile and hCaptcha widgets carry data-sitekey
+    // too, and an earlier version of this code misclassified them as
+    // reCAPTCHA → CapSolver got the wrong task type and failed.
     const hcap = d.querySelector('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]');
     if (hcap) {
       const sitekey = hcap.getAttribute('data-sitekey') || hcap.getAttribute('data-hcaptcha-sitekey');
@@ -190,6 +234,9 @@ const DETECT_CODE = `(() => {
       const sitekey = turn.getAttribute('data-sitekey') || turn.getAttribute('data-turnstile-sitekey');
       if (sitekey) return { type: 'turnstile', websiteKey: sitekey };
     }
+    // reCAPTCHA v2/v3, classic or Enterprise. Both selectors are
+    // reCAPTCHA-specific, so this still doesn't grab a bare data-sitekey
+    // belonging to another provider.
     const recap = d.querySelector('.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey], [data-recaptcha-sitekey]');
     if (recap) {
       const sitekey = recap.getAttribute('data-sitekey') || recap.getAttribute('data-recaptcha-sitekey');
@@ -197,20 +244,48 @@ const DETECT_CODE = `(() => {
         const size = recap.getAttribute('data-size');
         const isInvisible = size === 'invisible';
         const action = recap.getAttribute('data-action') || recap.getAttribute('data-recaptcha-action') || null;
-        const hasClassicScript = d.querySelector('script[src*="recaptcha/api.js"]') != null;
-        const hasEnterpriseScript = d.querySelector('script[src*="recaptcha/enterprise"]') != null;
+        // Script tags decide both version and edition. Look in the parent
+        // document too: when the widget lives in a same-origin iframe the
+        // loader tag usually stays in the top document.
+        const scriptSrcs = [];
+        for (const doc of (d === document ? [d] : [d, document])) {
+          for (const s of doc.querySelectorAll('script[src]')) {
+            try { if (s.src) scriptSrcs.push(s.src); } catch (_) {}
+          }
+        }
+        const hasClassicScript = scriptSrcs.some(s => s.includes('recaptcha/api.js'));
+        const hasEnterpriseScript = scriptSrcs.some(s => s.includes('recaptcha/enterprise'));
+        // data-enterprise / data-sitekey-type aren't Google attributes — they
+        // are wrapper-library conventions (django-recaptcha, some Rails and
+        // Vue helpers). Cheap to check, so we take them as hints before
+        // falling back to which loader script the page pulled in.
         const isEnterprise = recap.getAttribute('data-enterprise') === 'true' ||
           recap.getAttribute('data-sitekey-type') === 'enterprise' ||
           recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
           (!hasClassicScript && hasEnterpriseScript);
+        // Version, in order of reliability:
+        //   1. an explicit wrapper-set data-version / .g-recaptcha-v3 marker
+        //   2. a render=<sitekey> loader script — the v3 signature; v2 loads
+        //      the script bare or with render=explicit
+        //   3. data-action with no data-size=invisible
+        // (3) alone is not enough in either direction: v2 invisible widgets
+        // carry data-action too, and some v3 wrappers copy data-size onto
+        // their host div. Without (2) both of those land on the wrong task
+        // type and CapSolver rejects the key.
         const version = recap.getAttribute('data-version') || (recap.classList.contains('g-recaptcha-v3') ? 'v3' : null);
-        const isV3 = version === 'v3' || (!!action && !isInvisible);
+        const renderScript = scriptSrcs.find(s =>
+          /recaptcha\\/(api|enterprise)\\.js/i.test(s) && s.includes('render=' + sitekey)) || null;
+        const isV3 = version === 'v3' || !!renderScript || (!!action && !isInvisible);
+        // v3 needs an action name to solve. Fall back to the loader script's
+        // ?action= when the host element doesn't carry one, and say so
+        // explicitly when neither does — solve_captcha refuses v3 without it.
+        const pageAction = action || (isV3 && renderScript ? getUrlAction(renderScript) : null);
         return {
           type: isV3 ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
           websiteKey: sitekey,
           isInvisible,
           isEnterprise,
-          ...(action ? { pageAction: action } : {}),
+          ...(pageAction ? { pageAction } : (isV3 ? { note: V3_NO_ACTION_NOTE } : {})),
         };
       }
     }
@@ -219,14 +294,30 @@ const DETECT_CODE = `(() => {
       return { type: 'turnstile_challenge', websiteKey: null, note: 'Cloudflare interstitial detected but no sitekey was exposed in the DOM. Pass websiteKey explicitly if you have it.' };
     }
   }
-  const getUrlAction = (urlStr) => {
-    try {
-      const u = new URL(urlStr, 'https://dummy.host');
-      const act = u.searchParams.get('action') || u.searchParams.get('pageAction') || u.searchParams.get('page_action');
-      return act ? act.trim() : null;
-    } catch (_) {}
+  // URL-string fallback — see chrome/captcha-solver.js for the full
+  // rationale. Scrapes the sitekey out of iframe.src / script.src when the
+  // widget never exposed it on a host element (hcaptcha.com/demo, some SPA
+  // mounts). Both are readable cross-origin from the parent page.
+
+  // hCaptcha and Turnstile expose the same ?sitekey= in either tag, so one
+  // matcher serves both passes below.
+  const nonRecaptchaFromUrl = (url) => {
+    if (/hcaptcha\\.com/i.test(url)) {
+      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
+      if (m) return { type: 'hcaptcha', websiteKey: m[1], detectedVia: 'url' };
+    }
+    if (/challenges\\.cloudflare\\.com\\/turnstile/i.test(url)) {
+      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
+      if (m) return { type: 'turnstile', websiteKey: m[1], detectedVia: 'url' };
+    }
     return null;
   };
+
+  // Split by tag type because reCAPTCHA needs both halves to classify a
+  // widget: the anchor iframe carries the sitekey, the loader script carries
+  // the version and action. Iframes are scanned first — a rendered anchor
+  // frame is a stronger signal that the widget is actually on this page than
+  // a script tag, which may just be a loader the page never used.
   const iframeUrls = [];
   const scriptUrls = [];
   for (const el of document.querySelectorAll('iframe[src], script[src]')) {
@@ -238,20 +329,17 @@ const DETECT_CODE = `(() => {
     } catch (_) {}
   }
   for (const url of iframeUrls) {
-    if (/hcaptcha\\.com/i.test(url)) {
-      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) return { type: 'hcaptcha', websiteKey: m[1], detectedVia: 'url' };
-    }
-    if (/challenges\\.cloudflare\\.com\\/turnstile/i.test(url)) {
-      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) return { type: 'turnstile', websiteKey: m[1], detectedVia: 'url' };
-    }
+    const other = nonRecaptchaFromUrl(url);
+    if (other) return other;
     if (/recaptcha\\/(api2|enterprise)\\/anchor/i.test(url)) {
       const m = url.match(/[?&#]k=([a-zA-Z0-9_-]{6,})/);
       if (m) {
         const sitekey = m[1];
         const isEnterprise = /recaptcha\\/enterprise/i.test(url);
         const isInvisible = /[?&#]size=invisible/i.test(url);
+        // v3 renders an anchor frame too (the badge), and it always carries
+        // size=invisible — so the frame alone can't tell v3 from an invisible
+        // v2. A loader script rendering this exact sitekey settles it.
         const matchingV3Script = scriptUrls.find(s => s.includes('render=' + sitekey));
         if (matchingV3Script) {
           const pageAction = getUrlAction(matchingV3Script);
@@ -259,7 +347,7 @@ const DETECT_CODE = `(() => {
             type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
             websiteKey: sitekey,
             isEnterprise,
-            ...(pageAction ? { pageAction } : {}),
+            ...(pageAction ? { pageAction } : { note: V3_NO_ACTION_NOTE }),
             detectedVia: 'url',
           };
         }
@@ -274,16 +362,12 @@ const DETECT_CODE = `(() => {
     }
   }
   for (const url of scriptUrls) {
-    if (/hcaptcha\\.com/i.test(url)) {
-      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) return { type: 'hcaptcha', websiteKey: m[1], detectedVia: 'url' };
-    }
-    if (/challenges\\.cloudflare\\.com\\/turnstile/i.test(url)) {
-      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) return { type: 'turnstile', websiteKey: m[1], detectedVia: 'url' };
-    }
+    const other = nonRecaptchaFromUrl(url);
+    if (other) return other;
     if (/recaptcha\\/(api\\.js|enterprise\\.js)/i.test(url)) {
       const m = url.match(/[?&#]render=([a-zA-Z0-9_-]{6,})/);
+      // render=explicit means the page renders a v2 widget by hand later —
+      // it is not a sitekey.
       if (m && m[1] !== 'explicit') {
         const isEnterprise = /enterprise/i.test(url);
         const pageAction = getUrlAction(url);
@@ -291,9 +375,8 @@ const DETECT_CODE = `(() => {
           type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
           websiteKey: m[1],
           isEnterprise,
-          ...(pageAction ? { pageAction } : {}),
+          ...(pageAction ? { pageAction } : { note: V3_NO_ACTION_NOTE }),
           detectedVia: 'url',
-          note: !pageAction ? 'reCAPTCHA v3 detected via script render tag without pageAction. Pass pageAction explicitly if the target site validates specific action names.' : undefined,
         };
       }
     }

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -217,11 +217,17 @@ const DETECT_CODE = `(() => {
       return { type: 'turnstile_challenge', websiteKey: null, note: 'Cloudflare interstitial detected but no sitekey was exposed in the DOM. Pass websiteKey explicitly if you have it.' };
     }
   }
-  const urlCandidates = [];
+  const iframeUrls = [];
+  const scriptUrls = [];
   for (const el of document.querySelectorAll('iframe[src], script[src]')) {
-    try { if (el.src) urlCandidates.push(el.src); } catch (_) {}
+    try {
+      if (el.src) {
+        if (el.tagName.toLowerCase() === 'iframe') iframeUrls.push(el.src);
+        else scriptUrls.push(el.src);
+      }
+    } catch (_) {}
   }
-  for (const url of urlCandidates) {
+  for (const url of iframeUrls) {
     if (/hcaptcha\\.com/i.test(url)) {
       const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
       if (m) return { type: 'hcaptcha', websiteKey: m[1], detectedVia: 'url' };
@@ -243,6 +249,16 @@ const DETECT_CODE = `(() => {
           detectedVia: 'url',
         };
       }
+    }
+  }
+  for (const url of scriptUrls) {
+    if (/hcaptcha\\.com/i.test(url)) {
+      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
+      if (m) return { type: 'hcaptcha', websiteKey: m[1], detectedVia: 'url' };
+    }
+    if (/challenges\\.cloudflare\\.com\\/turnstile/i.test(url)) {
+      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
+      if (m) return { type: 'turnstile', websiteKey: m[1], detectedVia: 'url' };
     }
     if (/recaptcha\\/(api\\.js|enterprise\\.js)/i.test(url)) {
       const m = url.match(/[?&#]render=([a-zA-Z0-9_-]{6,})/);

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -202,7 +202,7 @@ const DETECT_CODE = `(() => {
           recap.getAttribute('data-sitekey-type') === 'enterprise' ||
           recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
           d.querySelector('script[src*="recaptcha/enterprise"]') != null;
-        const isV3 = version === 'v3';
+        const isV3 = version === 'v3' || (!!action && !isInvisible);
         return {
           type: isV3 ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
           websiteKey: sitekey,

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -192,10 +192,11 @@ const DETECT_CODE = `(() => {
       if (sitekey) {
         const size = recap.getAttribute('data-size');
         const isInvisible = size === 'invisible';
-        const action = recap.getAttribute('data-action') || null;
+        const action = recap.getAttribute('data-action') || d.querySelector('[data-action]')?.getAttribute('data-action') || null;
         const isEnterprise = recap.getAttribute('data-enterprise') === 'true' ||
           recap.getAttribute('data-sitekey-type') === 'enterprise' ||
-          recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null;
+          recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
+          d.querySelector('script[src*="recaptcha/enterprise"]') != null;
         return {
           type: action ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
           websiteKey: sitekey,
@@ -241,11 +242,15 @@ const DETECT_CODE = `(() => {
       const m = url.match(/[?&#]render=([a-zA-Z0-9_-]{6,})/);
       if (m && m[1] !== 'explicit') {
         const isEnterprise = /enterprise/i.test(url);
+        const actionMatch = url.match(/[?&#](action|pageAction)=([a-zA-Z0-9_-]+)/i);
+        const pageAction = actionMatch ? actionMatch[2] : (document.querySelector('[data-action]')?.getAttribute('data-action') || null);
         return {
           type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
           websiteKey: m[1],
           isEnterprise,
+          ...(pageAction ? { pageAction } : {}),
           detectedVia: 'url',
+          note: !pageAction ? 'reCAPTCHA v3 detected via script render tag without pageAction. Pass pageAction explicitly if the target site validates specific action names.' : undefined,
         };
       }
     }

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -197,11 +197,13 @@ const DETECT_CODE = `(() => {
         const size = recap.getAttribute('data-size');
         const isInvisible = size === 'invisible';
         const action = recap.getAttribute('data-action') || recap.getAttribute('data-recaptcha-action') || null;
-        const version = recap.getAttribute('data-version') || (recap.classList.contains('g-recaptcha-v3') ? 'v3' : null);
+        const hasClassicScript = d.querySelector('script[src*="recaptcha/api.js"]') != null;
+        const hasEnterpriseScript = d.querySelector('script[src*="recaptcha/enterprise"]') != null;
         const isEnterprise = recap.getAttribute('data-enterprise') === 'true' ||
           recap.getAttribute('data-sitekey-type') === 'enterprise' ||
           recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
-          d.querySelector('script[src*="recaptcha/enterprise"]') != null;
+          (!hasClassicScript && hasEnterpriseScript);
+        const version = recap.getAttribute('data-version') || (recap.classList.contains('g-recaptcha-v3') ? 'v3' : null);
         const isV3 = version === 'v3' || (!!action && !isInvisible);
         return {
           type: isV3 ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
@@ -239,11 +241,24 @@ const DETECT_CODE = `(() => {
     if (/recaptcha\\/(api2|enterprise)\\/anchor/i.test(url)) {
       const m = url.match(/[?&#]k=([a-zA-Z0-9_-]{6,})/);
       if (m) {
+        const sitekey = m[1];
         const isEnterprise = /recaptcha\\/enterprise/i.test(url);
         const isInvisible = /[?&#]size=invisible/i.test(url);
+        const matchingV3Script = scriptUrls.find(s => s.includes('render=' + sitekey));
+        if (matchingV3Script) {
+          const actionMatch = matchingV3Script.match(/[?&#](action|pageAction)=([a-zA-Z0-9_-]+)/i);
+          const pageAction = actionMatch ? actionMatch[2] : null;
+          return {
+            type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
+            websiteKey: sitekey,
+            isEnterprise,
+            ...(pageAction ? { pageAction } : {}),
+            detectedVia: 'url',
+          };
+        }
         return {
           type: isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2',
-          websiteKey: m[1],
+          websiteKey: sitekey,
           isInvisible,
           isEnterprise,
           detectedVia: 'url',

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -192,7 +192,7 @@ const DETECT_CODE = `(() => {
       if (sitekey) {
         const size = recap.getAttribute('data-size');
         const isInvisible = size === 'invisible';
-        const action = recap.getAttribute('data-action') || d.querySelector('[data-action]')?.getAttribute('data-action') || null;
+        const action = recap.getAttribute('data-action') || recap.getAttribute('data-recaptcha-action') || null;
         const isEnterprise = recap.getAttribute('data-enterprise') === 'true' ||
           recap.getAttribute('data-sitekey-type') === 'enterprise' ||
           recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
@@ -243,7 +243,7 @@ const DETECT_CODE = `(() => {
       if (m && m[1] !== 'explicit') {
         const isEnterprise = /enterprise/i.test(url);
         const actionMatch = url.match(/[?&#](action|pageAction)=([a-zA-Z0-9_-]+)/i);
-        const pageAction = actionMatch ? actionMatch[2] : (document.querySelector('[data-action]')?.getAttribute('data-action') || null);
+        const pageAction = actionMatch ? actionMatch[2] : null;
         return {
           type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
           websiteKey: m[1],

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -40,9 +40,11 @@ function capsolverError(prefix, body) {
   const desc = body.errorDescription || body.errorCode || 'unknown error';
   const code = String(body.errorCode || '');
   const looksLikeDemoRejection =
-    code === 'ERROR_WRONG_CAPTCHA_TYPE' ||
+    (code === 'ERROR_WRONG_CAPTCHA_TYPE' ||
     code === 'ERROR_INVALID_TASK_DATA' ||
-    /don['’]?t support|not support|unsupported/i.test(desc);
+    /don['’]?t support|not support|unsupported/i.test(desc)) &&
+    !/invalid input|check captcha type/i.test(desc) &&
+    /test|demo|unsupported|don['’]?t support|not support/i.test(desc);
   if (looksLikeDemoRejection) {
     return new Error(
       `${prefix}: ${desc}. This usually means CapSolver refused the sitekey — most often because it is a public TEST/DEMO key (Google's recaptcha demo, hcaptcha.com/demo, etc.) that no captcha-solving service will farm. Try the same flow on a real production site.`
@@ -86,22 +88,25 @@ async function pollTaskResult(apiKey, taskId, { timeoutMs = POLL_TIMEOUT_MS } = 
 
 function buildTask({ type, websiteURL, websiteKey, ...rest }) {
   const t = String(type || '').toLowerCase();
-  if (t === 'recaptcha_v2' || t === 'recaptchav2') {
+  const isEnterprise = !!rest.isEnterprise || t.includes('enterprise');
+  if (t === 'recaptcha_v2' || t === 'recaptchav2' || t === 'recaptcha_v2_enterprise' || t === 'recaptcha_enterprise') {
     return {
-      type: 'ReCaptchaV2TaskProxyLess',
+      type: isEnterprise ? 'ReCaptchaV2EnterpriseTaskProxyLess' : 'ReCaptchaV2TaskProxyLess',
       websiteURL,
       websiteKey,
       ...(rest.isInvisible != null ? { isInvisible: !!rest.isInvisible } : {}),
+      ...(rest.enterprisePayload ? { enterprisePayload: rest.enterprisePayload } : {}),
       ...(rest.userAgent ? { userAgent: rest.userAgent } : {}),
     };
   }
-  if (t === 'recaptcha_v3' || t === 'recaptchav3') {
+  if (t === 'recaptcha_v3' || t === 'recaptchav3' || t === 'recaptcha_v3_enterprise') {
     return {
-      type: 'ReCaptchaV3TaskProxyLess',
+      type: isEnterprise ? 'ReCaptchaV3EnterpriseTaskProxyLess' : 'ReCaptchaV3TaskProxyLess',
       websiteURL,
       websiteKey,
       pageAction: rest.pageAction || rest.action || 'verify',
       ...(rest.minScore ? { minScore: rest.minScore } : {}),
+      ...(rest.enterprisePayload ? { enterprisePayload: rest.enterprisePayload } : {}),
     };
   }
   if (t === 'hcaptcha') {
@@ -135,7 +140,7 @@ function buildTask({ type, websiteURL, websiteKey, ...rest }) {
 
 function solutionFor(type, solution) {
   const t = String(type || '').toLowerCase();
-  if (t === 'recaptcha_v2' || t === 'recaptchav2' || t === 'recaptcha_v3' || t === 'recaptchav3') {
+  if (t.startsWith('recaptcha') || t === 'recaptcha_v2' || t === 'recaptchav2' || t === 'recaptcha_v3' || t === 'recaptchav3') {
     return { token: solution.gRecaptchaResponse, fieldName: 'g-recaptcha-response' };
   }
   if (t === 'hcaptcha') {
@@ -168,9 +173,6 @@ const DETECT_CODE = `(() => {
     try { if (f.contentDocument) docs.push(f.contentDocument); } catch {}
   }
   for (const d of docs) {
-    // Provider-specific widgets are checked BEFORE the generic reCAPTCHA
-    // fallback so a Turnstile/hCaptcha widget with data-sitekey + data-callback
-    // doesn't get misclassified as reCAPTCHA.
     const hcap = d.querySelector('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]');
     if (hcap) {
       const sitekey = hcap.getAttribute('data-sitekey') || hcap.getAttribute('data-hcaptcha-sitekey');
@@ -184,16 +186,19 @@ const DETECT_CODE = `(() => {
       const sitekey = turn.getAttribute('data-sitekey') || turn.getAttribute('data-turnstile-sitekey');
       if (sitekey) return { type: 'turnstile', websiteKey: sitekey };
     }
-    const recap = d.querySelector('.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey]');
+    const recap = d.querySelector('.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey], [data-recaptcha-sitekey]');
     if (recap) {
-      const sitekey = recap.getAttribute('data-sitekey');
+      const sitekey = recap.getAttribute('data-sitekey') || recap.getAttribute('data-recaptcha-sitekey');
       if (sitekey) {
         const size = recap.getAttribute('data-size');
+        const isInvisible = size === 'invisible';
         const action = recap.getAttribute('data-action') || null;
+        const isEnterprise = recap.getAttribute('data-enterprise') === 'true' || d.querySelector('script[src*="recaptcha/enterprise"]') != null;
         return {
-          type: action ? 'recaptcha_v3' : 'recaptcha_v2',
+          type: action ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
           websiteKey: sitekey,
-          isInvisible: size === 'invisible',
+          isInvisible,
+          isEnterprise,
           ...(action ? { pageAction: action } : {}),
         };
       }
@@ -203,10 +208,6 @@ const DETECT_CODE = `(() => {
       return { type: 'turnstile_challenge', websiteKey: null, note: 'Cloudflare interstitial detected but no sitekey was exposed in the DOM. Pass websiteKey explicitly if you have it.' };
     }
   }
-  // URL-string fallback — see chrome/captcha-solver.js for the full
-  // rationale. Scrapes the sitekey out of iframe.src / script.src URLs
-  // when the widget did not expose it on a host element in the main DOM
-  // (e.g. hcaptcha.com/demo, some SPA mounts).
   const urlCandidates = [];
   for (const el of document.querySelectorAll('iframe[src], script[src]')) {
     try { if (el.src) urlCandidates.push(el.src); } catch (_) {}
@@ -222,7 +223,29 @@ const DETECT_CODE = `(() => {
     }
     if (/recaptcha\\/(api2|enterprise)\\/anchor/i.test(url)) {
       const m = url.match(/[?&#]k=([a-zA-Z0-9_-]{6,})/);
-      if (m) return { type: 'recaptcha_v2', websiteKey: m[1], detectedVia: 'url' };
+      if (m) {
+        const isEnterprise = /recaptcha\\/enterprise/i.test(url);
+        const isInvisible = /[?&#]size=invisible/i.test(url);
+        return {
+          type: isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2',
+          websiteKey: m[1],
+          isInvisible,
+          isEnterprise,
+          detectedVia: 'url',
+        };
+      }
+    }
+    if (/recaptcha\\/(api\\.js|enterprise\\.js)/i.test(url)) {
+      const m = url.match(/[?&#]render=([a-zA-Z0-9_-]{6,})/);
+      if (m && m[1] !== 'explicit') {
+        const isEnterprise = /enterprise/i.test(url);
+        return {
+          type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
+          websiteKey: m[1],
+          isEnterprise,
+          detectedVia: 'url',
+        };
+      }
     }
   }
   return null;

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -100,11 +100,15 @@ function buildTask({ type, websiteURL, websiteKey, ...rest }) {
     };
   }
   if (t === 'recaptcha_v3' || t === 'recaptchav3' || t === 'recaptcha_v3_enterprise') {
+    const pageAction = rest.pageAction || rest.action;
+    if (!pageAction) {
+      throw new Error(`solve_captcha: ${type} requires a pageAction (e.g. "login", "submit").`);
+    }
     return {
       type: isEnterprise ? 'ReCaptchaV3EnterpriseTaskProxyLess' : 'ReCaptchaV3TaskProxyLess',
       websiteURL,
       websiteKey,
-      pageAction: rest.pageAction || rest.action || 'verify',
+      pageAction,
       ...(rest.minScore ? { minScore: rest.minScore } : {}),
       ...(rest.enterprisePayload ? { enterprisePayload: rest.enterprisePayload } : {}),
     };
@@ -193,12 +197,14 @@ const DETECT_CODE = `(() => {
         const size = recap.getAttribute('data-size');
         const isInvisible = size === 'invisible';
         const action = recap.getAttribute('data-action') || recap.getAttribute('data-recaptcha-action') || null;
+        const version = recap.getAttribute('data-version') || (recap.classList.contains('g-recaptcha-v3') ? 'v3' : null);
         const isEnterprise = recap.getAttribute('data-enterprise') === 'true' ||
           recap.getAttribute('data-sitekey-type') === 'enterprise' ||
           recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
           d.querySelector('script[src*="recaptcha/enterprise"]') != null;
+        const isV3 = version === 'v3';
         return {
-          type: action ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
+          type: isV3 ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
           websiteKey: sitekey,
           isInvisible,
           isEnterprise,

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -219,6 +219,14 @@ const DETECT_CODE = `(() => {
       return { type: 'turnstile_challenge', websiteKey: null, note: 'Cloudflare interstitial detected but no sitekey was exposed in the DOM. Pass websiteKey explicitly if you have it.' };
     }
   }
+  const getUrlAction = (urlStr) => {
+    try {
+      const u = new URL(urlStr, 'https://dummy.host');
+      const act = u.searchParams.get('action') || u.searchParams.get('pageAction') || u.searchParams.get('page_action');
+      return act ? act.trim() : null;
+    } catch (_) {}
+    return null;
+  };
   const iframeUrls = [];
   const scriptUrls = [];
   for (const el of document.querySelectorAll('iframe[src], script[src]')) {
@@ -246,8 +254,7 @@ const DETECT_CODE = `(() => {
         const isInvisible = /[?&#]size=invisible/i.test(url);
         const matchingV3Script = scriptUrls.find(s => s.includes('render=' + sitekey));
         if (matchingV3Script) {
-          const actionMatch = matchingV3Script.match(/[?&#](action|pageAction)=([a-zA-Z0-9_-]+)/i);
-          const pageAction = actionMatch ? actionMatch[2] : null;
+          const pageAction = getUrlAction(matchingV3Script);
           return {
             type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
             websiteKey: sitekey,
@@ -279,8 +286,7 @@ const DETECT_CODE = `(() => {
       const m = url.match(/[?&#]render=([a-zA-Z0-9_-]{6,})/);
       if (m && m[1] !== 'explicit') {
         const isEnterprise = /enterprise/i.test(url);
-        const actionMatch = url.match(/[?&#](action|pageAction)=([a-zA-Z0-9_-]+)/i);
-        const pageAction = actionMatch ? actionMatch[2] : null;
+        const pageAction = getUrlAction(url);
         return {
           type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
           websiteKey: m[1],

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -193,7 +193,9 @@ const DETECT_CODE = `(() => {
         const size = recap.getAttribute('data-size');
         const isInvisible = size === 'invisible';
         const action = recap.getAttribute('data-action') || null;
-        const isEnterprise = recap.getAttribute('data-enterprise') === 'true' || d.querySelector('script[src*="recaptcha/enterprise"]') != null;
+        const isEnterprise = recap.getAttribute('data-enterprise') === 'true' ||
+          recap.getAttribute('data-sitekey-type') === 'enterprise' ||
+          recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null;
         return {
           type: action ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
           websiteKey: sitekey,

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -911,11 +911,12 @@ export const AGENT_TOOLS = [
         properties: {
           type: {
             type: 'string',
-            enum: ['recaptcha_v2', 'recaptcha_v3', 'hcaptcha', 'turnstile', 'image_to_text'],
+            enum: ['recaptcha_v2', 'recaptcha_v3', 'recaptcha_v2_enterprise', 'recaptcha_v3_enterprise', 'hcaptcha', 'turnstile', 'image_to_text'],
             description: 'CAPTCHA type. Omit to auto-detect from the page DOM.',
           },
           websiteKey: { type: 'string', description: 'Site key from the captcha widget\'s data-sitekey attribute. Auto-detected when omitted.' },
           isInvisible: { type: 'boolean', description: 'reCAPTCHA v2 / hCaptcha only — true when the widget uses invisible mode (no visible checkbox). Auto-detected when omitted.' },
+          isEnterprise: { type: 'boolean', description: 'reCAPTCHA v2/v3 only — true when the widget uses Google reCAPTCHA Enterprise. Auto-detected when omitted.' },
           pageAction: { type: 'string', description: 'reCAPTCHA v3 only — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action when present.' },
           minScore: { type: 'number', description: 'reCAPTCHA v3 only — minimum score requested (0.3 is the usual lower bound, 0.7+ is hard).' },
           imageBase64: { type: 'string', description: 'image_to_text only — base64-encoded image bytes (no data: prefix).' },

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -917,7 +917,7 @@ export const AGENT_TOOLS = [
           websiteKey: { type: 'string', description: 'Site key from the captcha widget\'s data-sitekey attribute. Auto-detected when omitted.' },
           isInvisible: { type: 'boolean', description: 'reCAPTCHA v2 / hCaptcha only — true when the widget uses invisible mode (no visible checkbox). Auto-detected when omitted.' },
           isEnterprise: { type: 'boolean', description: 'reCAPTCHA v2/v3 only — true when the widget uses Google reCAPTCHA Enterprise. Auto-detected when omitted.' },
-          pageAction: { type: 'string', description: 'reCAPTCHA v3 only — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action when present.' },
+          pageAction: { type: 'string', description: 'Required for reCAPTCHA v3 — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action or the loader script when present; pass it explicitly if detection reports it missing.' },
           minScore: { type: 'number', description: 'reCAPTCHA v3 only — minimum score requested (0.3 is the usual lower bound, 0.7+ is hard).' },
           imageBase64: { type: 'string', description: 'image_to_text only — base64-encoded image bytes (no data: prefix).' },
           inject: { type: 'boolean', description: 'After solving, inject the token into the page\'s response field (textarea[name=g-recaptcha-response] etc.) and fire the widget\'s callback. Default true. Set false to get just the token back.' },

--- a/test/run.js
+++ b/test/run.js
@@ -50292,4 +50292,270 @@ test('linkedin shadow-dom reachability: pierce, overlay hoist, placeholder match
   }
 });
 
+// ─── CapSolver captcha detection ───────────────────────────────────────
+//
+// The detector runs in the page world, so it can only be exercised against a
+// DOM. This stub implements the slice of the DOM API detectCaptchaInPage /
+// DETECT_CODE actually use: querySelector(All) over a flat node list with
+// tag, class and attribute selectors ([attr], [attr="v"], [attr^="v"],
+// [attr*="v"]). Both builds are driven through their real public export —
+// detectCaptcha() — with the extension API stubbed, so the Firefox code
+// string is parsed and run exactly as the browser would.
+
+function captchaEl(tag, attrs = {}, children = []) {
+  const el = {
+    tagName: tag.toUpperCase(),
+    children,
+    src: attrs.src,
+    classList: { contains: (c) => String(attrs.class || '').split(/\s+/).includes(c) },
+    getAttribute: (n) => (n in attrs ? attrs[n] : null),
+    querySelector: (sel) => captchaMatchAll(children, sel)[0] || null,
+    querySelectorAll: (sel) => captchaMatchAll(children, sel),
+  };
+  return el;
+}
+
+function captchaMatchAll(roots, selectorList) {
+  const flat = [];
+  (function walk(nodes) {
+    for (const n of nodes) { flat.push(n); walk(n.children || []); }
+  })(roots);
+  const selectors = String(selectorList).split(',').map(s => s.trim()).filter(Boolean);
+  const matchesOne = (el, sel) => {
+    // Tokenize into tag / .class / [attr…] parts. Splitting naively on "."
+    // would break selectors like script[src*="recaptcha/api.js"].
+    const parts = sel.match(/\[[^\]]*\]|\.[\w-]+|^[a-zA-Z][\w-]*/g) || [];
+    for (const part of parts) {
+      if (part.startsWith('.')) {
+        if (!el.classList.contains(part.slice(1))) return false;
+      } else if (part.startsWith('[')) {
+        const m = part.match(/^\[([\w-]+)(?:([\^*$]?)=["']([^"']*)["'])?\]$/);
+        if (!m) return false;
+        const value = el.getAttribute(m[1]);
+        if (value == null) return false;
+        if (m[3] != null) {
+          if (m[2] === '^' && !value.startsWith(m[3])) return false;
+          if (m[2] === '*' && !value.includes(m[3])) return false;
+          if (m[2] === '$' && !value.endsWith(m[3])) return false;
+          if (m[2] === '' && value !== m[3]) return false;
+        }
+      } else if (el.tagName.toLowerCase() !== part.toLowerCase()) {
+        return false;
+      }
+    }
+    return parts.length > 0;
+  };
+  return flat.filter(el => selectors.some(sel => matchesOne(el, sel)));
+}
+
+async function detectCaptchaOnFakePage(build, nodes) {
+  const document = {
+    querySelector: (s) => captchaMatchAll(nodes, s)[0] || null,
+    querySelectorAll: (s) => captchaMatchAll(nodes, s),
+  };
+  const previous = {
+    document: globalThis.document,
+    chrome: globalThis.chrome,
+    browser: globalThis.browser,
+  };
+  globalThis.document = document;
+  // The detector reaches for the extension API by name; give each build the
+  // executeScript shape it expects and run the payload in-process.
+  globalThis.chrome = {
+    scripting: {
+      executeScript: async ({ func }) => [{ result: func() }],
+    },
+  };
+  globalThis.browser = {
+    tabs: {
+      executeScript: async (_tabId, { code }) => [vm.runInNewContext(code, { document, URL })],
+    },
+  };
+  try {
+    const mod = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-solver.js`)).href);
+    return await mod.detectCaptcha(1);
+  } finally {
+    globalThis.document = previous.document;
+    globalThis.chrome = previous.chrome;
+    globalThis.browser = previous.browser;
+  }
+}
+
+test('captcha detection: reCAPTCHA version, Enterprise edition and action stay in Chrome/Firefox parity', async () => {
+  const cases = [
+    {
+      label: 'classic v2 checkbox',
+      nodes: () => [
+        captchaEl('div', { class: 'g-recaptcha', 'data-sitekey': 'KEY_V2' }),
+        captchaEl('script', { src: 'https://www.google.com/recaptcha/api.js' }),
+      ],
+      expect: { type: 'recaptcha_v2', websiteKey: 'KEY_V2', isEnterprise: false, pageAction: undefined },
+    },
+    {
+      label: 'v2 invisible carrying data-action is still v2',
+      // data-action alone used to promote this to v3, which sends CapSolver
+      // a V3 task against a v2 sitekey.
+      nodes: () => [
+        captchaEl('div', { class: 'g-recaptcha', 'data-sitekey': 'KEY_V2_INV', 'data-size': 'invisible', 'data-action': 'submit' }),
+        captchaEl('script', { src: 'https://www.google.com/recaptcha/api.js' }),
+      ],
+      expect: { type: 'recaptcha_v2', websiteKey: 'KEY_V2_INV', isInvisible: true },
+    },
+    {
+      label: 'v3 host div that also sets data-size=invisible is still v3',
+      // Mirror of the case above: some v3 wrappers copy data-size onto the
+      // host div, so the render=<sitekey> script has to win.
+      nodes: () => [
+        captchaEl('div', { class: 'g-recaptcha', 'data-sitekey': 'KEY_V3_INV', 'data-action': 'login', 'data-size': 'invisible' }),
+        captchaEl('script', { src: 'https://www.google.com/recaptcha/api.js?render=KEY_V3_INV' }),
+      ],
+      expect: { type: 'recaptcha_v3', websiteKey: 'KEY_V3_INV', pageAction: 'login' },
+    },
+    {
+      label: 'v3 without data-action takes the action from the loader script',
+      nodes: () => [
+        captchaEl('div', { class: 'g-recaptcha', 'data-sitekey': 'KEY_V3_SCRIPT' }),
+        captchaEl('script', { src: 'https://www.google.com/recaptcha/api.js?render=KEY_V3_SCRIPT&action=checkout' }),
+      ],
+      expect: { type: 'recaptcha_v3', websiteKey: 'KEY_V3_SCRIPT', pageAction: 'checkout' },
+    },
+    {
+      label: 'Enterprise loader promotes the widget to an Enterprise task',
+      nodes: () => [
+        captchaEl('div', { class: 'g-recaptcha', 'data-sitekey': 'KEY_ENT' }),
+        captchaEl('script', { src: 'https://www.google.com/recaptcha/enterprise.js' }),
+      ],
+      expect: { type: 'recaptcha_v2_enterprise', websiteKey: 'KEY_ENT', isEnterprise: true },
+    },
+    {
+      label: 'URL fallback: v3 badge iframe plus render script',
+      // The badge anchor frame is indistinguishable from an invisible v2
+      // frame on its own; the matching render script is what settles it.
+      nodes: () => [
+        captchaEl('iframe', { src: 'https://www.google.com/recaptcha/api2/anchor?ar=1&k=KEY_URL_V3&size=invisible' }),
+        captchaEl('script', { src: 'https://www.google.com/recaptcha/api.js?render=KEY_URL_V3&action=sign%20up' }),
+      ],
+      expect: { type: 'recaptcha_v3', websiteKey: 'KEY_URL_V3', pageAction: 'sign up', detectedVia: 'url' },
+    },
+    {
+      label: 'URL fallback: Enterprise anchor iframe with no render script',
+      nodes: () => [
+        captchaEl('iframe', { src: 'https://www.google.com/recaptcha/enterprise/anchor?ar=1&k=KEY_URL_ENT' }),
+      ],
+      expect: { type: 'recaptcha_v2_enterprise', websiteKey: 'KEY_URL_ENT', isEnterprise: true, detectedVia: 'url' },
+    },
+    {
+      label: 'URL fallback: render=explicit is not a sitekey',
+      nodes: () => [
+        captchaEl('script', { src: 'https://www.google.com/recaptcha/api.js?render=explicit' }),
+      ],
+      expect: null,
+    },
+    {
+      label: 'provider-specific widgets still win over the reCAPTCHA scan',
+      nodes: () => [
+        captchaEl('div', { class: 'h-captcha', 'data-sitekey': 'HKEY_123456' }),
+        captchaEl('div', { class: 'g-recaptcha', 'data-sitekey': 'KEY_V2' }),
+      ],
+      expect: { type: 'hcaptcha', websiteKey: 'HKEY_123456' },
+    },
+  ];
+
+  for (const { label, nodes, expect } of cases) {
+    const chromeResult = await detectCaptchaOnFakePage('chrome', nodes());
+    const firefoxResult = await detectCaptchaOnFakePage('firefox', nodes());
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(firefoxResult ?? null)),
+      JSON.parse(JSON.stringify(chromeResult ?? null)),
+      `${label}: chrome and firefox detectors disagree`,
+    );
+    if (expect === null) {
+      assert.equal(chromeResult, null, `${label}: expected no detection`);
+      continue;
+    }
+    for (const [key, value] of Object.entries(expect)) {
+      assert.equal(chromeResult?.[key], value, `${label}: ${key}`);
+    }
+  }
+});
+
+test('captcha detection: v3 without an action reports why, and solve_captcha refuses to dispatch', async () => {
+  const nodes = [captchaEl('script', { src: 'https://www.google.com/recaptcha/enterprise.js?render=KEY_NO_ACTION' })];
+  for (const build of ['chrome', 'firefox']) {
+    const detected = await detectCaptchaOnFakePage(build, nodes);
+    assert.equal(detected.type, 'recaptcha_v3_enterprise', `${build}: enterprise v3 detected`);
+    assert.equal(detected.pageAction, undefined, `${build}: no action was available to report`);
+    assert.match(detected.note, /pageAction/, `${build}: detector explains the missing action`);
+
+    // captchaParamError is what agent.js consults *before* it flags the tool
+    // call as dispatched, so a missing action never looks like a CapSolver
+    // request that already happened.
+    const mod = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-solver.js`)).href);
+    assert.match(
+      mod.captchaParamError({ type: detected.type, websiteKey: detected.websiteKey }) || '',
+      /requires a `pageAction`/,
+      `${build}: v3 without pageAction is rejected before dispatch`,
+    );
+    assert.equal(
+      mod.captchaParamError({ type: detected.type, websiteKey: detected.websiteKey, pageAction: 'login' }),
+      null,
+      `${build}: v3 with a pageAction passes`,
+    );
+    assert.equal(
+      mod.captchaParamError({ type: 'recaptcha_v2_enterprise', websiteKey: 'KEY' }),
+      null,
+      `${build}: v2 does not need a pageAction`,
+    );
+  }
+});
+
+test('capsolver errors: demo-key refusals and task-config errors get different remedies', async () => {
+  const cases = [
+    {
+      label: 'demo key refusal',
+      body: { errorId: 1, errorCode: 'ERROR_INVALID_TASK_DATA', errorDescription: "We don't support this service." },
+      expect: /public TEST\/DEMO key/,
+    },
+    {
+      label: 'wrong task type for the widget',
+      // Exactly what an Enterprise sitekey returns for a plain V2 task. This
+      // must NOT be blamed on a demo key: the fix is to correct the task
+      // type, not to give up and move to another site.
+      body: { errorId: 1, errorCode: 'ERROR_INVALID_TASK_DATA', errorDescription: 'Invalid input: check captcha type or parameters' },
+      expect: /rejected the task configuration/,
+    },
+    {
+      label: 'ordinary parameter error containing the substring "test"',
+      // A bare /test/ match here treats "latest" as a test key.
+      body: { errorId: 1, errorCode: 'ERROR_INVALID_TASK_DATA', errorDescription: 'websiteKey is required for the latest task version' },
+      expect: /^CapSolver: websiteKey is required for the latest task version$/,
+    },
+    {
+      label: 'unrelated failure passes through untouched',
+      body: { errorId: 1, errorCode: 'ERROR_ZERO_BALANCE', errorDescription: 'Your balance is zero' },
+      expect: /^CapSolver: Your balance is zero$/,
+    },
+  ];
+
+  const previousFetch = globalThis.fetch;
+  try {
+    for (const build of ['chrome', 'firefox']) {
+      const mod = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-solver.js`)).href);
+      for (const { label, body, expect } of cases) {
+        globalThis.fetch = async () => ({ ok: true, json: async () => body });
+        await assert.rejects(
+          () => mod.getBalance('test-key'),
+          (err) => {
+            assert.match(err.message, expect, `${build}: ${label}`);
+            return true;
+          },
+          `${build}: ${label} should reject`,
+        );
+      }
+    }
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
 await run();


### PR DESCRIPTION
## Summary
- Adds support for ReCaptchaV2EnterpriseTaskProxyLess and ReCaptchaV3EnterpriseTaskProxyLess task types in CapSolver REST integration.
- Updates detectCaptcha() URL candidate parser to extract isEnterprise and isInvisible (size=invisible) parameters from reCAPTCHA anchor/script URLs.
- Updates DOM element detection to recognize reCAPTCHA Enterprise markers.
- Refines capsolverError() to avoid misinterpreting invalid input task configuration errors as public demo key rejections.