### PR TITLE
Fix frame-aware CAPTCHA solving

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -13856,6 +13856,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 `solve_captcha: requested type "${type}" conflicts with the active detected candidate "${detected.type}" in ${detected.frameUrl}. Retry without type or use the detected type.`
               );
             }
+            if (pageAction && detected.pageAction && String(pageAction) !== String(detected.pageAction)) {
+              return noDispatchFailure(
+                `solve_captcha: requested pageAction "${pageAction}" conflicts with the active detected candidate action "${detected.pageAction}" in ${detected.frameUrl}. Retry without pageAction or use the detected action.`
+              );
+            }
             type = type || detected.type;
             websiteURL = captchaWebsiteUrl(detected.frameUrl, websiteURL);
             frameUrl = detected.frameUrl || frameUrl;

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -13921,6 +13921,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 frameUrl: detected.frameUrl,
                 websiteKey: detected.websiteKey,
                 type: detected.type,
+                explicitWebsiteKey: detected.explicitWebsiteKey === true,
               } : null,
             });
           } catch (e) {

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -13841,7 +13841,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           if (detection?.error) {
             const hasDetectedCandidates = Array.isArray(detection.candidates) && detection.candidates.length > 0;
             const needsDetection = !type || !websiteKey || !!frameUrl;
-            if (detection.ambiguous || hasDetectedCandidates || needsDetection) {
+            const explicitTokenOnlyFallback = args?.inject === false
+              && !!type
+              && !!websiteKey
+              && !(detection.candidates || []).some(candidate =>
+                candidate?.websiteKey === websiteKey
+              );
+            if (!explicitTokenOnlyFallback
+                && (detection.ambiguous || hasDetectedCandidates || needsDetection)) {
               const candidates = hasDetectedCandidates ? ` Candidates: ${JSON.stringify(detection.candidates)}` : '';
               return noDispatchFailure(`solve_captcha: ${detection.error}${candidates}`);
             }
@@ -13871,6 +13878,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             if (!pageAction && detected.pageAction) pageAction = detected.pageAction;
             if (!enterprisePayload && detected.enterprisePayload) enterprisePayload = detected.enterprisePayload;
             if (!recaptchaDataSValue && detected.recaptchaDataSValue) recaptchaDataSValue = detected.recaptchaDataSValue;
+          }
+          if (!detected && args?.inject === false && frameUrl) {
+            websiteURL = captchaWebsiteUrl(frameUrl, websiteURL);
           }
         }
 
@@ -13921,6 +13931,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               fieldName: result.fieldName,
               alsoSet: result.alsoSet,
               token: result.token,
+              callbackHint: detected.callbackName || null,
               target: detected ? {
                 frameId: detected.frameId,
                 framePath: detected.framePath,
@@ -13928,6 +13939,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 websiteKey: detected.websiteKey,
                 type: detected.type,
                 explicitWebsiteKey: detected.explicitWebsiteKey === true,
+                responseFieldId: detected.responseFieldId,
+                responseFieldIndex: detected.responseFieldIndex,
                 documentTimeOrigin: detected.documentTimeOrigin,
               } : null,
             });

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -29,7 +29,7 @@ import {
 } from './pdf-tools.js';
 import * as trace from '../trace/recorder.js';
 import { tracesToMarkdown } from './trace-export.js';
-import { solveCaptcha, detectCaptcha, injectToken, captchaParamError, captchaTypesMatch } from './captcha-solver.js';
+import { solveCaptcha, detectCaptcha, injectToken, captchaParamError, captchaTypesMatch, captchaWebsiteUrl } from './captcha-solver.js';
 import { getRecordingStateFresh as recorderStateFresh } from '../recorder/host.js';
 import { Capability, CAPABILITY_LABEL, capabilitiesFor, requiredHosts, frameHostMatches, isNetworkMutation, normalizeHost, PermissionManager, UNTRUSTED_CONTENT_TOOLS } from './permission-gate.js';
 import {
@@ -13857,7 +13857,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               );
             }
             type = type || detected.type;
-            websiteURL = detected.frameUrl || websiteURL;
+            websiteURL = captchaWebsiteUrl(detected.frameUrl, websiteURL);
             frameUrl = detected.frameUrl || frameUrl;
             detectionNote = detected.note || null;
             if (!websiteKey) websiteKey = detected.websiteKey;
@@ -13912,6 +13912,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               token: result.token,
               target: detected ? {
                 frameId: detected.frameId,
+                framePath: detected.framePath,
                 frameUrl: detected.frameUrl,
                 websiteKey: detected.websiteKey,
                 type: detected.type,
@@ -13930,6 +13931,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           token: result.token,
           tokenPreview: result.token ? `${String(result.token).slice(0, 24)}…(${String(result.token).length} chars)` : null,
           selectedFrameId: Number.isInteger(detected?.frameId) ? detected.frameId : null,
+          selectedFramePath: Array.isArray(detected?.framePath) ? detected.framePath : null,
           selectedFrameUrl: detected?.frameUrl || null,
           selectionReason: detected?.selectionReason || null,
           detectedType: detected?.type || null,

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -13902,12 +13902,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           return noDispatchFailure(detectionNote ? `${paramError} ${detectionNote}` : paramError);
         }
 
+        const wantInject = args?.inject !== false && type !== 'image_to_text';
+        if (wantInject && !detected) {
+          return noDispatchFailure(
+            'solve_captcha: token injection requires a detected CAPTCHA frame. The explicit type and websiteKey were not sent to CapSolver because no safe injection target could be verified. Retry with `inject: false` to receive the token without page injection, or ask the user to solve the challenge manually.'
+          );
+        }
+
         dispatched = true;
         const result = await solveCaptcha(apiKey, params);
 
         // For non-image types, push the token into the page response field
         // unless the caller explicitly opted out.
-        const wantInject = args?.inject !== false && type !== 'image_to_text';
         let injection = null;
         if (wantInject && result.fieldName && result.token) {
           try {
@@ -13922,6 +13928,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 websiteKey: detected.websiteKey,
                 type: detected.type,
                 explicitWebsiteKey: detected.explicitWebsiteKey === true,
+                documentTimeOrigin: detected.documentTimeOrigin,
               } : null,
             });
           } catch (e) {

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -13837,7 +13837,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         let detectionNote = null;
         let detected = null;
         if (type !== 'image_to_text') {
-          const detection = await detectCaptcha(tabId, { type, frameUrl, websiteKey });
+          let detection = null;
+          try {
+            detection = await detectCaptcha(tabId, { type, frameUrl, websiteKey });
+          } catch (detectionError) {
+            const explicitTokenOnlyFallback = args?.inject === false && !!type && !!websiteKey;
+            if (!explicitTokenOnlyFallback) {
+              return noDispatchFailure(
+                `solve_captcha: CAPTCHA frame detection failed before dispatch: ${detectionError?.message || String(detectionError)}`
+              );
+            }
+            detectionNote = `CAPTCHA frame detection was unavailable: ${detectionError?.message || String(detectionError)}`;
+          }
           if (detection?.error) {
             const hasDetectedCandidates = Array.isArray(detection.candidates) && detection.candidates.length > 0;
             const needsDetection = !type || !websiteKey || !!frameUrl;

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -29,7 +29,7 @@ import {
 } from './pdf-tools.js';
 import * as trace from '../trace/recorder.js';
 import { tracesToMarkdown } from './trace-export.js';
-import { solveCaptcha, detectCaptcha, injectToken, captchaParamError } from './captcha-solver.js';
+import { solveCaptcha, detectCaptcha, injectToken, captchaParamError, captchaTypesMatch } from './captcha-solver.js';
 import { getRecordingStateFresh as recorderStateFresh } from '../recorder/host.js';
 import { Capability, CAPABILITY_LABEL, capabilitiesFor, requiredHosts, frameHostMatches, isNetworkMutation, normalizeHost, PermissionManager, UNTRUSTED_CONTENT_TOOLS } from './permission-gate.js';
 import {
@@ -13810,32 +13810,63 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           return noDispatchFailure('CapSolver is enabled but no API key is configured. Ask the user to set one in Settings → General → Advanced, or fall back to asking them to solve the captcha manually.');
         }
 
-        // Resolve the website URL — the active tab's URL is what the
-        // captcha vendor needs to match its sitekey allowlist.
+        // Use the top-level URL as a fallback. Frame-aware detection below
+        // replaces it with the exact frame URL that loaded the selected
+        // widget, which is the URL CapSolver needs for nested challenges.
         let websiteURL = '';
         try {
           const tab = await chrome.tabs.get(tabId);
           websiteURL = tab?.url || '';
         } catch {}
 
-        // Detect when the model didn't pre-specify a captcha type. Image-
-        // to-text is a special case that needs an explicit imageBase64.
-        let { type, websiteKey, isInvisible, isEnterprise, pageAction, minScore, imageBase64 } = args || {};
+        let {
+          type,
+          websiteKey,
+          frameUrl,
+          isInvisible,
+          isEnterprise,
+          pageAction,
+          minScore,
+          imageBase64,
+          enterprisePayload,
+          recaptchaDataSValue,
+        } = args || {};
         // Detection notes explain *why* a field is missing (e.g. a v3 widget
         // that never exposed its action name). Carry it into the failure so
         // the model gets the remedy, not just the rejection.
         let detectionNote = null;
-        if (!type) {
-          const detected = await detectCaptcha(tabId);
-          if (!detected) {
+        let detected = null;
+        if (type !== 'image_to_text') {
+          const detection = await detectCaptcha(tabId, { frameUrl, websiteKey });
+          if (detection?.error) {
+            const hasDetectedCandidates = Array.isArray(detection.candidates) && detection.candidates.length > 0;
+            const needsDetection = !type || !websiteKey || !!frameUrl;
+            if (detection.ambiguous || hasDetectedCandidates || needsDetection) {
+              const candidates = hasDetectedCandidates ? ` Candidates: ${JSON.stringify(detection.candidates)}` : '';
+              return noDispatchFailure(`solve_captcha: ${detection.error}${candidates}`);
+            }
+          }
+          detected = detection?.selected || null;
+          if (!detected && (!type || !websiteKey)) {
             return noDispatchFailure('No CAPTCHA detected on the page. If the captcha lives inside a cross-origin iframe or uses a non-standard widget, pass `type` and `websiteKey` explicitly.');
           }
-          type = detected.type;
-          detectionNote = detected.note || null;
-          if (!websiteKey) websiteKey = detected.websiteKey;
-          if (isInvisible == null && detected.isInvisible != null) isInvisible = detected.isInvisible;
-          if (isEnterprise == null && detected.isEnterprise != null) isEnterprise = detected.isEnterprise;
-          if (!pageAction && detected.pageAction) pageAction = detected.pageAction;
+          if (detected) {
+            if (type && !captchaTypesMatch(type, detected.type, isEnterprise, detected.isEnterprise)) {
+              return noDispatchFailure(
+                `solve_captcha: requested type "${type}" conflicts with the active detected candidate "${detected.type}" in ${detected.frameUrl}. Retry without type or use the detected type.`
+              );
+            }
+            type = type || detected.type;
+            websiteURL = detected.frameUrl || websiteURL;
+            frameUrl = detected.frameUrl || frameUrl;
+            detectionNote = detected.note || null;
+            if (!websiteKey) websiteKey = detected.websiteKey;
+            if (isInvisible == null && detected.isInvisible != null) isInvisible = detected.isInvisible;
+            if (isEnterprise == null && detected.isEnterprise != null) isEnterprise = detected.isEnterprise;
+            if (!pageAction && detected.pageAction) pageAction = detected.pageAction;
+            if (!enterprisePayload && detected.enterprisePayload) enterprisePayload = detected.enterprisePayload;
+            if (!recaptchaDataSValue && detected.recaptchaDataSValue) recaptchaDataSValue = detected.recaptchaDataSValue;
+          }
         }
 
         const params = {
@@ -13846,6 +13877,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           ...(isEnterprise != null ? { isEnterprise } : {}),
           ...(pageAction ? { pageAction } : {}),
           ...(minScore ? { minScore } : {}),
+          ...(enterprisePayload ? { enterprisePayload } : {}),
+          ...(recaptchaDataSValue ? { recaptchaDataSValue } : {}),
           ...(imageBase64 ? { body: imageBase64 } : {}),
         };
 
@@ -13877,6 +13910,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               fieldName: result.fieldName,
               alsoSet: result.alsoSet,
               token: result.token,
+              target: detected ? {
+                frameId: detected.frameId,
+                frameUrl: detected.frameUrl,
+                websiteKey: detected.websiteKey,
+                type: detected.type,
+              } : null,
             });
           } catch (e) {
             injection = { success: false, error: e.message };
@@ -13890,11 +13929,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           taskId: result.taskId,
           token: result.token,
           tokenPreview: result.token ? `${String(result.token).slice(0, 24)}…(${String(result.token).length} chars)` : null,
+          selectedFrameId: Number.isInteger(detected?.frameId) ? detected.frameId : null,
+          selectedFrameUrl: detected?.frameUrl || null,
+          selectionReason: detected?.selectionReason || null,
+          detectedType: detected?.type || null,
           injected: injection?.success === true,
           injection,
-          note: wantInject
-            ? 'Token was injected into the page response field. Click the form\'s submit button next; do NOT call solve_captcha again.'
-            : 'Token returned, not injected. Pass it to the form via type_text on the response field, then submit.',
+          note: !wantInject
+            ? 'Token returned without injection. Apply this token to the intended response field; do not request another paid solve for the same challenge.'
+            : injection?.success
+              ? (injection.calledCallback
+                ? 'Token was inserted into the selected frame and its callback was invoked. Wait for the page to react, then verify whether the challenge cleared.'
+                : 'Token was inserted into the selected frame, but no unique callback was invoked. Verify page progress before submitting or taking another action; do not request another paid solve.')
+              : 'CapSolver returned a token, but targeted injection failed. The challenge is not confirmed cleared; do not request another paid solve for the same token.',
         };
       } catch (e) {
         const error = `solve_captcha failed: ${e.message}`;

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -13863,6 +13863,25 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 `solve_captcha: requested type "${type}" conflicts with the active detected candidate "${detected.type}" in ${detected.frameUrl}. Retry without type or use the detected type.`
               );
             }
+            const visibilityModeApplies = /^(?:recaptcha_v2(?:_enterprise)?|hcaptcha)$/.test(
+              String(detected.type || '')
+            );
+            if (visibilityModeApplies
+                && isInvisible != null
+                && detected.isInvisible != null
+                && Boolean(isInvisible) !== Boolean(detected.isInvisible)) {
+              return noDispatchFailure(
+                `solve_captcha: requested isInvisible=${Boolean(isInvisible)} conflicts with the active detected candidate isInvisible=${Boolean(detected.isInvisible)} in ${detected.frameUrl}. Retry without isInvisible or use the detected value.`
+              );
+            }
+            if (/^recaptcha_v[23](?:_enterprise)?$/.test(String(detected.type || ''))
+                && isEnterprise != null
+                && detected.isEnterprise != null
+                && Boolean(isEnterprise) !== Boolean(detected.isEnterprise)) {
+              return noDispatchFailure(
+                `solve_captcha: requested isEnterprise=${Boolean(isEnterprise)} conflicts with the active detected candidate isEnterprise=${Boolean(detected.isEnterprise)} in ${detected.frameUrl}. Retry without isEnterprise or use the detected value.`
+              );
+            }
             if (pageAction && detected.pageAction && String(pageAction) !== String(detected.pageAction)) {
               return noDispatchFailure(
                 `solve_captcha: requested pageAction "${pageAction}" conflicts with the active detected candidate action "${detected.pageAction}" in ${detected.frameUrl}. Retry without pageAction or use the detected action.`
@@ -13941,6 +13960,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 explicitWebsiteKey: detected.explicitWebsiteKey === true,
                 responseFieldId: detected.responseFieldId,
                 responseFieldIndex: detected.responseFieldIndex,
+                alsoResponseFieldId: detected.alsoResponseFieldId,
+                alsoResponseFieldIndex: detected.alsoResponseFieldIndex,
                 documentTimeOrigin: detected.documentTimeOrigin,
               } : null,
             });

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -13823,6 +13823,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           type,
           websiteKey,
           frameUrl,
+          frameId,
+          framePath,
           isInvisible,
           isEnterprise,
           pageAction,
@@ -13839,7 +13841,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (type !== 'image_to_text') {
           let detection = null;
           try {
-            detection = await detectCaptcha(tabId, { type, frameUrl, websiteKey });
+            detection = await detectCaptcha(tabId, {
+              type,
+              frameUrl,
+              frameId,
+              framePath,
+              websiteKey,
+            });
           } catch (detectionError) {
             const explicitTokenOnlyFallback = args?.inject === false && !!type && !!websiteKey;
             if (!explicitTokenOnlyFallback) {
@@ -13851,7 +13859,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           }
           if (detection?.error) {
             const hasDetectedCandidates = Array.isArray(detection.candidates) && detection.candidates.length > 0;
-            const needsDetection = !type || !websiteKey || !!frameUrl;
+            const needsDetection = !type
+              || !websiteKey
+              || !!frameUrl
+              || Number.isInteger(frameId)
+              || Array.isArray(framePath);
             const explicitTokenOnlyFallback = args?.inject === false
               && !!type
               && !!websiteKey
@@ -13899,7 +13911,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               );
             }
             type = type || detected.type;
-            websiteURL = captchaWebsiteUrl(detected.frameUrl, websiteURL);
+            websiteURL = detected.websiteURL || captchaWebsiteUrl(detected.frameUrl, websiteURL);
             frameUrl = detected.frameUrl || frameUrl;
             detectionNote = detected.note || null;
             if (!websiteKey) websiteKey = detected.websiteKey;

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -13837,7 +13837,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         let detectionNote = null;
         let detected = null;
         if (type !== 'image_to_text') {
-          const detection = await detectCaptcha(tabId, { frameUrl, websiteKey });
+          const detection = await detectCaptcha(tabId, { type, frameUrl, websiteKey });
           if (detection?.error) {
             const hasDetectedCandidates = Array.isArray(detection.candidates) && detection.candidates.length > 0;
             const needsDetection = !type || !websiteKey || !!frameUrl;

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -122,7 +122,88 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
     return visible;
   };
 
-  return (Array.isArray(candidates) ? candidates : []).map(candidate => {
+  const sourceCandidates = Array.isArray(candidates) ? candidates : [];
+  const pathIsStrictAncestor = (sourcePath, targetPath) => {
+    const source = Array.isArray(sourcePath) ? sourcePath : [];
+    const target = Array.isArray(targetPath) ? targetPath : [];
+    if (source.length >= target.length) return false;
+    return source.every((segment, index) =>
+      Number(segment?.index) === Number(target[index]?.index)
+    );
+  };
+  const ancestorDistance = (source, target) => {
+    if (!Number.isInteger(source?.frameId) || !Number.isInteger(target?.frameId)) return null;
+    const sourcePath = Array.isArray(source.framePath) ? source.framePath : [];
+    const targetPath = Array.isArray(target.framePath) ? target.framePath : [];
+    if (source.frameId === target.frameId) {
+      if (!pathIsStrictAncestor(sourcePath, targetPath)) return null;
+      return targetPath.length - sourcePath.length;
+    }
+    // A candidate reached through an inherited-origin framePath lives below
+    // its injectable frameId. Treating that base frame as its location would
+    // let metadata leak sideways into a sibling browser frame.
+    if (sourcePath.length) return null;
+    let currentFrameId = target.frameId;
+    let distance = targetPath.length;
+    const visited = new Set();
+    while (Number.isInteger(currentFrameId) && !visited.has(currentFrameId)) {
+      visited.add(currentFrameId);
+      const parentFrameId = navigationByFrameId.get(currentFrameId)?.parentFrameId;
+      if (!Number.isInteger(parentFrameId) || parentFrameId === -1) return null;
+      distance += 1;
+      if (parentFrameId === source.frameId) return distance;
+      currentFrameId = parentFrameId;
+    }
+    return null;
+  };
+  const reconcileAncestorLoader = (candidate) => {
+    if (!candidate?.websiteKey
+        || !/^recaptcha_v[23](?:_enterprise)?$/.test(String(candidate.type || ''))
+        || candidate.detectedVia === 'script') {
+      return candidate;
+    }
+    const matchingLoaders = sourceCandidates
+      .filter(source =>
+        source !== candidate
+        && source?.detectedVia === 'script'
+        && source?.websiteKey === candidate.websiteKey
+        && /^recaptcha_v3(?:_enterprise)?$/.test(String(source.type || ''))
+      )
+      .map(source => ({ source, distance: ancestorDistance(source, candidate) }))
+      .filter(entry => entry.distance != null)
+      .sort((left, right) => left.distance - right.distance);
+    if (!matchingLoaders.length) return candidate;
+    const nearestDistance = matchingLoaders[0].distance;
+    const nearest = matchingLoaders.filter(entry => entry.distance === nearestDistance);
+    const signatures = new Set(nearest.map(({ source }) => JSON.stringify([
+      source.type,
+      source.isEnterprise === true,
+      source.pageAction || null,
+    ])));
+    if (signatures.size > 1) {
+      return {
+        ...candidate,
+        parameterConflicts: [...new Set([
+          ...(Array.isArray(candidate.parameterConflicts) ? candidate.parameterConflicts : []),
+          'ancestorLoader',
+        ])],
+      };
+    }
+    const loader = nearest[0].source;
+    const pageAction = candidate.pageAction || loader.pageAction || null;
+    return {
+      ...candidate,
+      type: loader.type,
+      isEnterprise: loader.isEnterprise === true || /_enterprise$/.test(loader.type),
+      normalCheckbox: false,
+      ...(pageAction ? { pageAction } : {}),
+      ...(!pageAction && loader.note ? { note: loader.note } : {}),
+      ancestorLoaderFrameId: loader.frameId,
+    };
+  };
+
+  return sourceCandidates.map(rawCandidate => {
+    const candidate = reconcileAncestorLoader(rawCandidate);
     const frameVisible = frameIsVisible(candidate?.frameId)
       && candidate?.frameVisibleWithinAnchor !== false;
     return {
@@ -153,6 +234,9 @@ function candidateSummary(candidate) {
     enterprisePayload: candidate?.enterprisePayload || null,
     recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
     explicitWebsiteKey: candidate?.explicitWebsiteKey === true,
+    ancestorLoaderFrameId: Number.isInteger(candidate?.ancestorLoaderFrameId)
+      ? candidate.ancestorLoaderFrameId
+      : null,
     parameterConflicts: Array.isArray(candidate?.parameterConflicts)
       ? candidate.parameterConflicts
       : [],

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -48,6 +48,80 @@ export function captchaTypesMatch(left, right, leftIsEnterprise = null, rightIsE
   return normalizeCaptchaType(left) === normalizeCaptchaType(right);
 }
 
+export function applyCaptchaFrameVisibility(candidates, frameContexts, navigationFrames) {
+  const contextsByFrameId = new Map();
+  for (const context of Array.isArray(frameContexts) ? frameContexts : []) {
+    if (Number.isInteger(context?.frameId)) contextsByFrameId.set(context.frameId, context);
+  }
+  const navigationByFrameId = new Map();
+  for (const frame of Array.isArray(navigationFrames) ? navigationFrames : []) {
+    if (Number.isInteger(frame?.frameId)) navigationByFrameId.set(frame.frameId, frame);
+  }
+
+  const uniqueMatch = (items) => items.length === 1 ? items[0] : null;
+  const findEmbeddingFrame = (frameId, parentFrameId) => {
+    const parentContext = contextsByFrameId.get(parentFrameId);
+    if (!parentContext) return null;
+    const childFrames = Array.isArray(parentContext.childFrames) ? parentContext.childFrames : [];
+    if (!childFrames.length) return null;
+
+    const childContext = contextsByFrameId.get(frameId);
+    const navigation = navigationByFrameId.get(frameId);
+    const frameName = String(childContext?.frameName || '');
+    const frameUrls = new Set([
+      childContext?.frameUrl,
+      navigation?.url,
+    ].filter(Boolean).map(String));
+    const urlMatches = childFrames.filter(child =>
+      frameUrls.has(String(child?.loadedUrl || '')) || frameUrls.has(String(child?.url || ''))
+    );
+    if (frameName) {
+      const exact = uniqueMatch(urlMatches.filter(child => String(child?.name || '') === frameName));
+      if (exact) return exact;
+    }
+    const byUrl = uniqueMatch(urlMatches);
+    if (byUrl) return byUrl;
+    if (frameName) {
+      const byName = uniqueMatch(childFrames.filter(child => String(child?.name || '') === frameName));
+      if (byName) return byName;
+    }
+    return childFrames.length === 1 ? childFrames[0] : null;
+  };
+
+  const visibilityByFrameId = new Map();
+  const frameIsVisible = (frameId, visiting = new Set()) => {
+    if (visibilityByFrameId.has(frameId)) return visibilityByFrameId.get(frameId);
+    if (!Number.isInteger(frameId) || visiting.has(frameId)) return false;
+    const navigation = navigationByFrameId.get(frameId);
+    const parentFrameId = navigation?.parentFrameId;
+    if (frameId === 0 || parentFrameId === -1) {
+      visibilityByFrameId.set(frameId, true);
+      return true;
+    }
+    if (!Number.isInteger(parentFrameId)) {
+      visibilityByFrameId.set(frameId, false);
+      return false;
+    }
+    visiting.add(frameId);
+    const parentVisible = frameIsVisible(parentFrameId, visiting);
+    visiting.delete(frameId);
+    const embeddingFrame = parentVisible ? findEmbeddingFrame(frameId, parentFrameId) : null;
+    const visible = parentVisible && embeddingFrame?.visible === true;
+    visibilityByFrameId.set(frameId, visible);
+    return visible;
+  };
+
+  return (Array.isArray(candidates) ? candidates : []).map(candidate => {
+    const frameVisible = frameIsVisible(candidate?.frameId);
+    return {
+      ...candidate,
+      frameVisible,
+      visible: candidate?.visible === true && frameVisible,
+      normalCheckbox: candidate?.normalCheckbox === true && candidate?.visible === true && frameVisible,
+    };
+  });
+}
+
 function candidateSummary(candidate) {
   return {
     frameId: Number.isInteger(candidate?.frameId) ? candidate.frameId : null,
@@ -57,6 +131,7 @@ function candidateSummary(candidate) {
     visible: candidate?.visible === true,
     normalCheckbox: candidate?.normalCheckbox === true,
     challengeFrame: candidate?.challengeFrame === true,
+    frameVisible: candidate?.frameVisible !== false,
     isInvisible: candidate?.isInvisible === true,
     isEnterprise: candidate?.isEnterprise === true,
     pageAction: candidate?.pageAction || null,
@@ -70,12 +145,13 @@ function candidateScore(candidate) {
   // Priority is tiered so no combination of secondary signals can make a
   // generic visible/background integration outrank an active challenge
   // frame or visible checkbox.
-  const primary = (candidate?.normalCheckbox && candidate?.visible) || candidate?.challengeFrame;
+  const activeChallengeFrame = candidate?.challengeFrame && candidate?.frameVisible !== false;
+  const primary = (candidate?.normalCheckbox && candidate?.visible) || activeChallengeFrame;
   const tier = primary ? 3 : (candidate?.visible ? 2 : 1);
   let score = tier * 1000;
   if (candidate?.normalCheckbox && candidate?.visible) score += 120;
   else if (candidate?.visible) score += 60;
-  if (candidate?.challengeFrame) score += 35;
+  if (activeChallengeFrame) score += 35;
   if (candidate?.responseField) score += 12;
   if (candidate?.detectedVia === 'host') score += 8;
   if (candidate?.websiteKey) score += 4;
@@ -182,9 +258,9 @@ function selectedReason(candidate, constraints) {
   if (constraints.frameUrl) return 'exact frameUrl match';
   if (constraints.websiteKey) return 'exact websiteKey match';
   if (candidate.normalCheckbox && candidate.visible) return 'visible checkbox challenge';
-  if (candidate.visible && candidate.challengeFrame) return 'visible challenge frame';
+  if (candidate.visible && candidate.challengeFrame && candidate.frameVisible !== false) return 'visible challenge frame';
   if (candidate.visible) return 'visible CAPTCHA widget';
-  if (candidate.challengeFrame) return 'challenge frame candidate';
+  if (candidate.challengeFrame && candidate.frameVisible !== false) return 'challenge frame candidate';
   return 'only detected CAPTCHA candidate';
 }
 
@@ -309,7 +385,10 @@ export function detectCaptchaCandidatesInPage() {
     });
   }
 
-  const iframeElements = Array.from(document.querySelectorAll('iframe[src]'));
+  const allIframeElements = Array.from(document.querySelectorAll('iframe'));
+  const iframeElements = allIframeElements.filter(element => {
+    try { return !!element.src; } catch (_) { return false; }
+  });
   const iframeUrls = iframeElements.map(element => {
     try { return { element, url: element.src || '' }; } catch (_) { return { element, url: '' }; }
   }).filter(item => item.url);
@@ -401,7 +480,31 @@ export function detectCaptchaCandidatesInPage() {
       detectedVia: 'script',
     });
   }
-  return candidates;
+  const childFrames = allIframeElements.map((element, index) => {
+    let url = '';
+    let loadedUrl = '';
+    let name = '';
+    try { url = String(element.src || ''); } catch (_) {}
+    try { loadedUrl = String(element.contentWindow?.location?.href || ''); } catch (_) {}
+    try { name = String(element.name || element.getAttribute?.('name') || ''); } catch (_) {}
+    return {
+      index,
+      url,
+      loadedUrl,
+      name,
+      visible: visibleElement(element),
+    };
+  });
+  let frameName = '';
+  try { frameName = typeof window !== 'undefined' ? String(window.name || '') : ''; } catch (_) {}
+  return {
+    candidates,
+    frameContext: {
+      frameUrl,
+      frameName,
+      childFrames,
+    },
+  };
 }
 
 // This function is also serialized into a page context. Keep it self-contained.

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -147,6 +147,7 @@ function candidateSummary(candidate) {
     pageAction: candidate?.pageAction || null,
     enterprisePayload: candidate?.enterprisePayload || null,
     recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
+    explicitWebsiteKey: candidate?.explicitWebsiteKey === true,
     parameterConflicts: Array.isArray(candidate?.parameterConflicts)
       ? candidate.parameterConflicts
       : [],
@@ -253,6 +254,7 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
   let pool = unique;
   const requestedFrameUrl = String(constraints.frameUrl || '');
   const requestedWebsiteKey = String(constraints.websiteKey || '');
+  const requestedType = normalizeCaptchaType(constraints.type);
   if (requestedFrameUrl) {
     pool = pool.filter(candidate => candidate.frameUrl === requestedFrameUrl);
     if (!pool.length) {
@@ -265,7 +267,20 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
     }
   }
   if (requestedWebsiteKey) {
-    pool = pool.filter(candidate => candidate.websiteKey === requestedWebsiteKey);
+    const exactKeyMatches = pool.filter(candidate => candidate.websiteKey === requestedWebsiteKey);
+    const explicitTurnstileFallbacks = requestedType === 'turnstile'
+      ? pool
+        .filter(candidate =>
+          candidate.type === 'turnstile_challenge' && !candidate.websiteKey
+        )
+        .map(candidate => ({
+          ...candidate,
+          type: 'turnstile',
+          websiteKey: requestedWebsiteKey,
+          explicitWebsiteKey: true,
+        }))
+      : [];
+    pool = exactKeyMatches.length ? exactKeyMatches : explicitTurnstileFallbacks;
     if (!pool.length) {
       return {
         selected: null,
@@ -318,6 +333,7 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
 }
 
 function selectedReason(candidate, constraints) {
+  if (candidate.explicitWebsiteKey) return 'explicit site key for detected Turnstile challenge';
   if (constraints.frameUrl) return 'exact frameUrl match';
   if (constraints.websiteKey) return 'exact websiteKey match';
   if (candidate.normalCheckbox && candidate.visible) return 'visible checkbox challenge';

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -239,6 +239,10 @@ function candidateSummary(candidate) {
     responseFieldIndex: Number.isInteger(candidate?.responseFieldIndex)
       ? candidate.responseFieldIndex
       : null,
+    alsoResponseFieldId: candidate?.alsoResponseFieldId || null,
+    alsoResponseFieldIndex: Number.isInteger(candidate?.alsoResponseFieldIndex)
+      ? candidate.alsoResponseFieldIndex
+      : null,
     documentTimeOrigin: Number.isFinite(candidate?.documentTimeOrigin)
       ? candidate.documentTimeOrigin
       : null,
@@ -314,7 +318,11 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
       candidate.responseFieldId || (
         Number.isInteger(candidate.responseFieldIndex)
           ? `response-field-${candidate.responseFieldIndex}`
-          : ''
+          : (candidate.alsoResponseFieldId || (
+            Number.isInteger(candidate.alsoResponseFieldIndex)
+              ? `also-response-field-${candidate.alsoResponseFieldIndex}`
+              : ''
+          ))
       ),
     ].join('|');
     if (fingerprintIndexes.has(fingerprint)) {
@@ -550,6 +558,15 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       ...(responseFieldIndex >= 0 ? { responseFieldIndex } : {}),
     };
   };
+  const alsoResponseFieldIdentity = (widget, name, fallbackIndex, widgetCount) => {
+    const identity = responseFieldIdentity(widget, name, fallbackIndex, widgetCount);
+    return {
+      ...(identity.responseFieldId ? { alsoResponseFieldId: identity.responseFieldId } : {}),
+      ...(Number.isInteger(identity.responseFieldIndex)
+        ? { alsoResponseFieldIndex: identity.responseFieldIndex }
+        : {}),
+    };
+  };
 
   const hcaptchaHosts = Array.from(pageDocument.querySelectorAll(
     '.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]'
@@ -566,6 +583,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       normalCheckbox: visibleElement(host) && !isInvisible,
       callbackName: host.getAttribute('data-callback') || null,
       ...responseFieldIdentity(host, 'h-captcha-response', widgetIndex, hcaptchaHosts.length),
+      ...alsoResponseFieldIdentity(host, 'g-recaptcha-response', widgetIndex, hcaptchaHosts.length),
       detectedVia: 'host',
     });
   }
@@ -657,6 +675,12 @@ export function detectCaptchaCandidatesInPage(scope = null) {
           ...responseFieldIdentity(
             element,
             'h-captcha-response',
+            hcaptchaFrames.findIndex(frame => frame.element === element),
+            hcaptchaFrames.length,
+          ),
+          ...alsoResponseFieldIdentity(
+            element,
+            'g-recaptcha-response',
             hcaptchaFrames.findIndex(frame => frame.element === element),
             hcaptchaFrames.length,
           ),
@@ -903,19 +927,23 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     const fields = Array.from(frameDocument.querySelectorAll(
       `textarea[name="${name}"], input[name="${name}"]`
     ));
-    if (primary && target.responseFieldId) {
+    const selectedFieldId = primary ? target.responseFieldId : target.alsoResponseFieldId;
+    const selectedFieldIndex = primary
+      ? target.responseFieldIndex
+      : target.alsoResponseFieldIndex;
+    if (selectedFieldId) {
       const exact = fields.find(element => {
         try {
-          return String(element.id || element.getAttribute?.('id') || '') === target.responseFieldId;
+          return String(element.id || element.getAttribute?.('id') || '') === selectedFieldId;
         } catch (_) {
           return false;
         }
       });
       if (exact) return { element: exact };
     }
-    if (Number.isInteger(target.responseFieldIndex)) {
-      if (fields[target.responseFieldIndex]) {
-        return { element: fields[target.responseFieldIndex] };
+    if (Number.isInteger(selectedFieldIndex)) {
+      if (fields[selectedFieldIndex]) {
+        return { element: fields[selectedFieldIndex] };
       }
       return {
         error: 'The selected CAPTCHA response field is no longer present in the target frame.',
@@ -1075,6 +1103,10 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     responseFieldId: target.responseFieldId || null,
     responseFieldIndex: Number.isInteger(target.responseFieldIndex)
       ? target.responseFieldIndex
+      : null,
+    alsoResponseFieldId: target.alsoResponseFieldId || null,
+    alsoResponseFieldIndex: Number.isInteger(target.alsoResponseFieldIndex)
+      ? target.alsoResponseFieldIndex
       : null,
     calledCallback,
     callbackSource,

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -147,6 +147,9 @@ function candidateSummary(candidate) {
     pageAction: candidate?.pageAction || null,
     enterprisePayload: candidate?.enterprisePayload || null,
     recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
+    parameterConflicts: Array.isArray(candidate?.parameterConflicts)
+      ? candidate.parameterConflicts
+      : [],
     detectedVia: candidate?.detectedVia || null,
   };
 }
@@ -172,6 +175,28 @@ function candidateScore(candidate) {
 export function selectCaptchaCandidate(candidates, constraints = {}) {
   const unique = [];
   const fingerprintIndexes = new Map();
+  const taskParameterFields = [
+    'isInvisible',
+    'isEnterprise',
+    'pageAction',
+    'enterprisePayload',
+    'recaptchaDataSValue',
+  ];
+  const hasParameterValue = value =>
+    value !== undefined && value !== null && value !== '';
+  const taskParameterApplies = (field, type) =>
+    field !== 'isInvisible' || !/^recaptcha_v3(?:_|$)/.test(type);
+  const stableParameterValue = value => {
+    if (Array.isArray(value)) {
+      return `[${value.map(stableParameterValue).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+      return `{${Object.keys(value).sort().map(key =>
+        `${JSON.stringify(key)}:${stableParameterValue(value[key])}`
+      ).join(',')}}`;
+    }
+    return JSON.stringify(value);
+  };
   for (const raw of Array.isArray(candidates) ? candidates : []) {
     if (!raw?.type) continue;
     const candidate = {
@@ -185,23 +210,40 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
       candidate.frameUrl,
       candidate.type,
       candidate.websiteKey || '',
+      stableParameterValue(Array.isArray(candidate.framePath) ? candidate.framePath : []),
     ].join('|');
     if (fingerprintIndexes.has(fingerprint)) {
       const index = fingerprintIndexes.get(fingerprint);
       const previous = unique[index];
       const preferred = candidateScore(candidate) > candidateScore(previous) ? candidate : previous;
       const fallback = preferred === candidate ? previous : candidate;
-      unique[index] = {
+      const parameterConflicts = new Set([
+        ...(Array.isArray(previous.parameterConflicts) ? previous.parameterConflicts : []),
+        ...(Array.isArray(candidate.parameterConflicts) ? candidate.parameterConflicts : []),
+      ]);
+      const merged = {
         ...fallback,
         ...preferred,
         visible: previous.visible === true || candidate.visible === true,
         normalCheckbox: previous.normalCheckbox === true || candidate.normalCheckbox === true,
         challengeFrame: previous.challengeFrame === true || candidate.challengeFrame === true,
         responseField: previous.responseField === true || candidate.responseField === true,
-        pageAction: previous.pageAction || candidate.pageAction || null,
-        enterprisePayload: previous.enterprisePayload || candidate.enterprisePayload || null,
-        recaptchaDataSValue: previous.recaptchaDataSValue || candidate.recaptchaDataSValue || null,
       };
+      for (const field of taskParameterFields) {
+        const previousValue = previous[field];
+        const candidateValue = candidate[field];
+        if (taskParameterApplies(field, candidate.type)
+            && hasParameterValue(previousValue)
+            && hasParameterValue(candidateValue)
+            && stableParameterValue(previousValue) !== stableParameterValue(candidateValue)) {
+          parameterConflicts.add(field);
+        }
+        merged[field] = hasParameterValue(previousValue)
+          ? previousValue
+          : (hasParameterValue(candidateValue) ? candidateValue : null);
+      }
+      merged.parameterConflicts = [...parameterConflicts].sort();
+      unique[index] = merged;
       continue;
     }
     fingerprintIndexes.set(fingerprint, unique.length);
@@ -248,6 +290,17 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
       ambiguous: true,
       error: 'Multiple CAPTCHA candidates are equally active. Pass an exact frameUrl or websiteKey to select one.',
       candidates: top.map(entry => candidateSummary(entry.candidate)),
+    };
+  }
+  const selectedConflicts = Array.isArray(top[0].candidate.parameterConflicts)
+    ? top[0].candidate.parameterConflicts
+    : [];
+  if (selectedConflicts.length) {
+    return {
+      selected: null,
+      ambiguous: true,
+      error: `Conflicting CAPTCHA task parameters were detected for the same frame, type, and site key: ${selectedConflicts.join(', ')}. Wait for the stale widget to disappear or reload the page before retrying.`,
+      candidates: [candidateSummary(top[0].candidate)],
     };
   }
 

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -201,6 +201,29 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
       ancestorLoaderFrameId: loader.frameId,
     };
   };
+  const isHttpUrl = value => /^https?:\/\//i.test(String(value || ''));
+  const nearestHttpUrl = (candidate) => {
+    if (isHttpUrl(candidate?.frameUrl)) return String(candidate.frameUrl);
+    const framePath = Array.isArray(candidate?.framePath) ? candidate.framePath : [];
+    for (let index = framePath.length - 2; index >= 0; index -= 1) {
+      if (isHttpUrl(framePath[index]?.frameUrl)) return String(framePath[index].frameUrl);
+    }
+    const baseFrameUrl = contextsByFrameId.get(candidate?.frameId)?.frameUrl
+      || navigationByFrameId.get(candidate?.frameId)?.url;
+    if (isHttpUrl(baseFrameUrl)) return String(baseFrameUrl);
+    let currentFrameId = candidate?.frameId;
+    const visited = new Set();
+    while (Number.isInteger(currentFrameId) && !visited.has(currentFrameId)) {
+      visited.add(currentFrameId);
+      const parentFrameId = navigationByFrameId.get(currentFrameId)?.parentFrameId;
+      if (!Number.isInteger(parentFrameId) || parentFrameId === -1) break;
+      const parentUrl = contextsByFrameId.get(parentFrameId)?.frameUrl
+        || navigationByFrameId.get(parentFrameId)?.url;
+      if (isHttpUrl(parentUrl)) return String(parentUrl);
+      currentFrameId = parentFrameId;
+    }
+    return null;
+  };
 
   return sourceCandidates.map(rawCandidate => {
     const candidate = reconcileAncestorLoader(rawCandidate);
@@ -209,6 +232,7 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
     return {
       ...candidate,
       frameVisible,
+      websiteURL: nearestHttpUrl(candidate),
       visible: candidate?.visible === true && frameVisible,
       normalCheckbox: candidate?.normalCheckbox === true && candidate?.visible === true && frameVisible,
     };
@@ -221,7 +245,11 @@ function candidateSummary(candidate) {
     ...(Array.isArray(candidate?.framePath) && candidate.framePath.length
       ? { framePath: candidate.framePath }
       : {}),
+    framePathIndexes: Array.isArray(candidate?.framePath)
+      ? candidate.framePath.map(segment => Number(segment?.index))
+      : [],
     frameUrl: candidate?.frameUrl || '',
+    websiteURL: candidate?.websiteURL || null,
     type: candidate?.type || '',
     websiteKey: candidate?.websiteKey || null,
     visible: candidate?.visible === true,
@@ -364,6 +392,47 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
   }
 
   let pool = unique;
+  const requestedFrameId = Number.isInteger(constraints.frameId) ? constraints.frameId : null;
+  if (requestedFrameId != null) {
+    pool = pool.filter(candidate => candidate.frameId === requestedFrameId);
+    if (!pool.length) {
+      return {
+        selected: null,
+        ambiguous: false,
+        error: `No CAPTCHA candidate was found in frameId ${requestedFrameId}.`,
+        candidates: unique.map(candidateSummary),
+      };
+    }
+  }
+  const hasRequestedFramePath = Array.isArray(constraints.framePath);
+  const requestedFramePath = hasRequestedFramePath
+    ? constraints.framePath.map(value => Number(value))
+    : [];
+  if (hasRequestedFramePath) {
+    if (requestedFramePath.some(value => !Number.isInteger(value) || value < 0)) {
+      return {
+        selected: null,
+        ambiguous: false,
+        error: 'framePath must be an array of non-negative iframe indexes.',
+        candidates: unique.map(candidateSummary),
+      };
+    }
+    pool = pool.filter(candidate => {
+      const candidatePath = Array.isArray(candidate.framePath)
+        ? candidate.framePath.map(segment => Number(segment?.index))
+        : [];
+      return candidatePath.length === requestedFramePath.length
+        && candidatePath.every((value, index) => value === requestedFramePath[index]);
+    });
+    if (!pool.length) {
+      return {
+        selected: null,
+        ambiguous: false,
+        error: `No CAPTCHA candidate was found at framePath [${requestedFramePath.join(', ')}].`,
+        candidates: unique.map(candidateSummary),
+      };
+    }
+  }
   const requestedFrameUrl = String(constraints.frameUrl || '');
   const requestedWebsiteKey = String(constraints.websiteKey || '');
   const requestedType = normalizeCaptchaType(constraints.type);
@@ -412,11 +481,30 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
   const topScore = ranked[0].score;
   const top = ranked.filter(entry => entry.score === topScore);
   if (top.length > 1) {
+    const summaries = top.map(entry => candidateSummary(entry.candidate));
+    const uniqueCount = selector => new Set(summaries.map(selector)).size;
+    const discriminators = [];
+    if (uniqueCount(candidate => candidate.frameUrl) > 1) discriminators.push('frameUrl');
+    if (uniqueCount(candidate => candidate.websiteKey) > 1) discriminators.push('websiteKey');
+    if (uniqueCount(candidate => candidate.frameId) > 1) discriminators.push('frameId');
+    if (uniqueCount(candidate => JSON.stringify(candidate.framePathIndexes)) > 1) {
+      discriminators.push('framePath');
+    }
+    const finalDiscriminator = discriminators.pop();
+    const discriminatorText = finalDiscriminator
+      ? discriminators.length === 0
+        ? finalDiscriminator
+        : discriminators.length === 1
+          ? `${discriminators[0]} or ${finalDiscriminator}`
+          : `${discriminators.join(', ')}, or ${finalDiscriminator}`
+      : null;
     return {
       selected: null,
       ambiguous: true,
-      error: 'Multiple CAPTCHA candidates are equally active. Pass an exact frameUrl or websiteKey to select one.',
-      candidates: top.map(entry => candidateSummary(entry.candidate)),
+      error: discriminatorText
+        ? `Multiple CAPTCHA candidates are equally active. Pass an exact ${discriminatorText} from the candidates to select one.`
+        : 'Multiple CAPTCHA candidates are equally active and expose no unique frame discriminator. Wait for one widget to become inactive before retrying.',
+      candidates: summaries,
     };
   }
   const selectedConflicts = Array.isArray(top[0].candidate.parameterConflicts)
@@ -446,6 +534,8 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
 
 function selectedReason(candidate, constraints) {
   if (candidate.explicitWebsiteKey) return 'explicit site key for detected Turnstile challenge';
+  if (Array.isArray(constraints.framePath)) return 'exact framePath match';
+  if (Number.isInteger(constraints.frameId)) return 'exact frameId match';
   if (constraints.frameUrl) return 'exact frameUrl match';
   if (constraints.websiteKey) return 'exact websiteKey match';
   if (candidate.normalCheckbox && candidate.visible) return 'visible checkbox challenge';

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -370,7 +370,11 @@ export function detectCaptchaCandidatesInPage(scope = null) {
 
   const urlParam = (urlStr, name) => {
     try {
-      return new URL(urlStr, frameUrl || 'https://dummy.host').searchParams.get(name);
+      const url = new URL(urlStr, frameUrl || 'https://dummy.host');
+      const queryValue = url.searchParams.get(name);
+      if (queryValue != null) return queryValue;
+      const fragment = String(url.hash || '').replace(/^#/, '');
+      return fragment ? new URLSearchParams(fragment).get(name) : null;
     } catch (_) {
       return null;
     }

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -23,6 +23,12 @@ export function normalizeCaptchaType(type) {
   return TYPE_ALIASES.get(value) || value;
 }
 
+export function captchaWebsiteUrl(frameUrl, topLevelUrl = '') {
+  return /^https?:\/\//i.test(String(frameUrl || ''))
+    ? String(frameUrl)
+    : String(topLevelUrl || '');
+}
+
 function recaptchaTypeDetails(type, isEnterprise) {
   const normalized = normalizeCaptchaType(type);
   const match = normalized.match(/^recaptcha_v([23])(_enterprise)?$/);
@@ -112,7 +118,8 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
   };
 
   return (Array.isArray(candidates) ? candidates : []).map(candidate => {
-    const frameVisible = frameIsVisible(candidate?.frameId);
+    const frameVisible = frameIsVisible(candidate?.frameId)
+      && candidate?.frameVisibleWithinAnchor !== false;
     return {
       ...candidate,
       frameVisible,
@@ -125,6 +132,9 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
 function candidateSummary(candidate) {
   return {
     frameId: Number.isInteger(candidate?.frameId) ? candidate.frameId : null,
+    ...(Array.isArray(candidate?.framePath) && candidate.framePath.length
+      ? { framePath: candidate.framePath }
+      : {}),
     frameUrl: candidate?.frameUrl || '',
     type: candidate?.type || '',
     websiteKey: candidate?.websiteKey || null,
@@ -266,11 +276,23 @@ function selectedReason(candidate, constraints) {
 
 // This function is serialized and executed in the web page. It must not
 // reference module-scope values.
-export function detectCaptchaCandidatesInPage() {
+export function detectCaptchaCandidatesInPage(scope = null) {
   const candidates = [];
-  const frameUrl = typeof location !== 'undefined' ? String(location.href || '') : '';
+  const pageWindow = scope?.window
+    || (typeof window !== 'undefined' ? window : null);
+  const pageDocument = scope?.document
+    || (typeof document !== 'undefined' ? document : null);
+  const pageLocation = pageWindow?.location
+    || (typeof location !== 'undefined' ? location : null);
+  const frameUrl = pageLocation ? String(pageLocation.href || '') : '';
+  if (!pageDocument) {
+    return {
+      candidates,
+      frameContext: { frameUrl, frameName: '', childFrames: [] },
+    };
+  }
   const challengeFrame = /(?:captcha|challenge|checkpoint|security[-_/ ]?verif)/i.test(frameUrl);
-  const responseField = !!document.querySelector(
+  const responseField = !!pageDocument.querySelector(
     'textarea[name="g-recaptcha-response"], input[name="g-recaptcha-response"], '
       + 'textarea[name="h-captcha-response"], input[name="h-captcha-response"], '
       + 'textarea[name="cf-turnstile-response"], input[name="cf-turnstile-response"]'
@@ -287,14 +309,16 @@ export function detectCaptchaCandidatesInPage() {
   const visibleElement = (element) => {
     if (!element) return false;
     try {
-      const style = typeof getComputedStyle === 'function' ? getComputedStyle(element) : null;
+      const style = typeof pageWindow?.getComputedStyle === 'function'
+        ? pageWindow.getComputedStyle(element)
+        : null;
       if (style && (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0)) return false;
       if (element.hidden || element.getAttribute?.('aria-hidden') === 'true') return false;
       if (typeof element.getBoundingClientRect === 'function') {
         const rect = element.getBoundingClientRect();
         if (!rect || rect.width <= 0 || rect.height <= 0) return false;
-        const viewportWidth = typeof innerWidth === 'number' ? innerWidth : rect.right;
-        const viewportHeight = typeof innerHeight === 'number' ? innerHeight : rect.bottom;
+        const viewportWidth = typeof pageWindow?.innerWidth === 'number' ? pageWindow.innerWidth : rect.right;
+        const viewportHeight = typeof pageWindow?.innerHeight === 'number' ? pageWindow.innerHeight : rect.bottom;
         if (rect.bottom <= 0 || rect.right <= 0 || rect.top >= viewportHeight || rect.left >= viewportWidth) return false;
       }
       return true;
@@ -311,12 +335,12 @@ export function detectCaptchaCandidatesInPage() {
       responseField,
     });
   };
-  const scriptElements = Array.from(document.querySelectorAll('script[src]'));
+  const scriptElements = Array.from(pageDocument.querySelectorAll('script[src]'));
   const scriptUrls = scriptElements.map(element => {
     try { return element.src || ''; } catch (_) { return ''; }
   }).filter(Boolean);
 
-  for (const host of Array.from(document.querySelectorAll('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]'))) {
+  for (const host of Array.from(pageDocument.querySelectorAll('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]'))) {
     const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-hcaptcha-sitekey');
     if (!websiteKey) continue;
     const isInvisible = host.getAttribute('data-size') === 'invisible';
@@ -331,7 +355,7 @@ export function detectCaptchaCandidatesInPage() {
     });
   }
 
-  for (const host of Array.from(document.querySelectorAll('.cf-turnstile[data-sitekey], [data-turnstile-sitekey]'))) {
+  for (const host of Array.from(pageDocument.querySelectorAll('.cf-turnstile[data-sitekey], [data-turnstile-sitekey]'))) {
     const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-turnstile-sitekey');
     if (!websiteKey) continue;
     add({
@@ -344,7 +368,7 @@ export function detectCaptchaCandidatesInPage() {
     });
   }
 
-  for (const host of Array.from(document.querySelectorAll(
+  for (const host of Array.from(pageDocument.querySelectorAll(
     '.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey], [data-recaptcha-sitekey]'
   ))) {
     const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-recaptcha-sitekey');
@@ -385,7 +409,7 @@ export function detectCaptchaCandidatesInPage() {
     });
   }
 
-  const allIframeElements = Array.from(document.querySelectorAll('iframe'));
+  const allIframeElements = Array.from(pageDocument.querySelectorAll('iframe'));
   const iframeElements = allIframeElements.filter(element => {
     try { return !!element.src; } catch (_) { return false; }
   });
@@ -468,8 +492,8 @@ export function detectCaptchaCandidatesInPage() {
   }
 
   if (!candidates.length && (
-    document.querySelector('script[src*="challenges.cloudflare.com/turnstile"]')
-    || document.querySelector('iframe[src*="challenges.cloudflare.com"]')
+    pageDocument.querySelector('script[src*="challenges.cloudflare.com/turnstile"]')
+    || pageDocument.querySelector('iframe[src*="challenges.cloudflare.com"]')
   )) {
     add({
       type: 'turnstile_challenge',
@@ -496,7 +520,7 @@ export function detectCaptchaCandidatesInPage() {
     };
   });
   let frameName = '';
-  try { frameName = typeof window !== 'undefined' ? String(window.name || '') : ''; } catch (_) {}
+  try { frameName = pageWindow ? String(pageWindow.name || '') : ''; } catch (_) {}
   return {
     candidates,
     frameContext: {
@@ -508,14 +532,23 @@ export function detectCaptchaCandidatesInPage() {
 }
 
 // This function is also serialized into a page context. Keep it self-contained.
-export function injectCaptchaTokenInPage(payload) {
+export function injectCaptchaTokenInPage(payload, scope = null) {
   const fieldName = payload?.fieldName;
   const alsoSet = payload?.alsoSet || null;
   const token = payload?.token;
   const target = payload?.target || {};
-  const frameUrl = typeof location !== 'undefined' ? String(location.href || '') : '';
+  const frameWindow = scope?.window
+    || (typeof window !== 'undefined' ? window : null);
+  const frameDocument = scope?.document
+    || (typeof document !== 'undefined' ? document : null);
+  const frameLocation = frameWindow?.location
+    || (typeof location !== 'undefined' ? location : null);
+  const frameUrl = frameLocation ? String(frameLocation.href || '') : '';
   if (!fieldName || !token) {
     return { success: false, fieldUpdated: false, error: 'fieldName and token required', frameUrl };
+  }
+  if (!frameDocument || !frameWindow) {
+    return { success: false, fieldUpdated: false, error: 'target frame document is unavailable', frameUrl };
   }
   if (!Number.isInteger(target.frameId) || !target.frameUrl || !target.websiteKey) {
     return {
@@ -540,7 +573,7 @@ export function injectCaptchaTokenInPage(payload) {
   };
   const frameHasSiteKey = (key) => {
     if (!key) return false;
-    for (const element of Array.from(document.querySelectorAll(
+    for (const element of Array.from(frameDocument.querySelectorAll(
       '[data-sitekey], [data-recaptcha-sitekey], [data-hcaptcha-sitekey], [data-turnstile-sitekey]'
     ))) {
       if ([
@@ -550,7 +583,7 @@ export function injectCaptchaTokenInPage(payload) {
         element.getAttribute('data-turnstile-sitekey'),
       ].includes(key)) return true;
     }
-    for (const element of Array.from(document.querySelectorAll('iframe[src], script[src]'))) {
+    for (const element of Array.from(frameDocument.querySelectorAll('iframe[src], script[src]'))) {
       try { if (element.src && urlHasKey(element.src, key)) return true; } catch (_) {}
     }
     return false;
@@ -566,17 +599,21 @@ export function injectCaptchaTokenInPage(payload) {
   }
 
   const setOn = (name) => {
-    let element = document.querySelector(`textarea[name="${name}"], input[name="${name}"]`);
+    let element = frameDocument.querySelector(`textarea[name="${name}"], input[name="${name}"]`);
     if (!element) {
-      element = document.createElement('textarea');
+      element = frameDocument.createElement('textarea');
       element.name = name;
       element.style.display = 'none';
-      (document.body || document.documentElement).appendChild(element);
+      (frameDocument.body || frameDocument.documentElement).appendChild(element);
     }
     try {
+      const TextAreaElement = frameWindow.HTMLTextAreaElement
+        || (typeof HTMLTextAreaElement !== 'undefined' ? HTMLTextAreaElement : null);
+      const InputElement = frameWindow.HTMLInputElement
+        || (typeof HTMLInputElement !== 'undefined' ? HTMLInputElement : null);
       const prototype = element.tagName === 'TEXTAREA'
-        ? HTMLTextAreaElement.prototype
-        : HTMLInputElement.prototype;
+        ? TextAreaElement?.prototype
+        : InputElement?.prototype;
       const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
       if (setter) setter.call(element, token);
       else element.value = token;
@@ -584,8 +621,12 @@ export function injectCaptchaTokenInPage(payload) {
       element.value = token;
     }
     element.textContent = token;
-    element.dispatchEvent(new Event('input', { bubbles: true }));
-    element.dispatchEvent(new Event('change', { bubbles: true }));
+    const PageEvent = frameWindow.Event
+      || (typeof Event !== 'undefined' ? Event : null);
+    if (PageEvent) {
+      element.dispatchEvent(new PageEvent('input', { bubbles: true }));
+      element.dispatchEvent(new PageEvent('change', { bubbles: true }));
+    }
     return element;
   };
   setOn(fieldName);
@@ -595,7 +636,7 @@ export function injectCaptchaTokenInPage(payload) {
     fieldsTouched += 1;
   }
 
-  const pageWindow = (typeof window !== 'undefined' && window.wrappedJSObject) || window;
+  const pageWindow = frameWindow.wrappedJSObject || frameWindow;
   const callbacks = [];
   const addCallback = (fn, source) => {
     if (typeof fn !== 'function') return;
@@ -610,7 +651,7 @@ export function injectCaptchaTokenInPage(payload) {
       return null;
     }
   };
-  for (const host of Array.from(document.querySelectorAll(
+  for (const host of Array.from(frameDocument.querySelectorAll(
     '.g-recaptcha[data-callback], .h-captcha[data-callback], .cf-turnstile[data-callback], '
       + '[data-recaptcha-sitekey][data-callback], [data-hcaptcha-sitekey][data-callback], '
       + '[data-turnstile-sitekey][data-callback]'

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -1,0 +1,582 @@
+// Shared, page-facing helpers for frame-aware CAPTCHA detection and token
+// injection. This file is mirrored in the Firefox tree; keep both copies
+// byte-identical so the two extension builds make the same decisions.
+
+const TYPE_ALIASES = new Map([
+  ['recaptchav2', 'recaptcha_v2'],
+  ['recaptcha_v2', 'recaptcha_v2'],
+  ['recaptcha_enterprise', 'recaptcha_v2_enterprise'],
+  ['recaptcha_v2_enterprise', 'recaptcha_v2_enterprise'],
+  ['recaptchav3', 'recaptcha_v3'],
+  ['recaptcha_v3', 'recaptcha_v3'],
+  ['recaptcha_v3_enterprise', 'recaptcha_v3_enterprise'],
+  ['cloudflare', 'turnstile'],
+  ['cf_turnstile', 'turnstile'],
+  ['turnstile', 'turnstile'],
+  ['hcaptcha', 'hcaptcha'],
+  ['image', 'image_to_text'],
+  ['image_to_text', 'image_to_text'],
+]);
+
+export function normalizeCaptchaType(type) {
+  const value = String(type || '').trim().toLowerCase();
+  return TYPE_ALIASES.get(value) || value;
+}
+
+function recaptchaTypeDetails(type, isEnterprise) {
+  const normalized = normalizeCaptchaType(type);
+  const match = normalized.match(/^recaptcha_v([23])(_enterprise)?$/);
+  if (!match) return null;
+  const enterpriseInType = !!match[2];
+  return {
+    baseType: `recaptcha_v${match[1]}`,
+    enterprise: enterpriseInType ? true : (isEnterprise == null ? null : !!isEnterprise),
+    invalid: enterpriseInType && isEnterprise === false,
+  };
+}
+
+export function captchaTypesMatch(left, right, leftIsEnterprise = null, rightIsEnterprise = null) {
+  const leftRecaptcha = recaptchaTypeDetails(left, leftIsEnterprise);
+  const rightRecaptcha = recaptchaTypeDetails(right, rightIsEnterprise);
+  if (leftRecaptcha || rightRecaptcha) {
+    if (!leftRecaptcha || !rightRecaptcha || leftRecaptcha.invalid || rightRecaptcha.invalid) return false;
+    if (leftRecaptcha.baseType !== rightRecaptcha.baseType) return false;
+    return leftRecaptcha.enterprise == null
+      || rightRecaptcha.enterprise == null
+      || leftRecaptcha.enterprise === rightRecaptcha.enterprise;
+  }
+  return normalizeCaptchaType(left) === normalizeCaptchaType(right);
+}
+
+function candidateSummary(candidate) {
+  return {
+    frameId: Number.isInteger(candidate?.frameId) ? candidate.frameId : null,
+    frameUrl: candidate?.frameUrl || '',
+    type: candidate?.type || '',
+    websiteKey: candidate?.websiteKey || null,
+    visible: candidate?.visible === true,
+    normalCheckbox: candidate?.normalCheckbox === true,
+    challengeFrame: candidate?.challengeFrame === true,
+    isInvisible: candidate?.isInvisible === true,
+    isEnterprise: candidate?.isEnterprise === true,
+    pageAction: candidate?.pageAction || null,
+    enterprisePayload: candidate?.enterprisePayload || null,
+    recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
+    detectedVia: candidate?.detectedVia || null,
+  };
+}
+
+function candidateScore(candidate) {
+  // Priority is tiered so no combination of secondary signals can make a
+  // generic visible/background integration outrank an active challenge
+  // frame or visible checkbox.
+  const primary = (candidate?.normalCheckbox && candidate?.visible) || candidate?.challengeFrame;
+  const tier = primary ? 3 : (candidate?.visible ? 2 : 1);
+  let score = tier * 1000;
+  if (candidate?.normalCheckbox && candidate?.visible) score += 120;
+  else if (candidate?.visible) score += 60;
+  if (candidate?.challengeFrame) score += 35;
+  if (candidate?.responseField) score += 12;
+  if (candidate?.detectedVia === 'host') score += 8;
+  if (candidate?.websiteKey) score += 4;
+  if (candidate?.isInvisible) score -= 3;
+  return score;
+}
+
+export function selectCaptchaCandidate(candidates, constraints = {}) {
+  const unique = [];
+  const fingerprintIndexes = new Map();
+  for (const raw of Array.isArray(candidates) ? candidates : []) {
+    if (!raw?.type) continue;
+    const candidate = {
+      ...raw,
+      type: normalizeCaptchaType(raw.type),
+      frameUrl: String(raw.frameUrl || ''),
+      websiteKey: raw.websiteKey || null,
+    };
+    const fingerprint = [
+      Number.isInteger(candidate.frameId) ? candidate.frameId : '',
+      candidate.frameUrl,
+      candidate.type,
+      candidate.websiteKey || '',
+    ].join('|');
+    if (fingerprintIndexes.has(fingerprint)) {
+      const index = fingerprintIndexes.get(fingerprint);
+      const previous = unique[index];
+      const preferred = candidateScore(candidate) > candidateScore(previous) ? candidate : previous;
+      const fallback = preferred === candidate ? previous : candidate;
+      unique[index] = {
+        ...fallback,
+        ...preferred,
+        visible: previous.visible === true || candidate.visible === true,
+        normalCheckbox: previous.normalCheckbox === true || candidate.normalCheckbox === true,
+        challengeFrame: previous.challengeFrame === true || candidate.challengeFrame === true,
+        responseField: previous.responseField === true || candidate.responseField === true,
+        pageAction: previous.pageAction || candidate.pageAction || null,
+        enterprisePayload: previous.enterprisePayload || candidate.enterprisePayload || null,
+        recaptchaDataSValue: previous.recaptchaDataSValue || candidate.recaptchaDataSValue || null,
+      };
+      continue;
+    }
+    fingerprintIndexes.set(fingerprint, unique.length);
+    unique.push(candidate);
+  }
+
+  let pool = unique;
+  const requestedFrameUrl = String(constraints.frameUrl || '');
+  const requestedWebsiteKey = String(constraints.websiteKey || '');
+  if (requestedFrameUrl) {
+    pool = pool.filter(candidate => candidate.frameUrl === requestedFrameUrl);
+    if (!pool.length) {
+      return {
+        selected: null,
+        ambiguous: false,
+        error: `No CAPTCHA candidate was found in the exact frame URL ${requestedFrameUrl}.`,
+        candidates: unique.map(candidateSummary),
+      };
+    }
+  }
+  if (requestedWebsiteKey) {
+    pool = pool.filter(candidate => candidate.websiteKey === requestedWebsiteKey);
+    if (!pool.length) {
+      return {
+        selected: null,
+        ambiguous: false,
+        error: 'No detected CAPTCHA candidate matched the supplied websiteKey.',
+        candidates: unique.map(candidateSummary),
+      };
+    }
+  }
+  if (!pool.length) {
+    return { selected: null, ambiguous: false, error: null, candidates: [] };
+  }
+
+  const ranked = pool
+    .map(candidate => ({ candidate, score: candidateScore(candidate) }))
+    .sort((left, right) => right.score - left.score);
+  const topScore = ranked[0].score;
+  const top = ranked.filter(entry => entry.score === topScore);
+  if (top.length > 1) {
+    return {
+      selected: null,
+      ambiguous: true,
+      error: 'Multiple CAPTCHA candidates are equally active. Pass an exact frameUrl or websiteKey to select one.',
+      candidates: top.map(entry => candidateSummary(entry.candidate)),
+    };
+  }
+
+  const selected = {
+    ...top[0].candidate,
+    selectionScore: topScore,
+    selectionReason: selectedReason(top[0].candidate, constraints),
+  };
+  return {
+    selected,
+    ambiguous: false,
+    error: null,
+    candidates: unique.map(candidateSummary),
+  };
+}
+
+function selectedReason(candidate, constraints) {
+  if (constraints.frameUrl) return 'exact frameUrl match';
+  if (constraints.websiteKey) return 'exact websiteKey match';
+  if (candidate.normalCheckbox && candidate.visible) return 'visible checkbox challenge';
+  if (candidate.visible && candidate.challengeFrame) return 'visible challenge frame';
+  if (candidate.visible) return 'visible CAPTCHA widget';
+  if (candidate.challengeFrame) return 'challenge frame candidate';
+  return 'only detected CAPTCHA candidate';
+}
+
+// This function is serialized and executed in the web page. It must not
+// reference module-scope values.
+export function detectCaptchaCandidatesInPage() {
+  const candidates = [];
+  const frameUrl = typeof location !== 'undefined' ? String(location.href || '') : '';
+  const challengeFrame = /(?:captcha|challenge|checkpoint|security[-_/ ]?verif)/i.test(frameUrl);
+  const responseField = !!document.querySelector(
+    'textarea[name="g-recaptcha-response"], input[name="g-recaptcha-response"], '
+      + 'textarea[name="h-captcha-response"], input[name="h-captcha-response"], '
+      + 'textarea[name="cf-turnstile-response"], input[name="cf-turnstile-response"]'
+  );
+  const V3_NO_ACTION_NOTE = 'reCAPTCHA v3 detected, but the page never exposed an action name. solve_captcha needs pageAction — read it from the grecaptcha.execute(...) call in the site JS, or infer it from the form (login, submit, checkout).';
+
+  const urlParam = (urlStr, name) => {
+    try {
+      return new URL(urlStr, frameUrl || 'https://dummy.host').searchParams.get(name);
+    } catch (_) {
+      return null;
+    }
+  };
+  const visibleElement = (element) => {
+    if (!element) return false;
+    try {
+      const style = typeof getComputedStyle === 'function' ? getComputedStyle(element) : null;
+      if (style && (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0)) return false;
+      if (element.hidden || element.getAttribute?.('aria-hidden') === 'true') return false;
+      if (typeof element.getBoundingClientRect === 'function') {
+        const rect = element.getBoundingClientRect();
+        if (!rect || rect.width <= 0 || rect.height <= 0) return false;
+        const viewportWidth = typeof innerWidth === 'number' ? innerWidth : rect.right;
+        const viewportHeight = typeof innerHeight === 'number' ? innerHeight : rect.bottom;
+        if (rect.bottom <= 0 || rect.right <= 0 || rect.top >= viewportHeight || rect.left >= viewportWidth) return false;
+      }
+      return true;
+    } catch (_) {
+      return false;
+    }
+  };
+  const add = (candidate) => {
+    if (!candidate?.type) return;
+    candidates.push({
+      ...candidate,
+      frameUrl,
+      challengeFrame,
+      responseField,
+    });
+  };
+  const scriptElements = Array.from(document.querySelectorAll('script[src]'));
+  const scriptUrls = scriptElements.map(element => {
+    try { return element.src || ''; } catch (_) { return ''; }
+  }).filter(Boolean);
+
+  for (const host of Array.from(document.querySelectorAll('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]'))) {
+    const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-hcaptcha-sitekey');
+    if (!websiteKey) continue;
+    const isInvisible = host.getAttribute('data-size') === 'invisible';
+    add({
+      type: 'hcaptcha',
+      websiteKey,
+      isInvisible,
+      visible: visibleElement(host) && !isInvisible,
+      normalCheckbox: visibleElement(host) && !isInvisible,
+      callbackName: host.getAttribute('data-callback') || null,
+      detectedVia: 'host',
+    });
+  }
+
+  for (const host of Array.from(document.querySelectorAll('.cf-turnstile[data-sitekey], [data-turnstile-sitekey]'))) {
+    const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-turnstile-sitekey');
+    if (!websiteKey) continue;
+    add({
+      type: 'turnstile',
+      websiteKey,
+      visible: visibleElement(host),
+      normalCheckbox: false,
+      callbackName: host.getAttribute('data-callback') || null,
+      detectedVia: 'host',
+    });
+  }
+
+  for (const host of Array.from(document.querySelectorAll(
+    '.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey], [data-recaptcha-sitekey]'
+  ))) {
+    const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-recaptcha-sitekey');
+    if (!websiteKey) continue;
+    const isInvisible = host.getAttribute('data-size') === 'invisible';
+    const action = host.getAttribute('data-action') || host.getAttribute('data-recaptcha-action') || null;
+    const hasClassicScript = scriptUrls.some(url => /recaptcha\/api\.js/i.test(url));
+    const hasEnterpriseScript = scriptUrls.some(url => /recaptcha\/enterprise(?:\.js|\/)/i.test(url));
+    const isEnterprise = host.getAttribute('data-enterprise') === 'true'
+      || host.getAttribute('data-sitekey-type') === 'enterprise'
+      || host.querySelector('iframe[src*="recaptcha/enterprise"]') != null
+      || (!hasClassicScript && hasEnterpriseScript);
+    const version = host.getAttribute('data-version') || (host.classList.contains('g-recaptcha-v3') ? 'v3' : null);
+    const renderScript = scriptUrls.find(url =>
+      /recaptcha\/(api|enterprise)\.js/i.test(url) && urlParam(url, 'render') === websiteKey
+    ) || null;
+    const isV3 = version === 'v3' || !!renderScript || (!!action && !isInvisible);
+    const pageAction = action || (isV3 && renderScript
+      ? (urlParam(renderScript, 'action') || urlParam(renderScript, 'pageAction') || urlParam(renderScript, 'page_action'))
+      : null);
+    const enterpriseS = host.getAttribute('data-s') || null;
+    const visible = visibleElement(host) && !isInvisible;
+    add({
+      type: isV3
+        ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3')
+        : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
+      websiteKey,
+      isInvisible,
+      isEnterprise,
+      visible,
+      normalCheckbox: visible && !isV3,
+      callbackName: host.getAttribute('data-callback') || null,
+      ...(pageAction ? { pageAction } : (isV3 ? { note: V3_NO_ACTION_NOTE } : {})),
+      ...(enterpriseS
+        ? (isEnterprise ? { enterprisePayload: { s: enterpriseS } } : { recaptchaDataSValue: enterpriseS })
+        : {}),
+      detectedVia: 'host',
+    });
+  }
+
+  const iframeElements = Array.from(document.querySelectorAll('iframe[src]'));
+  const iframeUrls = iframeElements.map(element => {
+    try { return { element, url: element.src || '' }; } catch (_) { return { element, url: '' }; }
+  }).filter(item => item.url);
+
+  for (const { element, url } of iframeUrls) {
+    if (/hcaptcha\.com/i.test(url)) {
+      const websiteKey = urlParam(url, 'sitekey');
+      if (websiteKey) {
+        add({
+          type: 'hcaptcha',
+          websiteKey,
+          visible: visibleElement(element),
+          normalCheckbox: visibleElement(element),
+          detectedVia: 'url',
+        });
+      }
+      continue;
+    }
+    if (/challenges\.cloudflare\.com\/turnstile/i.test(url)) {
+      const websiteKey = urlParam(url, 'sitekey');
+      if (websiteKey) {
+        add({
+          type: 'turnstile',
+          websiteKey,
+          visible: visibleElement(element),
+          normalCheckbox: false,
+          detectedVia: 'url',
+        });
+      }
+      continue;
+    }
+    if (!/recaptcha\/(api2|enterprise)\/anchor/i.test(url)) continue;
+    const websiteKey = urlParam(url, 'k');
+    if (!websiteKey) continue;
+    const isEnterprise = /recaptcha\/enterprise/i.test(url);
+    const isInvisible = urlParam(url, 'size') === 'invisible';
+    const matchingV3Script = scriptUrls.find(scriptUrl => urlParam(scriptUrl, 'render') === websiteKey) || null;
+    const isV3 = !!matchingV3Script;
+    const pageAction = isV3
+      ? (urlParam(matchingV3Script, 'action') || urlParam(matchingV3Script, 'pageAction') || urlParam(matchingV3Script, 'page_action'))
+      : (urlParam(url, 'sa') || null);
+    const sValue = urlParam(url, 's');
+    const visible = visibleElement(element) && !isInvisible;
+    add({
+      type: isV3
+        ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3')
+        : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
+      websiteKey,
+      isInvisible,
+      isEnterprise,
+      visible,
+      normalCheckbox: visible && !isV3,
+      ...(pageAction ? { pageAction } : (isV3 ? { note: V3_NO_ACTION_NOTE } : {})),
+      ...(sValue
+        ? (isEnterprise ? { enterprisePayload: { s: sValue } } : { recaptchaDataSValue: sValue })
+        : {}),
+      detectedVia: 'url',
+    });
+  }
+
+  for (const url of scriptUrls) {
+    if (!/recaptcha\/(api\.js|enterprise\.js)/i.test(url)) continue;
+    const websiteKey = urlParam(url, 'render');
+    if (!websiteKey || websiteKey === 'explicit') continue;
+    const isEnterprise = /recaptcha\/enterprise/i.test(url);
+    const pageAction = urlParam(url, 'action') || urlParam(url, 'pageAction') || urlParam(url, 'page_action');
+    add({
+      type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
+      websiteKey,
+      isInvisible: true,
+      isEnterprise,
+      visible: false,
+      normalCheckbox: false,
+      ...(pageAction ? { pageAction } : { note: V3_NO_ACTION_NOTE }),
+      detectedVia: 'script',
+    });
+  }
+
+  if (!candidates.length && (
+    document.querySelector('script[src*="challenges.cloudflare.com/turnstile"]')
+    || document.querySelector('iframe[src*="challenges.cloudflare.com"]')
+  )) {
+    add({
+      type: 'turnstile_challenge',
+      websiteKey: null,
+      visible: true,
+      normalCheckbox: false,
+      note: 'Cloudflare interstitial detected but no sitekey was exposed in the DOM. Pass websiteKey explicitly if you have it.',
+      detectedVia: 'script',
+    });
+  }
+  return candidates;
+}
+
+// This function is also serialized into a page context. Keep it self-contained.
+export function injectCaptchaTokenInPage(payload) {
+  const fieldName = payload?.fieldName;
+  const alsoSet = payload?.alsoSet || null;
+  const token = payload?.token;
+  const target = payload?.target || {};
+  const frameUrl = typeof location !== 'undefined' ? String(location.href || '') : '';
+  if (!fieldName || !token) {
+    return { success: false, fieldUpdated: false, error: 'fieldName and token required', frameUrl };
+  }
+  if (!Number.isInteger(target.frameId) || !target.frameUrl || !target.websiteKey) {
+    return {
+      success: false,
+      fieldUpdated: false,
+      targetRequired: true,
+      error: 'A selected CAPTCHA frame identity, URL, and site key are required for token injection.',
+      frameUrl,
+    };
+  }
+  if (target.frameUrl && frameUrl !== target.frameUrl) {
+    return { success: false, fieldUpdated: false, skipped: true, error: 'frame URL did not match target', frameUrl };
+  }
+
+  const urlHasKey = (urlStr, key) => {
+    try {
+      const url = new URL(urlStr, frameUrl || 'https://dummy.host');
+      return ['k', 'render', 'sitekey'].some(name => url.searchParams.get(name) === key);
+    } catch (_) {
+      return false;
+    }
+  };
+  const frameHasSiteKey = (key) => {
+    if (!key) return false;
+    for (const element of Array.from(document.querySelectorAll(
+      '[data-sitekey], [data-recaptcha-sitekey], [data-hcaptcha-sitekey], [data-turnstile-sitekey]'
+    ))) {
+      if ([
+        element.getAttribute('data-sitekey'),
+        element.getAttribute('data-recaptcha-sitekey'),
+        element.getAttribute('data-hcaptcha-sitekey'),
+        element.getAttribute('data-turnstile-sitekey'),
+      ].includes(key)) return true;
+    }
+    for (const element of Array.from(document.querySelectorAll('iframe[src], script[src]'))) {
+      try { if (element.src && urlHasKey(element.src, key)) return true; } catch (_) {}
+    }
+    return false;
+  };
+  if (!frameHasSiteKey(target.websiteKey)) {
+    return {
+      success: false,
+      fieldUpdated: false,
+      staleTarget: true,
+      error: 'The selected CAPTCHA site key is no longer present in the target frame.',
+      frameUrl,
+    };
+  }
+
+  const setOn = (name) => {
+    let element = document.querySelector(`textarea[name="${name}"], input[name="${name}"]`);
+    if (!element) {
+      element = document.createElement('textarea');
+      element.name = name;
+      element.style.display = 'none';
+      (document.body || document.documentElement).appendChild(element);
+    }
+    try {
+      const prototype = element.tagName === 'TEXTAREA'
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+      const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+      if (setter) setter.call(element, token);
+      else element.value = token;
+    } catch (_) {
+      element.value = token;
+    }
+    element.textContent = token;
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+    return element;
+  };
+  setOn(fieldName);
+  let fieldsTouched = 1;
+  if (alsoSet) {
+    setOn(alsoSet);
+    fieldsTouched += 1;
+  }
+
+  const pageWindow = (typeof window !== 'undefined' && window.wrappedJSObject) || window;
+  const callbacks = [];
+  const addCallback = (fn, source) => {
+    if (typeof fn !== 'function') return;
+    if (callbacks.some(entry => entry.fn === fn)) return;
+    callbacks.push({ fn, source });
+  };
+  const resolveNamedCallback = (name) => {
+    if (!name) return null;
+    try {
+      return String(name).split('.').reduce((value, part) => value?.[part], pageWindow);
+    } catch (_) {
+      return null;
+    }
+  };
+  for (const host of Array.from(document.querySelectorAll(
+    '.g-recaptcha[data-callback], .h-captcha[data-callback], .cf-turnstile[data-callback], '
+      + '[data-recaptcha-sitekey][data-callback], [data-hcaptcha-sitekey][data-callback], '
+      + '[data-turnstile-sitekey][data-callback]'
+  ))) {
+    const hostKey = host.getAttribute('data-sitekey') || host.getAttribute('data-recaptcha-sitekey')
+      || host.getAttribute('data-hcaptcha-sitekey') || host.getAttribute('data-turnstile-sitekey');
+    if (target.websiteKey && hostKey !== target.websiteKey) continue;
+    const callbackName = host.getAttribute('data-callback');
+    addCallback(resolveNamedCallback(callbackName), `data-callback:${callbackName}`);
+  }
+
+  const collectGoogleCallbacks = () => {
+    let clients;
+    try { clients = pageWindow?.___grecaptcha_cfg?.clients; } catch (_) { return; }
+    if (!clients || typeof clients !== 'object') return;
+    let clientValues;
+    try { clientValues = Object.values(clients); } catch (_) { return; }
+    for (const client of clientValues) {
+      let containsKey = !target.websiteKey;
+      const clientCallbacks = [];
+      const seen = new Set();
+      const walk = (value, depth, propertyName = '') => {
+        if (depth > 8 || value == null) return;
+        if (typeof value === 'string') {
+          if (value === target.websiteKey) containsKey = true;
+          return;
+        }
+        if (typeof value === 'function') {
+          if (/callback/i.test(propertyName)) clientCallbacks.push(value);
+          return;
+        }
+        if (typeof value !== 'object' || seen.has(value)) return;
+        seen.add(value);
+        let entries;
+        try { entries = Object.entries(value); } catch (_) { return; }
+        for (const [key, child] of entries) walk(child, depth + 1, key);
+      };
+      walk(client, 0);
+      if (containsKey) {
+        for (const callback of clientCallbacks) addCallback(callback, 'grecaptcha-client');
+      }
+    }
+  };
+  if (!callbacks.length) collectGoogleCallbacks();
+
+  let calledCallback = false;
+  let callbackSource = null;
+  let callbackError = null;
+  if (callbacks.length === 1) {
+    try {
+      callbacks[0].fn.call(pageWindow, token);
+      calledCallback = true;
+      callbackSource = callbacks[0].source;
+    } catch (error) {
+      callbackError = error?.message || String(error);
+    }
+  }
+
+  return {
+    success: true,
+    fieldUpdated: true,
+    fieldsUpdated: [fieldName, ...(alsoSet ? [alsoSet] : [])],
+    fieldsTouched,
+    calledCallback,
+    callbackSource,
+    callbackAmbiguous: callbacks.length > 1,
+    callbackCandidates: callbacks.length,
+    callbackError,
+    siteKeyMatched: true,
+    frameUrl,
+  };
+}

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -234,6 +234,9 @@ function candidateSummary(candidate) {
     enterprisePayload: candidate?.enterprisePayload || null,
     recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
     explicitWebsiteKey: candidate?.explicitWebsiteKey === true,
+    documentTimeOrigin: Number.isFinite(candidate?.documentTimeOrigin)
+      ? candidate.documentTimeOrigin
+      : null,
     ancestorLoaderFrameId: Number.isInteger(candidate?.ancestorLoaderFrameId)
       ? candidate.ancestorLoaderFrameId
       : null,
@@ -458,6 +461,11 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       + 'textarea[name="cf-turnstile-response"], input[name="cf-turnstile-response"]'
   );
   const V3_NO_ACTION_NOTE = 'reCAPTCHA v3 detected, but the page never exposed an action name. solve_captcha needs pageAction — read it from the grecaptcha.execute(...) call in the site JS, or infer it from the form (login, submit, checkout).';
+  let documentTimeOrigin = null;
+  try {
+    const value = Number(pageWindow?.performance?.timeOrigin);
+    if (Number.isFinite(value) && value > 0) documentTimeOrigin = value;
+  } catch (_) {}
 
   const urlParam = (urlStr, name) => {
     try {
@@ -497,6 +505,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       frameUrl,
       challengeFrame,
       responseField,
+      documentTimeOrigin,
     });
   };
   const scriptElements = Array.from(pageDocument.querySelectorAll('script[src]'));
@@ -724,8 +733,49 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
       frameUrl,
     };
   }
-  if (target.frameUrl && frameUrl !== target.frameUrl) {
-    return { success: false, fieldUpdated: false, skipped: true, error: 'frame URL did not match target', frameUrl };
+  let currentDocumentTimeOrigin = null;
+  try {
+    const value = Number(frameWindow.performance?.timeOrigin);
+    if (Number.isFinite(value) && value > 0) currentDocumentTimeOrigin = value;
+  } catch (_) {}
+  const targetHasDocumentIdentity = Number.isFinite(target.documentTimeOrigin);
+  const currentHasDocumentIdentity = Number.isFinite(currentDocumentTimeOrigin);
+  if (targetHasDocumentIdentity
+      && currentHasDocumentIdentity
+      && target.documentTimeOrigin !== currentDocumentTimeOrigin) {
+    return {
+      success: false,
+      fieldUpdated: false,
+      skipped: true,
+      staleTarget: true,
+      error: 'target frame navigated to a different document',
+      frameUrl,
+    };
+  }
+  const sameStableUrl = (left, right) => {
+    try {
+      const leftUrl = new URL(left);
+      const rightUrl = new URL(right);
+      return leftUrl.origin === rightUrl.origin && leftUrl.pathname === rightUrl.pathname;
+    } catch (_) {
+      return false;
+    }
+  };
+  const sameDocumentIdentity = targetHasDocumentIdentity
+    && currentHasDocumentIdentity
+    && target.documentTimeOrigin === currentDocumentTimeOrigin;
+  if (target.frameUrl
+      && frameUrl !== target.frameUrl
+      && !sameDocumentIdentity
+      && !sameStableUrl(frameUrl, target.frameUrl)) {
+    return {
+      success: false,
+      fieldUpdated: false,
+      skipped: true,
+      staleTarget: true,
+      error: 'frame URL did not match target document',
+      frameUrl,
+    };
   }
 
   const urlHasKey = (urlStr, key) => {

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -112,7 +112,12 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
     const parentVisible = frameIsVisible(parentFrameId, visiting);
     visiting.delete(frameId);
     const embeddingFrame = parentVisible ? findEmbeddingFrame(frameId, parentFrameId) : null;
-    const visible = parentVisible && embeddingFrame?.visible === true;
+    // A cross-origin child can redirect while its embedding iframe keeps the
+    // original src. In that case parent code cannot read loadedUrl, so a
+    // missing match means visibility is unknown rather than hidden. Only
+    // demote when a matched embedding frame is conclusively hidden.
+    const visible = parentVisible
+      && (embeddingFrame ? embeddingFrame.visible === true : true);
     visibilityByFrameId.set(frameId, visible);
     return visible;
   };
@@ -566,7 +571,8 @@ export function detectCaptchaCandidatesInPage(scope = null) {
     });
   }
 
-  if (!candidates.length && (
+  const hasDetectedTurnstile = candidates.some(candidate => candidate.type === 'turnstile');
+  if (!hasDetectedTurnstile && (
     pageDocument.querySelector('script[src*="challenges.cloudflare.com/turnstile"]')
     || pageDocument.querySelector('iframe[src*="challenges.cloudflare.com"]')
   )) {

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -1046,6 +1046,10 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
         }
       });
       if (exact) return { element: exact };
+      return {
+        error: 'The selected CAPTCHA response field ID is no longer present in the target frame.',
+        staleTarget: true,
+      };
     }
     if (Number.isInteger(selectedFieldIndex)) {
       if (fields[selectedFieldIndex]) {
@@ -1073,7 +1077,7 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     ...field,
     ...resolveResponseField(field.name, field.primary),
   }));
-  const unresolvedField = resolvedFields.find(field => field.error);
+  const unresolvedField = resolvedFields.find(field => field.primary && field.error);
   if (unresolvedField) {
     return {
       success: false,
@@ -1084,6 +1088,8 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
       frameUrl,
     };
   }
+  const skippedFields = resolvedFields.filter(field => !field.primary && field.error);
+  const injectableFields = resolvedFields.filter(field => !field.error);
 
   const setOn = (name, existingElement) => {
     let element = existingElement;
@@ -1116,10 +1122,10 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     }
     return element;
   };
-  for (const field of resolvedFields) {
+  for (const field of injectableFields) {
     setOn(field.name, field.element);
   }
-  const fieldsTouched = resolvedFields.length;
+  const fieldsTouched = injectableFields.length;
 
   const pageWindow = frameWindow.wrappedJSObject || frameWindow;
   const callbacks = [];
@@ -1204,8 +1210,10 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
   return {
     success: true,
     fieldUpdated: true,
-    fieldsUpdated: [fieldName, ...(alsoSet ? [alsoSet] : [])],
+    fieldsUpdated: injectableFields.map(field => field.name),
     fieldsTouched,
+    compatibilityFieldSkipped: skippedFields.length > 0,
+    compatibilityFieldError: skippedFields[0]?.error || null,
     responseFieldId: target.responseFieldId || null,
     responseFieldIndex: Number.isInteger(target.responseFieldIndex)
       ? target.responseFieldIndex

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -639,7 +639,11 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
   const urlHasKey = (urlStr, key) => {
     try {
       const url = new URL(urlStr, frameUrl || 'https://dummy.host');
-      return ['k', 'render', 'sitekey'].some(name => url.searchParams.get(name) === key);
+      const fragment = String(url.hash || '').replace(/^#/, '');
+      const fragmentParams = fragment ? new URLSearchParams(fragment) : null;
+      return ['k', 'render', 'sitekey'].some(name =>
+        url.searchParams.get(name) === key || fragmentParams?.get(name) === key
+      );
     } catch (_) {
       return false;
     }
@@ -661,12 +665,21 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     }
     return false;
   };
-  if (!frameHasSiteKey(target.websiteKey)) {
+  const siteKeyMatched = frameHasSiteKey(target.websiteKey);
+  const explicitTurnstileTarget = target.explicitWebsiteKey === true
+    && target.type === 'turnstile';
+  const challengeMarkerMatched = explicitTurnstileTarget && !!(
+    frameDocument.querySelector('script[src*="challenges.cloudflare.com/turnstile"]')
+    || frameDocument.querySelector('iframe[src*="challenges.cloudflare.com"]')
+  );
+  if (!siteKeyMatched && !challengeMarkerMatched) {
     return {
       success: false,
       fieldUpdated: false,
       staleTarget: true,
-      error: 'The selected CAPTCHA site key is no longer present in the target frame.',
+      error: explicitTurnstileTarget
+        ? 'The selected Turnstile challenge marker is no longer present in the target frame.'
+        : 'The selected CAPTCHA site key is no longer present in the target frame.',
       frameUrl,
     };
   }
@@ -793,7 +806,8 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     callbackAmbiguous: callbacks.length > 1,
     callbackCandidates: callbacks.length,
     callbackError,
-    siteKeyMatched: true,
+    siteKeyMatched,
+    challengeMarkerMatched,
     frameUrl,
   };
 }

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -65,6 +65,14 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
   }
 
   const uniqueMatch = (items) => items.length === 1 ? items[0] : null;
+  const httpOrigin = (value) => {
+    try {
+      const parsed = new URL(String(value || ''));
+      return /^https?:$/.test(parsed.protocol) ? parsed.origin : '';
+    } catch (_) {
+      return '';
+    }
+  };
   const findEmbeddingFrame = (frameId, parentFrameId) => {
     const parentContext = contextsByFrameId.get(parentFrameId);
     if (!parentContext) return null;
@@ -91,6 +99,13 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
       const byName = uniqueMatch(childFrames.filter(child => String(child?.name || '') === frameName));
       if (byName) return byName;
     }
+    const frameOrigins = new Set([...frameUrls].map(httpOrigin).filter(Boolean));
+    if (frameOrigins.size) {
+      const byOrigin = uniqueMatch(childFrames.filter(child =>
+        [child?.loadedUrl, child?.url].some(url => frameOrigins.has(httpOrigin(url)))
+      ));
+      if (byOrigin) return byOrigin;
+    }
     return childFrames.length === 1 ? childFrames[0] : null;
   };
 
@@ -112,12 +127,13 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
     const parentVisible = frameIsVisible(parentFrameId, visiting);
     visiting.delete(frameId);
     const embeddingFrame = parentVisible ? findEmbeddingFrame(frameId, parentFrameId) : null;
-    // A cross-origin child can redirect while its embedding iframe keeps the
-    // original src. In that case parent code cannot read loadedUrl, so a
-    // missing match means visibility is unknown rather than hidden. Only
-    // demote when a matched embedding frame is conclusively hidden.
+    // A unique origin match covers common cross-origin redirects whose iframe
+    // keeps its original src. When multiple embedding elements are still
+    // indistinguishable, visibility is unknown; fail closed so an internally
+    // visible widget inside a hidden iframe is not promoted into the paid-task
+    // ranking tier.
     const visible = parentVisible
-      && (embeddingFrame ? embeddingFrame.visible === true : true);
+      && embeddingFrame?.visible === true;
     visibilityByFrameId.set(frameId, visible);
     return visible;
   };

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -234,6 +234,11 @@ function candidateSummary(candidate) {
     enterprisePayload: candidate?.enterprisePayload || null,
     recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
     explicitWebsiteKey: candidate?.explicitWebsiteKey === true,
+    callbackName: candidate?.callbackName || null,
+    responseFieldId: candidate?.responseFieldId || null,
+    responseFieldIndex: Number.isInteger(candidate?.responseFieldIndex)
+      ? candidate.responseFieldIndex
+      : null,
     documentTimeOrigin: Number.isFinite(candidate?.documentTimeOrigin)
       ? candidate.documentTimeOrigin
       : null,
@@ -306,6 +311,11 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
       candidate.type,
       candidate.websiteKey || '',
       stableParameterValue(Array.isArray(candidate.framePath) ? candidate.framePath : []),
+      candidate.responseFieldId || (
+        Number.isInteger(candidate.responseFieldIndex)
+          ? `response-field-${candidate.responseFieldIndex}`
+          : ''
+      ),
     ].join('|');
     if (fingerprintIndexes.has(fingerprint)) {
       const index = fingerprintIndexes.get(fingerprint);
@@ -512,8 +522,39 @@ export function detectCaptchaCandidatesInPage(scope = null) {
   const scriptUrls = scriptElements.map(element => {
     try { return element.src || ''; } catch (_) { return ''; }
   }).filter(Boolean);
+  const responseFieldIdentity = (widget, name, fallbackIndex, widgetCount) => {
+    const selector = `textarea[name="${name}"], input[name="${name}"]`;
+    const fields = Array.from(pageDocument.querySelectorAll(selector));
+    let field = null;
+    try { field = widget?.querySelector?.(selector) || null; } catch (_) {}
+    let ancestor = widget?.parentElement || null;
+    for (let depth = 0; !field && ancestor && depth < 4; depth += 1) {
+      let contained = [];
+      try { contained = Array.from(ancestor.querySelectorAll(selector)); } catch (_) {}
+      if (contained.length === 1) field = contained[0];
+      ancestor = ancestor.parentElement;
+    }
+    if (!field
+        && fields.length === widgetCount
+        && Number.isInteger(fallbackIndex)
+        && fallbackIndex >= 0
+        && fallbackIndex < fields.length) {
+      field = fields[fallbackIndex];
+    }
+    if (!field) return {};
+    const responseFieldIndex = fields.indexOf(field);
+    let responseFieldId = '';
+    try { responseFieldId = String(field.id || field.getAttribute?.('id') || ''); } catch (_) {}
+    return {
+      ...(responseFieldId ? { responseFieldId } : {}),
+      ...(responseFieldIndex >= 0 ? { responseFieldIndex } : {}),
+    };
+  };
 
-  for (const host of Array.from(pageDocument.querySelectorAll('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]'))) {
+  const hcaptchaHosts = Array.from(pageDocument.querySelectorAll(
+    '.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]'
+  ));
+  for (const [widgetIndex, host] of hcaptchaHosts.entries()) {
     const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-hcaptcha-sitekey');
     if (!websiteKey) continue;
     const isInvisible = host.getAttribute('data-size') === 'invisible';
@@ -524,11 +565,15 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       visible: visibleElement(host) && !isInvisible,
       normalCheckbox: visibleElement(host) && !isInvisible,
       callbackName: host.getAttribute('data-callback') || null,
+      ...responseFieldIdentity(host, 'h-captcha-response', widgetIndex, hcaptchaHosts.length),
       detectedVia: 'host',
     });
   }
 
-  for (const host of Array.from(pageDocument.querySelectorAll('.cf-turnstile[data-sitekey], [data-turnstile-sitekey]'))) {
+  const turnstileHosts = Array.from(pageDocument.querySelectorAll(
+    '.cf-turnstile[data-sitekey], [data-turnstile-sitekey]'
+  ));
+  for (const [widgetIndex, host] of turnstileHosts.entries()) {
     const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-turnstile-sitekey');
     if (!websiteKey) continue;
     add({
@@ -537,13 +582,15 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       visible: visibleElement(host),
       normalCheckbox: false,
       callbackName: host.getAttribute('data-callback') || null,
+      ...responseFieldIdentity(host, 'cf-turnstile-response', widgetIndex, turnstileHosts.length),
       detectedVia: 'host',
     });
   }
 
-  for (const host of Array.from(pageDocument.querySelectorAll(
+  const recaptchaHosts = Array.from(pageDocument.querySelectorAll(
     '.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey], [data-recaptcha-sitekey]'
-  ))) {
+  ));
+  for (const [widgetIndex, host] of recaptchaHosts.entries()) {
     const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-recaptcha-sitekey');
     if (!websiteKey) continue;
     const isInvisible = host.getAttribute('data-size') === 'invisible';
@@ -578,6 +625,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       ...(enterpriseS
         ? (isEnterprise ? { enterprisePayload: { s: enterpriseS } } : { recaptchaDataSValue: enterpriseS })
         : {}),
+      ...responseFieldIdentity(host, 'g-recaptcha-response', widgetIndex, recaptchaHosts.length),
       detectedVia: 'host',
     });
   }
@@ -589,6 +637,13 @@ export function detectCaptchaCandidatesInPage(scope = null) {
   const iframeUrls = iframeElements.map(element => {
     try { return { element, url: element.src || '' }; } catch (_) { return { element, url: '' }; }
   }).filter(item => item.url);
+  const hcaptchaFrames = iframeUrls.filter(({ url }) => /hcaptcha\.com/i.test(url));
+  const turnstileFrames = iframeUrls.filter(({ url }) =>
+    /challenges\.cloudflare\.com\/turnstile/i.test(url)
+  );
+  const recaptchaFrames = iframeUrls.filter(({ url }) =>
+    /recaptcha\/(api2|enterprise)\/anchor/i.test(url)
+  );
 
   for (const { element, url } of iframeUrls) {
     if (/hcaptcha\.com/i.test(url)) {
@@ -599,6 +654,12 @@ export function detectCaptchaCandidatesInPage(scope = null) {
           websiteKey,
           visible: visibleElement(element),
           normalCheckbox: visibleElement(element),
+          ...responseFieldIdentity(
+            element,
+            'h-captcha-response',
+            hcaptchaFrames.findIndex(frame => frame.element === element),
+            hcaptchaFrames.length,
+          ),
           detectedVia: 'url',
         });
       }
@@ -612,6 +673,12 @@ export function detectCaptchaCandidatesInPage(scope = null) {
           websiteKey,
           visible: visibleElement(element),
           normalCheckbox: false,
+          ...responseFieldIdentity(
+            element,
+            'cf-turnstile-response',
+            turnstileFrames.findIndex(frame => frame.element === element),
+            turnstileFrames.length,
+          ),
           detectedVia: 'url',
         });
       }
@@ -642,6 +709,12 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       ...(sValue
         ? (isEnterprise ? { enterprisePayload: { s: sValue } } : { recaptchaDataSValue: sValue })
         : {}),
+      ...responseFieldIdentity(
+        element,
+        'g-recaptcha-response',
+        recaptchaFrames.findIndex(frame => frame.element === element),
+        recaptchaFrames.length,
+      ),
       detectedVia: 'url',
     });
   }
@@ -826,8 +899,60 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     };
   }
 
-  const setOn = (name) => {
-    let element = frameDocument.querySelector(`textarea[name="${name}"], input[name="${name}"]`);
+  const resolveResponseField = (name, primary) => {
+    const fields = Array.from(frameDocument.querySelectorAll(
+      `textarea[name="${name}"], input[name="${name}"]`
+    ));
+    if (primary && target.responseFieldId) {
+      const exact = fields.find(element => {
+        try {
+          return String(element.id || element.getAttribute?.('id') || '') === target.responseFieldId;
+        } catch (_) {
+          return false;
+        }
+      });
+      if (exact) return { element: exact };
+    }
+    if (Number.isInteger(target.responseFieldIndex)) {
+      if (fields[target.responseFieldIndex]) {
+        return { element: fields[target.responseFieldIndex] };
+      }
+      return {
+        error: 'The selected CAPTCHA response field is no longer present in the target frame.',
+        staleTarget: true,
+      };
+    }
+    if (fields.length === 1) return { element: fields[0] };
+    if (fields.length > 1) {
+      return {
+        error: 'Multiple CAPTCHA response fields matched without a selected widget identity.',
+        ambiguousResponseField: true,
+      };
+    }
+    return { element: null };
+  };
+  const requestedFields = [
+    { name: fieldName, primary: true },
+    ...(alsoSet ? [{ name: alsoSet, primary: false }] : []),
+  ];
+  const resolvedFields = requestedFields.map(field => ({
+    ...field,
+    ...resolveResponseField(field.name, field.primary),
+  }));
+  const unresolvedField = resolvedFields.find(field => field.error);
+  if (unresolvedField) {
+    return {
+      success: false,
+      fieldUpdated: false,
+      staleTarget: unresolvedField.staleTarget === true,
+      ambiguousResponseField: unresolvedField.ambiguousResponseField === true,
+      error: unresolvedField.error,
+      frameUrl,
+    };
+  }
+
+  const setOn = (name, existingElement) => {
+    let element = existingElement;
     if (!element) {
       element = frameDocument.createElement('textarea');
       element.name = name;
@@ -857,12 +982,10 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     }
     return element;
   };
-  setOn(fieldName);
-  let fieldsTouched = 1;
-  if (alsoSet) {
-    setOn(alsoSet);
-    fieldsTouched += 1;
+  for (const field of resolvedFields) {
+    setOn(field.name, field.element);
   }
+  const fieldsTouched = resolvedFields.length;
 
   const pageWindow = frameWindow.wrappedJSObject || frameWindow;
   const callbacks = [];
@@ -879,16 +1002,22 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
       return null;
     }
   };
-  for (const host of Array.from(frameDocument.querySelectorAll(
-    '.g-recaptcha[data-callback], .h-captcha[data-callback], .cf-turnstile[data-callback], '
-      + '[data-recaptcha-sitekey][data-callback], [data-hcaptcha-sitekey][data-callback], '
-      + '[data-turnstile-sitekey][data-callback]'
-  ))) {
-    const hostKey = host.getAttribute('data-sitekey') || host.getAttribute('data-recaptcha-sitekey')
-      || host.getAttribute('data-hcaptcha-sitekey') || host.getAttribute('data-turnstile-sitekey');
-    if (target.websiteKey && hostKey !== target.websiteKey) continue;
-    const callbackName = host.getAttribute('data-callback');
-    addCallback(resolveNamedCallback(callbackName), `data-callback:${callbackName}`);
+  const callbackHint = payload?.callbackHint || null;
+  if (callbackHint) {
+    addCallback(resolveNamedCallback(callbackHint), `data-callback:${callbackHint}`);
+  }
+  if (!callbacks.length) {
+    for (const host of Array.from(frameDocument.querySelectorAll(
+      '.g-recaptcha[data-callback], .h-captcha[data-callback], .cf-turnstile[data-callback], '
+        + '[data-recaptcha-sitekey][data-callback], [data-hcaptcha-sitekey][data-callback], '
+        + '[data-turnstile-sitekey][data-callback]'
+    ))) {
+      const hostKey = host.getAttribute('data-sitekey') || host.getAttribute('data-recaptcha-sitekey')
+        || host.getAttribute('data-hcaptcha-sitekey') || host.getAttribute('data-turnstile-sitekey');
+      if (target.websiteKey && hostKey !== target.websiteKey) continue;
+      const callbackName = host.getAttribute('data-callback');
+      addCallback(resolveNamedCallback(callbackName), `data-callback:${callbackName}`);
+    }
   }
 
   const collectGoogleCallbacks = () => {
@@ -943,6 +1072,10 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     fieldUpdated: true,
     fieldsUpdated: [fieldName, ...(alsoSet ? [alsoSet] : [])],
     fieldsTouched,
+    responseFieldId: target.responseFieldId || null,
+    responseFieldIndex: Number.isInteger(target.responseFieldIndex)
+      ? target.responseFieldIndex
+      : null,
     calledCallback,
     callbackSource,
     callbackAmbiguous: callbacks.length > 1,

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -159,7 +159,9 @@ function candidateScore(candidate) {
   // Priority is tiered so no combination of secondary signals can make a
   // generic visible/background integration outrank an active challenge
   // frame or visible checkbox.
-  const activeChallengeFrame = candidate?.challengeFrame && candidate?.frameVisible !== false;
+  const activeChallengeFrame = candidate?.challengeFrame
+    && candidate?.visible === true
+    && candidate?.frameVisible !== false;
   const primary = (candidate?.normalCheckbox && candidate?.visible) || activeChallengeFrame;
   const tier = primary ? 3 : (candidate?.visible ? 2 : 1);
   let score = tier * 1000;

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -13,6 +13,16 @@
 // drive them by passing an explicit `type` to solve_captcha and the right
 // `taskTypeOverride`.
 
+import {
+  captchaTypesMatch,
+  detectCaptchaCandidatesInPage,
+  injectCaptchaTokenInPage,
+  normalizeCaptchaType,
+  selectCaptchaCandidate,
+} from './captcha-frame-runtime.js';
+
+export { captchaTypesMatch, normalizeCaptchaType, selectCaptchaCandidate };
+
 const API_BASE = 'https://api.capsolver.com';
 const POLL_INTERVAL_MS = 2500;
 const POLL_TIMEOUT_MS = 120_000;
@@ -114,11 +124,10 @@ async function pollTaskResult(apiKey, taskId, { timeoutMs = POLL_TIMEOUT_MS } = 
 // proxy — that's the simplest path and what virtually every reCAPTCHA /
 // hCaptcha / Turnstile setup actually needs.
 //
-// `enterprisePayload` is accepted but deliberately absent from the
-// solve_captcha schema (same as on the hCaptcha branch): it carries the
-// site-specific `s` token some Enterprise deployments require, which a model
-// has no way to obtain from the page. It stays here so callers that do have
-// one can pass it through.
+// `enterprisePayload` is deliberately absent from the solve_captcha schema
+// (same as on the hCaptcha branch): the frame detector extracts the
+// site-specific Enterprise `s` token from the widget host or anchor URL and
+// passes it through internally.
 
 // Type aliases the model or the detector may hand us. Kept as sets rather
 // than inline `||` chains so buildTask and captchaParamError below can't
@@ -140,7 +149,7 @@ export function captchaParamError(params) {
   return null;
 }
 
-function buildTask({ type, websiteURL, websiteKey, ...rest }) {
+export function buildTask({ type, websiteURL, websiteKey, ...rest }) {
   const t = String(type || '').toLowerCase();
   const isEnterprise = !!rest.isEnterprise || t.includes('enterprise');
   if (RECAPTCHA_V2_TYPES.has(t)) {
@@ -149,6 +158,8 @@ function buildTask({ type, websiteURL, websiteKey, ...rest }) {
       websiteURL,
       websiteKey,
       ...(rest.isInvisible != null ? { isInvisible: !!rest.isInvisible } : {}),
+      ...(rest.pageAction ? { pageAction: rest.pageAction } : {}),
+      ...(rest.recaptchaDataSValue ? { recaptchaDataSValue: rest.recaptchaDataSValue } : {}),
       ...(rest.enterprisePayload ? { enterprisePayload: rest.enterprisePayload } : {}),
       ...(rest.userAgent ? { userAgent: rest.userAgent } : {}),
     };
@@ -232,299 +243,75 @@ export async function solveCaptcha(apiKey, params) {
 
 // ─── Page-side detection ───────────────────────────────────────────────
 //
-// Runs in the page world via chrome.scripting.executeScript. Looks for the
-// well-known DOM markers each provider drops in. Returns null when nothing
-// is found so the caller can decide whether to error or fall back to
-// asking the user.
-//
-// We intentionally inspect light DOM only — every major captcha widget
-// renders its container element (the `data-sitekey` host) in the host
-// page's light DOM, even if its UI lives inside a same-origin iframe.
+// Runs the self-contained detector in every frame, then ranks the returned
+// candidates centrally. Keeping each candidate bound to the frame that
+// exposed it lets the caller use the correct websiteURL and injection target.
 
-function detectCaptchaInPage() {
-  // Helpers are declared inside the function, not at module scope: this whole
-  // body is serialised into the page world by chrome.scripting.executeScript,
-  // so it cannot close over anything outside itself.
-  const V3_NO_ACTION_NOTE = 'reCAPTCHA v3 detected, but the page never exposed an action name. solve_captcha needs pageAction — read it from the grecaptcha.execute(...) call in the site JS, or infer it from the form (login, submit, checkout).';
-
-  // reCAPTCHA v3 puts the action name in the loader script's query string.
-  // Parse it with URL so percent-encoded action names come back decoded.
-  const getUrlAction = (urlStr) => {
-    try {
-      const u = new URL(urlStr, 'https://dummy.host');
-      const act = u.searchParams.get('action') || u.searchParams.get('pageAction') || u.searchParams.get('page_action');
-      return act ? act.trim() : null;
-    } catch {}
-    return null;
-  };
-
-  // Helper: visit same-origin iframes too, since reCAPTCHA on many sites
-  // is rendered inside a same-origin wrapper. Cross-origin frames are
-  // skipped (their .contentDocument throws on access).
-  const docs = [document];
-  for (const f of document.querySelectorAll('iframe')) {
-    try {
-      const d = f.contentDocument;
-      if (d) docs.push(d);
-    } catch { /* cross-origin */ }
-  }
-
-  for (const d of docs) {
-    // Order matters: check provider-specific widgets BEFORE the generic
-    // reCAPTCHA fallback. Cloudflare Turnstile and hCaptcha widgets can
-    // carry `data-sitekey` + `data-callback` too, and an earlier version
-    // of this function caught them with `div[data-sitekey][data-callback]`
-    // and misclassified them as reCAPTCHA → CapSolver got the wrong task
-    // type and failed.
-
-    // hCaptcha (.h-captcha[data-sitekey])
-    const hcap = d.querySelector('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]');
-    if (hcap) {
-      const sitekey = hcap.getAttribute('data-sitekey') || hcap.getAttribute('data-hcaptcha-sitekey');
-      if (sitekey) {
-        const size = hcap.getAttribute('data-size');
-        return {
-          type: 'hcaptcha',
-          websiteKey: sitekey,
-          isInvisible: size === 'invisible',
-        };
-      }
-    }
-    // Cloudflare Turnstile (.cf-turnstile[data-sitekey])
-    const turn = d.querySelector('.cf-turnstile[data-sitekey], [data-turnstile-sitekey]');
-    if (turn) {
-      const sitekey = turn.getAttribute('data-sitekey') || turn.getAttribute('data-turnstile-sitekey');
-      if (sitekey) {
-        return { type: 'turnstile', websiteKey: sitekey };
-      }
-    }
-    // reCAPTCHA v2/v3, classic or Enterprise. `.g-recaptcha` is the documented
-    // host class; `data-recaptcha-sitekey` is a wrapper convention several
-    // form libraries use. Both are reCAPTCHA-specific, so this still doesn't
-    // grab a bare `data-sitekey` belonging to another provider.
-    const recap = d.querySelector('.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey], [data-recaptcha-sitekey]');
-    if (recap) {
-      const sitekey = recap.getAttribute('data-sitekey') || recap.getAttribute('data-recaptcha-sitekey');
-      if (sitekey) {
-        const size = recap.getAttribute('data-size');
-        const isInvisible = size === 'invisible';
-        const action = recap.getAttribute('data-action') || recap.getAttribute('data-recaptcha-action') || null;
-        // Script tags decide both version and edition. Look in the parent
-        // document too: when the widget lives in a same-origin iframe the
-        // loader tag usually stays in the top document.
-        const scriptSrcs = [];
-        for (const doc of (d === document ? [d] : [d, document])) {
-          for (const s of doc.querySelectorAll('script[src]')) {
-            try { if (s.src) scriptSrcs.push(s.src); } catch {}
-          }
-        }
-        const hasClassicScript = scriptSrcs.some(s => s.includes('recaptcha/api.js'));
-        const hasEnterpriseScript = scriptSrcs.some(s => s.includes('recaptcha/enterprise'));
-        // data-enterprise / data-sitekey-type aren't Google attributes — they
-        // are wrapper-library conventions (django-recaptcha, some Rails and
-        // Vue helpers). Cheap to check, so we take them as hints before
-        // falling back to which loader script the page pulled in.
-        const isEnterprise = recap.getAttribute('data-enterprise') === 'true' ||
-          recap.getAttribute('data-sitekey-type') === 'enterprise' ||
-          recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
-          (!hasClassicScript && hasEnterpriseScript);
-        // Version, in order of reliability:
-        //   1. an explicit wrapper-set data-version / .g-recaptcha-v3 marker
-        //   2. a `render=<sitekey>` loader script — the v3 signature; v2 loads
-        //      the script bare or with render=explicit
-        //   3. data-action with no data-size=invisible
-        // (3) alone is not enough in either direction: v2 invisible widgets
-        // carry data-action too, and some v3 wrappers copy data-size onto
-        // their host div. Without (2) both of those land on the wrong task
-        // type and CapSolver rejects the key.
-        const version = recap.getAttribute('data-version') || (recap.classList.contains('g-recaptcha-v3') ? 'v3' : null);
-        const renderScript = scriptSrcs.find(s =>
-          /recaptcha\/(api|enterprise)\.js/i.test(s) && s.includes(`render=${sitekey}`)) || null;
-        const isV3 = version === 'v3' || !!renderScript || (!!action && !isInvisible);
-        // v3 needs an action name to solve. Fall back to the loader script's
-        // ?action= when the host element doesn't carry one, and say so
-        // explicitly when neither does — solve_captcha refuses v3 without it.
-        const pageAction = action || (isV3 && renderScript ? getUrlAction(renderScript) : null);
-        return {
-          type: isV3 ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
-          websiteKey: sitekey,
-          isInvisible,
-          isEnterprise,
-          ...(pageAction ? { pageAction } : (isV3 ? { note: V3_NO_ACTION_NOTE } : {})),
-        };
-      }
-    }
-    // Cloudflare "challenge platform" (the bare interstitial — no sitekey
-    // exposed in DOM, just the script tag). Best we can report is presence;
-    // solve_captcha will error if no key is provided.
-    if (d.querySelector('script[src*="challenges.cloudflare.com/turnstile"]') ||
-        d.querySelector('iframe[src*="challenges.cloudflare.com"]')) {
-      return { type: 'turnstile_challenge', websiteKey: null, note: 'Cloudflare interstitial detected but no sitekey was exposed in the DOM. Pass websiteKey explicitly if you have it.' };
-    }
-  }
-
-  // ── URL-string fallback ─────────────────────────────────────────────
-  // The DOM-element checks above cover the vast majority of production
-  // integrations (`<div class="h-captcha" data-sitekey="...">` etc.).
-  // Some pages — notably the official hcaptcha.com/demo and a handful of
-  // SPA integrations that mount the widget via JS — never put the sitekey
-  // on a host element in the main DOM. The sitekey IS still leaking
-  // through iframe `src=` and script `src=` URLs, though, because the
-  // widget script fetches its iframe with a `?sitekey=` (hCaptcha,
-  // Turnstile) or `?k=` (reCAPTCHA) query parameter. iframe.src and
-  // script.src are readable across origins from the parent page, so we
-  // can scrape them even when the widget renders cross-origin.
-  // hCaptcha and Turnstile expose the same `?sitekey=` in either tag, so one
-  // matcher serves both passes below.
-  const nonRecaptchaFromUrl = (url) => {
-    if (/hcaptcha\.com/i.test(url)) {
-      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) return { type: 'hcaptcha', websiteKey: m[1], detectedVia: 'url' };
-    }
-    if (/challenges\.cloudflare\.com\/turnstile/i.test(url)) {
-      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) return { type: 'turnstile', websiteKey: m[1], detectedVia: 'url' };
-    }
-    return null;
-  };
-
-  // Split by tag type because reCAPTCHA needs both halves to classify a
-  // widget: the anchor iframe carries the sitekey, the loader script carries
-  // the version and action. Iframes are scanned first — a rendered anchor
-  // frame is a stronger signal that the widget is actually on this page than
-  // a script tag, which may just be a loader the page never used.
-  const iframeUrls = [];
-  const scriptUrls = [];
-  for (const el of document.querySelectorAll('iframe[src], script[src]')) {
-    try {
-      if (el.src) {
-        if (el.tagName.toLowerCase() === 'iframe') iframeUrls.push(el.src);
-        else scriptUrls.push(el.src);
-      }
-    } catch {}
-  }
-  for (const url of iframeUrls) {
-    const other = nonRecaptchaFromUrl(url);
-    if (other) return other;
-    if (/recaptcha\/(api2|enterprise)\/anchor/i.test(url)) {
-      const m = url.match(/[?&#]k=([a-zA-Z0-9_-]{6,})/);
-      if (m) {
-        const sitekey = m[1];
-        const isEnterprise = /recaptcha\/enterprise/i.test(url);
-        const isInvisible = /[?&#]size=invisible/i.test(url);
-        // v3 renders an anchor frame too (the badge), and it always carries
-        // size=invisible — so the frame alone can't tell v3 from an invisible
-        // v2. A loader script rendering this exact sitekey settles it.
-        const matchingV3Script = scriptUrls.find(s => s.includes(`render=${sitekey}`));
-        if (matchingV3Script) {
-          const pageAction = getUrlAction(matchingV3Script);
-          return {
-            type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
-            websiteKey: sitekey,
-            isEnterprise,
-            ...(pageAction ? { pageAction } : { note: V3_NO_ACTION_NOTE }),
-            detectedVia: 'url',
-          };
-        }
-        return {
-          type: isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2',
-          websiteKey: sitekey,
-          isInvisible,
-          isEnterprise,
-          detectedVia: 'url',
-        };
-      }
-    }
-  }
-  for (const url of scriptUrls) {
-    const other = nonRecaptchaFromUrl(url);
-    if (other) return other;
-    if (/recaptcha\/(api\.js|enterprise\.js)/i.test(url)) {
-      const m = url.match(/[?&#]render=([a-zA-Z0-9_-]{6,})/);
-      // render=explicit means the page renders a v2 widget by hand later —
-      // it is not a sitekey.
-      if (m && m[1] !== 'explicit') {
-        const isEnterprise = /enterprise/i.test(url);
-        const pageAction = getUrlAction(url);
-        return {
-          type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
-          websiteKey: m[1],
-          isEnterprise,
-          ...(pageAction ? { pageAction } : { note: V3_NO_ACTION_NOTE }),
-          detectedVia: 'url',
-        };
-      }
-    }
-  }
-  return null;
-}
-
-export async function detectCaptcha(tabId) {
+export async function detectCaptcha(tabId, constraints = {}) {
   const results = await chrome.scripting.executeScript({
-    target: { tabId, allFrames: false },
-    func: detectCaptchaInPage,
+    target: { tabId, allFrames: true },
+    func: detectCaptchaCandidatesInPage,
   });
-  for (const r of results || []) {
-    if (r?.result) return r.result;
+  const candidates = [];
+  for (const entry of results || []) {
+    for (const candidate of Array.isArray(entry?.result) ? entry.result : []) {
+      candidates.push({
+        ...candidate,
+        frameId: Number.isInteger(entry.frameId) ? entry.frameId : null,
+      });
+    }
   }
-  return null;
+  return selectCaptchaCandidate(candidates, constraints);
 }
 
 // ─── Token injection ───────────────────────────────────────────────────
 
-function injectTokenIntoPage({ fieldName, alsoSet, token, callbackHint }) {
-  if (!fieldName || !token) return { success: false, error: 'no field/token' };
-  const docs = [document];
-  for (const f of document.querySelectorAll('iframe')) {
-    try { if (f.contentDocument) docs.push(f.contentDocument); } catch {}
-  }
-  const setOn = (d, name) => {
-    let el = d.querySelector(`textarea[name="${name}"]`)
-          || d.querySelector(`input[name="${name}"]`);
-    if (!el) {
-      // Some sites only render the response textarea after the user
-      // engages the widget. Create one if missing so the submit handler
-      // can pick it up.
-      el = d.createElement('textarea');
-      el.name = name;
-      el.style.display = 'none';
-      (d.body || d.documentElement).appendChild(el);
-    }
-    el.value = token;
-    el.textContent = token;
-    el.dispatchEvent(new Event('input', { bubbles: true }));
-    el.dispatchEvent(new Event('change', { bubbles: true }));
-    return el;
-  };
-  let touched = 0;
-  for (const d of docs) {
-    setOn(d, fieldName);
-    touched++;
-    if (alsoSet) setOn(d, alsoSet);
-  }
-  // Best-effort: trigger callback registered by the widget (reCAPTCHA
-  // v2/v3 sites usually wire `data-callback="onCaptcha"` on the host
-  // element; some hCaptcha sites do the same with `data-callback`).
-  let calledCallback = false;
-  for (const d of docs) {
-    const host = d.querySelector('[data-callback]');
-    const cbName = host?.getAttribute('data-callback');
-    if (cbName) {
-      try {
-        const fn = (typeof window !== 'undefined' && typeof window[cbName] === 'function') ? window[cbName] : null;
-        if (fn) { fn(token); calledCallback = true; }
-      } catch { /* ignore */ }
-    }
-  }
-  return { success: true, fieldsTouched: touched, calledCallback, callbackHint: callbackHint || null };
-}
-
-export async function injectToken(tabId, { fieldName, alsoSet, token, callbackHint }) {
+export async function injectToken(tabId, {
+  fieldName,
+  alsoSet,
+  token,
+  callbackHint,
+  target = null,
+}) {
   if (!fieldName || !token) return { success: false, error: 'fieldName and token required' };
+  if (!Number.isInteger(target?.frameId) || !target?.frameUrl || !target?.websiteKey) {
+    return {
+      success: false,
+      fieldUpdated: false,
+      targetRequired: true,
+      error: 'Token was not injected because no detected CAPTCHA frame identity, URL, and site key were selected.',
+    };
+  }
+  const pagePayload = {
+    fieldName,
+    alsoSet,
+    token,
+    callbackHint,
+    target: target || {},
+  };
+  const targetSpec = Number.isInteger(target?.frameId)
+    ? { tabId, frameIds: [target.frameId] }
+    : (target?.frameUrl ? { tabId, allFrames: true } : { tabId });
   const results = await chrome.scripting.executeScript({
-    target: { tabId, allFrames: false },
-    args: [{ fieldName, alsoSet, token, callbackHint }],
-    func: injectTokenIntoPage,
+    target: targetSpec,
+    world: 'MAIN',
+    args: [pagePayload],
+    func: injectCaptchaTokenInPage,
   });
-  return results?.[0]?.result || { success: false, error: 'injection script returned no result' };
+  const outputs = (results || []).map(entry => ({
+    ...(entry?.result || {}),
+    frameId: Number.isInteger(entry?.frameId) ? entry.frameId : null,
+  }));
+  const successes = outputs.filter(output => output.success === true);
+  if (successes.length === 1) return successes[0];
+  if (successes.length > 1) {
+    return {
+      success: false,
+      ambiguousTarget: true,
+      error: 'Token injection matched more than one frame; pass an exact frameUrl.',
+      matchedFrames: successes.map(output => ({ frameId: output.frameId, frameUrl: output.frameUrl })),
+    };
+  }
+  return outputs.find(output => !output.skipped)
+    || { success: false, error: 'injection script returned no matching frame result' };
 }

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -14,6 +14,7 @@
 // `taskTypeOverride`.
 
 import {
+  applyCaptchaFrameVisibility,
   captchaTypesMatch,
   detectCaptchaCandidatesInPage,
   injectCaptchaTokenInPage,
@@ -248,20 +249,40 @@ export async function solveCaptcha(apiKey, params) {
 // exposed it lets the caller use the correct websiteURL and injection target.
 
 export async function detectCaptcha(tabId, constraints = {}) {
-  const results = await chrome.scripting.executeScript({
-    target: { tabId, allFrames: true },
-    func: detectCaptchaCandidatesInPage,
-  });
+  const frameTreePromise = typeof chrome.webNavigation?.getAllFrames === 'function'
+    ? chrome.webNavigation.getAllFrames({ tabId }).catch(() => [])
+    : Promise.resolve([]);
+  const [results, navigationFrames] = await Promise.all([
+    chrome.scripting.executeScript({
+      target: { tabId, allFrames: true },
+      func: detectCaptchaCandidatesInPage,
+    }),
+    frameTreePromise,
+  ]);
   const candidates = [];
+  const frameContexts = [];
   for (const entry of results || []) {
-    for (const candidate of Array.isArray(entry?.result) ? entry.result : []) {
+    const payload = entry?.result;
+    const pageCandidates = Array.isArray(payload)
+      ? payload
+      : (Array.isArray(payload?.candidates) ? payload.candidates : []);
+    for (const candidate of pageCandidates) {
       candidates.push({
         ...candidate,
         frameId: Number.isInteger(entry.frameId) ? entry.frameId : null,
       });
     }
+    if (!Array.isArray(payload) && payload?.frameContext) {
+      frameContexts.push({
+        ...payload.frameContext,
+        frameId: Number.isInteger(entry.frameId) ? entry.frameId : null,
+      });
+    }
   }
-  return selectCaptchaCandidate(candidates, constraints);
+  return selectCaptchaCandidate(
+    applyCaptchaFrameVisibility(candidates, frameContexts, navigationFrames),
+    constraints,
+  );
 }
 
 // ─── Token injection ───────────────────────────────────────────────────

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -15,6 +15,7 @@
 
 import {
   applyCaptchaFrameVisibility,
+  captchaWebsiteUrl,
   captchaTypesMatch,
   detectCaptchaCandidatesInPage,
   injectCaptchaTokenInPage,
@@ -22,7 +23,7 @@ import {
   selectCaptchaCandidate,
 } from './captcha-frame-runtime.js';
 
-export { captchaTypesMatch, normalizeCaptchaType, selectCaptchaCandidate };
+export { captchaTypesMatch, captchaWebsiteUrl, normalizeCaptchaType, selectCaptchaCandidate };
 
 const API_BASE = 'https://api.capsolver.com';
 const POLL_INTERVAL_MS = 2500;

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -1054,7 +1054,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'solve_captcha',
-      description: 'Solve a CAPTCHA on the current page using the CapSolver API (only available when the user has enabled CapSolver and provided an API key in Settings → General → Advanced). The tool scans every frame, ranks the active visible widget above hidden/background integrations, and fills missing type/site-key parameters from the selected frame. Returns the token, selected frame/type, and targeted injection/callback status; verify page progress afterward because token injection alone does not prove the challenge cleared. On failure (no CapSolver key configured, ambiguous candidates, unknown type, API error, timeout) the tool returns `{ success: false, error: "..." }` — use an exact frameUrl/websiteKey when offered, otherwise ask the user to solve it manually.',
+      description: 'Solve a CAPTCHA on the current page using the CapSolver API (only available when the user has enabled CapSolver and provided an API key in Settings → General → Advanced). The tool scans every frame, ranks the active visible widget above hidden/background integrations, and fills missing type/site-key parameters from the selected frame. Returns the token, selected frame/type, and targeted injection/callback status; verify page progress afterward because token injection alone does not prove the challenge cleared. On failure (no CapSolver key configured, ambiguous candidates, unknown type, API error, timeout) the tool returns `{ success: false, error: "..." }` — use only the exact frameUrl, websiteKey, frameId, or framePath discriminator offered by the ambiguity result; otherwise ask the user to solve it manually.',
       parameters: {
         type: 'object',
         properties: {
@@ -1065,6 +1065,12 @@ export const AGENT_TOOLS = [
           },
           websiteKey: { type: 'string', description: 'Site key from the captcha widget\'s data-sitekey attribute. Auto-detected when omitted.' },
           frameUrl: { type: 'string', description: 'Exact URL of the frame containing the intended CAPTCHA. Usually omit; use a candidate URL returned by an ambiguity error to select among equally active widgets.' },
+          frameId: { type: 'integer', description: 'Exact browser frame ID from an ambiguity result. Use when tied candidates share the same frameUrl and site key.' },
+          framePath: {
+            type: 'array',
+            items: { type: 'integer', minimum: 0 },
+            description: 'Exact iframe-index path from a candidate\'s framePathIndexes diagnostic. Use with frameId when inherited-origin candidates share the same URL and site key.',
+          },
           isInvisible: { type: 'boolean', description: 'reCAPTCHA v2 / hCaptcha only — true when the widget uses invisible mode (no visible checkbox). Auto-detected when omitted.' },
           isEnterprise: { type: 'boolean', description: 'reCAPTCHA v2/v3 only — true when the widget uses Google reCAPTCHA Enterprise. Auto-detected when omitted.' },
           pageAction: { type: 'string', description: 'Required for reCAPTCHA v3 — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action or the loader script when present; pass it explicitly if detection reports it missing.' },

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -1054,7 +1054,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'solve_captcha',
-      description: 'Solve a CAPTCHA on the current page using the CapSolver API (only available when the user has enabled CapSolver and provided an API key in Settings → General → Advanced). If `type` and `websiteKey` are omitted, the tool scans the page for known widgets (reCAPTCHA v2/v3, hCaptcha, Cloudflare Turnstile) and uses what it finds. Returns the solution token and whether it was injected into the page; you usually still need to click the form\'s submit button afterward. On failure (no CapSolver key configured, unknown captcha type, API error, timeout) the tool returns `{ success: false, error: "..." }` — fall back to asking the user to solve it manually.',
+      description: 'Solve a CAPTCHA on the current page using the CapSolver API (only available when the user has enabled CapSolver and provided an API key in Settings → General → Advanced). The tool scans every frame, ranks the active visible widget above hidden/background integrations, and fills missing type/site-key parameters from the selected frame. Returns the token, selected frame/type, and targeted injection/callback status; verify page progress afterward because token injection alone does not prove the challenge cleared. On failure (no CapSolver key configured, ambiguous candidates, unknown type, API error, timeout) the tool returns `{ success: false, error: "..." }` — use an exact frameUrl/websiteKey when offered, otherwise ask the user to solve it manually.',
       parameters: {
         type: 'object',
         properties: {
@@ -1064,6 +1064,7 @@ export const AGENT_TOOLS = [
             description: 'CAPTCHA type. Omit to auto-detect from the page DOM.',
           },
           websiteKey: { type: 'string', description: 'Site key from the captcha widget\'s data-sitekey attribute. Auto-detected when omitted.' },
+          frameUrl: { type: 'string', description: 'Exact URL of the frame containing the intended CAPTCHA. Usually omit; use a candidate URL returned by an ambiguity error to select among equally active widgets.' },
           isInvisible: { type: 'boolean', description: 'reCAPTCHA v2 / hCaptcha only — true when the widget uses invisible mode (no visible checkbox). Auto-detected when omitted.' },
           isEnterprise: { type: 'boolean', description: 'reCAPTCHA v2/v3 only — true when the widget uses Google reCAPTCHA Enterprise. Auto-detected when omitted.' },
           pageAction: { type: 'string', description: 'Required for reCAPTCHA v3 — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action or the loader script when present; pass it explicitly if detection reports it missing.' },

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -1070,7 +1070,7 @@ export const AGENT_TOOLS = [
           pageAction: { type: 'string', description: 'Required for reCAPTCHA v3 — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action or the loader script when present; pass it explicitly if detection reports it missing.' },
           minScore: { type: 'number', description: 'reCAPTCHA v3 only — minimum score requested (0.3 is the usual lower bound, 0.7+ is hard).' },
           imageBase64: { type: 'string', description: 'image_to_text only — base64-encoded image bytes (no data: prefix).' },
-          inject: { type: 'boolean', description: 'After solving, inject the token into the page\'s response field (textarea[name=g-recaptcha-response] etc.) and fire the widget\'s callback. Default true. Set false to get just the token back.' },
+          inject: { type: 'boolean', description: 'After solving, inject the token into the detected frame\'s response field (textarea[name=g-recaptcha-response] etc.) and fire the widget\'s callback. Default true and requires a detected frame target. If the widget cannot be detected but type/websiteKey are known, set false to get only the token without page injection.' },
         },
         required: [],
       },

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -12115,7 +12115,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         let detectionNote = null;
         let detected = null;
         if (type !== 'image_to_text') {
-          const detection = await detectCaptcha(tabId, { frameUrl, websiteKey });
+          const detection = await detectCaptcha(tabId, { type, frameUrl, websiteKey });
           if (detection?.error) {
             const hasDetectedCandidates = Array.isArray(detection.candidates) && detection.candidates.length > 0;
             const needsDetection = !type || !websiteKey || !!frameUrl;

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -31,7 +31,7 @@ import {
 } from './pdf-tools.js';
 import * as trace from '../trace/recorder.js';
 import { tracesToMarkdown } from './trace-export.js';
-import { solveCaptcha, detectCaptcha, injectToken, captchaParamError, captchaTypesMatch } from './captcha-solver.js';
+import { solveCaptcha, detectCaptcha, injectToken, captchaParamError, captchaTypesMatch, captchaWebsiteUrl } from './captcha-solver.js';
 import { Capability, CAPABILITY_LABEL, capabilitiesFor, requiredHosts, frameHostMatches, isNetworkMutation, normalizeHost, PermissionManager, UNTRUSTED_CONTENT_TOOLS } from './permission-gate.js';
 import {
   buildPlannerMessages,
@@ -12135,7 +12135,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               );
             }
             type = type || detected.type;
-            websiteURL = detected.frameUrl || websiteURL;
+            websiteURL = captchaWebsiteUrl(detected.frameUrl, websiteURL);
             frameUrl = detected.frameUrl || frameUrl;
             detectionNote = detected.note || null;
             if (!websiteKey) websiteKey = detected.websiteKey;
@@ -12188,6 +12188,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               token: result.token,
               target: detected ? {
                 frameId: detected.frameId,
+                framePath: detected.framePath,
                 frameUrl: detected.frameUrl,
                 websiteKey: detected.websiteKey,
                 type: detected.type,
@@ -12206,6 +12207,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           token: result.token,
           tokenPreview: result.token ? `${String(result.token).slice(0, 24)}…(${String(result.token).length} chars)` : null,
           selectedFrameId: Number.isInteger(detected?.frameId) ? detected.frameId : null,
+          selectedFramePath: Array.isArray(detected?.framePath) ? detected.framePath : null,
           selectedFrameUrl: detected?.frameUrl || null,
           selectionReason: detected?.selectionReason || null,
           detectedType: detected?.type || null,

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -12180,10 +12180,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           return noDispatchFailure(detectionNote ? `${paramError} ${detectionNote}` : paramError);
         }
 
+        const wantInject = args?.inject !== false && type !== 'image_to_text';
+        if (wantInject && !detected) {
+          return noDispatchFailure(
+            'solve_captcha: token injection requires a detected CAPTCHA frame. The explicit type and websiteKey were not sent to CapSolver because no safe injection target could be verified. Retry with `inject: false` to receive the token without page injection, or ask the user to solve the challenge manually.'
+          );
+        }
+
         dispatched = true;
         const result = await solveCaptcha(apiKey, params);
 
-        const wantInject = args?.inject !== false && type !== 'image_to_text';
         let injection = null;
         if (wantInject && result.fieldName && result.token) {
           try {
@@ -12198,6 +12204,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 websiteKey: detected.websiteKey,
                 type: detected.type,
                 explicitWebsiteKey: detected.explicitWebsiteKey === true,
+                documentTimeOrigin: detected.documentTimeOrigin,
               } : null,
             });
           } catch (e) {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -12141,6 +12141,25 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 `solve_captcha: requested type "${type}" conflicts with the active detected candidate "${detected.type}" in ${detected.frameUrl}. Retry without type or use the detected type.`
               );
             }
+            const visibilityModeApplies = /^(?:recaptcha_v2(?:_enterprise)?|hcaptcha)$/.test(
+              String(detected.type || '')
+            );
+            if (visibilityModeApplies
+                && isInvisible != null
+                && detected.isInvisible != null
+                && Boolean(isInvisible) !== Boolean(detected.isInvisible)) {
+              return noDispatchFailure(
+                `solve_captcha: requested isInvisible=${Boolean(isInvisible)} conflicts with the active detected candidate isInvisible=${Boolean(detected.isInvisible)} in ${detected.frameUrl}. Retry without isInvisible or use the detected value.`
+              );
+            }
+            if (/^recaptcha_v[23](?:_enterprise)?$/.test(String(detected.type || ''))
+                && isEnterprise != null
+                && detected.isEnterprise != null
+                && Boolean(isEnterprise) !== Boolean(detected.isEnterprise)) {
+              return noDispatchFailure(
+                `solve_captcha: requested isEnterprise=${Boolean(isEnterprise)} conflicts with the active detected candidate isEnterprise=${Boolean(detected.isEnterprise)} in ${detected.frameUrl}. Retry without isEnterprise or use the detected value.`
+              );
+            }
             if (pageAction && detected.pageAction && String(pageAction) !== String(detected.pageAction)) {
               return noDispatchFailure(
                 `solve_captcha: requested pageAction "${pageAction}" conflicts with the active detected candidate action "${detected.pageAction}" in ${detected.frameUrl}. Retry without pageAction or use the detected action.`
@@ -12217,6 +12236,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 explicitWebsiteKey: detected.explicitWebsiteKey === true,
                 responseFieldId: detected.responseFieldId,
                 responseFieldIndex: detected.responseFieldIndex,
+                alsoResponseFieldId: detected.alsoResponseFieldId,
+                alsoResponseFieldIndex: detected.alsoResponseFieldIndex,
                 documentTimeOrigin: detected.documentTimeOrigin,
               } : null,
             });

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -12197,6 +12197,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 frameUrl: detected.frameUrl,
                 websiteKey: detected.websiteKey,
                 type: detected.type,
+                explicitWebsiteKey: detected.explicitWebsiteKey === true,
               } : null,
             });
           } catch (e) {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -12134,6 +12134,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 `solve_captcha: requested type "${type}" conflicts with the active detected candidate "${detected.type}" in ${detected.frameUrl}. Retry without type or use the detected type.`
               );
             }
+            if (pageAction && detected.pageAction && String(pageAction) !== String(detected.pageAction)) {
+              return noDispatchFailure(
+                `solve_captcha: requested pageAction "${pageAction}" conflicts with the active detected candidate action "${detected.pageAction}" in ${detected.frameUrl}. Retry without pageAction or use the detected action.`
+              );
+            }
             type = type || detected.type;
             websiteURL = captchaWebsiteUrl(detected.frameUrl, websiteURL);
             frameUrl = detected.frameUrl || frameUrl;

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -31,7 +31,7 @@ import {
 } from './pdf-tools.js';
 import * as trace from '../trace/recorder.js';
 import { tracesToMarkdown } from './trace-export.js';
-import { solveCaptcha, detectCaptcha, injectToken, captchaParamError } from './captcha-solver.js';
+import { solveCaptcha, detectCaptcha, injectToken, captchaParamError, captchaTypesMatch } from './captcha-solver.js';
 import { Capability, CAPABILITY_LABEL, capabilitiesFor, requiredHosts, frameHostMatches, isNetworkMutation, normalizeHost, PermissionManager, UNTRUSTED_CONTENT_TOOLS } from './permission-gate.js';
 import {
   buildPlannerMessages,
@@ -12097,22 +12097,54 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           websiteURL = tab?.url || '';
         } catch {}
 
-        let { type, websiteKey, isInvisible, isEnterprise, pageAction, minScore, imageBase64 } = args || {};
+        let {
+          type,
+          websiteKey,
+          frameUrl,
+          isInvisible,
+          isEnterprise,
+          pageAction,
+          minScore,
+          imageBase64,
+          enterprisePayload,
+          recaptchaDataSValue,
+        } = args || {};
         // Detection notes explain *why* a field is missing (e.g. a v3 widget
         // that never exposed its action name). Carry it into the failure so
         // the model gets the remedy, not just the rejection.
         let detectionNote = null;
-        if (!type) {
-          const detected = await detectCaptcha(tabId);
-          if (!detected) {
+        let detected = null;
+        if (type !== 'image_to_text') {
+          const detection = await detectCaptcha(tabId, { frameUrl, websiteKey });
+          if (detection?.error) {
+            const hasDetectedCandidates = Array.isArray(detection.candidates) && detection.candidates.length > 0;
+            const needsDetection = !type || !websiteKey || !!frameUrl;
+            if (detection.ambiguous || hasDetectedCandidates || needsDetection) {
+              const candidates = hasDetectedCandidates ? ` Candidates: ${JSON.stringify(detection.candidates)}` : '';
+              return noDispatchFailure(`solve_captcha: ${detection.error}${candidates}`);
+            }
+          }
+          detected = detection?.selected || null;
+          if (!detected && (!type || !websiteKey)) {
             return noDispatchFailure('No CAPTCHA detected on the page. If the captcha lives inside a cross-origin iframe or uses a non-standard widget, pass `type` and `websiteKey` explicitly.');
           }
-          type = detected.type;
-          detectionNote = detected.note || null;
-          if (!websiteKey) websiteKey = detected.websiteKey;
-          if (isInvisible == null && detected.isInvisible != null) isInvisible = detected.isInvisible;
-          if (isEnterprise == null && detected.isEnterprise != null) isEnterprise = detected.isEnterprise;
-          if (!pageAction && detected.pageAction) pageAction = detected.pageAction;
+          if (detected) {
+            if (type && !captchaTypesMatch(type, detected.type, isEnterprise, detected.isEnterprise)) {
+              return noDispatchFailure(
+                `solve_captcha: requested type "${type}" conflicts with the active detected candidate "${detected.type}" in ${detected.frameUrl}. Retry without type or use the detected type.`
+              );
+            }
+            type = type || detected.type;
+            websiteURL = detected.frameUrl || websiteURL;
+            frameUrl = detected.frameUrl || frameUrl;
+            detectionNote = detected.note || null;
+            if (!websiteKey) websiteKey = detected.websiteKey;
+            if (isInvisible == null && detected.isInvisible != null) isInvisible = detected.isInvisible;
+            if (isEnterprise == null && detected.isEnterprise != null) isEnterprise = detected.isEnterprise;
+            if (!pageAction && detected.pageAction) pageAction = detected.pageAction;
+            if (!enterprisePayload && detected.enterprisePayload) enterprisePayload = detected.enterprisePayload;
+            if (!recaptchaDataSValue && detected.recaptchaDataSValue) recaptchaDataSValue = detected.recaptchaDataSValue;
+          }
         }
 
         const params = {
@@ -12123,6 +12155,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           ...(isEnterprise != null ? { isEnterprise } : {}),
           ...(pageAction ? { pageAction } : {}),
           ...(minScore ? { minScore } : {}),
+          ...(enterprisePayload ? { enterprisePayload } : {}),
+          ...(recaptchaDataSValue ? { recaptchaDataSValue } : {}),
           ...(imageBase64 ? { body: imageBase64 } : {}),
         };
 
@@ -12152,6 +12186,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               fieldName: result.fieldName,
               alsoSet: result.alsoSet,
               token: result.token,
+              target: detected ? {
+                frameId: detected.frameId,
+                frameUrl: detected.frameUrl,
+                websiteKey: detected.websiteKey,
+                type: detected.type,
+              } : null,
             });
           } catch (e) {
             injection = { success: false, error: e.message };
@@ -12165,11 +12205,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           taskId: result.taskId,
           token: result.token,
           tokenPreview: result.token ? `${String(result.token).slice(0, 24)}…(${String(result.token).length} chars)` : null,
+          selectedFrameId: Number.isInteger(detected?.frameId) ? detected.frameId : null,
+          selectedFrameUrl: detected?.frameUrl || null,
+          selectionReason: detected?.selectionReason || null,
+          detectedType: detected?.type || null,
           injected: injection?.success === true,
           injection,
-          note: wantInject
-            ? 'Token was injected into the page response field. Click the form\'s submit button next; do NOT call solve_captcha again.'
-            : 'Token returned, not injected. Pass it to the form via type_text on the response field, then submit.',
+          note: !wantInject
+            ? 'Token returned without injection. Apply this token to the intended response field; do not request another paid solve for the same challenge.'
+            : injection?.success
+              ? (injection.calledCallback
+                ? 'Token was inserted into the selected frame and its callback was invoked. Wait for the page to react, then verify whether the challenge cleared.'
+                : 'Token was inserted into the selected frame, but no unique callback was invoked. Verify page progress before submitting or taking another action; do not request another paid solve.')
+              : 'CapSolver returned a token, but targeted injection failed. The challenge is not confirmed cleared; do not request another paid solve for the same token.',
         };
       } catch (e) {
         const error = `solve_captcha failed: ${e.message}`;

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -12115,7 +12115,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         let detectionNote = null;
         let detected = null;
         if (type !== 'image_to_text') {
-          const detection = await detectCaptcha(tabId, { type, frameUrl, websiteKey });
+          let detection = null;
+          try {
+            detection = await detectCaptcha(tabId, { type, frameUrl, websiteKey });
+          } catch (detectionError) {
+            const explicitTokenOnlyFallback = args?.inject === false && !!type && !!websiteKey;
+            if (!explicitTokenOnlyFallback) {
+              return noDispatchFailure(
+                `solve_captcha: CAPTCHA frame detection failed before dispatch: ${detectionError?.message || String(detectionError)}`
+              );
+            }
+            detectionNote = `CAPTCHA frame detection was unavailable: ${detectionError?.message || String(detectionError)}`;
+          }
           if (detection?.error) {
             const hasDetectedCandidates = Array.isArray(detection.candidates) && detection.candidates.length > 0;
             const needsDetection = !type || !websiteKey || !!frameUrl;

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -12119,7 +12119,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           if (detection?.error) {
             const hasDetectedCandidates = Array.isArray(detection.candidates) && detection.candidates.length > 0;
             const needsDetection = !type || !websiteKey || !!frameUrl;
-            if (detection.ambiguous || hasDetectedCandidates || needsDetection) {
+            const explicitTokenOnlyFallback = args?.inject === false
+              && !!type
+              && !!websiteKey
+              && !(detection.candidates || []).some(candidate =>
+                candidate?.websiteKey === websiteKey
+              );
+            if (!explicitTokenOnlyFallback
+                && (detection.ambiguous || hasDetectedCandidates || needsDetection)) {
               const candidates = hasDetectedCandidates ? ` Candidates: ${JSON.stringify(detection.candidates)}` : '';
               return noDispatchFailure(`solve_captcha: ${detection.error}${candidates}`);
             }
@@ -12149,6 +12156,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             if (!pageAction && detected.pageAction) pageAction = detected.pageAction;
             if (!enterprisePayload && detected.enterprisePayload) enterprisePayload = detected.enterprisePayload;
             if (!recaptchaDataSValue && detected.recaptchaDataSValue) recaptchaDataSValue = detected.recaptchaDataSValue;
+          }
+          if (!detected && args?.inject === false && frameUrl) {
+            websiteURL = captchaWebsiteUrl(frameUrl, websiteURL);
           }
         }
 
@@ -12197,6 +12207,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               fieldName: result.fieldName,
               alsoSet: result.alsoSet,
               token: result.token,
+              callbackHint: detected.callbackName || null,
               target: detected ? {
                 frameId: detected.frameId,
                 framePath: detected.framePath,
@@ -12204,6 +12215,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 websiteKey: detected.websiteKey,
                 type: detected.type,
                 explicitWebsiteKey: detected.explicitWebsiteKey === true,
+                responseFieldId: detected.responseFieldId,
+                responseFieldIndex: detected.responseFieldIndex,
                 documentTimeOrigin: detected.documentTimeOrigin,
               } : null,
             });

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -12101,6 +12101,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           type,
           websiteKey,
           frameUrl,
+          frameId,
+          framePath,
           isInvisible,
           isEnterprise,
           pageAction,
@@ -12117,7 +12119,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (type !== 'image_to_text') {
           let detection = null;
           try {
-            detection = await detectCaptcha(tabId, { type, frameUrl, websiteKey });
+            detection = await detectCaptcha(tabId, {
+              type,
+              frameUrl,
+              frameId,
+              framePath,
+              websiteKey,
+            });
           } catch (detectionError) {
             const explicitTokenOnlyFallback = args?.inject === false && !!type && !!websiteKey;
             if (!explicitTokenOnlyFallback) {
@@ -12129,7 +12137,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           }
           if (detection?.error) {
             const hasDetectedCandidates = Array.isArray(detection.candidates) && detection.candidates.length > 0;
-            const needsDetection = !type || !websiteKey || !!frameUrl;
+            const needsDetection = !type
+              || !websiteKey
+              || !!frameUrl
+              || Number.isInteger(frameId)
+              || Array.isArray(framePath);
             const explicitTokenOnlyFallback = args?.inject === false
               && !!type
               && !!websiteKey
@@ -12177,7 +12189,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               );
             }
             type = type || detected.type;
-            websiteURL = captchaWebsiteUrl(detected.frameUrl, websiteURL);
+            websiteURL = detected.websiteURL || captchaWebsiteUrl(detected.frameUrl, websiteURL);
             frameUrl = detected.frameUrl || frameUrl;
             detectionNote = detected.note || null;
             if (!websiteKey) websiteKey = detected.websiteKey;

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -122,7 +122,88 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
     return visible;
   };
 
-  return (Array.isArray(candidates) ? candidates : []).map(candidate => {
+  const sourceCandidates = Array.isArray(candidates) ? candidates : [];
+  const pathIsStrictAncestor = (sourcePath, targetPath) => {
+    const source = Array.isArray(sourcePath) ? sourcePath : [];
+    const target = Array.isArray(targetPath) ? targetPath : [];
+    if (source.length >= target.length) return false;
+    return source.every((segment, index) =>
+      Number(segment?.index) === Number(target[index]?.index)
+    );
+  };
+  const ancestorDistance = (source, target) => {
+    if (!Number.isInteger(source?.frameId) || !Number.isInteger(target?.frameId)) return null;
+    const sourcePath = Array.isArray(source.framePath) ? source.framePath : [];
+    const targetPath = Array.isArray(target.framePath) ? target.framePath : [];
+    if (source.frameId === target.frameId) {
+      if (!pathIsStrictAncestor(sourcePath, targetPath)) return null;
+      return targetPath.length - sourcePath.length;
+    }
+    // A candidate reached through an inherited-origin framePath lives below
+    // its injectable frameId. Treating that base frame as its location would
+    // let metadata leak sideways into a sibling browser frame.
+    if (sourcePath.length) return null;
+    let currentFrameId = target.frameId;
+    let distance = targetPath.length;
+    const visited = new Set();
+    while (Number.isInteger(currentFrameId) && !visited.has(currentFrameId)) {
+      visited.add(currentFrameId);
+      const parentFrameId = navigationByFrameId.get(currentFrameId)?.parentFrameId;
+      if (!Number.isInteger(parentFrameId) || parentFrameId === -1) return null;
+      distance += 1;
+      if (parentFrameId === source.frameId) return distance;
+      currentFrameId = parentFrameId;
+    }
+    return null;
+  };
+  const reconcileAncestorLoader = (candidate) => {
+    if (!candidate?.websiteKey
+        || !/^recaptcha_v[23](?:_enterprise)?$/.test(String(candidate.type || ''))
+        || candidate.detectedVia === 'script') {
+      return candidate;
+    }
+    const matchingLoaders = sourceCandidates
+      .filter(source =>
+        source !== candidate
+        && source?.detectedVia === 'script'
+        && source?.websiteKey === candidate.websiteKey
+        && /^recaptcha_v3(?:_enterprise)?$/.test(String(source.type || ''))
+      )
+      .map(source => ({ source, distance: ancestorDistance(source, candidate) }))
+      .filter(entry => entry.distance != null)
+      .sort((left, right) => left.distance - right.distance);
+    if (!matchingLoaders.length) return candidate;
+    const nearestDistance = matchingLoaders[0].distance;
+    const nearest = matchingLoaders.filter(entry => entry.distance === nearestDistance);
+    const signatures = new Set(nearest.map(({ source }) => JSON.stringify([
+      source.type,
+      source.isEnterprise === true,
+      source.pageAction || null,
+    ])));
+    if (signatures.size > 1) {
+      return {
+        ...candidate,
+        parameterConflicts: [...new Set([
+          ...(Array.isArray(candidate.parameterConflicts) ? candidate.parameterConflicts : []),
+          'ancestorLoader',
+        ])],
+      };
+    }
+    const loader = nearest[0].source;
+    const pageAction = candidate.pageAction || loader.pageAction || null;
+    return {
+      ...candidate,
+      type: loader.type,
+      isEnterprise: loader.isEnterprise === true || /_enterprise$/.test(loader.type),
+      normalCheckbox: false,
+      ...(pageAction ? { pageAction } : {}),
+      ...(!pageAction && loader.note ? { note: loader.note } : {}),
+      ancestorLoaderFrameId: loader.frameId,
+    };
+  };
+
+  return sourceCandidates.map(rawCandidate => {
+    const candidate = reconcileAncestorLoader(rawCandidate);
     const frameVisible = frameIsVisible(candidate?.frameId)
       && candidate?.frameVisibleWithinAnchor !== false;
     return {
@@ -153,6 +234,9 @@ function candidateSummary(candidate) {
     enterprisePayload: candidate?.enterprisePayload || null,
     recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
     explicitWebsiteKey: candidate?.explicitWebsiteKey === true,
+    ancestorLoaderFrameId: Number.isInteger(candidate?.ancestorLoaderFrameId)
+      ? candidate.ancestorLoaderFrameId
+      : null,
     parameterConflicts: Array.isArray(candidate?.parameterConflicts)
       ? candidate.parameterConflicts
       : [],

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -48,6 +48,80 @@ export function captchaTypesMatch(left, right, leftIsEnterprise = null, rightIsE
   return normalizeCaptchaType(left) === normalizeCaptchaType(right);
 }
 
+export function applyCaptchaFrameVisibility(candidates, frameContexts, navigationFrames) {
+  const contextsByFrameId = new Map();
+  for (const context of Array.isArray(frameContexts) ? frameContexts : []) {
+    if (Number.isInteger(context?.frameId)) contextsByFrameId.set(context.frameId, context);
+  }
+  const navigationByFrameId = new Map();
+  for (const frame of Array.isArray(navigationFrames) ? navigationFrames : []) {
+    if (Number.isInteger(frame?.frameId)) navigationByFrameId.set(frame.frameId, frame);
+  }
+
+  const uniqueMatch = (items) => items.length === 1 ? items[0] : null;
+  const findEmbeddingFrame = (frameId, parentFrameId) => {
+    const parentContext = contextsByFrameId.get(parentFrameId);
+    if (!parentContext) return null;
+    const childFrames = Array.isArray(parentContext.childFrames) ? parentContext.childFrames : [];
+    if (!childFrames.length) return null;
+
+    const childContext = contextsByFrameId.get(frameId);
+    const navigation = navigationByFrameId.get(frameId);
+    const frameName = String(childContext?.frameName || '');
+    const frameUrls = new Set([
+      childContext?.frameUrl,
+      navigation?.url,
+    ].filter(Boolean).map(String));
+    const urlMatches = childFrames.filter(child =>
+      frameUrls.has(String(child?.loadedUrl || '')) || frameUrls.has(String(child?.url || ''))
+    );
+    if (frameName) {
+      const exact = uniqueMatch(urlMatches.filter(child => String(child?.name || '') === frameName));
+      if (exact) return exact;
+    }
+    const byUrl = uniqueMatch(urlMatches);
+    if (byUrl) return byUrl;
+    if (frameName) {
+      const byName = uniqueMatch(childFrames.filter(child => String(child?.name || '') === frameName));
+      if (byName) return byName;
+    }
+    return childFrames.length === 1 ? childFrames[0] : null;
+  };
+
+  const visibilityByFrameId = new Map();
+  const frameIsVisible = (frameId, visiting = new Set()) => {
+    if (visibilityByFrameId.has(frameId)) return visibilityByFrameId.get(frameId);
+    if (!Number.isInteger(frameId) || visiting.has(frameId)) return false;
+    const navigation = navigationByFrameId.get(frameId);
+    const parentFrameId = navigation?.parentFrameId;
+    if (frameId === 0 || parentFrameId === -1) {
+      visibilityByFrameId.set(frameId, true);
+      return true;
+    }
+    if (!Number.isInteger(parentFrameId)) {
+      visibilityByFrameId.set(frameId, false);
+      return false;
+    }
+    visiting.add(frameId);
+    const parentVisible = frameIsVisible(parentFrameId, visiting);
+    visiting.delete(frameId);
+    const embeddingFrame = parentVisible ? findEmbeddingFrame(frameId, parentFrameId) : null;
+    const visible = parentVisible && embeddingFrame?.visible === true;
+    visibilityByFrameId.set(frameId, visible);
+    return visible;
+  };
+
+  return (Array.isArray(candidates) ? candidates : []).map(candidate => {
+    const frameVisible = frameIsVisible(candidate?.frameId);
+    return {
+      ...candidate,
+      frameVisible,
+      visible: candidate?.visible === true && frameVisible,
+      normalCheckbox: candidate?.normalCheckbox === true && candidate?.visible === true && frameVisible,
+    };
+  });
+}
+
 function candidateSummary(candidate) {
   return {
     frameId: Number.isInteger(candidate?.frameId) ? candidate.frameId : null,
@@ -57,6 +131,7 @@ function candidateSummary(candidate) {
     visible: candidate?.visible === true,
     normalCheckbox: candidate?.normalCheckbox === true,
     challengeFrame: candidate?.challengeFrame === true,
+    frameVisible: candidate?.frameVisible !== false,
     isInvisible: candidate?.isInvisible === true,
     isEnterprise: candidate?.isEnterprise === true,
     pageAction: candidate?.pageAction || null,
@@ -70,12 +145,13 @@ function candidateScore(candidate) {
   // Priority is tiered so no combination of secondary signals can make a
   // generic visible/background integration outrank an active challenge
   // frame or visible checkbox.
-  const primary = (candidate?.normalCheckbox && candidate?.visible) || candidate?.challengeFrame;
+  const activeChallengeFrame = candidate?.challengeFrame && candidate?.frameVisible !== false;
+  const primary = (candidate?.normalCheckbox && candidate?.visible) || activeChallengeFrame;
   const tier = primary ? 3 : (candidate?.visible ? 2 : 1);
   let score = tier * 1000;
   if (candidate?.normalCheckbox && candidate?.visible) score += 120;
   else if (candidate?.visible) score += 60;
-  if (candidate?.challengeFrame) score += 35;
+  if (activeChallengeFrame) score += 35;
   if (candidate?.responseField) score += 12;
   if (candidate?.detectedVia === 'host') score += 8;
   if (candidate?.websiteKey) score += 4;
@@ -182,9 +258,9 @@ function selectedReason(candidate, constraints) {
   if (constraints.frameUrl) return 'exact frameUrl match';
   if (constraints.websiteKey) return 'exact websiteKey match';
   if (candidate.normalCheckbox && candidate.visible) return 'visible checkbox challenge';
-  if (candidate.visible && candidate.challengeFrame) return 'visible challenge frame';
+  if (candidate.visible && candidate.challengeFrame && candidate.frameVisible !== false) return 'visible challenge frame';
   if (candidate.visible) return 'visible CAPTCHA widget';
-  if (candidate.challengeFrame) return 'challenge frame candidate';
+  if (candidate.challengeFrame && candidate.frameVisible !== false) return 'challenge frame candidate';
   return 'only detected CAPTCHA candidate';
 }
 
@@ -309,7 +385,10 @@ export function detectCaptchaCandidatesInPage() {
     });
   }
 
-  const iframeElements = Array.from(document.querySelectorAll('iframe[src]'));
+  const allIframeElements = Array.from(document.querySelectorAll('iframe'));
+  const iframeElements = allIframeElements.filter(element => {
+    try { return !!element.src; } catch (_) { return false; }
+  });
   const iframeUrls = iframeElements.map(element => {
     try { return { element, url: element.src || '' }; } catch (_) { return { element, url: '' }; }
   }).filter(item => item.url);
@@ -401,7 +480,31 @@ export function detectCaptchaCandidatesInPage() {
       detectedVia: 'script',
     });
   }
-  return candidates;
+  const childFrames = allIframeElements.map((element, index) => {
+    let url = '';
+    let loadedUrl = '';
+    let name = '';
+    try { url = String(element.src || ''); } catch (_) {}
+    try { loadedUrl = String(element.contentWindow?.location?.href || ''); } catch (_) {}
+    try { name = String(element.name || element.getAttribute?.('name') || ''); } catch (_) {}
+    return {
+      index,
+      url,
+      loadedUrl,
+      name,
+      visible: visibleElement(element),
+    };
+  });
+  let frameName = '';
+  try { frameName = typeof window !== 'undefined' ? String(window.name || '') : ''; } catch (_) {}
+  return {
+    candidates,
+    frameContext: {
+      frameUrl,
+      frameName,
+      childFrames,
+    },
+  };
 }
 
 // This function is also serialized into a page context. Keep it self-contained.

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -147,6 +147,7 @@ function candidateSummary(candidate) {
     pageAction: candidate?.pageAction || null,
     enterprisePayload: candidate?.enterprisePayload || null,
     recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
+    explicitWebsiteKey: candidate?.explicitWebsiteKey === true,
     parameterConflicts: Array.isArray(candidate?.parameterConflicts)
       ? candidate.parameterConflicts
       : [],
@@ -253,6 +254,7 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
   let pool = unique;
   const requestedFrameUrl = String(constraints.frameUrl || '');
   const requestedWebsiteKey = String(constraints.websiteKey || '');
+  const requestedType = normalizeCaptchaType(constraints.type);
   if (requestedFrameUrl) {
     pool = pool.filter(candidate => candidate.frameUrl === requestedFrameUrl);
     if (!pool.length) {
@@ -265,7 +267,20 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
     }
   }
   if (requestedWebsiteKey) {
-    pool = pool.filter(candidate => candidate.websiteKey === requestedWebsiteKey);
+    const exactKeyMatches = pool.filter(candidate => candidate.websiteKey === requestedWebsiteKey);
+    const explicitTurnstileFallbacks = requestedType === 'turnstile'
+      ? pool
+        .filter(candidate =>
+          candidate.type === 'turnstile_challenge' && !candidate.websiteKey
+        )
+        .map(candidate => ({
+          ...candidate,
+          type: 'turnstile',
+          websiteKey: requestedWebsiteKey,
+          explicitWebsiteKey: true,
+        }))
+      : [];
+    pool = exactKeyMatches.length ? exactKeyMatches : explicitTurnstileFallbacks;
     if (!pool.length) {
       return {
         selected: null,
@@ -318,6 +333,7 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
 }
 
 function selectedReason(candidate, constraints) {
+  if (candidate.explicitWebsiteKey) return 'explicit site key for detected Turnstile challenge';
   if (constraints.frameUrl) return 'exact frameUrl match';
   if (constraints.websiteKey) return 'exact websiteKey match';
   if (candidate.normalCheckbox && candidate.visible) return 'visible checkbox challenge';

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -239,6 +239,10 @@ function candidateSummary(candidate) {
     responseFieldIndex: Number.isInteger(candidate?.responseFieldIndex)
       ? candidate.responseFieldIndex
       : null,
+    alsoResponseFieldId: candidate?.alsoResponseFieldId || null,
+    alsoResponseFieldIndex: Number.isInteger(candidate?.alsoResponseFieldIndex)
+      ? candidate.alsoResponseFieldIndex
+      : null,
     documentTimeOrigin: Number.isFinite(candidate?.documentTimeOrigin)
       ? candidate.documentTimeOrigin
       : null,
@@ -314,7 +318,11 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
       candidate.responseFieldId || (
         Number.isInteger(candidate.responseFieldIndex)
           ? `response-field-${candidate.responseFieldIndex}`
-          : ''
+          : (candidate.alsoResponseFieldId || (
+            Number.isInteger(candidate.alsoResponseFieldIndex)
+              ? `also-response-field-${candidate.alsoResponseFieldIndex}`
+              : ''
+          ))
       ),
     ].join('|');
     if (fingerprintIndexes.has(fingerprint)) {
@@ -550,6 +558,15 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       ...(responseFieldIndex >= 0 ? { responseFieldIndex } : {}),
     };
   };
+  const alsoResponseFieldIdentity = (widget, name, fallbackIndex, widgetCount) => {
+    const identity = responseFieldIdentity(widget, name, fallbackIndex, widgetCount);
+    return {
+      ...(identity.responseFieldId ? { alsoResponseFieldId: identity.responseFieldId } : {}),
+      ...(Number.isInteger(identity.responseFieldIndex)
+        ? { alsoResponseFieldIndex: identity.responseFieldIndex }
+        : {}),
+    };
+  };
 
   const hcaptchaHosts = Array.from(pageDocument.querySelectorAll(
     '.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]'
@@ -566,6 +583,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       normalCheckbox: visibleElement(host) && !isInvisible,
       callbackName: host.getAttribute('data-callback') || null,
       ...responseFieldIdentity(host, 'h-captcha-response', widgetIndex, hcaptchaHosts.length),
+      ...alsoResponseFieldIdentity(host, 'g-recaptcha-response', widgetIndex, hcaptchaHosts.length),
       detectedVia: 'host',
     });
   }
@@ -657,6 +675,12 @@ export function detectCaptchaCandidatesInPage(scope = null) {
           ...responseFieldIdentity(
             element,
             'h-captcha-response',
+            hcaptchaFrames.findIndex(frame => frame.element === element),
+            hcaptchaFrames.length,
+          ),
+          ...alsoResponseFieldIdentity(
+            element,
+            'g-recaptcha-response',
             hcaptchaFrames.findIndex(frame => frame.element === element),
             hcaptchaFrames.length,
           ),
@@ -903,19 +927,23 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     const fields = Array.from(frameDocument.querySelectorAll(
       `textarea[name="${name}"], input[name="${name}"]`
     ));
-    if (primary && target.responseFieldId) {
+    const selectedFieldId = primary ? target.responseFieldId : target.alsoResponseFieldId;
+    const selectedFieldIndex = primary
+      ? target.responseFieldIndex
+      : target.alsoResponseFieldIndex;
+    if (selectedFieldId) {
       const exact = fields.find(element => {
         try {
-          return String(element.id || element.getAttribute?.('id') || '') === target.responseFieldId;
+          return String(element.id || element.getAttribute?.('id') || '') === selectedFieldId;
         } catch (_) {
           return false;
         }
       });
       if (exact) return { element: exact };
     }
-    if (Number.isInteger(target.responseFieldIndex)) {
-      if (fields[target.responseFieldIndex]) {
-        return { element: fields[target.responseFieldIndex] };
+    if (Number.isInteger(selectedFieldIndex)) {
+      if (fields[selectedFieldIndex]) {
+        return { element: fields[selectedFieldIndex] };
       }
       return {
         error: 'The selected CAPTCHA response field is no longer present in the target frame.',
@@ -1075,6 +1103,10 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     responseFieldId: target.responseFieldId || null,
     responseFieldIndex: Number.isInteger(target.responseFieldIndex)
       ? target.responseFieldIndex
+      : null,
+    alsoResponseFieldId: target.alsoResponseFieldId || null,
+    alsoResponseFieldIndex: Number.isInteger(target.alsoResponseFieldIndex)
+      ? target.alsoResponseFieldIndex
       : null,
     calledCallback,
     callbackSource,

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -147,6 +147,9 @@ function candidateSummary(candidate) {
     pageAction: candidate?.pageAction || null,
     enterprisePayload: candidate?.enterprisePayload || null,
     recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
+    parameterConflicts: Array.isArray(candidate?.parameterConflicts)
+      ? candidate.parameterConflicts
+      : [],
     detectedVia: candidate?.detectedVia || null,
   };
 }
@@ -172,6 +175,28 @@ function candidateScore(candidate) {
 export function selectCaptchaCandidate(candidates, constraints = {}) {
   const unique = [];
   const fingerprintIndexes = new Map();
+  const taskParameterFields = [
+    'isInvisible',
+    'isEnterprise',
+    'pageAction',
+    'enterprisePayload',
+    'recaptchaDataSValue',
+  ];
+  const hasParameterValue = value =>
+    value !== undefined && value !== null && value !== '';
+  const taskParameterApplies = (field, type) =>
+    field !== 'isInvisible' || !/^recaptcha_v3(?:_|$)/.test(type);
+  const stableParameterValue = value => {
+    if (Array.isArray(value)) {
+      return `[${value.map(stableParameterValue).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+      return `{${Object.keys(value).sort().map(key =>
+        `${JSON.stringify(key)}:${stableParameterValue(value[key])}`
+      ).join(',')}}`;
+    }
+    return JSON.stringify(value);
+  };
   for (const raw of Array.isArray(candidates) ? candidates : []) {
     if (!raw?.type) continue;
     const candidate = {
@@ -185,23 +210,40 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
       candidate.frameUrl,
       candidate.type,
       candidate.websiteKey || '',
+      stableParameterValue(Array.isArray(candidate.framePath) ? candidate.framePath : []),
     ].join('|');
     if (fingerprintIndexes.has(fingerprint)) {
       const index = fingerprintIndexes.get(fingerprint);
       const previous = unique[index];
       const preferred = candidateScore(candidate) > candidateScore(previous) ? candidate : previous;
       const fallback = preferred === candidate ? previous : candidate;
-      unique[index] = {
+      const parameterConflicts = new Set([
+        ...(Array.isArray(previous.parameterConflicts) ? previous.parameterConflicts : []),
+        ...(Array.isArray(candidate.parameterConflicts) ? candidate.parameterConflicts : []),
+      ]);
+      const merged = {
         ...fallback,
         ...preferred,
         visible: previous.visible === true || candidate.visible === true,
         normalCheckbox: previous.normalCheckbox === true || candidate.normalCheckbox === true,
         challengeFrame: previous.challengeFrame === true || candidate.challengeFrame === true,
         responseField: previous.responseField === true || candidate.responseField === true,
-        pageAction: previous.pageAction || candidate.pageAction || null,
-        enterprisePayload: previous.enterprisePayload || candidate.enterprisePayload || null,
-        recaptchaDataSValue: previous.recaptchaDataSValue || candidate.recaptchaDataSValue || null,
       };
+      for (const field of taskParameterFields) {
+        const previousValue = previous[field];
+        const candidateValue = candidate[field];
+        if (taskParameterApplies(field, candidate.type)
+            && hasParameterValue(previousValue)
+            && hasParameterValue(candidateValue)
+            && stableParameterValue(previousValue) !== stableParameterValue(candidateValue)) {
+          parameterConflicts.add(field);
+        }
+        merged[field] = hasParameterValue(previousValue)
+          ? previousValue
+          : (hasParameterValue(candidateValue) ? candidateValue : null);
+      }
+      merged.parameterConflicts = [...parameterConflicts].sort();
+      unique[index] = merged;
       continue;
     }
     fingerprintIndexes.set(fingerprint, unique.length);
@@ -248,6 +290,17 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
       ambiguous: true,
       error: 'Multiple CAPTCHA candidates are equally active. Pass an exact frameUrl or websiteKey to select one.',
       candidates: top.map(entry => candidateSummary(entry.candidate)),
+    };
+  }
+  const selectedConflicts = Array.isArray(top[0].candidate.parameterConflicts)
+    ? top[0].candidate.parameterConflicts
+    : [];
+  if (selectedConflicts.length) {
+    return {
+      selected: null,
+      ambiguous: true,
+      error: `Conflicting CAPTCHA task parameters were detected for the same frame, type, and site key: ${selectedConflicts.join(', ')}. Wait for the stale widget to disappear or reload the page before retrying.`,
+      candidates: [candidateSummary(top[0].candidate)],
     };
   }
 

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -201,6 +201,29 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
       ancestorLoaderFrameId: loader.frameId,
     };
   };
+  const isHttpUrl = value => /^https?:\/\//i.test(String(value || ''));
+  const nearestHttpUrl = (candidate) => {
+    if (isHttpUrl(candidate?.frameUrl)) return String(candidate.frameUrl);
+    const framePath = Array.isArray(candidate?.framePath) ? candidate.framePath : [];
+    for (let index = framePath.length - 2; index >= 0; index -= 1) {
+      if (isHttpUrl(framePath[index]?.frameUrl)) return String(framePath[index].frameUrl);
+    }
+    const baseFrameUrl = contextsByFrameId.get(candidate?.frameId)?.frameUrl
+      || navigationByFrameId.get(candidate?.frameId)?.url;
+    if (isHttpUrl(baseFrameUrl)) return String(baseFrameUrl);
+    let currentFrameId = candidate?.frameId;
+    const visited = new Set();
+    while (Number.isInteger(currentFrameId) && !visited.has(currentFrameId)) {
+      visited.add(currentFrameId);
+      const parentFrameId = navigationByFrameId.get(currentFrameId)?.parentFrameId;
+      if (!Number.isInteger(parentFrameId) || parentFrameId === -1) break;
+      const parentUrl = contextsByFrameId.get(parentFrameId)?.frameUrl
+        || navigationByFrameId.get(parentFrameId)?.url;
+      if (isHttpUrl(parentUrl)) return String(parentUrl);
+      currentFrameId = parentFrameId;
+    }
+    return null;
+  };
 
   return sourceCandidates.map(rawCandidate => {
     const candidate = reconcileAncestorLoader(rawCandidate);
@@ -209,6 +232,7 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
     return {
       ...candidate,
       frameVisible,
+      websiteURL: nearestHttpUrl(candidate),
       visible: candidate?.visible === true && frameVisible,
       normalCheckbox: candidate?.normalCheckbox === true && candidate?.visible === true && frameVisible,
     };
@@ -221,7 +245,11 @@ function candidateSummary(candidate) {
     ...(Array.isArray(candidate?.framePath) && candidate.framePath.length
       ? { framePath: candidate.framePath }
       : {}),
+    framePathIndexes: Array.isArray(candidate?.framePath)
+      ? candidate.framePath.map(segment => Number(segment?.index))
+      : [],
     frameUrl: candidate?.frameUrl || '',
+    websiteURL: candidate?.websiteURL || null,
     type: candidate?.type || '',
     websiteKey: candidate?.websiteKey || null,
     visible: candidate?.visible === true,
@@ -364,6 +392,47 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
   }
 
   let pool = unique;
+  const requestedFrameId = Number.isInteger(constraints.frameId) ? constraints.frameId : null;
+  if (requestedFrameId != null) {
+    pool = pool.filter(candidate => candidate.frameId === requestedFrameId);
+    if (!pool.length) {
+      return {
+        selected: null,
+        ambiguous: false,
+        error: `No CAPTCHA candidate was found in frameId ${requestedFrameId}.`,
+        candidates: unique.map(candidateSummary),
+      };
+    }
+  }
+  const hasRequestedFramePath = Array.isArray(constraints.framePath);
+  const requestedFramePath = hasRequestedFramePath
+    ? constraints.framePath.map(value => Number(value))
+    : [];
+  if (hasRequestedFramePath) {
+    if (requestedFramePath.some(value => !Number.isInteger(value) || value < 0)) {
+      return {
+        selected: null,
+        ambiguous: false,
+        error: 'framePath must be an array of non-negative iframe indexes.',
+        candidates: unique.map(candidateSummary),
+      };
+    }
+    pool = pool.filter(candidate => {
+      const candidatePath = Array.isArray(candidate.framePath)
+        ? candidate.framePath.map(segment => Number(segment?.index))
+        : [];
+      return candidatePath.length === requestedFramePath.length
+        && candidatePath.every((value, index) => value === requestedFramePath[index]);
+    });
+    if (!pool.length) {
+      return {
+        selected: null,
+        ambiguous: false,
+        error: `No CAPTCHA candidate was found at framePath [${requestedFramePath.join(', ')}].`,
+        candidates: unique.map(candidateSummary),
+      };
+    }
+  }
   const requestedFrameUrl = String(constraints.frameUrl || '');
   const requestedWebsiteKey = String(constraints.websiteKey || '');
   const requestedType = normalizeCaptchaType(constraints.type);
@@ -412,11 +481,30 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
   const topScore = ranked[0].score;
   const top = ranked.filter(entry => entry.score === topScore);
   if (top.length > 1) {
+    const summaries = top.map(entry => candidateSummary(entry.candidate));
+    const uniqueCount = selector => new Set(summaries.map(selector)).size;
+    const discriminators = [];
+    if (uniqueCount(candidate => candidate.frameUrl) > 1) discriminators.push('frameUrl');
+    if (uniqueCount(candidate => candidate.websiteKey) > 1) discriminators.push('websiteKey');
+    if (uniqueCount(candidate => candidate.frameId) > 1) discriminators.push('frameId');
+    if (uniqueCount(candidate => JSON.stringify(candidate.framePathIndexes)) > 1) {
+      discriminators.push('framePath');
+    }
+    const finalDiscriminator = discriminators.pop();
+    const discriminatorText = finalDiscriminator
+      ? discriminators.length === 0
+        ? finalDiscriminator
+        : discriminators.length === 1
+          ? `${discriminators[0]} or ${finalDiscriminator}`
+          : `${discriminators.join(', ')}, or ${finalDiscriminator}`
+      : null;
     return {
       selected: null,
       ambiguous: true,
-      error: 'Multiple CAPTCHA candidates are equally active. Pass an exact frameUrl or websiteKey to select one.',
-      candidates: top.map(entry => candidateSummary(entry.candidate)),
+      error: discriminatorText
+        ? `Multiple CAPTCHA candidates are equally active. Pass an exact ${discriminatorText} from the candidates to select one.`
+        : 'Multiple CAPTCHA candidates are equally active and expose no unique frame discriminator. Wait for one widget to become inactive before retrying.',
+      candidates: summaries,
     };
   }
   const selectedConflicts = Array.isArray(top[0].candidate.parameterConflicts)
@@ -446,6 +534,8 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
 
 function selectedReason(candidate, constraints) {
   if (candidate.explicitWebsiteKey) return 'explicit site key for detected Turnstile challenge';
+  if (Array.isArray(constraints.framePath)) return 'exact framePath match';
+  if (Number.isInteger(constraints.frameId)) return 'exact frameId match';
   if (constraints.frameUrl) return 'exact frameUrl match';
   if (constraints.websiteKey) return 'exact websiteKey match';
   if (candidate.normalCheckbox && candidate.visible) return 'visible checkbox challenge';

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -370,7 +370,11 @@ export function detectCaptchaCandidatesInPage(scope = null) {
 
   const urlParam = (urlStr, name) => {
     try {
-      return new URL(urlStr, frameUrl || 'https://dummy.host').searchParams.get(name);
+      const url = new URL(urlStr, frameUrl || 'https://dummy.host');
+      const queryValue = url.searchParams.get(name);
+      if (queryValue != null) return queryValue;
+      const fragment = String(url.hash || '').replace(/^#/, '');
+      return fragment ? new URLSearchParams(fragment).get(name) : null;
     } catch (_) {
       return null;
     }

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -23,6 +23,12 @@ export function normalizeCaptchaType(type) {
   return TYPE_ALIASES.get(value) || value;
 }
 
+export function captchaWebsiteUrl(frameUrl, topLevelUrl = '') {
+  return /^https?:\/\//i.test(String(frameUrl || ''))
+    ? String(frameUrl)
+    : String(topLevelUrl || '');
+}
+
 function recaptchaTypeDetails(type, isEnterprise) {
   const normalized = normalizeCaptchaType(type);
   const match = normalized.match(/^recaptcha_v([23])(_enterprise)?$/);
@@ -112,7 +118,8 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
   };
 
   return (Array.isArray(candidates) ? candidates : []).map(candidate => {
-    const frameVisible = frameIsVisible(candidate?.frameId);
+    const frameVisible = frameIsVisible(candidate?.frameId)
+      && candidate?.frameVisibleWithinAnchor !== false;
     return {
       ...candidate,
       frameVisible,
@@ -125,6 +132,9 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
 function candidateSummary(candidate) {
   return {
     frameId: Number.isInteger(candidate?.frameId) ? candidate.frameId : null,
+    ...(Array.isArray(candidate?.framePath) && candidate.framePath.length
+      ? { framePath: candidate.framePath }
+      : {}),
     frameUrl: candidate?.frameUrl || '',
     type: candidate?.type || '',
     websiteKey: candidate?.websiteKey || null,
@@ -266,11 +276,23 @@ function selectedReason(candidate, constraints) {
 
 // This function is serialized and executed in the web page. It must not
 // reference module-scope values.
-export function detectCaptchaCandidatesInPage() {
+export function detectCaptchaCandidatesInPage(scope = null) {
   const candidates = [];
-  const frameUrl = typeof location !== 'undefined' ? String(location.href || '') : '';
+  const pageWindow = scope?.window
+    || (typeof window !== 'undefined' ? window : null);
+  const pageDocument = scope?.document
+    || (typeof document !== 'undefined' ? document : null);
+  const pageLocation = pageWindow?.location
+    || (typeof location !== 'undefined' ? location : null);
+  const frameUrl = pageLocation ? String(pageLocation.href || '') : '';
+  if (!pageDocument) {
+    return {
+      candidates,
+      frameContext: { frameUrl, frameName: '', childFrames: [] },
+    };
+  }
   const challengeFrame = /(?:captcha|challenge|checkpoint|security[-_/ ]?verif)/i.test(frameUrl);
-  const responseField = !!document.querySelector(
+  const responseField = !!pageDocument.querySelector(
     'textarea[name="g-recaptcha-response"], input[name="g-recaptcha-response"], '
       + 'textarea[name="h-captcha-response"], input[name="h-captcha-response"], '
       + 'textarea[name="cf-turnstile-response"], input[name="cf-turnstile-response"]'
@@ -287,14 +309,16 @@ export function detectCaptchaCandidatesInPage() {
   const visibleElement = (element) => {
     if (!element) return false;
     try {
-      const style = typeof getComputedStyle === 'function' ? getComputedStyle(element) : null;
+      const style = typeof pageWindow?.getComputedStyle === 'function'
+        ? pageWindow.getComputedStyle(element)
+        : null;
       if (style && (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0)) return false;
       if (element.hidden || element.getAttribute?.('aria-hidden') === 'true') return false;
       if (typeof element.getBoundingClientRect === 'function') {
         const rect = element.getBoundingClientRect();
         if (!rect || rect.width <= 0 || rect.height <= 0) return false;
-        const viewportWidth = typeof innerWidth === 'number' ? innerWidth : rect.right;
-        const viewportHeight = typeof innerHeight === 'number' ? innerHeight : rect.bottom;
+        const viewportWidth = typeof pageWindow?.innerWidth === 'number' ? pageWindow.innerWidth : rect.right;
+        const viewportHeight = typeof pageWindow?.innerHeight === 'number' ? pageWindow.innerHeight : rect.bottom;
         if (rect.bottom <= 0 || rect.right <= 0 || rect.top >= viewportHeight || rect.left >= viewportWidth) return false;
       }
       return true;
@@ -311,12 +335,12 @@ export function detectCaptchaCandidatesInPage() {
       responseField,
     });
   };
-  const scriptElements = Array.from(document.querySelectorAll('script[src]'));
+  const scriptElements = Array.from(pageDocument.querySelectorAll('script[src]'));
   const scriptUrls = scriptElements.map(element => {
     try { return element.src || ''; } catch (_) { return ''; }
   }).filter(Boolean);
 
-  for (const host of Array.from(document.querySelectorAll('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]'))) {
+  for (const host of Array.from(pageDocument.querySelectorAll('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]'))) {
     const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-hcaptcha-sitekey');
     if (!websiteKey) continue;
     const isInvisible = host.getAttribute('data-size') === 'invisible';
@@ -331,7 +355,7 @@ export function detectCaptchaCandidatesInPage() {
     });
   }
 
-  for (const host of Array.from(document.querySelectorAll('.cf-turnstile[data-sitekey], [data-turnstile-sitekey]'))) {
+  for (const host of Array.from(pageDocument.querySelectorAll('.cf-turnstile[data-sitekey], [data-turnstile-sitekey]'))) {
     const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-turnstile-sitekey');
     if (!websiteKey) continue;
     add({
@@ -344,7 +368,7 @@ export function detectCaptchaCandidatesInPage() {
     });
   }
 
-  for (const host of Array.from(document.querySelectorAll(
+  for (const host of Array.from(pageDocument.querySelectorAll(
     '.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey], [data-recaptcha-sitekey]'
   ))) {
     const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-recaptcha-sitekey');
@@ -385,7 +409,7 @@ export function detectCaptchaCandidatesInPage() {
     });
   }
 
-  const allIframeElements = Array.from(document.querySelectorAll('iframe'));
+  const allIframeElements = Array.from(pageDocument.querySelectorAll('iframe'));
   const iframeElements = allIframeElements.filter(element => {
     try { return !!element.src; } catch (_) { return false; }
   });
@@ -468,8 +492,8 @@ export function detectCaptchaCandidatesInPage() {
   }
 
   if (!candidates.length && (
-    document.querySelector('script[src*="challenges.cloudflare.com/turnstile"]')
-    || document.querySelector('iframe[src*="challenges.cloudflare.com"]')
+    pageDocument.querySelector('script[src*="challenges.cloudflare.com/turnstile"]')
+    || pageDocument.querySelector('iframe[src*="challenges.cloudflare.com"]')
   )) {
     add({
       type: 'turnstile_challenge',
@@ -496,7 +520,7 @@ export function detectCaptchaCandidatesInPage() {
     };
   });
   let frameName = '';
-  try { frameName = typeof window !== 'undefined' ? String(window.name || '') : ''; } catch (_) {}
+  try { frameName = pageWindow ? String(pageWindow.name || '') : ''; } catch (_) {}
   return {
     candidates,
     frameContext: {
@@ -508,14 +532,23 @@ export function detectCaptchaCandidatesInPage() {
 }
 
 // This function is also serialized into a page context. Keep it self-contained.
-export function injectCaptchaTokenInPage(payload) {
+export function injectCaptchaTokenInPage(payload, scope = null) {
   const fieldName = payload?.fieldName;
   const alsoSet = payload?.alsoSet || null;
   const token = payload?.token;
   const target = payload?.target || {};
-  const frameUrl = typeof location !== 'undefined' ? String(location.href || '') : '';
+  const frameWindow = scope?.window
+    || (typeof window !== 'undefined' ? window : null);
+  const frameDocument = scope?.document
+    || (typeof document !== 'undefined' ? document : null);
+  const frameLocation = frameWindow?.location
+    || (typeof location !== 'undefined' ? location : null);
+  const frameUrl = frameLocation ? String(frameLocation.href || '') : '';
   if (!fieldName || !token) {
     return { success: false, fieldUpdated: false, error: 'fieldName and token required', frameUrl };
+  }
+  if (!frameDocument || !frameWindow) {
+    return { success: false, fieldUpdated: false, error: 'target frame document is unavailable', frameUrl };
   }
   if (!Number.isInteger(target.frameId) || !target.frameUrl || !target.websiteKey) {
     return {
@@ -540,7 +573,7 @@ export function injectCaptchaTokenInPage(payload) {
   };
   const frameHasSiteKey = (key) => {
     if (!key) return false;
-    for (const element of Array.from(document.querySelectorAll(
+    for (const element of Array.from(frameDocument.querySelectorAll(
       '[data-sitekey], [data-recaptcha-sitekey], [data-hcaptcha-sitekey], [data-turnstile-sitekey]'
     ))) {
       if ([
@@ -550,7 +583,7 @@ export function injectCaptchaTokenInPage(payload) {
         element.getAttribute('data-turnstile-sitekey'),
       ].includes(key)) return true;
     }
-    for (const element of Array.from(document.querySelectorAll('iframe[src], script[src]'))) {
+    for (const element of Array.from(frameDocument.querySelectorAll('iframe[src], script[src]'))) {
       try { if (element.src && urlHasKey(element.src, key)) return true; } catch (_) {}
     }
     return false;
@@ -566,17 +599,21 @@ export function injectCaptchaTokenInPage(payload) {
   }
 
   const setOn = (name) => {
-    let element = document.querySelector(`textarea[name="${name}"], input[name="${name}"]`);
+    let element = frameDocument.querySelector(`textarea[name="${name}"], input[name="${name}"]`);
     if (!element) {
-      element = document.createElement('textarea');
+      element = frameDocument.createElement('textarea');
       element.name = name;
       element.style.display = 'none';
-      (document.body || document.documentElement).appendChild(element);
+      (frameDocument.body || frameDocument.documentElement).appendChild(element);
     }
     try {
+      const TextAreaElement = frameWindow.HTMLTextAreaElement
+        || (typeof HTMLTextAreaElement !== 'undefined' ? HTMLTextAreaElement : null);
+      const InputElement = frameWindow.HTMLInputElement
+        || (typeof HTMLInputElement !== 'undefined' ? HTMLInputElement : null);
       const prototype = element.tagName === 'TEXTAREA'
-        ? HTMLTextAreaElement.prototype
-        : HTMLInputElement.prototype;
+        ? TextAreaElement?.prototype
+        : InputElement?.prototype;
       const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
       if (setter) setter.call(element, token);
       else element.value = token;
@@ -584,8 +621,12 @@ export function injectCaptchaTokenInPage(payload) {
       element.value = token;
     }
     element.textContent = token;
-    element.dispatchEvent(new Event('input', { bubbles: true }));
-    element.dispatchEvent(new Event('change', { bubbles: true }));
+    const PageEvent = frameWindow.Event
+      || (typeof Event !== 'undefined' ? Event : null);
+    if (PageEvent) {
+      element.dispatchEvent(new PageEvent('input', { bubbles: true }));
+      element.dispatchEvent(new PageEvent('change', { bubbles: true }));
+    }
     return element;
   };
   setOn(fieldName);
@@ -595,7 +636,7 @@ export function injectCaptchaTokenInPage(payload) {
     fieldsTouched += 1;
   }
 
-  const pageWindow = (typeof window !== 'undefined' && window.wrappedJSObject) || window;
+  const pageWindow = frameWindow.wrappedJSObject || frameWindow;
   const callbacks = [];
   const addCallback = (fn, source) => {
     if (typeof fn !== 'function') return;
@@ -610,7 +651,7 @@ export function injectCaptchaTokenInPage(payload) {
       return null;
     }
   };
-  for (const host of Array.from(document.querySelectorAll(
+  for (const host of Array.from(frameDocument.querySelectorAll(
     '.g-recaptcha[data-callback], .h-captcha[data-callback], .cf-turnstile[data-callback], '
       + '[data-recaptcha-sitekey][data-callback], [data-hcaptcha-sitekey][data-callback], '
       + '[data-turnstile-sitekey][data-callback]'

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -1,0 +1,582 @@
+// Shared, page-facing helpers for frame-aware CAPTCHA detection and token
+// injection. This file is mirrored in the Firefox tree; keep both copies
+// byte-identical so the two extension builds make the same decisions.
+
+const TYPE_ALIASES = new Map([
+  ['recaptchav2', 'recaptcha_v2'],
+  ['recaptcha_v2', 'recaptcha_v2'],
+  ['recaptcha_enterprise', 'recaptcha_v2_enterprise'],
+  ['recaptcha_v2_enterprise', 'recaptcha_v2_enterprise'],
+  ['recaptchav3', 'recaptcha_v3'],
+  ['recaptcha_v3', 'recaptcha_v3'],
+  ['recaptcha_v3_enterprise', 'recaptcha_v3_enterprise'],
+  ['cloudflare', 'turnstile'],
+  ['cf_turnstile', 'turnstile'],
+  ['turnstile', 'turnstile'],
+  ['hcaptcha', 'hcaptcha'],
+  ['image', 'image_to_text'],
+  ['image_to_text', 'image_to_text'],
+]);
+
+export function normalizeCaptchaType(type) {
+  const value = String(type || '').trim().toLowerCase();
+  return TYPE_ALIASES.get(value) || value;
+}
+
+function recaptchaTypeDetails(type, isEnterprise) {
+  const normalized = normalizeCaptchaType(type);
+  const match = normalized.match(/^recaptcha_v([23])(_enterprise)?$/);
+  if (!match) return null;
+  const enterpriseInType = !!match[2];
+  return {
+    baseType: `recaptcha_v${match[1]}`,
+    enterprise: enterpriseInType ? true : (isEnterprise == null ? null : !!isEnterprise),
+    invalid: enterpriseInType && isEnterprise === false,
+  };
+}
+
+export function captchaTypesMatch(left, right, leftIsEnterprise = null, rightIsEnterprise = null) {
+  const leftRecaptcha = recaptchaTypeDetails(left, leftIsEnterprise);
+  const rightRecaptcha = recaptchaTypeDetails(right, rightIsEnterprise);
+  if (leftRecaptcha || rightRecaptcha) {
+    if (!leftRecaptcha || !rightRecaptcha || leftRecaptcha.invalid || rightRecaptcha.invalid) return false;
+    if (leftRecaptcha.baseType !== rightRecaptcha.baseType) return false;
+    return leftRecaptcha.enterprise == null
+      || rightRecaptcha.enterprise == null
+      || leftRecaptcha.enterprise === rightRecaptcha.enterprise;
+  }
+  return normalizeCaptchaType(left) === normalizeCaptchaType(right);
+}
+
+function candidateSummary(candidate) {
+  return {
+    frameId: Number.isInteger(candidate?.frameId) ? candidate.frameId : null,
+    frameUrl: candidate?.frameUrl || '',
+    type: candidate?.type || '',
+    websiteKey: candidate?.websiteKey || null,
+    visible: candidate?.visible === true,
+    normalCheckbox: candidate?.normalCheckbox === true,
+    challengeFrame: candidate?.challengeFrame === true,
+    isInvisible: candidate?.isInvisible === true,
+    isEnterprise: candidate?.isEnterprise === true,
+    pageAction: candidate?.pageAction || null,
+    enterprisePayload: candidate?.enterprisePayload || null,
+    recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
+    detectedVia: candidate?.detectedVia || null,
+  };
+}
+
+function candidateScore(candidate) {
+  // Priority is tiered so no combination of secondary signals can make a
+  // generic visible/background integration outrank an active challenge
+  // frame or visible checkbox.
+  const primary = (candidate?.normalCheckbox && candidate?.visible) || candidate?.challengeFrame;
+  const tier = primary ? 3 : (candidate?.visible ? 2 : 1);
+  let score = tier * 1000;
+  if (candidate?.normalCheckbox && candidate?.visible) score += 120;
+  else if (candidate?.visible) score += 60;
+  if (candidate?.challengeFrame) score += 35;
+  if (candidate?.responseField) score += 12;
+  if (candidate?.detectedVia === 'host') score += 8;
+  if (candidate?.websiteKey) score += 4;
+  if (candidate?.isInvisible) score -= 3;
+  return score;
+}
+
+export function selectCaptchaCandidate(candidates, constraints = {}) {
+  const unique = [];
+  const fingerprintIndexes = new Map();
+  for (const raw of Array.isArray(candidates) ? candidates : []) {
+    if (!raw?.type) continue;
+    const candidate = {
+      ...raw,
+      type: normalizeCaptchaType(raw.type),
+      frameUrl: String(raw.frameUrl || ''),
+      websiteKey: raw.websiteKey || null,
+    };
+    const fingerprint = [
+      Number.isInteger(candidate.frameId) ? candidate.frameId : '',
+      candidate.frameUrl,
+      candidate.type,
+      candidate.websiteKey || '',
+    ].join('|');
+    if (fingerprintIndexes.has(fingerprint)) {
+      const index = fingerprintIndexes.get(fingerprint);
+      const previous = unique[index];
+      const preferred = candidateScore(candidate) > candidateScore(previous) ? candidate : previous;
+      const fallback = preferred === candidate ? previous : candidate;
+      unique[index] = {
+        ...fallback,
+        ...preferred,
+        visible: previous.visible === true || candidate.visible === true,
+        normalCheckbox: previous.normalCheckbox === true || candidate.normalCheckbox === true,
+        challengeFrame: previous.challengeFrame === true || candidate.challengeFrame === true,
+        responseField: previous.responseField === true || candidate.responseField === true,
+        pageAction: previous.pageAction || candidate.pageAction || null,
+        enterprisePayload: previous.enterprisePayload || candidate.enterprisePayload || null,
+        recaptchaDataSValue: previous.recaptchaDataSValue || candidate.recaptchaDataSValue || null,
+      };
+      continue;
+    }
+    fingerprintIndexes.set(fingerprint, unique.length);
+    unique.push(candidate);
+  }
+
+  let pool = unique;
+  const requestedFrameUrl = String(constraints.frameUrl || '');
+  const requestedWebsiteKey = String(constraints.websiteKey || '');
+  if (requestedFrameUrl) {
+    pool = pool.filter(candidate => candidate.frameUrl === requestedFrameUrl);
+    if (!pool.length) {
+      return {
+        selected: null,
+        ambiguous: false,
+        error: `No CAPTCHA candidate was found in the exact frame URL ${requestedFrameUrl}.`,
+        candidates: unique.map(candidateSummary),
+      };
+    }
+  }
+  if (requestedWebsiteKey) {
+    pool = pool.filter(candidate => candidate.websiteKey === requestedWebsiteKey);
+    if (!pool.length) {
+      return {
+        selected: null,
+        ambiguous: false,
+        error: 'No detected CAPTCHA candidate matched the supplied websiteKey.',
+        candidates: unique.map(candidateSummary),
+      };
+    }
+  }
+  if (!pool.length) {
+    return { selected: null, ambiguous: false, error: null, candidates: [] };
+  }
+
+  const ranked = pool
+    .map(candidate => ({ candidate, score: candidateScore(candidate) }))
+    .sort((left, right) => right.score - left.score);
+  const topScore = ranked[0].score;
+  const top = ranked.filter(entry => entry.score === topScore);
+  if (top.length > 1) {
+    return {
+      selected: null,
+      ambiguous: true,
+      error: 'Multiple CAPTCHA candidates are equally active. Pass an exact frameUrl or websiteKey to select one.',
+      candidates: top.map(entry => candidateSummary(entry.candidate)),
+    };
+  }
+
+  const selected = {
+    ...top[0].candidate,
+    selectionScore: topScore,
+    selectionReason: selectedReason(top[0].candidate, constraints),
+  };
+  return {
+    selected,
+    ambiguous: false,
+    error: null,
+    candidates: unique.map(candidateSummary),
+  };
+}
+
+function selectedReason(candidate, constraints) {
+  if (constraints.frameUrl) return 'exact frameUrl match';
+  if (constraints.websiteKey) return 'exact websiteKey match';
+  if (candidate.normalCheckbox && candidate.visible) return 'visible checkbox challenge';
+  if (candidate.visible && candidate.challengeFrame) return 'visible challenge frame';
+  if (candidate.visible) return 'visible CAPTCHA widget';
+  if (candidate.challengeFrame) return 'challenge frame candidate';
+  return 'only detected CAPTCHA candidate';
+}
+
+// This function is serialized and executed in the web page. It must not
+// reference module-scope values.
+export function detectCaptchaCandidatesInPage() {
+  const candidates = [];
+  const frameUrl = typeof location !== 'undefined' ? String(location.href || '') : '';
+  const challengeFrame = /(?:captcha|challenge|checkpoint|security[-_/ ]?verif)/i.test(frameUrl);
+  const responseField = !!document.querySelector(
+    'textarea[name="g-recaptcha-response"], input[name="g-recaptcha-response"], '
+      + 'textarea[name="h-captcha-response"], input[name="h-captcha-response"], '
+      + 'textarea[name="cf-turnstile-response"], input[name="cf-turnstile-response"]'
+  );
+  const V3_NO_ACTION_NOTE = 'reCAPTCHA v3 detected, but the page never exposed an action name. solve_captcha needs pageAction — read it from the grecaptcha.execute(...) call in the site JS, or infer it from the form (login, submit, checkout).';
+
+  const urlParam = (urlStr, name) => {
+    try {
+      return new URL(urlStr, frameUrl || 'https://dummy.host').searchParams.get(name);
+    } catch (_) {
+      return null;
+    }
+  };
+  const visibleElement = (element) => {
+    if (!element) return false;
+    try {
+      const style = typeof getComputedStyle === 'function' ? getComputedStyle(element) : null;
+      if (style && (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0)) return false;
+      if (element.hidden || element.getAttribute?.('aria-hidden') === 'true') return false;
+      if (typeof element.getBoundingClientRect === 'function') {
+        const rect = element.getBoundingClientRect();
+        if (!rect || rect.width <= 0 || rect.height <= 0) return false;
+        const viewportWidth = typeof innerWidth === 'number' ? innerWidth : rect.right;
+        const viewportHeight = typeof innerHeight === 'number' ? innerHeight : rect.bottom;
+        if (rect.bottom <= 0 || rect.right <= 0 || rect.top >= viewportHeight || rect.left >= viewportWidth) return false;
+      }
+      return true;
+    } catch (_) {
+      return false;
+    }
+  };
+  const add = (candidate) => {
+    if (!candidate?.type) return;
+    candidates.push({
+      ...candidate,
+      frameUrl,
+      challengeFrame,
+      responseField,
+    });
+  };
+  const scriptElements = Array.from(document.querySelectorAll('script[src]'));
+  const scriptUrls = scriptElements.map(element => {
+    try { return element.src || ''; } catch (_) { return ''; }
+  }).filter(Boolean);
+
+  for (const host of Array.from(document.querySelectorAll('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]'))) {
+    const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-hcaptcha-sitekey');
+    if (!websiteKey) continue;
+    const isInvisible = host.getAttribute('data-size') === 'invisible';
+    add({
+      type: 'hcaptcha',
+      websiteKey,
+      isInvisible,
+      visible: visibleElement(host) && !isInvisible,
+      normalCheckbox: visibleElement(host) && !isInvisible,
+      callbackName: host.getAttribute('data-callback') || null,
+      detectedVia: 'host',
+    });
+  }
+
+  for (const host of Array.from(document.querySelectorAll('.cf-turnstile[data-sitekey], [data-turnstile-sitekey]'))) {
+    const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-turnstile-sitekey');
+    if (!websiteKey) continue;
+    add({
+      type: 'turnstile',
+      websiteKey,
+      visible: visibleElement(host),
+      normalCheckbox: false,
+      callbackName: host.getAttribute('data-callback') || null,
+      detectedVia: 'host',
+    });
+  }
+
+  for (const host of Array.from(document.querySelectorAll(
+    '.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey], [data-recaptcha-sitekey]'
+  ))) {
+    const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-recaptcha-sitekey');
+    if (!websiteKey) continue;
+    const isInvisible = host.getAttribute('data-size') === 'invisible';
+    const action = host.getAttribute('data-action') || host.getAttribute('data-recaptcha-action') || null;
+    const hasClassicScript = scriptUrls.some(url => /recaptcha\/api\.js/i.test(url));
+    const hasEnterpriseScript = scriptUrls.some(url => /recaptcha\/enterprise(?:\.js|\/)/i.test(url));
+    const isEnterprise = host.getAttribute('data-enterprise') === 'true'
+      || host.getAttribute('data-sitekey-type') === 'enterprise'
+      || host.querySelector('iframe[src*="recaptcha/enterprise"]') != null
+      || (!hasClassicScript && hasEnterpriseScript);
+    const version = host.getAttribute('data-version') || (host.classList.contains('g-recaptcha-v3') ? 'v3' : null);
+    const renderScript = scriptUrls.find(url =>
+      /recaptcha\/(api|enterprise)\.js/i.test(url) && urlParam(url, 'render') === websiteKey
+    ) || null;
+    const isV3 = version === 'v3' || !!renderScript || (!!action && !isInvisible);
+    const pageAction = action || (isV3 && renderScript
+      ? (urlParam(renderScript, 'action') || urlParam(renderScript, 'pageAction') || urlParam(renderScript, 'page_action'))
+      : null);
+    const enterpriseS = host.getAttribute('data-s') || null;
+    const visible = visibleElement(host) && !isInvisible;
+    add({
+      type: isV3
+        ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3')
+        : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
+      websiteKey,
+      isInvisible,
+      isEnterprise,
+      visible,
+      normalCheckbox: visible && !isV3,
+      callbackName: host.getAttribute('data-callback') || null,
+      ...(pageAction ? { pageAction } : (isV3 ? { note: V3_NO_ACTION_NOTE } : {})),
+      ...(enterpriseS
+        ? (isEnterprise ? { enterprisePayload: { s: enterpriseS } } : { recaptchaDataSValue: enterpriseS })
+        : {}),
+      detectedVia: 'host',
+    });
+  }
+
+  const iframeElements = Array.from(document.querySelectorAll('iframe[src]'));
+  const iframeUrls = iframeElements.map(element => {
+    try { return { element, url: element.src || '' }; } catch (_) { return { element, url: '' }; }
+  }).filter(item => item.url);
+
+  for (const { element, url } of iframeUrls) {
+    if (/hcaptcha\.com/i.test(url)) {
+      const websiteKey = urlParam(url, 'sitekey');
+      if (websiteKey) {
+        add({
+          type: 'hcaptcha',
+          websiteKey,
+          visible: visibleElement(element),
+          normalCheckbox: visibleElement(element),
+          detectedVia: 'url',
+        });
+      }
+      continue;
+    }
+    if (/challenges\.cloudflare\.com\/turnstile/i.test(url)) {
+      const websiteKey = urlParam(url, 'sitekey');
+      if (websiteKey) {
+        add({
+          type: 'turnstile',
+          websiteKey,
+          visible: visibleElement(element),
+          normalCheckbox: false,
+          detectedVia: 'url',
+        });
+      }
+      continue;
+    }
+    if (!/recaptcha\/(api2|enterprise)\/anchor/i.test(url)) continue;
+    const websiteKey = urlParam(url, 'k');
+    if (!websiteKey) continue;
+    const isEnterprise = /recaptcha\/enterprise/i.test(url);
+    const isInvisible = urlParam(url, 'size') === 'invisible';
+    const matchingV3Script = scriptUrls.find(scriptUrl => urlParam(scriptUrl, 'render') === websiteKey) || null;
+    const isV3 = !!matchingV3Script;
+    const pageAction = isV3
+      ? (urlParam(matchingV3Script, 'action') || urlParam(matchingV3Script, 'pageAction') || urlParam(matchingV3Script, 'page_action'))
+      : (urlParam(url, 'sa') || null);
+    const sValue = urlParam(url, 's');
+    const visible = visibleElement(element) && !isInvisible;
+    add({
+      type: isV3
+        ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3')
+        : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
+      websiteKey,
+      isInvisible,
+      isEnterprise,
+      visible,
+      normalCheckbox: visible && !isV3,
+      ...(pageAction ? { pageAction } : (isV3 ? { note: V3_NO_ACTION_NOTE } : {})),
+      ...(sValue
+        ? (isEnterprise ? { enterprisePayload: { s: sValue } } : { recaptchaDataSValue: sValue })
+        : {}),
+      detectedVia: 'url',
+    });
+  }
+
+  for (const url of scriptUrls) {
+    if (!/recaptcha\/(api\.js|enterprise\.js)/i.test(url)) continue;
+    const websiteKey = urlParam(url, 'render');
+    if (!websiteKey || websiteKey === 'explicit') continue;
+    const isEnterprise = /recaptcha\/enterprise/i.test(url);
+    const pageAction = urlParam(url, 'action') || urlParam(url, 'pageAction') || urlParam(url, 'page_action');
+    add({
+      type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
+      websiteKey,
+      isInvisible: true,
+      isEnterprise,
+      visible: false,
+      normalCheckbox: false,
+      ...(pageAction ? { pageAction } : { note: V3_NO_ACTION_NOTE }),
+      detectedVia: 'script',
+    });
+  }
+
+  if (!candidates.length && (
+    document.querySelector('script[src*="challenges.cloudflare.com/turnstile"]')
+    || document.querySelector('iframe[src*="challenges.cloudflare.com"]')
+  )) {
+    add({
+      type: 'turnstile_challenge',
+      websiteKey: null,
+      visible: true,
+      normalCheckbox: false,
+      note: 'Cloudflare interstitial detected but no sitekey was exposed in the DOM. Pass websiteKey explicitly if you have it.',
+      detectedVia: 'script',
+    });
+  }
+  return candidates;
+}
+
+// This function is also serialized into a page context. Keep it self-contained.
+export function injectCaptchaTokenInPage(payload) {
+  const fieldName = payload?.fieldName;
+  const alsoSet = payload?.alsoSet || null;
+  const token = payload?.token;
+  const target = payload?.target || {};
+  const frameUrl = typeof location !== 'undefined' ? String(location.href || '') : '';
+  if (!fieldName || !token) {
+    return { success: false, fieldUpdated: false, error: 'fieldName and token required', frameUrl };
+  }
+  if (!Number.isInteger(target.frameId) || !target.frameUrl || !target.websiteKey) {
+    return {
+      success: false,
+      fieldUpdated: false,
+      targetRequired: true,
+      error: 'A selected CAPTCHA frame identity, URL, and site key are required for token injection.',
+      frameUrl,
+    };
+  }
+  if (target.frameUrl && frameUrl !== target.frameUrl) {
+    return { success: false, fieldUpdated: false, skipped: true, error: 'frame URL did not match target', frameUrl };
+  }
+
+  const urlHasKey = (urlStr, key) => {
+    try {
+      const url = new URL(urlStr, frameUrl || 'https://dummy.host');
+      return ['k', 'render', 'sitekey'].some(name => url.searchParams.get(name) === key);
+    } catch (_) {
+      return false;
+    }
+  };
+  const frameHasSiteKey = (key) => {
+    if (!key) return false;
+    for (const element of Array.from(document.querySelectorAll(
+      '[data-sitekey], [data-recaptcha-sitekey], [data-hcaptcha-sitekey], [data-turnstile-sitekey]'
+    ))) {
+      if ([
+        element.getAttribute('data-sitekey'),
+        element.getAttribute('data-recaptcha-sitekey'),
+        element.getAttribute('data-hcaptcha-sitekey'),
+        element.getAttribute('data-turnstile-sitekey'),
+      ].includes(key)) return true;
+    }
+    for (const element of Array.from(document.querySelectorAll('iframe[src], script[src]'))) {
+      try { if (element.src && urlHasKey(element.src, key)) return true; } catch (_) {}
+    }
+    return false;
+  };
+  if (!frameHasSiteKey(target.websiteKey)) {
+    return {
+      success: false,
+      fieldUpdated: false,
+      staleTarget: true,
+      error: 'The selected CAPTCHA site key is no longer present in the target frame.',
+      frameUrl,
+    };
+  }
+
+  const setOn = (name) => {
+    let element = document.querySelector(`textarea[name="${name}"], input[name="${name}"]`);
+    if (!element) {
+      element = document.createElement('textarea');
+      element.name = name;
+      element.style.display = 'none';
+      (document.body || document.documentElement).appendChild(element);
+    }
+    try {
+      const prototype = element.tagName === 'TEXTAREA'
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+      const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+      if (setter) setter.call(element, token);
+      else element.value = token;
+    } catch (_) {
+      element.value = token;
+    }
+    element.textContent = token;
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+    return element;
+  };
+  setOn(fieldName);
+  let fieldsTouched = 1;
+  if (alsoSet) {
+    setOn(alsoSet);
+    fieldsTouched += 1;
+  }
+
+  const pageWindow = (typeof window !== 'undefined' && window.wrappedJSObject) || window;
+  const callbacks = [];
+  const addCallback = (fn, source) => {
+    if (typeof fn !== 'function') return;
+    if (callbacks.some(entry => entry.fn === fn)) return;
+    callbacks.push({ fn, source });
+  };
+  const resolveNamedCallback = (name) => {
+    if (!name) return null;
+    try {
+      return String(name).split('.').reduce((value, part) => value?.[part], pageWindow);
+    } catch (_) {
+      return null;
+    }
+  };
+  for (const host of Array.from(document.querySelectorAll(
+    '.g-recaptcha[data-callback], .h-captcha[data-callback], .cf-turnstile[data-callback], '
+      + '[data-recaptcha-sitekey][data-callback], [data-hcaptcha-sitekey][data-callback], '
+      + '[data-turnstile-sitekey][data-callback]'
+  ))) {
+    const hostKey = host.getAttribute('data-sitekey') || host.getAttribute('data-recaptcha-sitekey')
+      || host.getAttribute('data-hcaptcha-sitekey') || host.getAttribute('data-turnstile-sitekey');
+    if (target.websiteKey && hostKey !== target.websiteKey) continue;
+    const callbackName = host.getAttribute('data-callback');
+    addCallback(resolveNamedCallback(callbackName), `data-callback:${callbackName}`);
+  }
+
+  const collectGoogleCallbacks = () => {
+    let clients;
+    try { clients = pageWindow?.___grecaptcha_cfg?.clients; } catch (_) { return; }
+    if (!clients || typeof clients !== 'object') return;
+    let clientValues;
+    try { clientValues = Object.values(clients); } catch (_) { return; }
+    for (const client of clientValues) {
+      let containsKey = !target.websiteKey;
+      const clientCallbacks = [];
+      const seen = new Set();
+      const walk = (value, depth, propertyName = '') => {
+        if (depth > 8 || value == null) return;
+        if (typeof value === 'string') {
+          if (value === target.websiteKey) containsKey = true;
+          return;
+        }
+        if (typeof value === 'function') {
+          if (/callback/i.test(propertyName)) clientCallbacks.push(value);
+          return;
+        }
+        if (typeof value !== 'object' || seen.has(value)) return;
+        seen.add(value);
+        let entries;
+        try { entries = Object.entries(value); } catch (_) { return; }
+        for (const [key, child] of entries) walk(child, depth + 1, key);
+      };
+      walk(client, 0);
+      if (containsKey) {
+        for (const callback of clientCallbacks) addCallback(callback, 'grecaptcha-client');
+      }
+    }
+  };
+  if (!callbacks.length) collectGoogleCallbacks();
+
+  let calledCallback = false;
+  let callbackSource = null;
+  let callbackError = null;
+  if (callbacks.length === 1) {
+    try {
+      callbacks[0].fn.call(pageWindow, token);
+      calledCallback = true;
+      callbackSource = callbacks[0].source;
+    } catch (error) {
+      callbackError = error?.message || String(error);
+    }
+  }
+
+  return {
+    success: true,
+    fieldUpdated: true,
+    fieldsUpdated: [fieldName, ...(alsoSet ? [alsoSet] : [])],
+    fieldsTouched,
+    calledCallback,
+    callbackSource,
+    callbackAmbiguous: callbacks.length > 1,
+    callbackCandidates: callbacks.length,
+    callbackError,
+    siteKeyMatched: true,
+    frameUrl,
+  };
+}

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -234,6 +234,9 @@ function candidateSummary(candidate) {
     enterprisePayload: candidate?.enterprisePayload || null,
     recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
     explicitWebsiteKey: candidate?.explicitWebsiteKey === true,
+    documentTimeOrigin: Number.isFinite(candidate?.documentTimeOrigin)
+      ? candidate.documentTimeOrigin
+      : null,
     ancestorLoaderFrameId: Number.isInteger(candidate?.ancestorLoaderFrameId)
       ? candidate.ancestorLoaderFrameId
       : null,
@@ -458,6 +461,11 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       + 'textarea[name="cf-turnstile-response"], input[name="cf-turnstile-response"]'
   );
   const V3_NO_ACTION_NOTE = 'reCAPTCHA v3 detected, but the page never exposed an action name. solve_captcha needs pageAction — read it from the grecaptcha.execute(...) call in the site JS, or infer it from the form (login, submit, checkout).';
+  let documentTimeOrigin = null;
+  try {
+    const value = Number(pageWindow?.performance?.timeOrigin);
+    if (Number.isFinite(value) && value > 0) documentTimeOrigin = value;
+  } catch (_) {}
 
   const urlParam = (urlStr, name) => {
     try {
@@ -497,6 +505,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       frameUrl,
       challengeFrame,
       responseField,
+      documentTimeOrigin,
     });
   };
   const scriptElements = Array.from(pageDocument.querySelectorAll('script[src]'));
@@ -724,8 +733,49 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
       frameUrl,
     };
   }
-  if (target.frameUrl && frameUrl !== target.frameUrl) {
-    return { success: false, fieldUpdated: false, skipped: true, error: 'frame URL did not match target', frameUrl };
+  let currentDocumentTimeOrigin = null;
+  try {
+    const value = Number(frameWindow.performance?.timeOrigin);
+    if (Number.isFinite(value) && value > 0) currentDocumentTimeOrigin = value;
+  } catch (_) {}
+  const targetHasDocumentIdentity = Number.isFinite(target.documentTimeOrigin);
+  const currentHasDocumentIdentity = Number.isFinite(currentDocumentTimeOrigin);
+  if (targetHasDocumentIdentity
+      && currentHasDocumentIdentity
+      && target.documentTimeOrigin !== currentDocumentTimeOrigin) {
+    return {
+      success: false,
+      fieldUpdated: false,
+      skipped: true,
+      staleTarget: true,
+      error: 'target frame navigated to a different document',
+      frameUrl,
+    };
+  }
+  const sameStableUrl = (left, right) => {
+    try {
+      const leftUrl = new URL(left);
+      const rightUrl = new URL(right);
+      return leftUrl.origin === rightUrl.origin && leftUrl.pathname === rightUrl.pathname;
+    } catch (_) {
+      return false;
+    }
+  };
+  const sameDocumentIdentity = targetHasDocumentIdentity
+    && currentHasDocumentIdentity
+    && target.documentTimeOrigin === currentDocumentTimeOrigin;
+  if (target.frameUrl
+      && frameUrl !== target.frameUrl
+      && !sameDocumentIdentity
+      && !sameStableUrl(frameUrl, target.frameUrl)) {
+    return {
+      success: false,
+      fieldUpdated: false,
+      skipped: true,
+      staleTarget: true,
+      error: 'frame URL did not match target document',
+      frameUrl,
+    };
   }
 
   const urlHasKey = (urlStr, key) => {

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -112,7 +112,12 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
     const parentVisible = frameIsVisible(parentFrameId, visiting);
     visiting.delete(frameId);
     const embeddingFrame = parentVisible ? findEmbeddingFrame(frameId, parentFrameId) : null;
-    const visible = parentVisible && embeddingFrame?.visible === true;
+    // A cross-origin child can redirect while its embedding iframe keeps the
+    // original src. In that case parent code cannot read loadedUrl, so a
+    // missing match means visibility is unknown rather than hidden. Only
+    // demote when a matched embedding frame is conclusively hidden.
+    const visible = parentVisible
+      && (embeddingFrame ? embeddingFrame.visible === true : true);
     visibilityByFrameId.set(frameId, visible);
     return visible;
   };
@@ -566,7 +571,8 @@ export function detectCaptchaCandidatesInPage(scope = null) {
     });
   }
 
-  if (!candidates.length && (
+  const hasDetectedTurnstile = candidates.some(candidate => candidate.type === 'turnstile');
+  if (!hasDetectedTurnstile && (
     pageDocument.querySelector('script[src*="challenges.cloudflare.com/turnstile"]')
     || pageDocument.querySelector('iframe[src*="challenges.cloudflare.com"]')
   )) {

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -1046,6 +1046,10 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
         }
       });
       if (exact) return { element: exact };
+      return {
+        error: 'The selected CAPTCHA response field ID is no longer present in the target frame.',
+        staleTarget: true,
+      };
     }
     if (Number.isInteger(selectedFieldIndex)) {
       if (fields[selectedFieldIndex]) {
@@ -1073,7 +1077,7 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     ...field,
     ...resolveResponseField(field.name, field.primary),
   }));
-  const unresolvedField = resolvedFields.find(field => field.error);
+  const unresolvedField = resolvedFields.find(field => field.primary && field.error);
   if (unresolvedField) {
     return {
       success: false,
@@ -1084,6 +1088,8 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
       frameUrl,
     };
   }
+  const skippedFields = resolvedFields.filter(field => !field.primary && field.error);
+  const injectableFields = resolvedFields.filter(field => !field.error);
 
   const setOn = (name, existingElement) => {
     let element = existingElement;
@@ -1116,10 +1122,10 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     }
     return element;
   };
-  for (const field of resolvedFields) {
+  for (const field of injectableFields) {
     setOn(field.name, field.element);
   }
-  const fieldsTouched = resolvedFields.length;
+  const fieldsTouched = injectableFields.length;
 
   const pageWindow = frameWindow.wrappedJSObject || frameWindow;
   const callbacks = [];
@@ -1204,8 +1210,10 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
   return {
     success: true,
     fieldUpdated: true,
-    fieldsUpdated: [fieldName, ...(alsoSet ? [alsoSet] : [])],
+    fieldsUpdated: injectableFields.map(field => field.name),
     fieldsTouched,
+    compatibilityFieldSkipped: skippedFields.length > 0,
+    compatibilityFieldError: skippedFields[0]?.error || null,
     responseFieldId: target.responseFieldId || null,
     responseFieldIndex: Number.isInteger(target.responseFieldIndex)
       ? target.responseFieldIndex

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -639,7 +639,11 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
   const urlHasKey = (urlStr, key) => {
     try {
       const url = new URL(urlStr, frameUrl || 'https://dummy.host');
-      return ['k', 'render', 'sitekey'].some(name => url.searchParams.get(name) === key);
+      const fragment = String(url.hash || '').replace(/^#/, '');
+      const fragmentParams = fragment ? new URLSearchParams(fragment) : null;
+      return ['k', 'render', 'sitekey'].some(name =>
+        url.searchParams.get(name) === key || fragmentParams?.get(name) === key
+      );
     } catch (_) {
       return false;
     }
@@ -661,12 +665,21 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     }
     return false;
   };
-  if (!frameHasSiteKey(target.websiteKey)) {
+  const siteKeyMatched = frameHasSiteKey(target.websiteKey);
+  const explicitTurnstileTarget = target.explicitWebsiteKey === true
+    && target.type === 'turnstile';
+  const challengeMarkerMatched = explicitTurnstileTarget && !!(
+    frameDocument.querySelector('script[src*="challenges.cloudflare.com/turnstile"]')
+    || frameDocument.querySelector('iframe[src*="challenges.cloudflare.com"]')
+  );
+  if (!siteKeyMatched && !challengeMarkerMatched) {
     return {
       success: false,
       fieldUpdated: false,
       staleTarget: true,
-      error: 'The selected CAPTCHA site key is no longer present in the target frame.',
+      error: explicitTurnstileTarget
+        ? 'The selected Turnstile challenge marker is no longer present in the target frame.'
+        : 'The selected CAPTCHA site key is no longer present in the target frame.',
       frameUrl,
     };
   }
@@ -793,7 +806,8 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     callbackAmbiguous: callbacks.length > 1,
     callbackCandidates: callbacks.length,
     callbackError,
-    siteKeyMatched: true,
+    siteKeyMatched,
+    challengeMarkerMatched,
     frameUrl,
   };
 }

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -65,6 +65,14 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
   }
 
   const uniqueMatch = (items) => items.length === 1 ? items[0] : null;
+  const httpOrigin = (value) => {
+    try {
+      const parsed = new URL(String(value || ''));
+      return /^https?:$/.test(parsed.protocol) ? parsed.origin : '';
+    } catch (_) {
+      return '';
+    }
+  };
   const findEmbeddingFrame = (frameId, parentFrameId) => {
     const parentContext = contextsByFrameId.get(parentFrameId);
     if (!parentContext) return null;
@@ -91,6 +99,13 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
       const byName = uniqueMatch(childFrames.filter(child => String(child?.name || '') === frameName));
       if (byName) return byName;
     }
+    const frameOrigins = new Set([...frameUrls].map(httpOrigin).filter(Boolean));
+    if (frameOrigins.size) {
+      const byOrigin = uniqueMatch(childFrames.filter(child =>
+        [child?.loadedUrl, child?.url].some(url => frameOrigins.has(httpOrigin(url)))
+      ));
+      if (byOrigin) return byOrigin;
+    }
     return childFrames.length === 1 ? childFrames[0] : null;
   };
 
@@ -112,12 +127,13 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
     const parentVisible = frameIsVisible(parentFrameId, visiting);
     visiting.delete(frameId);
     const embeddingFrame = parentVisible ? findEmbeddingFrame(frameId, parentFrameId) : null;
-    // A cross-origin child can redirect while its embedding iframe keeps the
-    // original src. In that case parent code cannot read loadedUrl, so a
-    // missing match means visibility is unknown rather than hidden. Only
-    // demote when a matched embedding frame is conclusively hidden.
+    // A unique origin match covers common cross-origin redirects whose iframe
+    // keeps its original src. When multiple embedding elements are still
+    // indistinguishable, visibility is unknown; fail closed so an internally
+    // visible widget inside a hidden iframe is not promoted into the paid-task
+    // ranking tier.
     const visible = parentVisible
-      && (embeddingFrame ? embeddingFrame.visible === true : true);
+      && embeddingFrame?.visible === true;
     visibilityByFrameId.set(frameId, visible);
     return visible;
   };

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -234,6 +234,11 @@ function candidateSummary(candidate) {
     enterprisePayload: candidate?.enterprisePayload || null,
     recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
     explicitWebsiteKey: candidate?.explicitWebsiteKey === true,
+    callbackName: candidate?.callbackName || null,
+    responseFieldId: candidate?.responseFieldId || null,
+    responseFieldIndex: Number.isInteger(candidate?.responseFieldIndex)
+      ? candidate.responseFieldIndex
+      : null,
     documentTimeOrigin: Number.isFinite(candidate?.documentTimeOrigin)
       ? candidate.documentTimeOrigin
       : null,
@@ -306,6 +311,11 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
       candidate.type,
       candidate.websiteKey || '',
       stableParameterValue(Array.isArray(candidate.framePath) ? candidate.framePath : []),
+      candidate.responseFieldId || (
+        Number.isInteger(candidate.responseFieldIndex)
+          ? `response-field-${candidate.responseFieldIndex}`
+          : ''
+      ),
     ].join('|');
     if (fingerprintIndexes.has(fingerprint)) {
       const index = fingerprintIndexes.get(fingerprint);
@@ -512,8 +522,39 @@ export function detectCaptchaCandidatesInPage(scope = null) {
   const scriptUrls = scriptElements.map(element => {
     try { return element.src || ''; } catch (_) { return ''; }
   }).filter(Boolean);
+  const responseFieldIdentity = (widget, name, fallbackIndex, widgetCount) => {
+    const selector = `textarea[name="${name}"], input[name="${name}"]`;
+    const fields = Array.from(pageDocument.querySelectorAll(selector));
+    let field = null;
+    try { field = widget?.querySelector?.(selector) || null; } catch (_) {}
+    let ancestor = widget?.parentElement || null;
+    for (let depth = 0; !field && ancestor && depth < 4; depth += 1) {
+      let contained = [];
+      try { contained = Array.from(ancestor.querySelectorAll(selector)); } catch (_) {}
+      if (contained.length === 1) field = contained[0];
+      ancestor = ancestor.parentElement;
+    }
+    if (!field
+        && fields.length === widgetCount
+        && Number.isInteger(fallbackIndex)
+        && fallbackIndex >= 0
+        && fallbackIndex < fields.length) {
+      field = fields[fallbackIndex];
+    }
+    if (!field) return {};
+    const responseFieldIndex = fields.indexOf(field);
+    let responseFieldId = '';
+    try { responseFieldId = String(field.id || field.getAttribute?.('id') || ''); } catch (_) {}
+    return {
+      ...(responseFieldId ? { responseFieldId } : {}),
+      ...(responseFieldIndex >= 0 ? { responseFieldIndex } : {}),
+    };
+  };
 
-  for (const host of Array.from(pageDocument.querySelectorAll('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]'))) {
+  const hcaptchaHosts = Array.from(pageDocument.querySelectorAll(
+    '.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]'
+  ));
+  for (const [widgetIndex, host] of hcaptchaHosts.entries()) {
     const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-hcaptcha-sitekey');
     if (!websiteKey) continue;
     const isInvisible = host.getAttribute('data-size') === 'invisible';
@@ -524,11 +565,15 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       visible: visibleElement(host) && !isInvisible,
       normalCheckbox: visibleElement(host) && !isInvisible,
       callbackName: host.getAttribute('data-callback') || null,
+      ...responseFieldIdentity(host, 'h-captcha-response', widgetIndex, hcaptchaHosts.length),
       detectedVia: 'host',
     });
   }
 
-  for (const host of Array.from(pageDocument.querySelectorAll('.cf-turnstile[data-sitekey], [data-turnstile-sitekey]'))) {
+  const turnstileHosts = Array.from(pageDocument.querySelectorAll(
+    '.cf-turnstile[data-sitekey], [data-turnstile-sitekey]'
+  ));
+  for (const [widgetIndex, host] of turnstileHosts.entries()) {
     const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-turnstile-sitekey');
     if (!websiteKey) continue;
     add({
@@ -537,13 +582,15 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       visible: visibleElement(host),
       normalCheckbox: false,
       callbackName: host.getAttribute('data-callback') || null,
+      ...responseFieldIdentity(host, 'cf-turnstile-response', widgetIndex, turnstileHosts.length),
       detectedVia: 'host',
     });
   }
 
-  for (const host of Array.from(pageDocument.querySelectorAll(
+  const recaptchaHosts = Array.from(pageDocument.querySelectorAll(
     '.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey], [data-recaptcha-sitekey]'
-  ))) {
+  ));
+  for (const [widgetIndex, host] of recaptchaHosts.entries()) {
     const websiteKey = host.getAttribute('data-sitekey') || host.getAttribute('data-recaptcha-sitekey');
     if (!websiteKey) continue;
     const isInvisible = host.getAttribute('data-size') === 'invisible';
@@ -578,6 +625,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       ...(enterpriseS
         ? (isEnterprise ? { enterprisePayload: { s: enterpriseS } } : { recaptchaDataSValue: enterpriseS })
         : {}),
+      ...responseFieldIdentity(host, 'g-recaptcha-response', widgetIndex, recaptchaHosts.length),
       detectedVia: 'host',
     });
   }
@@ -589,6 +637,13 @@ export function detectCaptchaCandidatesInPage(scope = null) {
   const iframeUrls = iframeElements.map(element => {
     try { return { element, url: element.src || '' }; } catch (_) { return { element, url: '' }; }
   }).filter(item => item.url);
+  const hcaptchaFrames = iframeUrls.filter(({ url }) => /hcaptcha\.com/i.test(url));
+  const turnstileFrames = iframeUrls.filter(({ url }) =>
+    /challenges\.cloudflare\.com\/turnstile/i.test(url)
+  );
+  const recaptchaFrames = iframeUrls.filter(({ url }) =>
+    /recaptcha\/(api2|enterprise)\/anchor/i.test(url)
+  );
 
   for (const { element, url } of iframeUrls) {
     if (/hcaptcha\.com/i.test(url)) {
@@ -599,6 +654,12 @@ export function detectCaptchaCandidatesInPage(scope = null) {
           websiteKey,
           visible: visibleElement(element),
           normalCheckbox: visibleElement(element),
+          ...responseFieldIdentity(
+            element,
+            'h-captcha-response',
+            hcaptchaFrames.findIndex(frame => frame.element === element),
+            hcaptchaFrames.length,
+          ),
           detectedVia: 'url',
         });
       }
@@ -612,6 +673,12 @@ export function detectCaptchaCandidatesInPage(scope = null) {
           websiteKey,
           visible: visibleElement(element),
           normalCheckbox: false,
+          ...responseFieldIdentity(
+            element,
+            'cf-turnstile-response',
+            turnstileFrames.findIndex(frame => frame.element === element),
+            turnstileFrames.length,
+          ),
           detectedVia: 'url',
         });
       }
@@ -642,6 +709,12 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       ...(sValue
         ? (isEnterprise ? { enterprisePayload: { s: sValue } } : { recaptchaDataSValue: sValue })
         : {}),
+      ...responseFieldIdentity(
+        element,
+        'g-recaptcha-response',
+        recaptchaFrames.findIndex(frame => frame.element === element),
+        recaptchaFrames.length,
+      ),
       detectedVia: 'url',
     });
   }
@@ -826,8 +899,60 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     };
   }
 
-  const setOn = (name) => {
-    let element = frameDocument.querySelector(`textarea[name="${name}"], input[name="${name}"]`);
+  const resolveResponseField = (name, primary) => {
+    const fields = Array.from(frameDocument.querySelectorAll(
+      `textarea[name="${name}"], input[name="${name}"]`
+    ));
+    if (primary && target.responseFieldId) {
+      const exact = fields.find(element => {
+        try {
+          return String(element.id || element.getAttribute?.('id') || '') === target.responseFieldId;
+        } catch (_) {
+          return false;
+        }
+      });
+      if (exact) return { element: exact };
+    }
+    if (Number.isInteger(target.responseFieldIndex)) {
+      if (fields[target.responseFieldIndex]) {
+        return { element: fields[target.responseFieldIndex] };
+      }
+      return {
+        error: 'The selected CAPTCHA response field is no longer present in the target frame.',
+        staleTarget: true,
+      };
+    }
+    if (fields.length === 1) return { element: fields[0] };
+    if (fields.length > 1) {
+      return {
+        error: 'Multiple CAPTCHA response fields matched without a selected widget identity.',
+        ambiguousResponseField: true,
+      };
+    }
+    return { element: null };
+  };
+  const requestedFields = [
+    { name: fieldName, primary: true },
+    ...(alsoSet ? [{ name: alsoSet, primary: false }] : []),
+  ];
+  const resolvedFields = requestedFields.map(field => ({
+    ...field,
+    ...resolveResponseField(field.name, field.primary),
+  }));
+  const unresolvedField = resolvedFields.find(field => field.error);
+  if (unresolvedField) {
+    return {
+      success: false,
+      fieldUpdated: false,
+      staleTarget: unresolvedField.staleTarget === true,
+      ambiguousResponseField: unresolvedField.ambiguousResponseField === true,
+      error: unresolvedField.error,
+      frameUrl,
+    };
+  }
+
+  const setOn = (name, existingElement) => {
+    let element = existingElement;
     if (!element) {
       element = frameDocument.createElement('textarea');
       element.name = name;
@@ -857,12 +982,10 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     }
     return element;
   };
-  setOn(fieldName);
-  let fieldsTouched = 1;
-  if (alsoSet) {
-    setOn(alsoSet);
-    fieldsTouched += 1;
+  for (const field of resolvedFields) {
+    setOn(field.name, field.element);
   }
+  const fieldsTouched = resolvedFields.length;
 
   const pageWindow = frameWindow.wrappedJSObject || frameWindow;
   const callbacks = [];
@@ -879,16 +1002,22 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
       return null;
     }
   };
-  for (const host of Array.from(frameDocument.querySelectorAll(
-    '.g-recaptcha[data-callback], .h-captcha[data-callback], .cf-turnstile[data-callback], '
-      + '[data-recaptcha-sitekey][data-callback], [data-hcaptcha-sitekey][data-callback], '
-      + '[data-turnstile-sitekey][data-callback]'
-  ))) {
-    const hostKey = host.getAttribute('data-sitekey') || host.getAttribute('data-recaptcha-sitekey')
-      || host.getAttribute('data-hcaptcha-sitekey') || host.getAttribute('data-turnstile-sitekey');
-    if (target.websiteKey && hostKey !== target.websiteKey) continue;
-    const callbackName = host.getAttribute('data-callback');
-    addCallback(resolveNamedCallback(callbackName), `data-callback:${callbackName}`);
+  const callbackHint = payload?.callbackHint || null;
+  if (callbackHint) {
+    addCallback(resolveNamedCallback(callbackHint), `data-callback:${callbackHint}`);
+  }
+  if (!callbacks.length) {
+    for (const host of Array.from(frameDocument.querySelectorAll(
+      '.g-recaptcha[data-callback], .h-captcha[data-callback], .cf-turnstile[data-callback], '
+        + '[data-recaptcha-sitekey][data-callback], [data-hcaptcha-sitekey][data-callback], '
+        + '[data-turnstile-sitekey][data-callback]'
+    ))) {
+      const hostKey = host.getAttribute('data-sitekey') || host.getAttribute('data-recaptcha-sitekey')
+        || host.getAttribute('data-hcaptcha-sitekey') || host.getAttribute('data-turnstile-sitekey');
+      if (target.websiteKey && hostKey !== target.websiteKey) continue;
+      const callbackName = host.getAttribute('data-callback');
+      addCallback(resolveNamedCallback(callbackName), `data-callback:${callbackName}`);
+    }
   }
 
   const collectGoogleCallbacks = () => {
@@ -943,6 +1072,10 @@ export function injectCaptchaTokenInPage(payload, scope = null) {
     fieldUpdated: true,
     fieldsUpdated: [fieldName, ...(alsoSet ? [alsoSet] : [])],
     fieldsTouched,
+    responseFieldId: target.responseFieldId || null,
+    responseFieldIndex: Number.isInteger(target.responseFieldIndex)
+      ? target.responseFieldIndex
+      : null,
     calledCallback,
     callbackSource,
     callbackAmbiguous: callbacks.length > 1,

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -159,7 +159,9 @@ function candidateScore(candidate) {
   // Priority is tiered so no combination of secondary signals can make a
   // generic visible/background integration outrank an active challenge
   // frame or visible checkbox.
-  const activeChallengeFrame = candidate?.challengeFrame && candidate?.frameVisible !== false;
+  const activeChallengeFrame = candidate?.challengeFrame
+    && candidate?.visible === true
+    && candidate?.frameVisible !== false;
   const primary = (candidate?.normalCheckbox && candidate?.visible) || activeChallengeFrame;
   const tier = primary ? 3 : (candidate?.visible ? 2 : 1);
   let score = tier * 1000;

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -10,6 +10,16 @@
 //   POST /getTaskResult  → { status: "ready"|"processing", solution? }
 //   POST /getBalance     → { balance, packages }
 
+import {
+  captchaTypesMatch,
+  detectCaptchaCandidatesInPage,
+  injectCaptchaTokenInPage,
+  normalizeCaptchaType,
+  selectCaptchaCandidate,
+} from './captcha-frame-runtime.js';
+
+export { captchaTypesMatch, normalizeCaptchaType, selectCaptchaCandidate };
+
 const API_BASE = 'https://api.capsolver.com';
 const POLL_INTERVAL_MS = 2500;
 const POLL_TIMEOUT_MS = 120_000;
@@ -88,10 +98,9 @@ async function pollTaskResult(apiKey, taskId, { timeoutMs = POLL_TIMEOUT_MS } = 
 }
 
 // We default to the "proxyless" task types so the user doesn't need to BYO
-// proxy. `enterprisePayload` is accepted but deliberately absent from the
-// solve_captcha schema (same as on the hCaptcha branch): it carries the
-// site-specific `s` token some Enterprise deployments require, which a model
-// has no way to obtain from the page.
+// proxy. `enterprisePayload` is deliberately absent from the solve_captcha
+// schema: the frame detector extracts the site-specific Enterprise `s` token
+// from the widget host or anchor URL and passes it through internally.
 
 // Type aliases the model or the detector may hand us. Kept as sets rather
 // than inline `||` chains so buildTask and captchaParamError below can't
@@ -113,7 +122,7 @@ export function captchaParamError(params) {
   return null;
 }
 
-function buildTask({ type, websiteURL, websiteKey, ...rest }) {
+export function buildTask({ type, websiteURL, websiteKey, ...rest }) {
   const t = String(type || '').toLowerCase();
   const isEnterprise = !!rest.isEnterprise || t.includes('enterprise');
   if (RECAPTCHA_V2_TYPES.has(t)) {
@@ -122,6 +131,8 @@ function buildTask({ type, websiteURL, websiteKey, ...rest }) {
       websiteURL,
       websiteKey,
       ...(rest.isInvisible != null ? { isInvisible: !!rest.isInvisible } : {}),
+      ...(rest.pageAction ? { pageAction: rest.pageAction } : {}),
+      ...(rest.recaptchaDataSValue ? { recaptchaDataSValue: rest.recaptchaDataSValue } : {}),
       ...(rest.enterprisePayload ? { enterprisePayload: rest.enterprisePayload } : {}),
       ...(rest.userAgent ? { userAgent: rest.userAgent } : {}),
     };
@@ -198,246 +209,74 @@ export async function solveCaptcha(apiKey, params) {
 
 // ─── Page-side helpers (Firefox MV2 executeScript with code string) ──
 
-const DETECT_CODE = `(() => {
-  const V3_NO_ACTION_NOTE = 'reCAPTCHA v3 detected, but the page never exposed an action name. solve_captcha needs pageAction — read it from the grecaptcha.execute(...) call in the site JS, or infer it from the form (login, submit, checkout).';
-
-  // reCAPTCHA v3 puts the action name in the loader script's query string.
-  // Parse it with URL so percent-encoded action names come back decoded.
-  const getUrlAction = (urlStr) => {
+export async function detectCaptcha(tabId, constraints = {}) {
+  let frames;
+  try {
+    frames = await browser.webNavigation.getAllFrames({ tabId });
+  } catch (_) {
+    frames = [{ frameId: 0, url: '' }];
+  }
+  if (!Array.isArray(frames) || !frames.length) frames = [{ frameId: 0, url: '' }];
+  const code = `(${detectCaptchaCandidatesInPage.toString()})()`;
+  const batches = await Promise.all(frames.map(async frame => {
     try {
-      const u = new URL(urlStr, 'https://dummy.host');
-      const act = u.searchParams.get('action') || u.searchParams.get('pageAction') || u.searchParams.get('page_action');
-      return act ? act.trim() : null;
-    } catch (_) {}
-    return null;
-  };
-
-  const docs = [document];
-  for (const f of document.querySelectorAll('iframe')) {
-    try { if (f.contentDocument) docs.push(f.contentDocument); } catch (_) {}
-  }
-  for (const d of docs) {
-    // Order matters: check provider-specific widgets BEFORE the generic
-    // reCAPTCHA fallback. Turnstile and hCaptcha widgets carry data-sitekey
-    // too, and an earlier version of this code misclassified them as
-    // reCAPTCHA → CapSolver got the wrong task type and failed.
-    const hcap = d.querySelector('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]');
-    if (hcap) {
-      const sitekey = hcap.getAttribute('data-sitekey') || hcap.getAttribute('data-hcaptcha-sitekey');
-      if (sitekey) {
-        const size = hcap.getAttribute('data-size');
-        return { type: 'hcaptcha', websiteKey: sitekey, isInvisible: size === 'invisible' };
-      }
+      const results = await browser.tabs.executeScript(tabId, { code, frameId: frame.frameId });
+      return (Array.isArray(results?.[0]) ? results[0] : []).map(candidate => ({
+        ...candidate,
+        frameId: Number.isInteger(frame.frameId) ? frame.frameId : null,
+        frameUrl: candidate.frameUrl || frame.url || '',
+      }));
+    } catch (_) {
+      return [];
     }
-    const turn = d.querySelector('.cf-turnstile[data-sitekey], [data-turnstile-sitekey]');
-    if (turn) {
-      const sitekey = turn.getAttribute('data-sitekey') || turn.getAttribute('data-turnstile-sitekey');
-      if (sitekey) return { type: 'turnstile', websiteKey: sitekey };
-    }
-    // reCAPTCHA v2/v3, classic or Enterprise. Both selectors are
-    // reCAPTCHA-specific, so this still doesn't grab a bare data-sitekey
-    // belonging to another provider.
-    const recap = d.querySelector('.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey], [data-recaptcha-sitekey]');
-    if (recap) {
-      const sitekey = recap.getAttribute('data-sitekey') || recap.getAttribute('data-recaptcha-sitekey');
-      if (sitekey) {
-        const size = recap.getAttribute('data-size');
-        const isInvisible = size === 'invisible';
-        const action = recap.getAttribute('data-action') || recap.getAttribute('data-recaptcha-action') || null;
-        // Script tags decide both version and edition. Look in the parent
-        // document too: when the widget lives in a same-origin iframe the
-        // loader tag usually stays in the top document.
-        const scriptSrcs = [];
-        for (const doc of (d === document ? [d] : [d, document])) {
-          for (const s of doc.querySelectorAll('script[src]')) {
-            try { if (s.src) scriptSrcs.push(s.src); } catch (_) {}
-          }
-        }
-        const hasClassicScript = scriptSrcs.some(s => s.includes('recaptcha/api.js'));
-        const hasEnterpriseScript = scriptSrcs.some(s => s.includes('recaptcha/enterprise'));
-        // data-enterprise / data-sitekey-type aren't Google attributes — they
-        // are wrapper-library conventions (django-recaptcha, some Rails and
-        // Vue helpers). Cheap to check, so we take them as hints before
-        // falling back to which loader script the page pulled in.
-        const isEnterprise = recap.getAttribute('data-enterprise') === 'true' ||
-          recap.getAttribute('data-sitekey-type') === 'enterprise' ||
-          recap.querySelector('iframe[src*="recaptcha/enterprise"]') != null ||
-          (!hasClassicScript && hasEnterpriseScript);
-        // Version, in order of reliability:
-        //   1. an explicit wrapper-set data-version / .g-recaptcha-v3 marker
-        //   2. a render=<sitekey> loader script — the v3 signature; v2 loads
-        //      the script bare or with render=explicit
-        //   3. data-action with no data-size=invisible
-        // (3) alone is not enough in either direction: v2 invisible widgets
-        // carry data-action too, and some v3 wrappers copy data-size onto
-        // their host div. Without (2) both of those land on the wrong task
-        // type and CapSolver rejects the key.
-        const version = recap.getAttribute('data-version') || (recap.classList.contains('g-recaptcha-v3') ? 'v3' : null);
-        const renderScript = scriptSrcs.find(s =>
-          /recaptcha\\/(api|enterprise)\\.js/i.test(s) && s.includes('render=' + sitekey)) || null;
-        const isV3 = version === 'v3' || !!renderScript || (!!action && !isInvisible);
-        // v3 needs an action name to solve. Fall back to the loader script's
-        // ?action= when the host element doesn't carry one, and say so
-        // explicitly when neither does — solve_captcha refuses v3 without it.
-        const pageAction = action || (isV3 && renderScript ? getUrlAction(renderScript) : null);
-        return {
-          type: isV3 ? (isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3') : (isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2'),
-          websiteKey: sitekey,
-          isInvisible,
-          isEnterprise,
-          ...(pageAction ? { pageAction } : (isV3 ? { note: V3_NO_ACTION_NOTE } : {})),
-        };
-      }
-    }
-    if (d.querySelector('script[src*="challenges.cloudflare.com/turnstile"]') ||
-        d.querySelector('iframe[src*="challenges.cloudflare.com"]')) {
-      return { type: 'turnstile_challenge', websiteKey: null, note: 'Cloudflare interstitial detected but no sitekey was exposed in the DOM. Pass websiteKey explicitly if you have it.' };
-    }
-  }
-  // URL-string fallback — see chrome/captcha-solver.js for the full
-  // rationale. Scrapes the sitekey out of iframe.src / script.src when the
-  // widget never exposed it on a host element (hcaptcha.com/demo, some SPA
-  // mounts). Both are readable cross-origin from the parent page.
-
-  // hCaptcha and Turnstile expose the same ?sitekey= in either tag, so one
-  // matcher serves both passes below.
-  const nonRecaptchaFromUrl = (url) => {
-    if (/hcaptcha\\.com/i.test(url)) {
-      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) return { type: 'hcaptcha', websiteKey: m[1], detectedVia: 'url' };
-    }
-    if (/challenges\\.cloudflare\\.com\\/turnstile/i.test(url)) {
-      const m = url.match(/[?&#][^?&#]*?sitekey=([a-zA-Z0-9_-]{6,})/);
-      if (m) return { type: 'turnstile', websiteKey: m[1], detectedVia: 'url' };
-    }
-    return null;
-  };
-
-  // Split by tag type because reCAPTCHA needs both halves to classify a
-  // widget: the anchor iframe carries the sitekey, the loader script carries
-  // the version and action. Iframes are scanned first — a rendered anchor
-  // frame is a stronger signal that the widget is actually on this page than
-  // a script tag, which may just be a loader the page never used.
-  const iframeUrls = [];
-  const scriptUrls = [];
-  for (const el of document.querySelectorAll('iframe[src], script[src]')) {
-    try {
-      if (el.src) {
-        if (el.tagName.toLowerCase() === 'iframe') iframeUrls.push(el.src);
-        else scriptUrls.push(el.src);
-      }
-    } catch (_) {}
-  }
-  for (const url of iframeUrls) {
-    const other = nonRecaptchaFromUrl(url);
-    if (other) return other;
-    if (/recaptcha\\/(api2|enterprise)\\/anchor/i.test(url)) {
-      const m = url.match(/[?&#]k=([a-zA-Z0-9_-]{6,})/);
-      if (m) {
-        const sitekey = m[1];
-        const isEnterprise = /recaptcha\\/enterprise/i.test(url);
-        const isInvisible = /[?&#]size=invisible/i.test(url);
-        // v3 renders an anchor frame too (the badge), and it always carries
-        // size=invisible — so the frame alone can't tell v3 from an invisible
-        // v2. A loader script rendering this exact sitekey settles it.
-        const matchingV3Script = scriptUrls.find(s => s.includes('render=' + sitekey));
-        if (matchingV3Script) {
-          const pageAction = getUrlAction(matchingV3Script);
-          return {
-            type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
-            websiteKey: sitekey,
-            isEnterprise,
-            ...(pageAction ? { pageAction } : { note: V3_NO_ACTION_NOTE }),
-            detectedVia: 'url',
-          };
-        }
-        return {
-          type: isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2',
-          websiteKey: sitekey,
-          isInvisible,
-          isEnterprise,
-          detectedVia: 'url',
-        };
-      }
-    }
-  }
-  for (const url of scriptUrls) {
-    const other = nonRecaptchaFromUrl(url);
-    if (other) return other;
-    if (/recaptcha\\/(api\\.js|enterprise\\.js)/i.test(url)) {
-      const m = url.match(/[?&#]render=([a-zA-Z0-9_-]{6,})/);
-      // render=explicit means the page renders a v2 widget by hand later —
-      // it is not a sitekey.
-      if (m && m[1] !== 'explicit') {
-        const isEnterprise = /enterprise/i.test(url);
-        const pageAction = getUrlAction(url);
-        return {
-          type: isEnterprise ? 'recaptcha_v3_enterprise' : 'recaptcha_v3',
-          websiteKey: m[1],
-          isEnterprise,
-          ...(pageAction ? { pageAction } : { note: V3_NO_ACTION_NOTE }),
-          detectedVia: 'url',
-        };
-      }
-    }
-  }
-  return null;
-})()`;
-
-export async function detectCaptcha(tabId) {
-  const results = await browser.tabs.executeScript(tabId, { code: DETECT_CODE });
-  for (const r of results || []) {
-    if (r) return r;
-  }
-  return null;
+  }));
+  return selectCaptchaCandidate(batches.flat(), constraints);
 }
 
-export async function injectToken(tabId, { fieldName, alsoSet, token }) {
+export async function injectToken(tabId, {
+  fieldName,
+  alsoSet,
+  token,
+  callbackHint,
+  target = null,
+}) {
   if (!fieldName || !token) return { success: false, error: 'fieldName and token required' };
-  // Inline the params into the code string — Firefox MV2 doesn't have
-  // chrome.scripting's args[] mechanism. JSON.stringify guarantees we
-  // don't break out of the string literal.
-  const code = `(() => {
-    const fieldName = ${JSON.stringify(fieldName)};
-    const alsoSet = ${JSON.stringify(alsoSet || null)};
-    const token = ${JSON.stringify(token)};
-    const docs = [document];
-    for (const f of document.querySelectorAll('iframe')) {
-      try { if (f.contentDocument) docs.push(f.contentDocument); } catch {}
-    }
-    const setOn = (d, name) => {
-      let el = d.querySelector('textarea[name="' + name + '"]')
-            || d.querySelector('input[name="' + name + '"]');
-      if (!el) {
-        el = d.createElement('textarea');
-        el.name = name;
-        el.style.display = 'none';
-        (d.body || d.documentElement).appendChild(el);
-      }
-      el.value = token;
-      el.textContent = token;
-      el.dispatchEvent(new Event('input', { bubbles: true }));
-      el.dispatchEvent(new Event('change', { bubbles: true }));
-      return el;
+  if (!Number.isInteger(target?.frameId) || !target?.frameUrl || !target?.websiteKey) {
+    return {
+      success: false,
+      fieldUpdated: false,
+      targetRequired: true,
+      error: 'Token was not injected because no detected CAPTCHA frame identity, URL, and site key were selected.',
     };
-    let touched = 0;
-    for (const d of docs) {
-      setOn(d, fieldName); touched++;
-      if (alsoSet) setOn(d, alsoSet);
-    }
-    let calledCallback = false;
-    for (const d of docs) {
-      const host = d.querySelector('[data-callback]');
-      const cbName = host && host.getAttribute('data-callback');
-      if (cbName) {
-        try {
-          const fn = (typeof window !== 'undefined' && typeof window[cbName] === 'function') ? window[cbName] : null;
-          if (fn) { fn(token); calledCallback = true; }
-        } catch {}
-      }
-    }
-    return { success: true, fieldsTouched: touched, calledCallback };
-  })()`;
-  const results = await browser.tabs.executeScript(tabId, { code });
-  return results?.[0] || { success: false, error: 'injection script returned no result' };
+  }
+  const pagePayload = {
+    fieldName,
+    alsoSet,
+    token,
+    callbackHint,
+    target: target || {},
+  };
+  const code = `(${injectCaptchaTokenInPage.toString()})(${JSON.stringify(pagePayload)})`;
+  const details = Number.isInteger(target?.frameId)
+    ? { code, frameId: target.frameId }
+    : { code, ...(target?.frameUrl ? { allFrames: true } : {}) };
+  const results = await browser.tabs.executeScript(tabId, details);
+  const outputs = (results || []).filter(Boolean);
+  const successes = outputs.filter(output => output.success === true);
+  if (successes.length === 1) {
+    return {
+      ...successes[0],
+      frameId: Number.isInteger(target?.frameId) ? target.frameId : null,
+    };
+  }
+  if (successes.length > 1) {
+    return {
+      success: false,
+      ambiguousTarget: true,
+      error: 'Token injection matched more than one frame; pass an exact frameUrl.',
+      matchedFrames: successes.map(output => ({ frameUrl: output.frameUrl })),
+    };
+  }
+  return outputs.find(output => !output.skipped)
+    || { success: false, error: 'injection script returned no matching frame result' };
 }

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -11,6 +11,7 @@
 //   POST /getBalance     → { balance, packages }
 
 import {
+  applyCaptchaFrameVisibility,
   captchaTypesMatch,
   detectCaptchaCandidatesInPage,
   injectCaptchaTokenInPage,
@@ -216,21 +217,36 @@ export async function detectCaptcha(tabId, constraints = {}) {
   } catch (_) {
     frames = [{ frameId: 0, url: '' }];
   }
-  if (!Array.isArray(frames) || !frames.length) frames = [{ frameId: 0, url: '' }];
+  if (!Array.isArray(frames) || !frames.length) frames = [{ frameId: 0, parentFrameId: -1, url: '' }];
   const code = `(${detectCaptchaCandidatesInPage.toString()})()`;
   const batches = await Promise.all(frames.map(async frame => {
     try {
       const results = await browser.tabs.executeScript(tabId, { code, frameId: frame.frameId });
-      return (Array.isArray(results?.[0]) ? results[0] : []).map(candidate => ({
-        ...candidate,
-        frameId: Number.isInteger(frame.frameId) ? frame.frameId : null,
-        frameUrl: candidate.frameUrl || frame.url || '',
-      }));
+      const payload = results?.[0];
+      const pageCandidates = Array.isArray(payload)
+        ? payload
+        : (Array.isArray(payload?.candidates) ? payload.candidates : []);
+      return {
+        candidates: pageCandidates.map(candidate => ({
+          ...candidate,
+          frameId: Number.isInteger(frame.frameId) ? frame.frameId : null,
+          frameUrl: candidate.frameUrl || frame.url || '',
+        })),
+        frameContext: !Array.isArray(payload) && payload?.frameContext ? {
+          ...payload.frameContext,
+          frameId: Number.isInteger(frame.frameId) ? frame.frameId : null,
+        } : null,
+      };
     } catch (_) {
-      return [];
+      return { candidates: [], frameContext: null };
     }
   }));
-  return selectCaptchaCandidate(batches.flat(), constraints);
+  const candidates = batches.flatMap(batch => batch.candidates);
+  const frameContexts = batches.map(batch => batch.frameContext).filter(Boolean);
+  return selectCaptchaCandidate(
+    applyCaptchaFrameVisibility(candidates, frameContexts, frames),
+    constraints,
+  );
 }
 
 export async function injectToken(tabId, {

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -12,6 +12,7 @@
 
 import {
   applyCaptchaFrameVisibility,
+  captchaWebsiteUrl,
   captchaTypesMatch,
   detectCaptchaCandidatesInPage,
   injectCaptchaTokenInPage,
@@ -19,7 +20,7 @@ import {
   selectCaptchaCandidate,
 } from './captcha-frame-runtime.js';
 
-export { captchaTypesMatch, normalizeCaptchaType, selectCaptchaCandidate };
+export { captchaTypesMatch, captchaWebsiteUrl, normalizeCaptchaType, selectCaptchaCandidate };
 
 const API_BASE = 'https://api.capsolver.com';
 const POLL_INTERVAL_MS = 2500;
@@ -218,19 +219,87 @@ export async function detectCaptcha(tabId, constraints = {}) {
     frames = [{ frameId: 0, url: '' }];
   }
   if (!Array.isArray(frames) || !frames.length) frames = [{ frameId: 0, parentFrameId: -1, url: '' }];
-  const code = `(${detectCaptchaCandidatesInPage.toString()})()`;
+  const code = `(() => {
+    const detect = ${detectCaptchaCandidatesInPage.toString()};
+    const direct = detect();
+    const inheritedCandidates = [];
+    const seenDocuments = new Set();
+    const rootDocument = typeof document !== 'undefined' ? document : null;
+    const rootWindow = typeof window !== 'undefined' ? window : globalThis;
+    const isInheritedOriginFrame = (element, childUrl) => {
+      try {
+        return element.hasAttribute?.('srcdoc')
+          || /^about:(?:blank|srcdoc)(?:[?#]|$)/i.test(childUrl)
+          || (!String(element.src || '') && childUrl === 'about:blank');
+      } catch (_) {
+        return false;
+      }
+    };
+    const visit = (currentDocument, currentWindow, currentResult, path, ancestorsVisible, depth) => {
+      if (!currentDocument || depth > 12 || seenDocuments.has(currentDocument)) return;
+      seenDocuments.add(currentDocument);
+      const elements = Array.from(currentDocument.querySelectorAll('iframe'));
+      const childFrames = Array.isArray(currentResult?.frameContext?.childFrames)
+        ? currentResult.frameContext.childFrames
+        : [];
+      elements.forEach((element, index) => {
+        let childDocument;
+        let childWindow;
+        let childUrl = '';
+        try {
+          childDocument = element.contentDocument;
+          childWindow = element.contentWindow;
+          childUrl = String(childWindow?.location?.href || '');
+        } catch (_) {
+          return;
+        }
+        if (!childDocument || !childWindow || !isInheritedOriginFrame(element, childUrl)) return;
+        const childResult = detect({ document: childDocument, window: childWindow });
+        const childContext = childResult?.frameContext || {};
+        const childVisible = ancestorsVisible && childFrames[index]?.visible === true;
+        const nextPath = [...path, {
+          index,
+          frameUrl: childContext.frameUrl || childUrl,
+          frameName: childContext.frameName || '',
+        }];
+        for (const candidate of childResult?.candidates || []) {
+          inheritedCandidates.push({
+            ...candidate,
+            framePath: nextPath,
+            frameVisibleWithinAnchor: childVisible,
+          });
+        }
+        visit(childDocument, childWindow, childResult, nextPath, childVisible, depth + 1);
+      });
+    };
+    visit(rootDocument, rootWindow, direct, [], true, 0);
+    return { direct, inheritedCandidates };
+  })()`;
   const batches = await Promise.all(frames.map(async frame => {
     try {
-      const results = await browser.tabs.executeScript(tabId, { code, frameId: frame.frameId });
-      const payload = results?.[0];
+      const results = await browser.tabs.executeScript(tabId, {
+        code,
+        frameId: frame.frameId,
+        matchAboutBlank: true,
+      });
+      const response = results?.[0];
+      const payload = response?.direct || response;
       const pageCandidates = Array.isArray(payload)
         ? payload
         : (Array.isArray(payload?.candidates) ? payload.candidates : []);
+      const inheritedCandidates = Array.isArray(response?.inheritedCandidates)
+        ? response.inheritedCandidates
+        : [];
       return {
-        candidates: pageCandidates.map(candidate => ({
+        directCandidates: pageCandidates.map(candidate => ({
           ...candidate,
           frameId: Number.isInteger(frame.frameId) ? frame.frameId : null,
           frameUrl: candidate.frameUrl || frame.url || '',
+        })),
+        inheritedCandidates: inheritedCandidates.map(candidate => ({
+          ...candidate,
+          frameId: Number.isInteger(frame.frameId) ? frame.frameId : null,
+          frameUrl: candidate.frameUrl || '',
         })),
         frameContext: !Array.isArray(payload) && payload?.frameContext ? {
           ...payload.frameContext,
@@ -238,10 +307,19 @@ export async function detectCaptcha(tabId, constraints = {}) {
         } : null,
       };
     } catch (_) {
-      return { candidates: [], frameContext: null };
+      return { directCandidates: [], inheritedCandidates: [], frameContext: null };
     }
   }));
-  const candidates = batches.flatMap(batch => batch.candidates);
+  const directCandidates = batches.flatMap(batch => batch.directCandidates);
+  const directSignatures = new Set(directCandidates.map(candidate =>
+    `${candidate.type || ''}\n${candidate.websiteKey || ''}\n${candidate.frameUrl || ''}`
+  ));
+  const inheritedCandidates = batches
+    .flatMap(batch => batch.inheritedCandidates)
+    .filter(candidate => !directSignatures.has(
+      `${candidate.type || ''}\n${candidate.websiteKey || ''}\n${candidate.frameUrl || ''}`
+    ));
+  const candidates = [...directCandidates, ...inheritedCandidates];
   const frameContexts = batches.map(batch => batch.frameContext).filter(Boolean);
   return selectCaptchaCandidate(
     applyCaptchaFrameVisibility(candidates, frameContexts, frames),
@@ -272,7 +350,51 @@ export async function injectToken(tabId, {
     callbackHint,
     target: target || {},
   };
-  const code = `(${injectCaptchaTokenInPage.toString()})(${JSON.stringify(pagePayload)})`;
+  const code = `(() => {
+    const inject = ${injectCaptchaTokenInPage.toString()};
+    const payload = ${JSON.stringify(pagePayload)};
+    let frameDocument = typeof document !== 'undefined' ? document : null;
+    let frameWindow = typeof window !== 'undefined' ? window : globalThis;
+    for (const segment of Array.isArray(payload?.target?.framePath) ? payload.target.framePath : []) {
+      const elements = frameDocument ? Array.from(frameDocument.querySelectorAll('iframe')) : [];
+      const element = elements[segment.index];
+      if (!element) {
+        return {
+          success: false,
+          fieldUpdated: false,
+          staleTarget: true,
+          error: 'The selected inherited-origin CAPTCHA frame path is no longer present.',
+        };
+      }
+      try {
+        const nextDocument = element.contentDocument;
+        const nextWindow = element.contentWindow;
+        const nextUrl = String(nextWindow?.location?.href || '');
+        const nextName = String(nextWindow?.name || element.name || '');
+        if (!nextDocument || !nextWindow
+            || (segment.frameUrl && nextUrl !== segment.frameUrl)
+            || (segment.frameName && nextName !== segment.frameName)) {
+          return {
+            success: false,
+            fieldUpdated: false,
+            staleTarget: true,
+            error: 'The selected inherited-origin CAPTCHA frame changed before token injection.',
+            frameUrl: nextUrl,
+          };
+        }
+        frameDocument = nextDocument;
+        frameWindow = nextWindow;
+      } catch (_) {
+        return {
+          success: false,
+          fieldUpdated: false,
+          staleTarget: true,
+          error: 'The selected inherited-origin CAPTCHA frame is no longer accessible.',
+        };
+      }
+    }
+    return inject(payload, { document: frameDocument, window: frameWindow });
+  })()`;
   const details = Number.isInteger(target?.frameId)
     ? { code, frameId: target.frameId }
     : { code, ...(target?.frameUrl ? { allFrames: true } : {}) };

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -396,7 +396,7 @@ export async function injectToken(tabId, {
     return inject(payload, { document: frameDocument, window: frameWindow });
   })()`;
   const details = Number.isInteger(target?.frameId)
-    ? { code, frameId: target.frameId }
+    ? { code, frameId: target.frameId, matchAboutBlank: true }
     : { code, ...(target?.frameUrl ? { allFrames: true } : {}) };
   const results = await browser.tabs.executeScript(tabId, details);
   const outputs = (results || []).filter(Boolean);

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -921,7 +921,7 @@ export const AGENT_TOOLS = [
           pageAction: { type: 'string', description: 'Required for reCAPTCHA v3 — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action or the loader script when present; pass it explicitly if detection reports it missing.' },
           minScore: { type: 'number', description: 'reCAPTCHA v3 only — minimum score requested (0.3 is the usual lower bound, 0.7+ is hard).' },
           imageBase64: { type: 'string', description: 'image_to_text only — base64-encoded image bytes (no data: prefix).' },
-          inject: { type: 'boolean', description: 'After solving, inject the token into the page\'s response field (textarea[name=g-recaptcha-response] etc.) and fire the widget\'s callback. Default true. Set false to get just the token back.' },
+          inject: { type: 'boolean', description: 'After solving, inject the token into the detected frame\'s response field (textarea[name=g-recaptcha-response] etc.) and fire the widget\'s callback. Default true and requires a detected frame target. If the widget cannot be detected but type/websiteKey are known, set false to get only the token without page injection.' },
         },
         required: [],
       },

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -905,7 +905,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'solve_captcha',
-      description: 'Solve a CAPTCHA on the current page using the CapSolver API (only available when the user has enabled CapSolver and provided an API key in Settings → General → Advanced). The tool scans every frame, ranks the active visible widget above hidden/background integrations, and fills missing type/site-key parameters from the selected frame. Returns the token, selected frame/type, and targeted injection/callback status; verify page progress afterward because token injection alone does not prove the challenge cleared. On failure (no CapSolver key configured, ambiguous candidates, unknown type, API error, timeout) the tool returns `{ success: false, error: "..." }` — use an exact frameUrl/websiteKey when offered, otherwise ask the user to solve it manually.',
+      description: 'Solve a CAPTCHA on the current page using the CapSolver API (only available when the user has enabled CapSolver and provided an API key in Settings → General → Advanced). The tool scans every frame, ranks the active visible widget above hidden/background integrations, and fills missing type/site-key parameters from the selected frame. Returns the token, selected frame/type, and targeted injection/callback status; verify page progress afterward because token injection alone does not prove the challenge cleared. On failure (no CapSolver key configured, ambiguous candidates, unknown type, API error, timeout) the tool returns `{ success: false, error: "..." }` — use only the exact frameUrl, websiteKey, frameId, or framePath discriminator offered by the ambiguity result; otherwise ask the user to solve it manually.',
       parameters: {
         type: 'object',
         properties: {
@@ -916,6 +916,12 @@ export const AGENT_TOOLS = [
           },
           websiteKey: { type: 'string', description: 'Site key from the captcha widget\'s data-sitekey attribute. Auto-detected when omitted.' },
           frameUrl: { type: 'string', description: 'Exact URL of the frame containing the intended CAPTCHA. Usually omit; use a candidate URL returned by an ambiguity error to select among equally active widgets.' },
+          frameId: { type: 'integer', description: 'Exact browser frame ID from an ambiguity result. Use when tied candidates share the same frameUrl and site key.' },
+          framePath: {
+            type: 'array',
+            items: { type: 'integer', minimum: 0 },
+            description: 'Exact iframe-index path from a candidate\'s framePathIndexes diagnostic. Use with frameId when inherited-origin candidates share the same URL and site key.',
+          },
           isInvisible: { type: 'boolean', description: 'reCAPTCHA v2 / hCaptcha only — true when the widget uses invisible mode (no visible checkbox). Auto-detected when omitted.' },
           isEnterprise: { type: 'boolean', description: 'reCAPTCHA v2/v3 only — true when the widget uses Google reCAPTCHA Enterprise. Auto-detected when omitted.' },
           pageAction: { type: 'string', description: 'Required for reCAPTCHA v3 — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action or the loader script when present; pass it explicitly if detection reports it missing.' },

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -905,7 +905,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'solve_captcha',
-      description: 'Solve a CAPTCHA on the current page using the CapSolver API (only available when the user has enabled CapSolver and provided an API key in Settings → General → Advanced). If `type` and `websiteKey` are omitted, the tool scans the page for known widgets (reCAPTCHA v2/v3, hCaptcha, Cloudflare Turnstile) and uses what it finds. Returns the solution token and whether it was injected into the page; you usually still need to click the form\'s submit button afterward. On failure (no CapSolver key configured, unknown captcha type, API error, timeout) the tool returns `{ success: false, error: "..." }` — fall back to asking the user to solve it manually.',
+      description: 'Solve a CAPTCHA on the current page using the CapSolver API (only available when the user has enabled CapSolver and provided an API key in Settings → General → Advanced). The tool scans every frame, ranks the active visible widget above hidden/background integrations, and fills missing type/site-key parameters from the selected frame. Returns the token, selected frame/type, and targeted injection/callback status; verify page progress afterward because token injection alone does not prove the challenge cleared. On failure (no CapSolver key configured, ambiguous candidates, unknown type, API error, timeout) the tool returns `{ success: false, error: "..." }` — use an exact frameUrl/websiteKey when offered, otherwise ask the user to solve it manually.',
       parameters: {
         type: 'object',
         properties: {
@@ -915,6 +915,7 @@ export const AGENT_TOOLS = [
             description: 'CAPTCHA type. Omit to auto-detect from the page DOM.',
           },
           websiteKey: { type: 'string', description: 'Site key from the captcha widget\'s data-sitekey attribute. Auto-detected when omitted.' },
+          frameUrl: { type: 'string', description: 'Exact URL of the frame containing the intended CAPTCHA. Usually omit; use a candidate URL returned by an ambiguity error to select among equally active widgets.' },
           isInvisible: { type: 'boolean', description: 'reCAPTCHA v2 / hCaptcha only — true when the widget uses invisible mode (no visible checkbox). Auto-detected when omitted.' },
           isEnterprise: { type: 'boolean', description: 'reCAPTCHA v2/v3 only — true when the widget uses Google reCAPTCHA Enterprise. Auto-detected when omitted.' },
           pageAction: { type: 'string', description: 'Required for reCAPTCHA v3 — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action or the loader script when present; pass it explicitly if detection reports it missing.' },

--- a/test/run.js
+++ b/test/run.js
@@ -50610,12 +50610,17 @@ test('linkedin shadow-dom reachability: pierce, overlay hoist, placeholder match
 // string is parsed and run exactly as the browser would.
 
 function captchaEl(tag, attrs = {}, children = []) {
+  const rect = attrs.rect || { left: 0, top: 0, right: 100, bottom: 40, width: 100, height: 40 };
   const el = {
     tagName: tag.toUpperCase(),
     children,
     src: attrs.src,
+    hidden: attrs.hidden === true,
+    style: {},
     classList: { contains: (c) => String(attrs.class || '').split(/\s+/).includes(c) },
     getAttribute: (n) => (n in attrs ? attrs[n] : null),
+    getBoundingClientRect: () => rect,
+    dispatchEvent: () => true,
     querySelector: (sel) => captchaMatchAll(children, sel)[0] || null,
     querySelectorAll: (sel) => captchaMatchAll(children, sel),
   };
@@ -50664,27 +50669,54 @@ async function detectCaptchaOnFakePage(build, nodes) {
     document: globalThis.document,
     chrome: globalThis.chrome,
     browser: globalThis.browser,
+    location: globalThis.location,
+    innerWidth: globalThis.innerWidth,
+    innerHeight: globalThis.innerHeight,
+    getComputedStyle: globalThis.getComputedStyle,
   };
+  const location = { href: 'https://example.test/form' };
   globalThis.document = document;
+  globalThis.location = location;
+  globalThis.innerWidth = 1280;
+  globalThis.innerHeight = 720;
+  globalThis.getComputedStyle = (element) => ({
+    display: element.hidden ? 'none' : 'block',
+    visibility: 'visible',
+    opacity: '1',
+  });
   // The detector reaches for the extension API by name; give each build the
   // executeScript shape it expects and run the payload in-process.
   globalThis.chrome = {
     scripting: {
-      executeScript: async ({ func }) => [{ result: func() }],
+      executeScript: async ({ func }) => [{ frameId: 0, result: func() }],
     },
   };
   globalThis.browser = {
+    webNavigation: {
+      getAllFrames: async () => [{ frameId: 0, url: location.href }],
+    },
     tabs: {
-      executeScript: async (_tabId, { code }) => [vm.runInNewContext(code, { document, URL })],
+      executeScript: async (_tabId, { code }) => [vm.runInNewContext(code, {
+        document,
+        location,
+        URL,
+        innerWidth: 1280,
+        innerHeight: 720,
+        getComputedStyle: globalThis.getComputedStyle,
+      })],
     },
   };
   try {
     const mod = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-solver.js`)).href);
-    return await mod.detectCaptcha(1);
+    return (await mod.detectCaptcha(1)).selected;
   } finally {
     globalThis.document = previous.document;
     globalThis.chrome = previous.chrome;
     globalThis.browser = previous.browser;
+    globalThis.location = previous.location;
+    globalThis.innerWidth = previous.innerWidth;
+    globalThis.innerHeight = previous.innerHeight;
+    globalThis.getComputedStyle = previous.getComputedStyle;
   }
 }
 
@@ -50752,6 +50784,33 @@ test('captcha detection: reCAPTCHA version, Enterprise edition and action stay i
       expect: { type: 'recaptcha_v2_enterprise', websiteKey: 'KEY_URL_ENT', isEnterprise: true, detectedVia: 'url' },
     },
     {
+      label: 'URL fallback: Enterprise anchor carries sa and s parameters',
+      nodes: () => [
+        captchaEl('iframe', {
+          src: 'https://www.google.com/recaptcha/enterprise/anchor?ar=1&k=KEY_URL_ENT_PARAMS&sa=signup&s=ENTERPRISE_S',
+        }),
+      ],
+      expect: {
+        type: 'recaptcha_v2_enterprise',
+        websiteKey: 'KEY_URL_ENT_PARAMS',
+        pageAction: 'signup',
+        enterprisePayload: { s: 'ENTERPRISE_S' },
+      },
+    },
+    {
+      label: 'URL fallback: classic anchor carries recaptchaDataSValue',
+      nodes: () => [
+        captchaEl('iframe', {
+          src: 'https://www.google.com/recaptcha/api2/anchor?ar=1&k=KEY_URL_CLASSIC_PARAMS&s=CLASSIC_S',
+        }),
+      ],
+      expect: {
+        type: 'recaptcha_v2',
+        websiteKey: 'KEY_URL_CLASSIC_PARAMS',
+        recaptchaDataSValue: 'CLASSIC_S',
+      },
+    },
+    {
       label: 'URL fallback: render=explicit is not a sitekey',
       nodes: () => [
         captchaEl('script', { src: 'https://www.google.com/recaptcha/api.js?render=explicit' }),
@@ -50759,10 +50818,9 @@ test('captcha detection: reCAPTCHA version, Enterprise edition and action stay i
       expect: null,
     },
     {
-      label: 'provider-specific widgets still win over the reCAPTCHA scan',
+      label: 'provider-specific hCaptcha is not misclassified as reCAPTCHA',
       nodes: () => [
         captchaEl('div', { class: 'h-captcha', 'data-sitekey': 'HKEY_123456' }),
-        captchaEl('div', { class: 'g-recaptcha', 'data-sitekey': 'KEY_V2' }),
       ],
       expect: { type: 'hcaptcha', websiteKey: 'HKEY_123456' },
     },
@@ -50781,7 +50839,7 @@ test('captcha detection: reCAPTCHA version, Enterprise edition and action stay i
       continue;
     }
     for (const [key, value] of Object.entries(expect)) {
-      assert.equal(chromeResult?.[key], value, `${label}: ${key}`);
+      assert.deepEqual(chromeResult?.[key], value, `${label}: ${key}`);
     }
   }
 });
@@ -50812,6 +50870,432 @@ test('captcha detection: v3 without an action reports why, and solve_captcha ref
       mod.captchaParamError({ type: 'recaptcha_v2_enterprise', websiteKey: 'KEY' }),
       null,
       `${build}: v2 does not need a pageAction`,
+    );
+  }
+});
+
+test('captcha detection ranks a visible nested v2 Enterprise challenge above background v3', async () => {
+  const topCandidate = {
+    type: 'recaptcha_v3_enterprise',
+    websiteKey: 'KEY_BACKGROUND_V3',
+    isInvisible: true,
+    isEnterprise: true,
+    visible: false,
+    normalCheckbox: false,
+    frameUrl: 'https://www.linkedin.com/signup',
+    detectedVia: 'script',
+  };
+  const activeCandidate = {
+    type: 'recaptcha_v2_enterprise',
+    websiteKey: 'KEY_ACTIVE_V2',
+    isInvisible: false,
+    isEnterprise: true,
+    visible: true,
+    normalCheckbox: true,
+    challengeFrame: true,
+    responseField: true,
+    frameUrl: 'https://www.linkedin.com/checkpoint/challenge/captchaInternal',
+    enterprisePayload: { s: 'enterprise-s' },
+    pageAction: 'signup',
+    detectedVia: 'url',
+  };
+  const previous = { chrome: globalThis.chrome, browser: globalThis.browser };
+  try {
+    for (const build of ['chrome', 'firefox']) {
+      const mod = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-solver.js`)).href);
+      if (build === 'chrome') {
+        globalThis.chrome = {
+          scripting: {
+            executeScript: async ({ target }) => {
+              assert.equal(target.allFrames, true, 'Chrome detector did not scan all frames');
+              return [
+                { frameId: 0, result: [topCandidate] },
+                { frameId: 12, result: [activeCandidate] },
+              ];
+            },
+          },
+        };
+      } else {
+        globalThis.browser = {
+          webNavigation: {
+            getAllFrames: async () => [
+              { frameId: 0, url: topCandidate.frameUrl },
+              { frameId: 12, url: activeCandidate.frameUrl },
+            ],
+          },
+          tabs: {
+            executeScript: async (_tabId, details) => [
+              details.frameId === 12 ? [activeCandidate] : [topCandidate],
+            ],
+          },
+        };
+      }
+      const detection = await mod.detectCaptcha(77);
+      assert.equal(detection.error, null, `${build}: nested selection unexpectedly failed`);
+      assert.equal(detection.selected.type, 'recaptcha_v2_enterprise', `${build}: background v3 won`);
+      assert.equal(detection.selected.websiteKey, 'KEY_ACTIVE_V2', `${build}: wrong site key`);
+      assert.equal(detection.selected.frameId, 12, `${build}: selected frame identity was lost`);
+      assert.equal(detection.selected.frameUrl, activeCandidate.frameUrl, `${build}: wrong websiteURL source`);
+      assert.equal(detection.selected.pageAction, 'signup', `${build}: v2 sa/pageAction was lost`);
+      assert.deepEqual(detection.selected.enterprisePayload, { s: 'enterprise-s' }, `${build}: Enterprise s payload was lost`);
+      assert.equal(detection.selected.selectionReason, 'visible checkbox challenge', `${build}: selection reason`);
+    }
+  } finally {
+    globalThis.chrome = previous.chrome;
+    globalThis.browser = previous.browser;
+  }
+});
+
+test('captcha candidate ranking fails closed on ties and honors exact targeting', async () => {
+  for (const build of ['chrome', 'firefox']) {
+    const runtime = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-frame-runtime.js`)).href);
+    const candidates = [
+      {
+        frameId: 4,
+        frameUrl: 'https://example.test/frame-a',
+        type: 'recaptcha_v2',
+        websiteKey: 'KEY_A',
+        visible: true,
+        normalCheckbox: true,
+        pageAction: 'signup',
+        recaptchaDataSValue: 'classic-s',
+      },
+      {
+        frameId: 5,
+        frameUrl: 'https://example.test/frame-b',
+        type: 'hcaptcha',
+        websiteKey: 'KEY_B',
+        visible: true,
+        normalCheckbox: true,
+      },
+    ];
+    const tied = runtime.selectCaptchaCandidate(candidates);
+    assert.equal(tied.selected, null, `${build}: tied candidates were auto-selected`);
+    assert.equal(tied.ambiguous, true, `${build}: tie was not marked ambiguous`);
+    assert.match(tied.error, /exact frameUrl or websiteKey/, `${build}: tie remedy missing`);
+    assert.equal(tied.candidates[0].pageAction, 'signup', `${build}: candidate action diagnostic missing`);
+    assert.equal(tied.candidates[0].recaptchaDataSValue, 'classic-s', `${build}: candidate s diagnostic missing`);
+
+    const byFrame = runtime.selectCaptchaCandidate(candidates, { frameUrl: candidates[1].frameUrl });
+    assert.equal(byFrame.selected.websiteKey, 'KEY_B', `${build}: exact frameUrl did not select candidate`);
+    assert.equal(byFrame.selected.selectionReason, 'exact frameUrl match', `${build}: exact-frame reason missing`);
+
+    const byKey = runtime.selectCaptchaCandidate(candidates, { websiteKey: 'KEY_A' });
+    assert.equal(byKey.selected.frameId, 4, `${build}: exact websiteKey did not select candidate`);
+
+    const activeChallenge = runtime.selectCaptchaCandidate([
+      {
+        frameId: 7,
+        frameUrl: 'https://example.test/checkpoint/challenge',
+        type: 'recaptcha_v2_enterprise',
+        websiteKey: 'KEY_ACTIVE',
+        visible: false,
+        challengeFrame: true,
+        responseField: true,
+        detectedVia: 'url',
+      },
+      {
+        frameId: 0,
+        frameUrl: 'https://example.test/',
+        type: 'turnstile',
+        websiteKey: 'KEY_BACKGROUND',
+        visible: true,
+        challengeFrame: false,
+        detectedVia: 'host',
+      },
+    ]);
+    assert.equal(
+      activeChallenge.selected.websiteKey,
+      'KEY_ACTIVE',
+      `${build}: generic visible widget outranked the active challenge frame`,
+    );
+  }
+});
+
+test('captcha type compatibility combines the base type with the Enterprise flag', async () => {
+  for (const build of ['chrome', 'firefox']) {
+    const runtime = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-frame-runtime.js`)).href);
+    assert.equal(
+      runtime.captchaTypesMatch('recaptcha_v2', 'recaptcha_v2_enterprise', true, true),
+      true,
+      `${build}: base v2 plus Enterprise flag should match detected Enterprise v2`,
+    );
+    assert.equal(
+      runtime.captchaTypesMatch('recaptcha_v2', 'recaptcha_v2_enterprise', null, true),
+      true,
+      `${build}: detection should be able to fill a missing Enterprise flag`,
+    );
+    assert.equal(
+      runtime.captchaTypesMatch('recaptcha_v2', 'recaptcha_v2_enterprise', false, true),
+      false,
+      `${build}: explicit classic v2 should conflict with detected Enterprise v2`,
+    );
+    assert.equal(
+      runtime.captchaTypesMatch('recaptcha_v3', 'recaptcha_v2_enterprise', true, true),
+      false,
+      `${build}: v2/v3 mismatch was accepted`,
+    );
+    assert.equal(
+      runtime.captchaTypesMatch('recaptcha_v2_enterprise', 'recaptcha_v2_enterprise', false, true),
+      false,
+      `${build}: contradictory Enterprise type and false flag was accepted`,
+    );
+  }
+});
+
+test('captcha task builders propagate frame URL and optional reCAPTCHA parameters', async () => {
+  for (const build of ['chrome', 'firefox']) {
+    const mod = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-solver.js`)).href);
+    const enterpriseTask = mod.buildTask({
+      type: 'recaptcha_v2_enterprise',
+      websiteURL: 'https://example.test/checkpoint/captcha',
+      websiteKey: 'KEY_ENTERPRISE',
+      isInvisible: false,
+      pageAction: 'signup',
+      enterprisePayload: { s: 'enterprise-s' },
+    });
+    assert.deepEqual(enterpriseTask, {
+      type: 'ReCaptchaV2EnterpriseTaskProxyLess',
+      websiteURL: 'https://example.test/checkpoint/captcha',
+      websiteKey: 'KEY_ENTERPRISE',
+      isInvisible: false,
+      pageAction: 'signup',
+      enterprisePayload: { s: 'enterprise-s' },
+    }, `${build}: Enterprise task payload`);
+
+    const classicTask = mod.buildTask({
+      type: 'recaptcha_v2',
+      websiteURL: 'https://example.test/form',
+      websiteKey: 'KEY_CLASSIC',
+      recaptchaDataSValue: 'classic-s',
+    });
+    assert.equal(classicTask.recaptchaDataSValue, 'classic-s', `${build}: classic s value was lost`);
+  }
+});
+
+test('captcha token injection revalidates the selected frame and calls one matched callback', async () => {
+  const previous = {
+    document: globalThis.document,
+    location: globalThis.location,
+    window: globalThis.window,
+    Event: globalThis.Event,
+    HTMLTextAreaElement: globalThis.HTMLTextAreaElement,
+    HTMLInputElement: globalThis.HTMLInputElement,
+  };
+  try {
+    for (const build of ['chrome', 'firefox']) {
+      const runtime = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-frame-runtime.js`)).href);
+      let callbackToken = null;
+      const response = {
+        tagName: 'TEXTAREA',
+        value: '',
+        textContent: '',
+        dispatchEvent: () => true,
+      };
+      const host = {
+        getAttribute: (name) => ({
+          'data-sitekey': 'KEY_ACTIVE',
+          'data-callback': 'onCaptchaSolved',
+        })[name] || null,
+      };
+      let declaredCallbackEnabled = true;
+      const document = {
+        querySelector: (selector) => selector.includes('g-recaptcha-response') ? response : null,
+        querySelectorAll: (selector) => {
+          if (selector.includes('[data-callback]')) return declaredCallbackEnabled ? [host] : [];
+          if (selector.includes('[data-sitekey]')) return [host];
+          if (selector === 'iframe[src], script[src]') return [];
+          return [];
+        },
+        createElement: () => response,
+        body: { appendChild: () => {} },
+        documentElement: { appendChild: () => {} },
+      };
+      globalThis.document = document;
+      globalThis.location = { href: 'https://example.test/checkpoint/captcha' };
+      globalThis.window = {
+        onCaptchaSolved: (token) => { callbackToken = token; },
+      };
+      globalThis.Event = class {
+        constructor(type, options) { this.type = type; this.bubbles = options?.bubbles; }
+      };
+      globalThis.HTMLTextAreaElement = class {};
+      globalThis.HTMLInputElement = class {};
+
+      const missingTarget = runtime.injectCaptchaTokenInPage({
+        fieldName: 'g-recaptcha-response',
+        token: 'TOKEN_UNTARGETED',
+        target: {},
+      });
+      assert.equal(missingTarget.success, false, `${build}: targetless page injection succeeded`);
+      assert.equal(missingTarget.targetRequired, true, `${build}: targetless page injection diagnostic missing`);
+      assert.equal(response.value, '', `${build}: targetless page injection touched the field`);
+
+      const injected = runtime.injectCaptchaTokenInPage({
+        fieldName: 'g-recaptcha-response',
+        token: 'TOKEN_123',
+        target: {
+          frameId: 9,
+          frameUrl: globalThis.location.href,
+          websiteKey: 'KEY_ACTIVE',
+        },
+      });
+      assert.equal(injected.success, true, `${build}: targeted injection failed`);
+      assert.equal(injected.siteKeyMatched, true, `${build}: key revalidation missing`);
+      assert.equal(injected.fieldUpdated, true, `${build}: response-field status missing`);
+      assert.deepEqual(injected.fieldsUpdated, ['g-recaptcha-response'], `${build}: updated-field diagnostic`);
+      assert.equal(injected.calledCallback, true, `${build}: unique callback was not invoked`);
+      assert.equal(callbackToken, 'TOKEN_123', `${build}: callback received wrong token`);
+      assert.equal(response.value, 'TOKEN_123', `${build}: response field was not set`);
+
+      declaredCallbackEnabled = false;
+      callbackToken = null;
+      response.value = '';
+      globalThis.window.___grecaptcha_cfg = {
+        clients: {
+          0: {
+            widget: {
+              sitekey: 'KEY_ACTIVE',
+              callback: (token) => { callbackToken = token; },
+            },
+          },
+        },
+      };
+      const internalCallback = runtime.injectCaptchaTokenInPage({
+        fieldName: 'g-recaptcha-response',
+        token: 'TOKEN_INTERNAL',
+        target: {
+          frameId: 9,
+          frameUrl: globalThis.location.href,
+          websiteKey: 'KEY_ACTIVE',
+        },
+      });
+      assert.equal(internalCallback.calledCallback, true, `${build}: unique Google client callback was not invoked`);
+      assert.equal(internalCallback.callbackSource, 'grecaptcha-client', `${build}: Google callback source missing`);
+      assert.equal(callbackToken, 'TOKEN_INTERNAL', `${build}: Google client callback received wrong token`);
+
+      response.value = '';
+      const stale = runtime.injectCaptchaTokenInPage({
+        fieldName: 'g-recaptcha-response',
+        token: 'TOKEN_STALE',
+        target: {
+          frameId: 9,
+          frameUrl: globalThis.location.href,
+          websiteKey: 'KEY_GONE',
+        },
+      });
+      assert.equal(stale.success, false, `${build}: stale site key was injected`);
+      assert.equal(stale.fieldUpdated, false, `${build}: stale field status was inaccurate`);
+      assert.equal(stale.staleTarget, true, `${build}: stale target marker missing`);
+      assert.equal(response.value, '', `${build}: stale token touched the field`);
+
+      const wrongFrame = runtime.injectCaptchaTokenInPage({
+        fieldName: 'g-recaptcha-response',
+        token: 'TOKEN_WRONG_FRAME',
+        target: {
+          frameId: 9,
+          frameUrl: 'https://example.test/other-frame',
+          websiteKey: 'KEY_ACTIVE',
+        },
+      });
+      assert.equal(wrongFrame.skipped, true, `${build}: wrong frame was not skipped`);
+      assert.equal(response.value, '', `${build}: wrong-frame token touched the field`);
+    }
+  } finally {
+    globalThis.document = previous.document;
+    globalThis.location = previous.location;
+    globalThis.window = previous.window;
+    globalThis.Event = previous.Event;
+    globalThis.HTMLTextAreaElement = previous.HTMLTextAreaElement;
+    globalThis.HTMLInputElement = previous.HTMLInputElement;
+  }
+});
+
+test('captcha injection wrappers target the selected frame in both builds', async () => {
+  const previous = { chrome: globalThis.chrome, browser: globalThis.browser };
+  try {
+    const chromeMod = await import(pathToFileURL(path.join(ROOT, 'src/chrome/src/agent/captcha-solver.js')).href);
+    let chromeCall = null;
+    globalThis.chrome = {
+      scripting: {
+        executeScript: async (details) => {
+          chromeCall = details;
+          return [{ frameId: 9, result: { success: true, frameUrl: 'https://example.test/captcha' } }];
+        },
+      },
+    };
+    const chromeResult = await chromeMod.injectToken(1, {
+      fieldName: 'g-recaptcha-response',
+      token: 'TOKEN',
+      target: { frameId: 9, frameUrl: 'https://example.test/captcha', websiteKey: 'KEY' },
+    });
+    assert.deepEqual(chromeCall.target.frameIds, [9], 'Chrome injection did not target selected frameId');
+    assert.equal(chromeCall.world, 'MAIN', 'Chrome callback injection did not use the page main world');
+    assert.equal(chromeResult.frameId, 9, 'Chrome injection result lost frameId');
+    chromeCall = null;
+    const chromeUntargeted = await chromeMod.injectToken(1, {
+      fieldName: 'g-recaptcha-response',
+      token: 'TOKEN',
+      target: null,
+    });
+    assert.equal(chromeUntargeted.success, false, 'Chrome targetless injection succeeded');
+    assert.equal(chromeUntargeted.targetRequired, true, 'Chrome targetless injection diagnostic missing');
+    assert.equal(chromeCall, null, 'Chrome targetless injection reached the page');
+
+    const firefoxMod = await import(pathToFileURL(path.join(ROOT, 'src/firefox/src/agent/captcha-solver.js')).href);
+    let firefoxCall = null;
+    globalThis.browser = {
+      tabs: {
+        executeScript: async (_tabId, details) => {
+          firefoxCall = details;
+          return [{ success: true, frameUrl: 'https://example.test/captcha' }];
+        },
+      },
+    };
+    const firefoxResult = await firefoxMod.injectToken(2, {
+      fieldName: 'g-recaptcha-response',
+      token: 'TOKEN',
+      target: { frameId: 11, frameUrl: 'https://example.test/captcha', websiteKey: 'KEY' },
+    });
+    assert.equal(firefoxCall.frameId, 11, 'Firefox injection did not target selected frameId');
+    assert.equal(firefoxResult.frameId, 11, 'Firefox injection result lost frameId');
+    firefoxCall = null;
+    const firefoxUntargeted = await firefoxMod.injectToken(2, {
+      fieldName: 'g-recaptcha-response',
+      token: 'TOKEN',
+      target: null,
+    });
+    assert.equal(firefoxUntargeted.success, false, 'Firefox targetless injection succeeded');
+    assert.equal(firefoxUntargeted.targetRequired, true, 'Firefox targetless injection diagnostic missing');
+    assert.equal(firefoxCall, null, 'Firefox targetless injection reached the page');
+  } finally {
+    globalThis.chrome = previous.chrome;
+    globalThis.browser = previous.browser;
+  }
+});
+
+test('solve_captcha runtime always detects missing fields and rejects type conflicts before dispatch', () => {
+  for (const build of ['chrome', 'firefox']) {
+    const agent = fs.readFileSync(path.join(ROOT, `src/${build}/src/agent/agent.js`), 'utf8');
+    assert.match(
+      agent,
+      /if \(type !== 'image_to_text'\) \{[\s\S]*?detectCaptcha\(tabId, \{ frameUrl, websiteKey \}\)/,
+      `${build}: solve_captcha does not run frame-aware detection when type is supplied`,
+    );
+    assert.match(
+      agent,
+      /type && !captchaTypesMatch\(type, detected\.type, isEnterprise, detected\.isEnterprise\)[\s\S]*?conflicts with the active detected candidate/,
+      `${build}: explicit type conflicts are not rejected locally`,
+    );
+    assert.match(
+      agent,
+      /if \(!websiteKey\) websiteKey = detected\.websiteKey/,
+      `${build}: detected site key does not fill a missing explicit argument`,
+    );
+    assert.match(
+      agent,
+      /target: detected \? \{[\s\S]*?frameId: detected\.frameId,[\s\S]*?frameUrl: detected\.frameUrl/,
+      `${build}: selected frame is not carried into token injection`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -51549,6 +51549,11 @@ test('solve_captcha runtime always detects missing fields and rejects type confl
     );
     assert.match(
       agent,
+      /pageAction && detected\.pageAction && String\(pageAction\) !== String\(detected\.pageAction\)[\s\S]*?requested pageAction[\s\S]*?conflicts with the active detected candidate action/,
+      `${build}: explicit pageAction conflicts are not rejected locally`,
+    );
+    assert.match(
+      agent,
       /if \(!websiteKey\) websiteKey = detected\.websiteKey/,
       `${build}: detected site key does not fill a missing explicit argument`,
     );

--- a/test/run.js
+++ b/test/run.js
@@ -51483,6 +51483,7 @@ test('captcha token injection revalidates the selected frame and calls one match
         tagName: 'TEXTAREA',
         value: '',
         textContent: '',
+        style: {},
         dispatchEvent: () => true,
       };
       const host = {
@@ -51492,12 +51493,21 @@ test('captcha token injection revalidates the selected frame and calls one match
         })[name] || null,
       };
       let declaredCallbackEnabled = true;
+      let turnstileChallengeMarkerEnabled = false;
+      let captchaUrlElements = [];
       const document = {
-        querySelector: (selector) => selector.includes('g-recaptcha-response') ? response : null,
+        querySelector: (selector) => {
+          if (selector.includes('g-recaptcha-response')) return response;
+          if (turnstileChallengeMarkerEnabled
+              && selector === 'script[src*="challenges.cloudflare.com/turnstile"]') {
+            return {};
+          }
+          return null;
+        },
         querySelectorAll: (selector) => {
           if (selector.includes('[data-callback]')) return declaredCallbackEnabled ? [host] : [];
           if (selector.includes('[data-sitekey]')) return [host];
-          if (selector === 'iframe[src], script[src]') return [];
+          if (selector === 'iframe[src], script[src]') return captchaUrlElements;
           return [];
         },
         createElement: () => response,
@@ -51581,6 +51591,62 @@ test('captcha token injection revalidates the selected frame and calls one match
       assert.equal(stale.fieldUpdated, false, `${build}: stale field status was inaccurate`);
       assert.equal(stale.staleTarget, true, `${build}: stale target marker missing`);
       assert.equal(response.value, '', `${build}: stale token touched the field`);
+
+      captchaUrlElements = [{
+        src: 'https://newassets.hcaptcha.com/captcha/v1/hcaptcha.html#frame=checkbox&sitekey=KEY_FRAGMENT',
+      }];
+      const fragmentKey = runtime.injectCaptchaTokenInPage({
+        fieldName: 'h-captcha-response',
+        token: 'TOKEN_FRAGMENT_KEY',
+        target: {
+          frameId: 9,
+          frameUrl: globalThis.location.href,
+          websiteKey: 'KEY_FRAGMENT',
+          type: 'hcaptcha',
+        },
+      });
+      assert.equal(fragmentKey.success, true, `${build}: fragment site key injection failed`);
+      assert.equal(fragmentKey.siteKeyMatched, true, `${build}: fragment site key was not revalidated`);
+      assert.equal(response.value, 'TOKEN_FRAGMENT_KEY', `${build}: fragment-key token was not injected`);
+      captchaUrlElements = [];
+      response.value = '';
+
+      turnstileChallengeMarkerEnabled = true;
+      const explicitTurnstile = runtime.injectCaptchaTokenInPage({
+        fieldName: 'cf-turnstile-response',
+        token: 'TOKEN_TURNSTILE',
+        target: {
+          frameId: 9,
+          frameUrl: globalThis.location.href,
+          websiteKey: 'TURNSTILE_EXPLICIT_KEY',
+          type: 'turnstile',
+          explicitWebsiteKey: true,
+        },
+      });
+      assert.equal(explicitTurnstile.success, true, `${build}: explicit-key Turnstile injection failed`);
+      assert.equal(explicitTurnstile.siteKeyMatched, false, `${build}: absent explicit key was reported as matched`);
+      assert.equal(
+        explicitTurnstile.challengeMarkerMatched,
+        true,
+        `${build}: keyless Turnstile marker was not revalidated`,
+      );
+      assert.equal(response.value, 'TOKEN_TURNSTILE', `${build}: Turnstile token was not injected`);
+      turnstileChallengeMarkerEnabled = false;
+      response.value = '';
+      const staleExplicitTurnstile = runtime.injectCaptchaTokenInPage({
+        fieldName: 'cf-turnstile-response',
+        token: 'TOKEN_TURNSTILE_STALE',
+        target: {
+          frameId: 9,
+          frameUrl: globalThis.location.href,
+          websiteKey: 'TURNSTILE_EXPLICIT_KEY',
+          type: 'turnstile',
+          explicitWebsiteKey: true,
+        },
+      });
+      assert.equal(staleExplicitTurnstile.success, false, `${build}: stale keyless Turnstile target was injected`);
+      assert.equal(staleExplicitTurnstile.staleTarget, true, `${build}: stale Turnstile marker missing`);
+      assert.equal(response.value, '', `${build}: stale Turnstile token touched the field`);
 
       const wrongFrame = runtime.injectCaptchaTokenInPage({
         fieldName: 'g-recaptcha-response',
@@ -51695,6 +51761,11 @@ test('solve_captcha runtime always detects missing fields and rejects type confl
       agent,
       /target: detected \? \{[\s\S]*?frameId: detected\.frameId,[\s\S]*?frameUrl: detected\.frameUrl/,
       `${build}: selected frame is not carried into token injection`,
+    );
+    assert.match(
+      agent,
+      /explicitWebsiteKey: detected\.explicitWebsiteKey === true/,
+      `${build}: explicit Turnstile key marker is not carried into token injection`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -51236,26 +51236,45 @@ test('captcha candidate ranking fails closed on ties and honors exact targeting'
     const byKey = runtime.selectCaptchaCandidate(candidates, { websiteKey: 'KEY_A' });
     assert.equal(byKey.selected.frameId, 4, `${build}: exact websiteKey did not select candidate`);
 
+    const hiddenChallenge = {
+      frameId: 7,
+      frameUrl: 'https://example.test/checkpoint/challenge',
+      type: 'recaptcha_v3',
+      websiteKey: 'KEY_HIDDEN',
+      visible: false,
+      challengeFrame: true,
+      responseField: true,
+      detectedVia: 'script',
+    };
+    const visibleTurnstile = {
+      frameId: 0,
+      frameUrl: 'https://example.test/',
+      type: 'turnstile',
+      websiteKey: 'KEY_VISIBLE',
+      visible: true,
+      normalCheckbox: false,
+      challengeFrame: false,
+      detectedVia: 'host',
+    };
+    const hiddenChallengeResult = runtime.selectCaptchaCandidate([
+      hiddenChallenge,
+      visibleTurnstile,
+    ]);
+    assert.equal(
+      hiddenChallengeResult.selected.websiteKey,
+      'KEY_VISIBLE',
+      `${build}: hidden challenge-frame integration outranked a visible widget`,
+    );
+
     const activeChallenge = runtime.selectCaptchaCandidate([
       {
-        frameId: 7,
-        frameUrl: 'https://example.test/checkpoint/challenge',
+        ...hiddenChallenge,
         type: 'recaptcha_v2_enterprise',
         websiteKey: 'KEY_ACTIVE',
-        visible: false,
-        challengeFrame: true,
-        responseField: true,
+        visible: true,
         detectedVia: 'url',
       },
-      {
-        frameId: 0,
-        frameUrl: 'https://example.test/',
-        type: 'turnstile',
-        websiteKey: 'KEY_BACKGROUND',
-        visible: true,
-        challengeFrame: false,
-        detectedVia: 'host',
-      },
+      visibleTurnstile,
     ]);
     assert.equal(
       activeChallenge.selected.websiteKey,

--- a/test/run.js
+++ b/test/run.js
@@ -50917,6 +50917,42 @@ test('captcha detection: v3 without an action reports why, and solve_captcha ref
   }
 });
 
+test('captcha detection binds the selected widget to its own response field', async () => {
+  for (const build of ['chrome', 'firefox']) {
+    const hiddenField = captchaEl('textarea', {
+      id: 'g-recaptcha-response-hidden',
+      name: 'g-recaptcha-response',
+    });
+    const activeField = captchaEl('textarea', {
+      id: 'g-recaptcha-response-active',
+      name: 'g-recaptcha-response',
+    });
+    const hiddenHost = captchaEl('div', {
+      class: 'g-recaptcha',
+      'data-sitekey': 'KEY_HIDDEN_WIDGET',
+      hidden: true,
+    }, [hiddenField]);
+    const activeHost = captchaEl('div', {
+      class: 'g-recaptcha',
+      'data-sitekey': 'KEY_ACTIVE_WIDGET',
+      'data-callback': 'onActiveCaptcha',
+    }, [activeField]);
+    const selected = await detectCaptchaOnFakePage(build, [
+      hiddenHost,
+      activeHost,
+      captchaEl('script', { src: 'https://www.google.com/recaptcha/api.js' }),
+    ]);
+    assert.equal(selected.websiteKey, 'KEY_ACTIVE_WIDGET', `${build}: active widget was not selected`);
+    assert.equal(
+      selected.responseFieldId,
+      'g-recaptcha-response-active',
+      `${build}: selected response field id was not preserved`,
+    );
+    assert.equal(selected.responseFieldIndex, 1, `${build}: selected response field index was not preserved`);
+    assert.equal(selected.callbackName, 'onActiveCaptcha', `${build}: selected callback was not preserved`);
+  }
+});
+
 test('captcha detection ranks a visible nested v2 Enterprise challenge above background v3', async () => {
   const topCandidate = {
     type: 'recaptcha_v3_enterprise',
@@ -51775,9 +51811,11 @@ test('captcha token injection revalidates the selected frame and calls one match
       let callbackToken = null;
       const response = {
         tagName: 'TEXTAREA',
+        id: 'g-recaptcha-response-only',
         value: '',
         textContent: '',
         style: {},
+        getAttribute: (name) => name === 'id' ? 'g-recaptcha-response-only' : null,
         dispatchEvent: () => true,
       };
       const host = {
@@ -51789,9 +51827,11 @@ test('captcha token injection revalidates the selected frame and calls one match
       let declaredCallbackEnabled = true;
       let turnstileChallengeMarkerEnabled = false;
       let captchaUrlElements = [];
+      let responseFields = [response];
+      let captchaHosts = [host];
       const document = {
         querySelector: (selector) => {
-          if (selector.includes('g-recaptcha-response')) return response;
+          if (selector.includes('g-recaptcha-response')) return responseFields[0] || null;
           if (turnstileChallengeMarkerEnabled
               && selector === 'script[src*="challenges.cloudflare.com/turnstile"]') {
             return {};
@@ -51799,8 +51839,11 @@ test('captcha token injection revalidates the selected frame and calls one match
           return null;
         },
         querySelectorAll: (selector) => {
-          if (selector.includes('[data-callback]')) return declaredCallbackEnabled ? [host] : [];
-          if (selector.includes('[data-sitekey]')) return [host];
+          if (selector.includes('textarea[name=') || selector.includes('input[name=')) {
+            return responseFields;
+          }
+          if (selector.includes('[data-callback]')) return declaredCallbackEnabled ? captchaHosts : [];
+          if (selector.includes('[data-sitekey]')) return captchaHosts;
           if (selector === 'iframe[src], script[src]') return captchaUrlElements;
           return [];
         },
@@ -51846,6 +51889,68 @@ test('captcha token injection revalidates the selected frame and calls one match
       assert.equal(callbackToken, 'TOKEN_123', `${build}: callback received wrong token`);
       assert.equal(response.value, 'TOKEN_123', `${build}: response field was not set`);
 
+      let hiddenCallbackToken = null;
+      let modalCallbackToken = null;
+      const makeResponse = id => ({
+        tagName: 'TEXTAREA',
+        id,
+        value: '',
+        textContent: '',
+        style: {},
+        getAttribute: (name) => name === 'id' ? id : null,
+        dispatchEvent: () => true,
+      });
+      const hiddenResponse = makeResponse('g-recaptcha-response-hidden');
+      const modalResponse = makeResponse('g-recaptcha-response-modal');
+      const makeHost = (callbackName) => ({
+        getAttribute: (name) => ({
+          'data-sitekey': 'KEY_SHARED_WIDGET',
+          'data-callback': callbackName,
+        })[name] || null,
+      });
+      responseFields = [hiddenResponse, modalResponse];
+      captchaHosts = [makeHost('onHiddenCaptcha'), makeHost('onModalCaptcha')];
+      globalThis.window.onHiddenCaptcha = token => { hiddenCallbackToken = token; };
+      globalThis.window.onModalCaptcha = token => { modalCallbackToken = token; };
+
+      const ambiguousField = runtime.injectCaptchaTokenInPage({
+        fieldName: 'g-recaptcha-response',
+        token: 'TOKEN_AMBIGUOUS_FIELD',
+        target: {
+          frameId: 9,
+          frameUrl: globalThis.location.href,
+          websiteKey: 'KEY_SHARED_WIDGET',
+        },
+      });
+      assert.equal(ambiguousField.success, false, `${build}: ambiguous response field was updated`);
+      assert.equal(
+        ambiguousField.ambiguousResponseField,
+        true,
+        `${build}: ambiguous response field diagnostic missing`,
+      );
+      assert.equal(hiddenResponse.value, '', `${build}: ambiguous solve touched the hidden response field`);
+      assert.equal(modalResponse.value, '', `${build}: ambiguous solve touched the modal response field`);
+
+      const targetedField = runtime.injectCaptchaTokenInPage({
+        fieldName: 'g-recaptcha-response',
+        token: 'TOKEN_MODAL_WIDGET',
+        callbackHint: 'onModalCaptcha',
+        target: {
+          frameId: 9,
+          frameUrl: globalThis.location.href,
+          websiteKey: 'KEY_SHARED_WIDGET',
+          responseFieldId: 'g-recaptcha-response-modal',
+          responseFieldIndex: 1,
+        },
+      });
+      assert.equal(targetedField.success, true, `${build}: selected response field injection failed`);
+      assert.equal(hiddenResponse.value, '', `${build}: hidden widget received the selected token`);
+      assert.equal(modalResponse.value, 'TOKEN_MODAL_WIDGET', `${build}: modal widget did not receive its token`);
+      assert.equal(hiddenCallbackToken, null, `${build}: hidden widget callback was invoked`);
+      assert.equal(modalCallbackToken, 'TOKEN_MODAL_WIDGET', `${build}: selected callback was not invoked`);
+
+      responseFields = [response];
+      captchaHosts = [host];
       const selectedFrameUrl = globalThis.location.href;
       globalThis.location.href = `${selectedFrameUrl}?step=verify#captcha`;
       response.value = '';
@@ -52108,6 +52213,16 @@ test('solve_captcha runtime always detects missing fields and rejects type confl
       agent,
       /documentTimeOrigin: detected\.documentTimeOrigin/,
       `${build}: selected document identity is not carried into token injection`,
+    );
+    assert.match(
+      agent,
+      /const explicitTokenOnlyFallback = args\?\.inject === false[\s\S]*?candidate\?\.websiteKey === websiteKey[\s\S]*?if \(!explicitTokenOnlyFallback/,
+      `${build}: unrelated candidates still block an explicit token-only solve`,
+    );
+    assert.match(
+      agent,
+      /callbackHint: detected\.callbackName \|\| null,[\s\S]*?responseFieldId: detected\.responseFieldId,[\s\S]*?responseFieldIndex: detected\.responseFieldIndex/,
+      `${build}: selected widget identity is not carried into token injection`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -51034,6 +51034,196 @@ test('captcha detection ranks a visible nested v2 Enterprise challenge above bac
   }
 });
 
+test('captcha detection inherits same-key reCAPTCHA loader metadata only from ancestor frames', async () => {
+  const topUrl = 'https://example.test/signup';
+  const childUrl = 'https://example.test/captcha-widget';
+  const siblingUrl = 'https://example.test/background-integration';
+  const websiteKey = 'KEY_ANCESTOR_V3_ENTERPRISE';
+  const ancestorLoader = {
+    type: 'recaptcha_v3_enterprise',
+    websiteKey,
+    isInvisible: true,
+    isEnterprise: true,
+    visible: false,
+    normalCheckbox: false,
+    pageAction: 'ancestor-login',
+    frameUrl: topUrl,
+    detectedVia: 'script',
+  };
+  const childHost = {
+    type: 'recaptcha_v2',
+    websiteKey,
+    isInvisible: false,
+    isEnterprise: false,
+    visible: true,
+    normalCheckbox: true,
+    frameUrl: childUrl,
+    detectedVia: 'host',
+  };
+  const siblingLoader = {
+    ...ancestorLoader,
+    type: 'recaptcha_v3',
+    isEnterprise: false,
+    pageAction: 'sibling-action',
+    frameUrl: siblingUrl,
+  };
+  const navigationFrames = [
+    { frameId: 0, parentFrameId: -1, url: topUrl },
+    { frameId: 12, parentFrameId: 0, url: childUrl },
+    { frameId: 13, parentFrameId: 0, url: siblingUrl },
+  ];
+  const framePayload = frameId => {
+    if (frameId === 12) {
+      return {
+        candidates: [childHost],
+        frameContext: {
+          frameUrl: childUrl,
+          frameName: 'captcha-widget',
+          childFrames: [],
+        },
+      };
+    }
+    if (frameId === 13) {
+      return {
+        candidates: [siblingLoader],
+        frameContext: {
+          frameUrl: siblingUrl,
+          frameName: 'background-integration',
+          childFrames: [],
+        },
+      };
+    }
+    return {
+      candidates: [ancestorLoader],
+      frameContext: {
+        frameUrl: topUrl,
+        frameName: '',
+        childFrames: [
+          {
+            url: childUrl,
+            loadedUrl: childUrl,
+            name: 'captcha-widget',
+            visible: true,
+          },
+          {
+            url: siblingUrl,
+            loadedUrl: siblingUrl,
+            name: 'background-integration',
+            visible: true,
+          },
+        ],
+      },
+    };
+  };
+  const previous = { chrome: globalThis.chrome, browser: globalThis.browser };
+  try {
+    for (const build of ['chrome', 'firefox']) {
+      const mod = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-solver.js`)).href);
+      if (build === 'chrome') {
+        globalThis.chrome = {
+          webNavigation: {
+            getAllFrames: async () => navigationFrames,
+          },
+          scripting: {
+            executeScript: async () => navigationFrames.map(({ frameId }) => ({
+              frameId,
+              result: framePayload(frameId),
+            })),
+          },
+        };
+      } else {
+        globalThis.browser = {
+          webNavigation: {
+            getAllFrames: async () => navigationFrames,
+          },
+          tabs: {
+            executeScript: async (_tabId, { frameId }) => [framePayload(frameId)],
+          },
+        };
+      }
+
+      const detection = await mod.detectCaptcha(88);
+      assert.equal(detection.error, null, `${build}: ancestor metadata reconciliation failed`);
+      assert.equal(detection.selected.frameId, 12, `${build}: visible child widget was not selected`);
+      assert.equal(
+        detection.selected.type,
+        'recaptcha_v3_enterprise',
+        `${build}: ancestor v3 Enterprise type was not inherited`,
+      );
+      assert.equal(detection.selected.isEnterprise, true, `${build}: Enterprise mode was not inherited`);
+      assert.equal(detection.selected.pageAction, 'ancestor-login', `${build}: ancestor action was not inherited`);
+      assert.equal(detection.selected.normalCheckbox, false, `${build}: reconciled v3 host remained a v2 checkbox`);
+      assert.equal(detection.selected.ancestorLoaderFrameId, 0, `${build}: loader ancestry was not reported`);
+      assert.equal(
+        detection.selected.selectionReason,
+        'visible CAPTCHA widget',
+        `${build}: reconciled v3 selection reason was inaccurate`,
+      );
+
+      const runtime = await import(pathToFileURL(
+        path.join(ROOT, `src/${build}/src/agent/captcha-frame-runtime.js`),
+      ).href);
+      const inheritedChildHost = {
+        ...childHost,
+        frameId: 0,
+        frameUrl: 'about:srcdoc',
+        framePath: [{ index: 1, frameUrl: 'about:srcdoc', frameName: 'captcha-child' }],
+      };
+      const inheritedSiblingLoader = {
+        ...siblingLoader,
+        frameId: 0,
+        frameUrl: 'about:srcdoc',
+        framePath: [{ index: 0, frameUrl: 'about:srcdoc', frameName: 'captcha-sibling' }],
+      };
+      const inheritedSiblingAdjusted = runtime.applyCaptchaFrameVisibility(
+        [inheritedSiblingLoader, inheritedChildHost],
+        [],
+        [{ frameId: 0, parentFrameId: -1, url: topUrl }],
+      );
+      assert.equal(
+        inheritedSiblingAdjusted[1].type,
+        'recaptcha_v2',
+        `${build}: inherited-origin sibling metadata leaked into the child`,
+      );
+
+      const inheritedAncestorAdjusted = runtime.applyCaptchaFrameVisibility(
+        [{ ...ancestorLoader, frameId: 0 }, inheritedChildHost],
+        [],
+        [{ frameId: 0, parentFrameId: -1, url: topUrl }],
+      );
+      assert.equal(
+        inheritedAncestorAdjusted[1].type,
+        'recaptcha_v3_enterprise',
+        `${build}: inherited-origin child did not receive base-frame loader metadata`,
+      );
+
+      const conflictingAdjusted = runtime.applyCaptchaFrameVisibility(
+        [
+          { ...ancestorLoader, frameId: 0 },
+          { ...ancestorLoader, frameId: 0, pageAction: 'conflicting-action' },
+          { ...childHost, frameId: 12 },
+        ],
+        [],
+        navigationFrames,
+      );
+      const conflictingSelection = runtime.selectCaptchaCandidate(conflictingAdjusted);
+      assert.equal(
+        conflictingSelection.selected,
+        null,
+        `${build}: conflicting nearest ancestor loaders were selected`,
+      );
+      assert.match(
+        conflictingSelection.error || '',
+        /ancestorLoader/,
+        `${build}: conflicting ancestor loader diagnostic was missing`,
+      );
+    }
+  } finally {
+    globalThis.chrome = previous.chrome;
+    globalThis.browser = previous.browser;
+  }
+});
+
 test('Firefox detects and injects an inherited-origin srcdoc CAPTCHA through its parent frame', async () => {
   const firefoxMod = await import(pathToFileURL(path.join(ROOT, 'src/firefox/src/agent/captcha-solver.js')).href);
   const response = captchaEl('textarea', { name: 'g-recaptcha-response' });

--- a/test/run.js
+++ b/test/run.js
@@ -50826,6 +50826,35 @@ test('captcha detection: reCAPTCHA version, Enterprise edition and action stay i
       expect: { type: 'hcaptcha', websiteKey: 'HKEY_123456' },
     },
     {
+      label: 'keyless Turnstile challenge remains visible beside background reCAPTCHA v3',
+      nodes: () => [
+        captchaEl('script', {
+          src: 'https://www.google.com/recaptcha/api.js?render=KEY_BACKGROUND&action=login',
+        }),
+        captchaEl('script', {
+          src: 'https://challenges.cloudflare.com/turnstile/v0/api.js',
+        }),
+      ],
+      expect: {
+        type: 'turnstile_challenge',
+        websiteKey: null,
+        visible: true,
+      },
+    },
+    {
+      label: 'keyed Turnstile widget does not gain a competing keyless marker',
+      nodes: () => [
+        captchaEl('div', { class: 'cf-turnstile', 'data-sitekey': 'TURNSTILE_KEYED' }),
+        captchaEl('script', {
+          src: 'https://challenges.cloudflare.com/turnstile/v0/api.js',
+        }),
+      ],
+      expect: {
+        type: 'turnstile',
+        websiteKey: 'TURNSTILE_KEYED',
+      },
+    },
+    {
       label: 'URL fallback: hCaptcha site key in iframe fragment',
       nodes: () => [
         captchaEl('iframe', {
@@ -51195,6 +51224,62 @@ test('captcha frame visibility propagation demotes descendants of hidden embeddi
       runtime.selectCaptchaCandidate(visibleAdjusted).selected.websiteKey,
       'KEY_HIDDEN_NESTED',
       `${build}: visible nested challenge was not restored`,
+    );
+
+    const redirectedCandidate = {
+      ...nestedCandidate,
+      frameId: 21,
+      frameUrl: 'https://captcha.vendor.test/final-challenge',
+      websiteKey: 'KEY_REDIRECTED',
+    };
+    const redirectedAdjusted = runtime.applyCaptchaFrameVisibility(
+      [visibleCandidate, redirectedCandidate],
+      [
+        {
+          frameId: 0,
+          frameUrl: visibleCandidate.frameUrl,
+          frameName: '',
+          childFrames: [
+            {
+              url: 'https://captcha.vendor.test/start',
+              loadedUrl: '',
+              name: '',
+              visible: true,
+            },
+            {
+              url: 'https://example.test/unrelated-frame',
+              loadedUrl: '',
+              name: '',
+              visible: false,
+            },
+          ],
+        },
+        {
+          frameId: 21,
+          frameUrl: redirectedCandidate.frameUrl,
+          frameName: '',
+          childFrames: [],
+        },
+      ],
+      [
+        { frameId: 0, parentFrameId: -1, url: visibleCandidate.frameUrl },
+        { frameId: 21, parentFrameId: 0, url: redirectedCandidate.frameUrl },
+      ],
+    );
+    assert.equal(
+      redirectedAdjusted[1].frameVisible,
+      true,
+      `${build}: unmatched redirected child was treated as hidden`,
+    );
+    assert.equal(
+      redirectedAdjusted[1].visible,
+      true,
+      `${build}: redirected visible CAPTCHA was demoted`,
+    );
+    assert.equal(
+      runtime.selectCaptchaCandidate(redirectedAdjusted).selected.websiteKey,
+      'KEY_REDIRECTED',
+      `${build}: redirected visible CAPTCHA lost to another candidate`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -51250,6 +51250,70 @@ test('captcha candidate ranking fails closed on ties and honors exact targeting'
   }
 });
 
+test('captcha candidate deduplication rejects conflicting paid-task parameters', async () => {
+  for (const build of ['chrome', 'firefox']) {
+    const runtime = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-frame-runtime.js`)).href);
+    const base = {
+      frameId: 4,
+      frameUrl: 'https://example.test/form',
+      type: 'recaptcha_v2_enterprise',
+      websiteKey: 'KEY_SHARED',
+      visible: true,
+      normalCheckbox: true,
+    };
+    const conflicts = [
+      ['pageAction', 'signup', 'checkout'],
+      ['recaptchaDataSValue', 'classic-s-old', 'classic-s-new'],
+      ['enterprisePayload', { s: 'enterprise-s-old' }, { s: 'enterprise-s-new' }],
+      ['isInvisible', false, true],
+    ];
+    for (const [field, first, second] of conflicts) {
+      const result = runtime.selectCaptchaCandidate([
+        { ...base, [field]: first, detectedVia: 'host' },
+        { ...base, [field]: second, detectedVia: 'url' },
+      ]);
+      assert.equal(result.selected, null, `${build}: conflicting ${field} candidate was selected`);
+      assert.equal(result.ambiguous, true, `${build}: conflicting ${field} was not marked ambiguous`);
+      assert.match(result.error, new RegExp(field), `${build}: conflicting ${field} diagnostic missing`);
+      assert.deepEqual(
+        result.candidates[0].parameterConflicts,
+        [field],
+        `${build}: conflicting ${field} was not exposed in candidate diagnostics`,
+      );
+    }
+
+    const consistent = runtime.selectCaptchaCandidate([
+      {
+        ...base,
+        pageAction: 'signup',
+        enterprisePayload: { s: 'enterprise-s', extra: 'value' },
+        detectedVia: 'host',
+      },
+      {
+        ...base,
+        pageAction: 'signup',
+        enterprisePayload: { extra: 'value', s: 'enterprise-s' },
+        detectedVia: 'url',
+      },
+    ]);
+    assert.equal(consistent.error, null, `${build}: equivalent task parameters were treated as conflicting`);
+    assert.equal(consistent.selected.pageAction, 'signup', `${build}: consistent action was lost`);
+    assert.deepEqual(
+      consistent.selected.enterprisePayload,
+      { s: 'enterprise-s', extra: 'value' },
+      `${build}: consistent Enterprise payload was lost`,
+    );
+
+    const inheritedFrameTie = runtime.selectCaptchaCandidate([
+      { ...base, frameId: 0, frameUrl: 'about:srcdoc', framePath: [{ index: 0 }] },
+      { ...base, frameId: 0, frameUrl: 'about:srcdoc', framePath: [{ index: 1 }] },
+    ]);
+    assert.equal(inheritedFrameTie.selected, null, `${build}: distinct inherited frames were deduplicated`);
+    assert.equal(inheritedFrameTie.ambiguous, true, `${build}: inherited-frame tie was not preserved`);
+    assert.equal(inheritedFrameTie.candidates.length, 2, `${build}: inherited frame identities collapsed`);
+  }
+});
+
 test('captcha type compatibility combines the base type with the Enterprise flag', async () => {
   for (const build of ['chrome', 'firefox']) {
     const runtime = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-frame-runtime.js`)).href);

--- a/test/run.js
+++ b/test/run.js
@@ -51314,6 +51314,60 @@ test('captcha candidate deduplication rejects conflicting paid-task parameters',
   }
 });
 
+test('keyless Turnstile markers accept only an explicit Turnstile type and site key', async () => {
+  for (const build of ['chrome', 'firefox']) {
+    const runtime = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-frame-runtime.js`)).href);
+    const keyless = {
+      frameId: 0,
+      frameUrl: 'https://example.test/challenge',
+      type: 'turnstile_challenge',
+      websiteKey: null,
+      visible: true,
+      challengeFrame: true,
+      detectedVia: 'script',
+    };
+    const explicit = runtime.selectCaptchaCandidate([keyless], {
+      type: 'turnstile',
+      websiteKey: 'TURNSTILE_EXPLICIT_KEY',
+    });
+    assert.equal(explicit.error, null, `${build}: explicit Turnstile fallback was rejected`);
+    assert.equal(explicit.selected.type, 'turnstile', `${build}: keyless marker kept an unsupported task type`);
+    assert.equal(
+      explicit.selected.websiteKey,
+      'TURNSTILE_EXPLICIT_KEY',
+      `${build}: explicit Turnstile site key was not bound to the marker`,
+    );
+    assert.equal(explicit.selected.explicitWebsiteKey, true, `${build}: explicit-key fallback was not reported`);
+    assert.equal(
+      explicit.selected.selectionReason,
+      'explicit site key for detected Turnstile challenge',
+      `${build}: explicit-key selection reason missing`,
+    );
+
+    for (const constraints of [
+      { websiteKey: 'TURNSTILE_EXPLICIT_KEY' },
+      { type: 'hcaptcha', websiteKey: 'TURNSTILE_EXPLICIT_KEY' },
+    ]) {
+      const rejected = runtime.selectCaptchaCandidate([keyless], constraints);
+      assert.equal(rejected.selected, null, `${build}: mismatched keyless fallback was selected`);
+      assert.match(rejected.error, /supplied websiteKey/, `${build}: keyless fallback rejection was unclear`);
+    }
+
+    const keyed = {
+      ...keyless,
+      type: 'turnstile',
+      websiteKey: 'TURNSTILE_EXPLICIT_KEY',
+      detectedVia: 'host',
+    };
+    const exactWins = runtime.selectCaptchaCandidate([keyless, keyed], {
+      type: 'turnstile',
+      websiteKey: keyed.websiteKey,
+    });
+    assert.equal(exactWins.selected.detectedVia, 'host', `${build}: exact detected site key did not win`);
+    assert.equal(exactWins.selected.explicitWebsiteKey, undefined, `${build}: exact match was mislabeled as fallback`);
+  }
+});
+
 test('captcha type compatibility combines the base type with the Enterprise flag', async () => {
   for (const build of ['chrome', 'firefox']) {
     const runtime = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-frame-runtime.js`)).href);
@@ -51603,7 +51657,7 @@ test('solve_captcha runtime always detects missing fields and rejects type confl
     const agent = fs.readFileSync(path.join(ROOT, `src/${build}/src/agent/agent.js`), 'utf8');
     assert.match(
       agent,
-      /if \(type !== 'image_to_text'\) \{[\s\S]*?detectCaptcha\(tabId, \{ frameUrl, websiteKey \}\)/,
+      /if \(type !== 'image_to_text'\) \{[\s\S]*?detectCaptcha\(tabId, \{ type, frameUrl, websiteKey \}\)/,
       `${build}: solve_captcha does not run frame-aware detection when type is supplied`,
     );
     assert.match(

--- a/test/run.js
+++ b/test/run.js
@@ -50950,6 +50950,28 @@ test('captcha detection binds the selected widget to its own response field', as
     );
     assert.equal(selected.responseFieldIndex, 1, `${build}: selected response field index was not preserved`);
     assert.equal(selected.callbackName, 'onActiveCaptcha', `${build}: selected callback was not preserved`);
+
+    const hcaptchaField = captchaEl('textarea', {
+      id: 'h-captcha-response-active',
+      name: 'h-captcha-response',
+    });
+    const compatibilityField = captchaEl('textarea', {
+      id: 'g-recaptcha-response-hcaptcha-active',
+      name: 'g-recaptcha-response',
+    });
+    const hcaptcha = await detectCaptchaOnFakePage(build, [
+      captchaEl('div', {
+        class: 'h-captcha',
+        'data-sitekey': 'HKEY_ACTIVE_WIDGET',
+      }, [hcaptchaField, compatibilityField]),
+    ]);
+    assert.equal(hcaptcha.responseFieldIndex, 0, `${build}: hCaptcha primary field index missing`);
+    assert.equal(
+      hcaptcha.alsoResponseFieldId,
+      'g-recaptcha-response-hcaptcha-active',
+      `${build}: hCaptcha compatibility field identity missing`,
+    );
+    assert.equal(hcaptcha.alsoResponseFieldIndex, 0, `${build}: hCaptcha compatibility field index missing`);
   }
 });
 
@@ -51949,6 +51971,66 @@ test('captcha token injection revalidates the selected frame and calls one match
       assert.equal(hiddenCallbackToken, null, `${build}: hidden widget callback was invoked`);
       assert.equal(modalCallbackToken, 'TOKEN_MODAL_WIDGET', `${build}: selected callback was not invoked`);
 
+      const canonicalHcaptchaResponse = makeResponse('h-captcha-response-only');
+      let createdCompatibilityResponse = null;
+      const hcaptchaHost = {
+        getAttribute: (name) => name === 'data-sitekey' ? 'HKEY_CANONICAL_ONLY' : null,
+      };
+      const hcaptchaDocument = {
+        querySelector: () => null,
+        querySelectorAll: (selector) => {
+          if (selector.includes('h-captcha-response')) return [canonicalHcaptchaResponse];
+          if (selector.includes('g-recaptcha-response')) return [];
+          if (selector.includes('[data-sitekey]')) return [hcaptchaHost];
+          return [];
+        },
+        createElement: () => makeResponse(''),
+        body: {
+          appendChild: (element) => {
+            createdCompatibilityResponse = element;
+          },
+        },
+        documentElement: { appendChild: () => {} },
+      };
+      const hcaptchaWindow = {
+        location: { href: 'https://example.test/hcaptcha' },
+        performance: { timeOrigin: 123456789 },
+        Event: globalThis.Event,
+        HTMLTextAreaElement: globalThis.HTMLTextAreaElement,
+        HTMLInputElement: globalThis.HTMLInputElement,
+      };
+      const canonicalOnlyHcaptcha = runtime.injectCaptchaTokenInPage({
+        fieldName: 'h-captcha-response',
+        alsoSet: 'g-recaptcha-response',
+        token: 'TOKEN_HCAPTCHA_CANONICAL_ONLY',
+        target: {
+          frameId: 9,
+          frameUrl: hcaptchaWindow.location.href,
+          websiteKey: 'HKEY_CANONICAL_ONLY',
+          responseFieldId: 'h-captcha-response-only',
+          responseFieldIndex: 0,
+          documentTimeOrigin: 123456789,
+        },
+      }, {
+        document: hcaptchaDocument,
+        window: hcaptchaWindow,
+      });
+      assert.equal(
+        canonicalOnlyHcaptcha.success,
+        true,
+        `${build}: missing hCaptcha compatibility field aborted injection`,
+      );
+      assert.equal(
+        canonicalHcaptchaResponse.value,
+        'TOKEN_HCAPTCHA_CANONICAL_ONLY',
+        `${build}: canonical hCaptcha field was not updated`,
+      );
+      assert.equal(
+        createdCompatibilityResponse?.value,
+        'TOKEN_HCAPTCHA_CANONICAL_ONLY',
+        `${build}: missing hCaptcha compatibility field was not created`,
+      );
+
       responseFields = [response];
       captchaHosts = [host];
       const selectedFrameUrl = globalThis.location.href;
@@ -52223,6 +52305,21 @@ test('solve_captcha runtime always detects missing fields and rejects type confl
       agent,
       /callbackHint: detected\.callbackName \|\| null,[\s\S]*?responseFieldId: detected\.responseFieldId,[\s\S]*?responseFieldIndex: detected\.responseFieldIndex/,
       `${build}: selected widget identity is not carried into token injection`,
+    );
+    assert.match(
+      agent,
+      /visibilityModeApplies[\s\S]*?isInvisible != null[\s\S]*?Boolean\(isInvisible\) !== Boolean\(detected\.isInvisible\)[\s\S]*?requested isInvisible=/,
+      `${build}: explicit visibility conflicts are not rejected locally`,
+    );
+    assert.match(
+      agent,
+      /isEnterprise != null[\s\S]*?Boolean\(isEnterprise\) !== Boolean\(detected\.isEnterprise\)[\s\S]*?requested isEnterprise=/,
+      `${build}: explicit Enterprise conflicts are not rejected locally`,
+    );
+    assert.match(
+      agent,
+      /alsoResponseFieldId: detected\.alsoResponseFieldId,[\s\S]*?alsoResponseFieldIndex: detected\.alsoResponseFieldIndex/,
+      `${build}: hCaptcha compatibility field identity is not carried into injection`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -50700,6 +50700,7 @@ async function detectCaptchaOnFakePage(build, nodes) {
         document,
         location,
         URL,
+        URLSearchParams,
         innerWidth: 1280,
         innerHeight: 720,
         getComputedStyle: globalThis.getComputedStyle,
@@ -50823,6 +50824,19 @@ test('captcha detection: reCAPTCHA version, Enterprise edition and action stay i
         captchaEl('div', { class: 'h-captcha', 'data-sitekey': 'HKEY_123456' }),
       ],
       expect: { type: 'hcaptcha', websiteKey: 'HKEY_123456' },
+    },
+    {
+      label: 'URL fallback: hCaptcha site key in iframe fragment',
+      nodes: () => [
+        captchaEl('iframe', {
+          src: 'https://newassets.hcaptcha.com/captcha/v1/checkbox/hcaptcha.html#id=widget&sitekey=HKEY_FRAGMENT_123456',
+        }),
+      ],
+      expect: {
+        type: 'hcaptcha',
+        websiteKey: 'HKEY_FRAGMENT_123456',
+        detectedVia: 'url',
+      },
     },
   ];
 
@@ -51064,6 +51078,7 @@ test('Firefox detects and injects an inherited-origin srcdoc CAPTCHA through its
             window: topWindow,
             location: topWindow.location,
             URL,
+            URLSearchParams,
             Event: PageEvent,
             HTMLTextAreaElement: topWindow.HTMLTextAreaElement,
             HTMLInputElement: topWindow.HTMLInputElement,
@@ -51636,6 +51651,7 @@ test('captcha injection wrappers target the selected frame in both builds', asyn
       target: { frameId: 11, frameUrl: 'https://example.test/captcha', websiteKey: 'KEY' },
     });
     assert.equal(firefoxCall.frameId, 11, 'Firefox injection did not target selected frameId');
+    assert.equal(firefoxCall.matchAboutBlank, true, 'Firefox injection did not enable inherited-origin matching');
     assert.equal(firefoxResult.frameId, 11, 'Firefox injection result lost frameId');
     firefoxCall = null;
     const firefoxUntargeted = await firefoxMod.injectToken(2, {

--- a/test/run.js
+++ b/test/run.js
@@ -51812,6 +51812,7 @@ test('captcha token injection revalidates the selected frame and calls one match
       globalThis.location = { href: 'https://example.test/checkpoint/captcha' };
       globalThis.window = {
         onCaptchaSolved: (token) => { callbackToken = token; },
+        performance: { timeOrigin: 123456789 },
       };
       globalThis.Event = class {
         constructor(type, options) { this.type = type; this.bubbles = options?.bubbles; }
@@ -51844,6 +51845,43 @@ test('captcha token injection revalidates the selected frame and calls one match
       assert.equal(injected.calledCallback, true, `${build}: unique callback was not invoked`);
       assert.equal(callbackToken, 'TOKEN_123', `${build}: callback received wrong token`);
       assert.equal(response.value, 'TOKEN_123', `${build}: response field was not set`);
+
+      const selectedFrameUrl = globalThis.location.href;
+      globalThis.location.href = `${selectedFrameUrl}?step=verify#captcha`;
+      response.value = '';
+      const sameDocumentUrlChange = runtime.injectCaptchaTokenInPage({
+        fieldName: 'g-recaptcha-response',
+        token: 'TOKEN_SPA_URL',
+        target: {
+          frameId: 9,
+          frameUrl: selectedFrameUrl,
+          websiteKey: 'KEY_ACTIVE',
+          documentTimeOrigin: 123456789,
+        },
+      });
+      assert.equal(
+        sameDocumentUrlChange.success,
+        true,
+        `${build}: same-document query/hash change blocked injection`,
+      );
+      assert.equal(response.value, 'TOKEN_SPA_URL', `${build}: SPA token was not injected`);
+
+      response.value = '';
+      globalThis.window.performance.timeOrigin = 987654321;
+      const replacedDocument = runtime.injectCaptchaTokenInPage({
+        fieldName: 'g-recaptcha-response',
+        token: 'TOKEN_REPLACED_DOCUMENT',
+        target: {
+          frameId: 9,
+          frameUrl: globalThis.location.href,
+          websiteKey: 'KEY_ACTIVE',
+          documentTimeOrigin: 123456789,
+        },
+      });
+      assert.equal(replacedDocument.success, false, `${build}: replacement document accepted a stale token`);
+      assert.equal(replacedDocument.staleTarget, true, `${build}: replacement document was not marked stale`);
+      assert.equal(response.value, '', `${build}: stale document token touched the field`);
+      globalThis.window.performance.timeOrigin = 123456789;
 
       declaredCallbackEnabled = false;
       callbackToken = null;
@@ -52060,6 +52098,16 @@ test('solve_captcha runtime always detects missing fields and rejects type confl
       agent,
       /explicitWebsiteKey: detected\.explicitWebsiteKey === true/,
       `${build}: explicit Turnstile key marker is not carried into token injection`,
+    );
+    assert.match(
+      agent,
+      /const wantInject = args\?\.inject !== false && type !== 'image_to_text';[\s\S]*?if \(wantInject && !detected\) \{[\s\S]*?no safe injection target could be verified[\s\S]*?\}[\s\S]*?dispatched = true;/,
+      `${build}: targetless default injection is not rejected before paid dispatch`,
+    );
+    assert.match(
+      agent,
+      /documentTimeOrigin: detected\.documentTimeOrigin/,
+      `${build}: selected document identity is not carried into token injection`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -52148,8 +52148,27 @@ test('captcha token injection revalidates the selected frame and calls one match
       assert.equal(hiddenCallbackToken, null, `${build}: hidden widget callback was invoked`);
       assert.equal(modalCallbackToken, 'TOKEN_MODAL_WIDGET', `${build}: selected callback was not invoked`);
 
+      hiddenResponse.value = '';
+      modalResponse.value = '';
+      const staleFieldId = runtime.injectCaptchaTokenInPage({
+        fieldName: 'g-recaptcha-response',
+        token: 'TOKEN_STALE_FIELD_ID',
+        target: {
+          frameId: 9,
+          frameUrl: globalThis.location.href,
+          websiteKey: 'KEY_SHARED_WIDGET',
+          responseFieldId: 'g-recaptcha-response-removed',
+          responseFieldIndex: 1,
+        },
+      });
+      assert.equal(staleFieldId.success, false, `${build}: missing selected field ID fell back to an index`);
+      assert.equal(staleFieldId.staleTarget, true, `${build}: missing selected field ID was not marked stale`);
+      assert.equal(hiddenResponse.value, '', `${build}: stale field ID touched the first response field`);
+      assert.equal(modalResponse.value, '', `${build}: stale field ID touched the old indexed response field`);
+
       const canonicalHcaptchaResponse = makeResponse('h-captcha-response-only');
       let createdCompatibilityResponse = null;
+      let hcaptchaCompatibilityResponses = [];
       const hcaptchaHost = {
         getAttribute: (name) => name === 'data-sitekey' ? 'HKEY_CANONICAL_ONLY' : null,
       };
@@ -52157,7 +52176,7 @@ test('captcha token injection revalidates the selected frame and calls one match
         querySelector: () => null,
         querySelectorAll: (selector) => {
           if (selector.includes('h-captcha-response')) return [canonicalHcaptchaResponse];
-          if (selector.includes('g-recaptcha-response')) return [];
+          if (selector.includes('g-recaptcha-response')) return hcaptchaCompatibilityResponses;
           if (selector.includes('[data-sitekey]')) return [hcaptchaHost];
           return [];
         },
@@ -52207,6 +52226,56 @@ test('captcha token injection revalidates the selected frame and calls one match
         'TOKEN_HCAPTCHA_CANONICAL_ONLY',
         `${build}: missing hCaptcha compatibility field was not created`,
       );
+
+      const firstCompatibilityResponse = makeResponse('g-recaptcha-response-first');
+      const secondCompatibilityResponse = makeResponse('g-recaptcha-response-second');
+      hcaptchaCompatibilityResponses = [firstCompatibilityResponse, secondCompatibilityResponse];
+      canonicalHcaptchaResponse.value = '';
+      createdCompatibilityResponse = null;
+      const ambiguousCompatibilityHcaptcha = runtime.injectCaptchaTokenInPage({
+        fieldName: 'h-captcha-response',
+        alsoSet: 'g-recaptcha-response',
+        token: 'TOKEN_HCAPTCHA_AMBIGUOUS_COMPATIBILITY',
+        target: {
+          frameId: 9,
+          frameUrl: hcaptchaWindow.location.href,
+          websiteKey: 'HKEY_CANONICAL_ONLY',
+          responseFieldId: 'h-captcha-response-only',
+          responseFieldIndex: 0,
+          documentTimeOrigin: 123456789,
+        },
+      }, {
+        document: hcaptchaDocument,
+        window: hcaptchaWindow,
+      });
+      assert.equal(
+        ambiguousCompatibilityHcaptcha.success,
+        true,
+        `${build}: ambiguous hCaptcha compatibility fields aborted canonical injection`,
+      );
+      assert.deepEqual(
+        ambiguousCompatibilityHcaptcha.fieldsUpdated,
+        ['h-captcha-response'],
+        `${build}: skipped compatibility field was reported as updated`,
+      );
+      assert.equal(
+        ambiguousCompatibilityHcaptcha.compatibilityFieldSkipped,
+        true,
+        `${build}: compatibility-field skip was not reported`,
+      );
+      assert.match(
+        ambiguousCompatibilityHcaptcha.compatibilityFieldError,
+        /Multiple CAPTCHA response fields/,
+        `${build}: compatibility-field ambiguity diagnostic missing`,
+      );
+      assert.equal(
+        canonicalHcaptchaResponse.value,
+        'TOKEN_HCAPTCHA_AMBIGUOUS_COMPATIBILITY',
+        `${build}: canonical hCaptcha field was not updated after compatibility ambiguity`,
+      );
+      assert.equal(firstCompatibilityResponse.value, '', `${build}: first ambiguous compatibility field was updated`);
+      assert.equal(secondCompatibilityResponse.value, '', `${build}: second ambiguous compatibility field was updated`);
+      assert.equal(createdCompatibilityResponse, null, `${build}: ambiguous compatibility field was recreated`);
 
       responseFields = [response];
       captchaHosts = [host];

--- a/test/run.js
+++ b/test/run.js
@@ -52303,6 +52303,11 @@ test('solve_captcha runtime always detects missing fields and rejects type confl
     );
     assert.match(
       agent,
+      /try \{\s*detection = await detectCaptcha\(tabId, \{ type, frameUrl, websiteKey \}\);[\s\S]*?catch \(detectionError\) \{[\s\S]*?args\?\.inject === false && !!type && !!websiteKey[\s\S]*?CAPTCHA frame detection failed before dispatch/,
+      `${build}: a detection exception still blocks a fully explicit token-only solve`,
+    );
+    assert.match(
+      agent,
       /callbackHint: detected\.callbackName \|\| null,[\s\S]*?responseFieldId: detected\.responseFieldId,[\s\S]*?responseFieldIndex: detected\.responseFieldIndex/,
       `${build}: selected widget identity is not carried into token injection`,
     );

--- a/test/run.js
+++ b/test/run.js
@@ -50905,12 +50905,43 @@ test('captcha detection ranks a visible nested v2 Enterprise challenge above bac
       const mod = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-solver.js`)).href);
       if (build === 'chrome') {
         globalThis.chrome = {
+          webNavigation: {
+            getAllFrames: async () => [
+              { frameId: 0, parentFrameId: -1, url: topCandidate.frameUrl },
+              { frameId: 12, parentFrameId: 0, url: activeCandidate.frameUrl },
+            ],
+          },
           scripting: {
             executeScript: async ({ target }) => {
               assert.equal(target.allFrames, true, 'Chrome detector did not scan all frames');
               return [
-                { frameId: 0, result: [topCandidate] },
-                { frameId: 12, result: [activeCandidate] },
+                {
+                  frameId: 0,
+                  result: {
+                    candidates: [topCandidate],
+                    frameContext: {
+                      frameUrl: topCandidate.frameUrl,
+                      frameName: '',
+                      childFrames: [{
+                        url: activeCandidate.frameUrl,
+                        loadedUrl: activeCandidate.frameUrl,
+                        name: 'captcha-internal',
+                        visible: true,
+                      }],
+                    },
+                  },
+                },
+                {
+                  frameId: 12,
+                  result: {
+                    candidates: [activeCandidate],
+                    frameContext: {
+                      frameUrl: activeCandidate.frameUrl,
+                      frameName: 'captcha-internal',
+                      childFrames: [],
+                    },
+                  },
+                },
               ];
             },
           },
@@ -50919,14 +50950,28 @@ test('captcha detection ranks a visible nested v2 Enterprise challenge above bac
         globalThis.browser = {
           webNavigation: {
             getAllFrames: async () => [
-              { frameId: 0, url: topCandidate.frameUrl },
-              { frameId: 12, url: activeCandidate.frameUrl },
+              { frameId: 0, parentFrameId: -1, url: topCandidate.frameUrl },
+              { frameId: 12, parentFrameId: 0, url: activeCandidate.frameUrl },
             ],
           },
           tabs: {
-            executeScript: async (_tabId, details) => [
-              details.frameId === 12 ? [activeCandidate] : [topCandidate],
-            ],
+            executeScript: async (_tabId, details) => [{
+              candidates: details.frameId === 12 ? [activeCandidate] : [topCandidate],
+              frameContext: details.frameId === 12 ? {
+                frameUrl: activeCandidate.frameUrl,
+                frameName: 'captcha-internal',
+                childFrames: [],
+              } : {
+                frameUrl: topCandidate.frameUrl,
+                frameName: '',
+                childFrames: [{
+                  url: activeCandidate.frameUrl,
+                  loadedUrl: activeCandidate.frameUrl,
+                  name: 'captcha-internal',
+                  visible: true,
+                }],
+              },
+            }],
           },
         };
       }
@@ -50943,6 +50988,93 @@ test('captcha detection ranks a visible nested v2 Enterprise challenge above bac
   } finally {
     globalThis.chrome = previous.chrome;
     globalThis.browser = previous.browser;
+  }
+});
+
+test('captcha frame visibility propagation demotes descendants of hidden embedding frames', async () => {
+  for (const build of ['chrome', 'firefox']) {
+    const runtime = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-frame-runtime.js`)).href);
+    const visibleCandidate = {
+      frameId: 0,
+      frameUrl: 'https://example.test/form',
+      type: 'recaptcha_v2',
+      websiteKey: 'KEY_VISIBLE',
+      visible: true,
+      normalCheckbox: true,
+      detectedVia: 'host',
+    };
+    const nestedCandidate = {
+      frameId: 12,
+      frameUrl: 'https://example.test/checkpoint/challenge/captchaInternal',
+      type: 'recaptcha_v2_enterprise',
+      websiteKey: 'KEY_HIDDEN_NESTED',
+      visible: true,
+      normalCheckbox: true,
+      challengeFrame: true,
+      detectedVia: 'host',
+    };
+    const navigationFrames = [
+      { frameId: 0, parentFrameId: -1, url: visibleCandidate.frameUrl },
+      { frameId: 7, parentFrameId: 0, url: 'https://example.test/hidden-wrapper' },
+      { frameId: 12, parentFrameId: 7, url: nestedCandidate.frameUrl },
+    ];
+    const frameContexts = [
+      {
+        frameId: 0,
+        frameUrl: visibleCandidate.frameUrl,
+        frameName: '',
+        childFrames: [{
+          url: 'https://example.test/hidden-wrapper',
+          loadedUrl: 'https://example.test/hidden-wrapper',
+          name: 'wrapper',
+          visible: false,
+        }],
+      },
+      {
+        frameId: 7,
+        frameUrl: 'https://example.test/hidden-wrapper',
+        frameName: 'wrapper',
+        childFrames: [{
+          url: nestedCandidate.frameUrl,
+          loadedUrl: nestedCandidate.frameUrl,
+          name: 'captcha-internal',
+          visible: true,
+        }],
+      },
+      {
+        frameId: 12,
+        frameUrl: nestedCandidate.frameUrl,
+        frameName: 'captcha-internal',
+        childFrames: [],
+      },
+    ];
+
+    const hiddenAdjusted = runtime.applyCaptchaFrameVisibility(
+      [visibleCandidate, nestedCandidate],
+      frameContexts,
+      navigationFrames,
+    );
+    assert.equal(hiddenAdjusted[1].frameVisible, false, `${build}: hidden ancestor was ignored`);
+    assert.equal(hiddenAdjusted[1].visible, false, `${build}: nested widget remained visible`);
+    assert.equal(hiddenAdjusted[1].normalCheckbox, false, `${build}: nested checkbox remained active`);
+    assert.equal(
+      runtime.selectCaptchaCandidate(hiddenAdjusted).selected.websiteKey,
+      'KEY_VISIBLE',
+      `${build}: hidden nested CAPTCHA outranked the visible candidate`,
+    );
+
+    frameContexts[0].childFrames[0].visible = true;
+    const visibleAdjusted = runtime.applyCaptchaFrameVisibility(
+      [visibleCandidate, nestedCandidate],
+      frameContexts,
+      navigationFrames,
+    );
+    assert.equal(visibleAdjusted[1].frameVisible, true, `${build}: visible ancestor chain was demoted`);
+    assert.equal(
+      runtime.selectCaptchaCandidate(visibleAdjusted).selected.websiteKey,
+      'KEY_HIDDEN_NESTED',
+      `${build}: visible nested challenge was not restored`,
+    );
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -51558,7 +51558,7 @@ test('captcha candidate ranking fails closed on ties and honors exact targeting'
     const tied = runtime.selectCaptchaCandidate(candidates);
     assert.equal(tied.selected, null, `${build}: tied candidates were auto-selected`);
     assert.equal(tied.ambiguous, true, `${build}: tie was not marked ambiguous`);
-    assert.match(tied.error, /exact frameUrl or websiteKey/, `${build}: tie remedy missing`);
+    assert.match(tied.error, /exact .*frameUrl.*websiteKey/, `${build}: tie remedy missing`);
     assert.equal(tied.candidates[0].pageAction, 'signup', `${build}: candidate action diagnostic missing`);
     assert.equal(tied.candidates[0].recaptchaDataSValue, 'classic-s', `${build}: candidate s diagnostic missing`);
 
@@ -51568,6 +51568,75 @@ test('captcha candidate ranking fails closed on ties and honors exact targeting'
 
     const byKey = runtime.selectCaptchaCandidate(candidates, { websiteKey: 'KEY_A' });
     assert.equal(byKey.selected.frameId, 4, `${build}: exact websiteKey did not select candidate`);
+
+    const repeatedFrameCandidates = [
+      {
+        ...candidates[0],
+        frameId: 21,
+        frameUrl: 'https://example.test/repeated-frame',
+        websiteKey: 'KEY_REPEATED',
+        responseFieldId: 'response-repeated-a',
+      },
+      {
+        ...candidates[0],
+        frameId: 22,
+        frameUrl: 'https://example.test/repeated-frame',
+        websiteKey: 'KEY_REPEATED',
+        responseFieldId: 'response-repeated-b',
+      },
+    ];
+    const repeatedFrameTie = runtime.selectCaptchaCandidate(repeatedFrameCandidates);
+    assert.match(
+      repeatedFrameTie.error,
+      /exact frameId/,
+      `${build}: same-URL same-key tie did not offer frameId`,
+    );
+    assert.doesNotMatch(
+      repeatedFrameTie.error,
+      /exact frameUrl|exact websiteKey/,
+      `${build}: tie suggested a non-unique URL or key`,
+    );
+    const byFrameId = runtime.selectCaptchaCandidate(repeatedFrameCandidates, { frameId: 22 });
+    assert.equal(byFrameId.selected.frameId, 22, `${build}: exact frameId did not select candidate`);
+    assert.equal(byFrameId.selected.selectionReason, 'exact frameId match', `${build}: frameId reason missing`);
+
+    const inheritedCandidates = [
+      {
+        ...candidates[0],
+        frameId: 0,
+        frameUrl: 'about:srcdoc',
+        websiteKey: 'KEY_INHERITED_REPEAT',
+        framePath: [{ index: 0, frameUrl: 'about:srcdoc' }],
+      },
+      {
+        ...candidates[0],
+        frameId: 0,
+        frameUrl: 'about:srcdoc',
+        websiteKey: 'KEY_INHERITED_REPEAT',
+        framePath: [{ index: 1, frameUrl: 'about:srcdoc' }],
+      },
+    ];
+    const inheritedTie = runtime.selectCaptchaCandidate(inheritedCandidates);
+    assert.match(inheritedTie.error, /exact framePath/, `${build}: inherited tie did not offer framePath`);
+    assert.deepEqual(
+      inheritedTie.candidates.map(candidate => candidate.framePathIndexes),
+      [[0], [1]],
+      `${build}: framePath index diagnostics missing`,
+    );
+    const byFramePath = runtime.selectCaptchaCandidate(inheritedCandidates, {
+      frameId: 0,
+      framePath: [1],
+    });
+    assert.deepEqual(
+      byFramePath.selected.framePath,
+      inheritedCandidates[1].framePath,
+      `${build}: exact framePath did not select candidate`,
+    );
+    assert.equal(
+      byFramePath.selected.selectionReason,
+      'exact framePath match',
+      `${build}: combined frame identity reason was not deterministic`,
+    );
 
     const hiddenChallenge = {
       frameId: 7,
@@ -51796,9 +51865,10 @@ test('captcha task builders propagate frame URL and optional reCAPTCHA parameter
   }
 });
 
-test('captcha website URL uses only HTTP(S) frame URLs and otherwise keeps the top-level URL', async () => {
+test('captcha website URL uses the selected HTTP frame or nearest HTTP ancestor', async () => {
   for (const build of ['chrome', 'firefox']) {
     const mod = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-solver.js`)).href);
+    const runtime = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-frame-runtime.js`)).href);
     const topLevelUrl = 'https://example.test/form';
     assert.equal(
       mod.captchaWebsiteUrl('https://example.test/checkpoint/captcha', topLevelUrl),
@@ -51814,6 +51884,57 @@ test('captcha website URL uses only HTTP(S) frame URLs and otherwise keeps the t
       mod.captchaWebsiteUrl('about:srcdoc', topLevelUrl),
       topLevelUrl,
       `${build}: about:srcdoc replaced the usable website URL`,
+    );
+    const challengeUrl = 'https://captcha.vendor.test/challenge';
+    const opaqueCandidate = {
+      frameId: 12,
+      frameUrl: 'about:srcdoc',
+      type: 'recaptcha_v2',
+      websiteKey: 'KEY_OPAQUE_NESTED',
+      visible: true,
+      normalCheckbox: true,
+    };
+    const opaqueAdjusted = runtime.applyCaptchaFrameVisibility(
+      [opaqueCandidate],
+      [
+        {
+          frameId: 0,
+          frameUrl: topLevelUrl,
+          childFrames: [{
+            url: challengeUrl,
+            loadedUrl: challengeUrl,
+            name: 'challenge',
+            visible: true,
+          }],
+        },
+        {
+          frameId: 7,
+          frameUrl: challengeUrl,
+          frameName: 'challenge',
+          childFrames: [{
+            url: 'about:srcdoc',
+            loadedUrl: 'about:srcdoc',
+            name: 'opaque',
+            visible: true,
+          }],
+        },
+        {
+          frameId: 12,
+          frameUrl: 'about:srcdoc',
+          frameName: 'opaque',
+          childFrames: [],
+        },
+      ],
+      [
+        { frameId: 0, parentFrameId: -1, url: topLevelUrl },
+        { frameId: 7, parentFrameId: 0, url: challengeUrl },
+        { frameId: 12, parentFrameId: 7, url: 'about:srcdoc' },
+      ],
+    );
+    assert.equal(
+      opaqueAdjusted[0].websiteURL,
+      challengeUrl,
+      `${build}: opaque frame did not inherit its nearest HTTP ancestor URL`,
     );
   }
 });
@@ -52258,7 +52379,7 @@ test('solve_captcha runtime always detects missing fields and rejects type confl
     const agent = fs.readFileSync(path.join(ROOT, `src/${build}/src/agent/agent.js`), 'utf8');
     assert.match(
       agent,
-      /if \(type !== 'image_to_text'\) \{[\s\S]*?detectCaptcha\(tabId, \{ type, frameUrl, websiteKey \}\)/,
+      /if \(type !== 'image_to_text'\) \{[\s\S]*?detectCaptcha\(tabId, \{\s*type,\s*frameUrl,\s*frameId,\s*framePath,\s*websiteKey,/,
       `${build}: solve_captcha does not run frame-aware detection when type is supplied`,
     );
     assert.match(
@@ -52303,8 +52424,13 @@ test('solve_captcha runtime always detects missing fields and rejects type confl
     );
     assert.match(
       agent,
-      /try \{\s*detection = await detectCaptcha\(tabId, \{ type, frameUrl, websiteKey \}\);[\s\S]*?catch \(detectionError\) \{[\s\S]*?args\?\.inject === false && !!type && !!websiteKey[\s\S]*?CAPTCHA frame detection failed before dispatch/,
+      /try \{\s*detection = await detectCaptcha\(tabId, \{[\s\S]*?frameId,[\s\S]*?framePath,[\s\S]*?websiteKey,[\s\S]*?\}\);[\s\S]*?catch \(detectionError\) \{[\s\S]*?args\?\.inject === false && !!type && !!websiteKey[\s\S]*?CAPTCHA frame detection failed before dispatch/,
       `${build}: a detection exception still blocks a fully explicit token-only solve`,
+    );
+    assert.match(
+      agent,
+      /websiteURL = detected\.websiteURL \|\| captchaWebsiteUrl\(detected\.frameUrl, websiteURL\)/,
+      `${build}: nearest HTTP ancestor URL is not used for opaque selected frames`,
     );
     assert.match(
       agent,

--- a/test/run.js
+++ b/test/run.js
@@ -50991,6 +50991,112 @@ test('captcha detection ranks a visible nested v2 Enterprise challenge above bac
   }
 });
 
+test('Firefox detects and injects an inherited-origin srcdoc CAPTCHA through its parent frame', async () => {
+  const firefoxMod = await import(pathToFileURL(path.join(ROOT, 'src/firefox/src/agent/captcha-solver.js')).href);
+  const response = captchaEl('textarea', { name: 'g-recaptcha-response' });
+  response.value = '';
+  response.textContent = '';
+  const childNodes = [
+    captchaEl('div', { class: 'g-recaptcha', 'data-sitekey': 'KEY_SRCDOC' }),
+    captchaEl('script', { src: 'https://www.google.com/recaptcha/api.js' }),
+    response,
+  ];
+  const makeDocument = (nodes) => ({
+    querySelector: (selector) => captchaMatchAll(nodes, selector)[0] || null,
+    querySelectorAll: (selector) => captchaMatchAll(nodes, selector),
+    createElement: () => captchaEl('textarea'),
+    body: { appendChild: () => {} },
+    documentElement: { appendChild: () => {} },
+  });
+  const childDocument = makeDocument(childNodes);
+  const PageEvent = class {
+    constructor(type, options) {
+      this.type = type;
+      this.bubbles = options?.bubbles;
+    }
+  };
+  const childWindow = {
+    location: { href: 'about:srcdoc' },
+    name: 'captcha-srcdoc',
+    innerWidth: 800,
+    innerHeight: 600,
+    getComputedStyle: () => ({ display: 'block', visibility: 'visible', opacity: '1' }),
+    Event: PageEvent,
+    HTMLTextAreaElement: class {},
+    HTMLInputElement: class {},
+  };
+  const iframe = captchaEl('iframe', {
+    srcdoc: '<div class="g-recaptcha"></div>',
+    name: 'captcha-srcdoc',
+  });
+  iframe.name = 'captcha-srcdoc';
+  iframe.hasAttribute = (name) => name === 'srcdoc';
+  iframe.contentDocument = childDocument;
+  iframe.contentWindow = childWindow;
+
+  const topDocument = makeDocument([iframe]);
+  const topWindow = {
+    location: { href: 'https://example.test/form' },
+    name: '',
+    innerWidth: 1280,
+    innerHeight: 720,
+    getComputedStyle: () => ({ display: 'block', visibility: 'visible', opacity: '1' }),
+    Event: PageEvent,
+    HTMLTextAreaElement: class {},
+    HTMLInputElement: class {},
+  };
+  const previousBrowser = globalThis.browser;
+  let sawBlankMatching = false;
+  try {
+    globalThis.browser = {
+      webNavigation: {
+        getAllFrames: async () => [
+          { frameId: 0, parentFrameId: -1, url: topWindow.location.href },
+          { frameId: 7, parentFrameId: 0, url: 'about:srcdoc' },
+        ],
+      },
+      tabs: {
+        executeScript: async (_tabId, details) => {
+          if (details.matchAboutBlank) sawBlankMatching = true;
+          if (details.frameId === 7) throw new Error('Firefox cannot inject directly into srcdoc');
+          return [vm.runInNewContext(details.code, {
+            document: topDocument,
+            window: topWindow,
+            location: topWindow.location,
+            URL,
+            Event: PageEvent,
+            HTMLTextAreaElement: topWindow.HTMLTextAreaElement,
+            HTMLInputElement: topWindow.HTMLInputElement,
+          })];
+        },
+      },
+    };
+
+    const detection = await firefoxMod.detectCaptcha(91);
+    assert.equal(sawBlankMatching, true, 'Firefox detector did not request about:blank matching');
+    assert.equal(detection.error, null, 'srcdoc CAPTCHA detection failed');
+    assert.equal(detection.selected.websiteKey, 'KEY_SRCDOC', 'srcdoc site key was lost');
+    assert.equal(detection.selected.frameUrl, 'about:srcdoc', 'srcdoc frame URL was lost');
+    assert.equal(detection.selected.frameId, 0, 'srcdoc fallback did not retain its injectable parent frame');
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(detection.selected.framePath)),
+      [{ index: 0, frameUrl: 'about:srcdoc', frameName: 'captcha-srcdoc' }],
+      'srcdoc frame path was not retained',
+    );
+
+    const injection = await firefoxMod.injectToken(91, {
+      fieldName: 'g-recaptcha-response',
+      token: 'TOKEN_SRCDOC',
+      target: detection.selected,
+    });
+    assert.equal(injection.success, true, 'srcdoc token injection through the parent failed');
+    assert.equal(injection.frameUrl, 'about:srcdoc', 'srcdoc injection ran in the wrong frame');
+    assert.equal(response.value, 'TOKEN_SRCDOC', 'srcdoc response field was not updated');
+  } finally {
+    globalThis.browser = previousBrowser;
+  }
+});
+
 test('captcha frame visibility propagation demotes descendants of hidden embedding frames', async () => {
   for (const build of ['chrome', 'firefox']) {
     const runtime = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-frame-runtime.js`)).href);
@@ -51202,6 +51308,28 @@ test('captcha task builders propagate frame URL and optional reCAPTCHA parameter
       recaptchaDataSValue: 'classic-s',
     });
     assert.equal(classicTask.recaptchaDataSValue, 'classic-s', `${build}: classic s value was lost`);
+  }
+});
+
+test('captcha website URL uses only HTTP(S) frame URLs and otherwise keeps the top-level URL', async () => {
+  for (const build of ['chrome', 'firefox']) {
+    const mod = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-solver.js`)).href);
+    const topLevelUrl = 'https://example.test/form';
+    assert.equal(
+      mod.captchaWebsiteUrl('https://example.test/checkpoint/captcha', topLevelUrl),
+      'https://example.test/checkpoint/captcha',
+      `${build}: HTTP frame URL was not used`,
+    );
+    assert.equal(
+      mod.captchaWebsiteUrl('about:blank', topLevelUrl),
+      topLevelUrl,
+      `${build}: about:blank replaced the usable website URL`,
+    );
+    assert.equal(
+      mod.captchaWebsiteUrl('about:srcdoc', topLevelUrl),
+      topLevelUrl,
+      `${build}: about:srcdoc replaced the usable website URL`,
+    );
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -51529,6 +51529,62 @@ test('captcha frame visibility propagation demotes descendants of hidden embeddi
       'KEY_REDIRECTED',
       `${build}: redirected visible CAPTCHA lost to another candidate`,
     );
+
+    const unmatchedOpaqueCandidate = {
+      ...nestedCandidate,
+      frameId: 31,
+      frameUrl: 'about:blank',
+      websiteKey: 'KEY_UNMATCHED_OPAQUE',
+    };
+    const unmatchedOpaqueAdjusted = runtime.applyCaptchaFrameVisibility(
+      [visibleCandidate, unmatchedOpaqueCandidate],
+      [
+        {
+          frameId: 0,
+          frameUrl: visibleCandidate.frameUrl,
+          frameName: '',
+          childFrames: [
+            {
+              url: 'about:blank',
+              loadedUrl: 'about:blank',
+              name: '',
+              visible: true,
+            },
+            {
+              url: 'about:blank',
+              loadedUrl: 'about:blank',
+              name: '',
+              visible: false,
+            },
+          ],
+        },
+        {
+          frameId: 31,
+          frameUrl: 'about:blank',
+          frameName: '',
+          childFrames: [],
+        },
+      ],
+      [
+        { frameId: 0, parentFrameId: -1, url: visibleCandidate.frameUrl },
+        { frameId: 31, parentFrameId: 0, url: 'about:blank' },
+      ],
+    );
+    assert.equal(
+      unmatchedOpaqueAdjusted[1].frameVisible,
+      false,
+      `${build}: unmatched opaque child was promoted to visible`,
+    );
+    assert.equal(
+      unmatchedOpaqueAdjusted[1].visible,
+      false,
+      `${build}: unmatched opaque CAPTCHA remained active`,
+    );
+    assert.equal(
+      runtime.selectCaptchaCandidate(unmatchedOpaqueAdjusted).selected.websiteKey,
+      'KEY_VISIBLE',
+      `${build}: unmatched opaque CAPTCHA displaced the proven visible widget`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

- scan and rank CAPTCHA candidates independently across every browser frame
- select active visible challenges over hidden/background integrations and fail closed on genuine ties
- build CapSolver tasks from the selected frame URL, site key, Enterprise type, action, and optional `s`/`sa` parameters
- inject returned tokens only into the revalidated selected frame and report field/callback status without claiming the challenge cleared
- keep Chrome and Firefox behavior mirrored

## Why

Pages can load multiple competing CAPTCHA integrations. In the reported LinkedIn flow, a hidden top-frame reCAPTCHA v3 Enterprise integration was selected instead of the visible reCAPTCHA v2 Enterprise checkbox in a nested challenge frame. That produced the wrong task parameters and prevented a correct solve attempt.

## Impact

`solve_captcha` now targets the active nested widget generically, avoids paid dispatch on ambiguity or parameter conflicts, and returns the token without unsafe injection if the selected frame becomes stale or cannot be identified.

## Validation

- `node test/run.js`: 1283 passed; 1 pre-existing repository failure because `package.json` is `25.9.2` while the newest changelog entry remains `25.9.0`
- `npm run test:security`: 60/60 passed
- syntax checks, `git diff --check`, and Chrome/Firefox frame-runtime byte parity passed
- no live paid CapSolver call was made