### PR TITLE
ui: fade the chat nav pill when idle, link the settings title

### DIFF
--- a/src/chrome/src/ui/settings.html
+++ b/src/chrome/src/ui/settings.html
@@ -54,6 +54,13 @@
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
     }
+    /* The title sits where a logo would, so it takes a pointer without
+       looking like a link or losing the gradient fill. */
+    h1 a {
+      color: inherit;
+      text-decoration: none;
+      -webkit-text-fill-color: inherit;
+    }
     .subtitle { color: var(--text2); font-size: 13px; margin-bottom: 24px; }
 
     .header-row {
@@ -1100,7 +1107,7 @@
 <body>
   <div class="header-row">
     <div>
-      <h1 data-i18n="st.title"></h1>
+      <h1><a id="settings-title-link" href="#" data-i18n="st.title"></a></h1>
       <p class="subtitle" id="subtitle"></p>
     </div>
     <a class="support-link" href="https://webbrain.one/docs" target="_blank" rel="noopener noreferrer">

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -203,6 +203,12 @@ function renderSubtitle() {
 }
 renderSubtitle();
 
+// The heading is a link only so it gets the pointer people expect from a
+// logo; swallow the click so it never leaves a stray '#' in the URL.
+document.getElementById('settings-title-link')?.addEventListener('click', (event) => {
+  event.preventDefault();
+});
+
 function normalizeGeneralSearchText(value) {
   return String(value || '')
     .toLowerCase()

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -1083,7 +1083,7 @@ body {
   display: inline-block;
   max-width: calc(100% - 36px);
   transform: translateX(-50%);
-  transition: transform 0.15s;
+  transition: transform 0.15s, opacity 0.4s ease;
 }
 
 .chat-navigation-action {
@@ -1096,7 +1096,7 @@ body {
   padding-inline: 12px 24px;
   border: 1px solid color-mix(in srgb, var(--accent) 26%, var(--border));
   border-radius: 999px;
-  background: color-mix(in srgb, var(--bg-secondary) 94%, transparent);
+  background: var(--bg-secondary);
   color: var(--text-primary);
   box-shadow: 0 5px 18px color-mix(in srgb, var(--overlay-bg-strong) 72%, transparent);
   backdrop-filter: blur(10px);
@@ -1112,13 +1112,24 @@ body {
   display: none;
 }
 
-.chat-navigation:hover {
+.chat-navigation:hover,
+.chat-navigation:focus-within {
   transform: translate(-50%, -1px);
+  opacity: 1;
+  transition: transform 0.15s, opacity 0.12s ease;
+}
+
+/* Idle at partial opacity so the control stops competing with the reply it
+   floats over; pointing at it brings it back to full strength. */
+@media (hover: hover) {
+  .chat-navigation {
+    opacity: 0.78;
+  }
 }
 
 .chat-navigation-action:hover {
   border-color: color-mix(in srgb, var(--accent) 52%, var(--border));
-  background: var(--bg-secondary);
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg-secondary));
   color: var(--text-primary);
 }
 

--- a/src/firefox/src/ui/settings.html
+++ b/src/firefox/src/ui/settings.html
@@ -54,6 +54,13 @@
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
     }
+    /* The title sits where a logo would, so it takes a pointer without
+       looking like a link or losing the gradient fill. */
+    h1 a {
+      color: inherit;
+      text-decoration: none;
+      -webkit-text-fill-color: inherit;
+    }
     .subtitle { color: var(--text2); font-size: 13px; margin-bottom: 24px; }
 
     .header-row {
@@ -1091,7 +1098,7 @@
 <body>
   <div class="header-row">
     <div>
-      <h1 data-i18n="st.title"></h1>
+      <h1><a id="settings-title-link" href="#" data-i18n="st.title"></a></h1>
       <p class="subtitle" id="subtitle"></p>
     </div>
     <a class="support-link" href="https://webbrain.one/docs" target="_blank" rel="noopener noreferrer">

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -203,6 +203,12 @@ function renderSubtitle() {
 }
 renderSubtitle();
 
+// The heading is a link only so it gets the pointer people expect from a
+// logo; swallow the click so it never leaves a stray '#' in the URL.
+document.getElementById('settings-title-link')?.addEventListener('click', (event) => {
+  event.preventDefault();
+});
+
 function normalizeGeneralSearchText(value) {
   return String(value || '')
     .toLowerCase()

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -960,7 +960,7 @@ body {
   display: inline-block;
   max-width: calc(100% - 36px);
   transform: translateX(-50%);
-  transition: transform 0.15s;
+  transition: transform 0.15s, opacity 0.4s ease;
 }
 
 .chat-navigation-action {
@@ -973,7 +973,7 @@ body {
   padding-inline: 12px 24px;
   border: 1px solid color-mix(in srgb, var(--accent) 26%, var(--border));
   border-radius: 999px;
-  background: color-mix(in srgb, var(--bg-secondary) 94%, transparent);
+  background: var(--bg-secondary);
   color: var(--text-primary);
   box-shadow: 0 5px 18px color-mix(in srgb, var(--overlay-bg-strong) 72%, transparent);
   backdrop-filter: blur(10px);
@@ -989,13 +989,24 @@ body {
   display: none;
 }
 
-.chat-navigation:hover {
+.chat-navigation:hover,
+.chat-navigation:focus-within {
   transform: translate(-50%, -1px);
+  opacity: 1;
+  transition: transform 0.15s, opacity 0.12s ease;
+}
+
+/* Idle at partial opacity so the control stops competing with the reply it
+   floats over; pointing at it brings it back to full strength. */
+@media (hover: hover) {
+  .chat-navigation {
+    opacity: 0.78;
+  }
 }
 
 .chat-navigation-action:hover {
   border-color: color-mix(in srgb, var(--accent) 52%, var(--border));
-  background: var(--bg-secondary);
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg-secondary));
   color: var(--text-primary);
 }
 


### PR DESCRIPTION
The floating "Back to question" / "Jump to latest" control sat at full strength over the reply it overlaps. It now rests at 78% opacity and fades back to full on hover or keyboard focus — slow out, fast in. Its background goes solid so the label stays readable while dimmed, and the dimming is scoped to (hover: hover) so touch input never gets a control it cannot restore.

The Settings heading sits where a logo would, so it is now an anchor purely for the pointer cursor: no underline, gradient fill preserved, and the click is swallowed so it leaves no stray '#' in the URL.