### PR TITLE
Add recovery actions for planner provider failures

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -125,6 +125,19 @@ function isBrowserNewTabUrl(url) {
   return BROWSER_NEW_TAB_URL_PREFIXES.some(prefix => value.startsWith(prefix));
 }
 
+function plannerRequestFailureKind(detail) {
+  const text = String(detail || '');
+  const statusMatch = text.match(/\b(?:error|http|status)\s*[:#-]?\s*(\d{3})\b/i)
+    || text.match(/\b(401|403|408|425|429|5\d\d)\b/);
+  const status = Number(statusMatch?.[1] || 0);
+  if (status === 401 || status === 403) return 'auth';
+  if ([408, 425, 429].includes(status) || status >= 500) return 'transient';
+  if (/\b(?:timed?\s*out|timeout|network|fetch failed|connection (?:closed|reset|refused)|econn\w+|temporar(?:y|ily)|unavailable)\b/i.test(text)) {
+    return 'transient';
+  }
+  return 'provider';
+}
+
 /**
  * The WebBrain Agent — orchestrates multi-step LLM + tool-use loops.
  */
@@ -7282,20 +7295,31 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     };
   }
 
-  _plannerRequestFailure(error, onUpdate) {
+  _plannerRequestFailure(error, onUpdate, provider = null) {
     const detail = sanitizePlannerText(
       error?.message || String(error || 'Unknown planner request error.'),
       500,
       { collapseWhitespace: true },
     );
-    const message = `Planner request failed before a valid response was available: ${detail}`;
-    onUpdate('warning', { message });
+    const message = `Planner request failed before a valid response was available: ${detail} No tools ran.`;
+    const failureKind = plannerRequestFailureKind(detail);
+    onUpdate('warning', {
+      code: 'planner_request_failed',
+      message,
+      failureKind,
+      provider: sanitizePlannerText(
+        provider?.config?.label || provider?.name || provider?.config?.providerName || '',
+        80,
+        { collapseWhitespace: true },
+      ),
+    });
     return {
       proceed: false,
       message,
       reason: 'planner_error',
       requestKind: 'respond',
       requiresStateChange: false,
+      failureKind,
     };
   }
 
@@ -7462,7 +7486,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (this._isCostAllowanceError(e)) {
         return { proceed: false, message: e.message, reason: 'cost_limit' };
       }
-      return this._plannerRequestFailure(e, onUpdate);
+      return this._plannerRequestFailure(e, onUpdate, provider);
     }
   }
 
@@ -7660,7 +7684,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (this._isCostAllowanceError(e)) {
         return { proceed: false, message: e.message, reason: 'cost_limit' };
       }
-      return this._plannerRequestFailure(e, onUpdate);
+      return this._plannerRequestFailure(e, onUpdate, provider);
     }
   }
 

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -1380,8 +1380,17 @@ function isClarificationRequiredRunUpdate(update) {
     && update?.data?.status === 'clarification_required';
 }
 
+function isPlannerRequestFailureUpdate(update) {
+  return update?.type === 'warning'
+    && update?.data?.code === 'planner_request_failed';
+}
+
 function runUpdatesSucceeded(updates = []) {
-  return !updates.some(update => update?.type === 'error' || isClarificationRequiredRunUpdate(update));
+  return !updates.some(update => (
+    update?.type === 'error'
+    || isClarificationRequiredRunUpdate(update)
+    || isPlannerRequestFailureUpdate(update)
+  ));
 }
 
 function terminalRunUiStatus(content, updates = [], error = null) {
@@ -1389,7 +1398,7 @@ function terminalRunUiStatus(content, updates = [], error = null) {
   const text = String(content || '');
   if (/stopped by user|aborted by user/i.test(text)) return 'stopped';
   if (/before executing requested tool calls/i.test(text)) return 'cancelled';
-  if (updates.some(update => update?.type === 'error')) return 'failed';
+  if (updates.some(update => update?.type === 'error' || isPlannerRequestFailureUpdate(update))) return 'failed';
   if (updates.some(isClarificationRequiredRunUpdate)) return 'clarification_required';
   return 'completed';
 }

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -1703,10 +1703,10 @@ function releaseRetryAttachmentPayload(retryId) {
 
 function releaseRetryAttachmentsInTree(root) {
   if (!root) return;
-  if (root.matches?.('.error-retry-btn[data-retry-id], .cost-allowance-retry-btn[data-retry-id]')) {
+  if (root.matches?.('.error-retry-btn[data-retry-id], .cost-allowance-retry-btn[data-retry-id], .planner-request-failure-retry-btn[data-retry-id]')) {
     releaseRetryAttachmentPayload(root.dataset.retryId);
   }
-  root.querySelectorAll?.('.error-retry-btn[data-retry-id], .cost-allowance-retry-btn[data-retry-id]').forEach((btn) => {
+  root.querySelectorAll?.('.error-retry-btn[data-retry-id], .cost-allowance-retry-btn[data-retry-id], .planner-request-failure-retry-btn[data-retry-id]').forEach((btn) => {
     releaseRetryAttachmentPayload(btn.dataset.retryId);
   });
 }
@@ -3738,6 +3738,15 @@ async function adoptRestoredRunState(tabId, state) {
       probeFirst: true,
       requireDurableSubmittedTurn: runUi.kind !== 'continue',
     });
+    const returnedPlannerFailure = plannerRequestFailureUpdate(res?.updates);
+    if (returnedPlannerFailure && sameTabId(currentTabId, tabId) && !isTabAbortRequested(tabId)) {
+      const targetAssistantEl = assistantEl || currentAssistantEl;
+      renderPlannerRequestFailure(
+        targetAssistantEl,
+        returnedPlannerFailure.data,
+        retryPayloadForRunAssistant(targetAssistantEl),
+      );
+    }
     const returnedErrorUpdate = Array.isArray(res?.updates)
       ? res.updates.find(update => update?.type === 'error')
       : null;
@@ -5165,7 +5174,7 @@ function bindErrorRetryButton(btn) {
 }
 
 function rebindRetryButtons() {
-  document.querySelectorAll('.error-retry-btn').forEach(bindErrorRetryButton);
+  document.querySelectorAll('.error-retry-btn, .planner-request-failure-retry-btn').forEach(bindErrorRetryButton);
 }
 
 function createActiveChatPayloadState(retryPayload, requestId = '') {
@@ -5202,6 +5211,81 @@ function retryPayloadForRunAssistant(assistantEl) {
     attachments: [],
     attachmentCount: Number(assistantEl?.dataset.retryAttachmentCount || 0) || 0,
   };
+}
+
+function plannerRequestFailureUpdate(updates = []) {
+  if (!Array.isArray(updates)) return null;
+  return updates.find(update => (
+    update?.type === 'warning'
+    && update?.data?.code === 'planner_request_failed'
+  )) || null;
+}
+
+function bindPlannerProviderSettingsButton(btn) {
+  if (!btn || btn.dataset.bound) return;
+  btn.dataset.bound = 'true';
+  btn.addEventListener('click', async (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    btn.disabled = true;
+    try {
+      await openProvidersSettingsPage();
+    } finally {
+      btn.disabled = false;
+    }
+  });
+}
+
+function rebindPlannerRequestFailureControls() {
+  document.querySelectorAll('.planner-request-failure-provider-btn')
+    .forEach(bindPlannerProviderSettingsButton);
+}
+
+function renderPlannerRequestFailure(assistantEl, data, retryPayload = null) {
+  if (!assistantEl || data?.code !== 'planner_request_failed') return false;
+  const textEl = assistantEl.querySelector('.message-text');
+  if (!textEl) return false;
+  if (textEl.querySelector('.planner-request-failure-actions')) return true;
+
+  clearAssistantTextStreamState(assistantEl);
+  assistantEl.classList.add('planner-request-failure');
+  textEl.classList.add('planner-request-failure-content');
+  textEl.replaceChildren();
+
+  const message = document.createElement('div');
+  message.className = 'planner-request-failure-message';
+  message.textContent = data.message || 'Planner request failed before a valid response was available.';
+
+  const actions = document.createElement('div');
+  actions.className = 'planner-request-failure-actions';
+
+  const retryBtn = document.createElement('button');
+  retryBtn.type = 'button';
+  retryBtn.className = 'planner-request-failure-action planner-request-failure-retry-btn';
+  retryBtn.textContent = t('sp.retry');
+  retryBtn.title = t('sp.retry');
+  retryBtn.setAttribute('aria-label', t('sp.retry'));
+  const retryReady = configureRetryButton(retryBtn, retryPayload);
+
+  const providerBtn = document.createElement('button');
+  providerBtn.type = 'button';
+  providerBtn.className = 'planner-request-failure-action planner-request-failure-provider-btn';
+  providerBtn.textContent = t('st.tab.providers');
+  providerBtn.title = `${t('sp.btn.settings')}: ${t('st.tab.providers')}`;
+  providerBtn.setAttribute('aria-label', providerBtn.title);
+  bindPlannerProviderSettingsButton(providerBtn);
+
+  const orderedActions = data.failureKind === 'auth'
+    ? [providerBtn, retryReady ? retryBtn : null]
+    : [retryReady ? retryBtn : null, providerBtn];
+  const visibleActions = orderedActions.filter(Boolean);
+  visibleActions[0]?.classList.add('primary');
+  visibleActions.forEach(btn => actions.appendChild(btn));
+
+  textEl.append(message, actions);
+  addMessageCopyButton(assistantEl);
+  scrollToBottom();
+  return true;
 }
 
 function clearActiveChatPayloadForTab(tabId) {
@@ -5262,6 +5346,7 @@ function rebindRestoredMessageControls() {
   rebindCopyButtons();
   rebindScreenshotSaveButtons();
   rebindRetryButtons();
+  rebindPlannerRequestFailureControls();
   rebindContinueButtons();
   rebindClarifyCards();
   rebindPlanReviewCards();
@@ -6989,6 +7074,14 @@ async function sendMessage(extraChatParams = {}) {
     accepted = true;
     completedSuccessfully = res?.successfulDone === true || updatesContainSuccessfulDone(res?.updates);
     promptEligibleCompletion = completedSuccessfully || isSuccessfulAskCompletion(modeForSend, res);
+    const returnedPlannerFailure = plannerRequestFailureUpdate(res?.updates);
+    if (returnedPlannerFailure
+        && renderToCurrentTab
+        && currentTabId === tabId
+        && !isTabAbortRequested(tabId)
+        && !clearedConversationRunRequestIds.has(requestId)) {
+      renderPlannerRequestFailure(assistantEl, returnedPlannerFailure.data, retryPayload);
+    }
     const returnedErrorUpdate = Array.isArray(res?.updates)
       ? res.updates.find(u => u?.type === 'error')
       : null;
@@ -7539,7 +7632,12 @@ function handleAgentUpdateMessage(msg) {
 
     case 'warning':
       hideActivity();
-      if (data?.code === 'ask_stream_fallback') {
+      if (data?.code === 'planner_request_failed') {
+        const targetAssistantEl = eventAssistantEl || currentAssistantEl;
+        const retryPayload = activeRetryPayloadForRequest(eventTabId, msg.requestId)
+          || retryPayloadForRunAssistant(targetAssistantEl);
+        renderPlannerRequestFailure(targetAssistantEl, data, retryPayload);
+      } else if (data?.code === 'ask_stream_fallback') {
         showComposerToast(t('sp.streaming.fallback'), { duration: 6000 });
       }
       break;

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -2861,6 +2861,72 @@ body {
   background: var(--accent-hover);
 }
 
+/* Planner transport/auth failure — actionable assistant card */
+.message.assistant.planner-request-failure .message-content {
+  background: rgba(244, 67, 54, 0.08);
+  border-color: rgba(244, 67, 54, 0.3);
+}
+
+.planner-request-failure-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.planner-request-failure-message {
+  color: var(--error-soft);
+}
+
+.planner-request-failure-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.planner-request-failure-action {
+  min-height: 30px;
+  padding: 5px 11px;
+  border: 1px solid rgba(244, 67, 54, 0.35);
+  border-radius: 6px;
+  background: rgba(244, 67, 54, 0.06);
+  color: var(--error-soft);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.planner-request-failure-action.primary {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #fff;
+}
+
+.planner-request-failure-action:hover:not(:disabled),
+.planner-request-failure-action:focus-visible {
+  border-color: rgba(244, 67, 54, 0.6);
+  background: rgba(244, 67, 54, 0.16);
+  color: var(--text-primary);
+}
+
+.planner-request-failure-action.primary:hover:not(:disabled),
+.planner-request-failure-action.primary:focus-visible {
+  border-color: var(--accent-hover);
+  background: var(--accent-hover);
+  color: #fff;
+}
+
+.planner-request-failure-action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.planner-request-failure-action:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
 /* Error messages */
 .message.error .message-content {
   background: rgba(244, 67, 54, 0.1);

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -120,6 +120,19 @@ function normalizeDoneOutcome(value) {
   return DONE_OUTCOMES.has(outcome) ? outcome : null;
 }
 
+function plannerRequestFailureKind(detail) {
+  const text = String(detail || '');
+  const statusMatch = text.match(/\b(?:error|http|status)\s*[:#-]?\s*(\d{3})\b/i)
+    || text.match(/\b(401|403|408|425|429|5\d\d)\b/);
+  const status = Number(statusMatch?.[1] || 0);
+  if (status === 401 || status === 403) return 'auth';
+  if ([408, 425, 429].includes(status) || status >= 500) return 'transient';
+  if (/\b(?:timed?\s*out|timeout|network|fetch failed|connection (?:closed|reset|refused)|econn\w+|temporar(?:y|ily)|unavailable)\b/i.test(text)) {
+    return 'transient';
+  }
+  return 'provider';
+}
+
 /**
  * The WebBrain Agent — orchestrates multi-step LLM + tool-use loops.
  */
@@ -6220,20 +6233,31 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     };
   }
 
-  _plannerRequestFailure(error, onUpdate) {
+  _plannerRequestFailure(error, onUpdate, provider = null) {
     const detail = sanitizePlannerText(
       error?.message || String(error || 'Unknown planner request error.'),
       500,
       { collapseWhitespace: true },
     );
-    const message = `Planner request failed before a valid response was available: ${detail}`;
-    onUpdate('warning', { message });
+    const message = `Planner request failed before a valid response was available: ${detail} No tools ran.`;
+    const failureKind = plannerRequestFailureKind(detail);
+    onUpdate('warning', {
+      code: 'planner_request_failed',
+      message,
+      failureKind,
+      provider: sanitizePlannerText(
+        provider?.config?.label || provider?.name || provider?.config?.providerName || '',
+        80,
+        { collapseWhitespace: true },
+      ),
+    });
     return {
       proceed: false,
       message,
       reason: 'planner_error',
       requestKind: 'respond',
       requiresStateChange: false,
+      failureKind,
     };
   }
 
@@ -6400,7 +6424,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (this._isCostAllowanceError(e)) {
         return { proceed: false, message: e.message, reason: 'cost_limit' };
       }
-      return this._plannerRequestFailure(e, onUpdate);
+      return this._plannerRequestFailure(e, onUpdate, provider);
     }
   }
 
@@ -6594,7 +6618,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (this._isCostAllowanceError(e)) {
         return { proceed: false, message: e.message, reason: 'cost_limit' };
       }
-      return this._plannerRequestFailure(e, onUpdate);
+      return this._plannerRequestFailure(e, onUpdate, provider);
     }
   }
 

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -1472,8 +1472,17 @@ function isClarificationRequiredRunUpdate(update) {
     && update?.data?.status === 'clarification_required';
 }
 
+function isPlannerRequestFailureUpdate(update) {
+  return update?.type === 'warning'
+    && update?.data?.code === 'planner_request_failed';
+}
+
 function runUpdatesSucceeded(updates = []) {
-  return !updates.some(update => update?.type === 'error' || isClarificationRequiredRunUpdate(update));
+  return !updates.some(update => (
+    update?.type === 'error'
+    || isClarificationRequiredRunUpdate(update)
+    || isPlannerRequestFailureUpdate(update)
+  ));
 }
 
 function terminalRunUiStatus(content, updates = [], error = null) {
@@ -1481,7 +1490,7 @@ function terminalRunUiStatus(content, updates = [], error = null) {
   const text = String(content || '');
   if (/stopped by user|aborted by user/i.test(text)) return 'stopped';
   if (/before executing requested tool calls/i.test(text)) return 'cancelled';
-  if (updates.some(update => update?.type === 'error')) return 'failed';
+  if (updates.some(update => update?.type === 'error' || isPlannerRequestFailureUpdate(update))) return 'failed';
   if (updates.some(isClarificationRequiredRunUpdate)) return 'clarification_required';
   return 'completed';
 }

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -1793,10 +1793,10 @@ function releaseRetryAttachmentPayload(retryId) {
 
 function releaseRetryAttachmentsInTree(root) {
   if (!root) return;
-  if (root.matches?.('.error-retry-btn[data-retry-id], .cost-allowance-retry-btn[data-retry-id]')) {
+  if (root.matches?.('.error-retry-btn[data-retry-id], .cost-allowance-retry-btn[data-retry-id], .planner-request-failure-retry-btn[data-retry-id]')) {
     releaseRetryAttachmentPayload(root.dataset.retryId);
   }
-  root.querySelectorAll?.('.error-retry-btn[data-retry-id], .cost-allowance-retry-btn[data-retry-id]').forEach((btn) => {
+  root.querySelectorAll?.('.error-retry-btn[data-retry-id], .cost-allowance-retry-btn[data-retry-id], .planner-request-failure-retry-btn[data-retry-id]').forEach((btn) => {
     releaseRetryAttachmentPayload(btn.dataset.retryId);
   });
 }
@@ -3587,6 +3587,15 @@ async function adoptRestoredRunState(tabId, state) {
       probeFirst: true,
       requireDurableSubmittedTurn: runUi.kind !== 'continue',
     });
+    const returnedPlannerFailure = plannerRequestFailureUpdate(res?.updates);
+    if (returnedPlannerFailure && sameTabId(currentTabId, tabId) && !isTabAbortRequested(tabId)) {
+      const targetAssistantEl = assistantEl || currentAssistantEl;
+      renderPlannerRequestFailure(
+        targetAssistantEl,
+        returnedPlannerFailure.data,
+        retryPayloadForRunAssistant(targetAssistantEl),
+      );
+    }
     const returnedErrorUpdate = Array.isArray(res?.updates)
       ? res.updates.find(update => update?.type === 'error')
       : null;
@@ -5002,7 +5011,7 @@ function bindErrorRetryButton(btn) {
 }
 
 function rebindRetryButtons() {
-  document.querySelectorAll('.error-retry-btn').forEach(bindErrorRetryButton);
+  document.querySelectorAll('.error-retry-btn, .planner-request-failure-retry-btn').forEach(bindErrorRetryButton);
 }
 
 function createActiveChatPayloadState(retryPayload, requestId = '') {
@@ -5039,6 +5048,81 @@ function retryPayloadForRunAssistant(assistantEl) {
     attachments: [],
     attachmentCount: Number(assistantEl?.dataset.retryAttachmentCount || 0) || 0,
   };
+}
+
+function plannerRequestFailureUpdate(updates = []) {
+  if (!Array.isArray(updates)) return null;
+  return updates.find(update => (
+    update?.type === 'warning'
+    && update?.data?.code === 'planner_request_failed'
+  )) || null;
+}
+
+function bindPlannerProviderSettingsButton(btn) {
+  if (!btn || btn.dataset.bound) return;
+  btn.dataset.bound = 'true';
+  btn.addEventListener('click', async (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    btn.disabled = true;
+    try {
+      await openProvidersSettingsPage();
+    } finally {
+      btn.disabled = false;
+    }
+  });
+}
+
+function rebindPlannerRequestFailureControls() {
+  document.querySelectorAll('.planner-request-failure-provider-btn')
+    .forEach(bindPlannerProviderSettingsButton);
+}
+
+function renderPlannerRequestFailure(assistantEl, data, retryPayload = null) {
+  if (!assistantEl || data?.code !== 'planner_request_failed') return false;
+  const textEl = assistantEl.querySelector('.message-text');
+  if (!textEl) return false;
+  if (textEl.querySelector('.planner-request-failure-actions')) return true;
+
+  clearAssistantTextStreamState(assistantEl);
+  assistantEl.classList.add('planner-request-failure');
+  textEl.classList.add('planner-request-failure-content');
+  textEl.replaceChildren();
+
+  const message = document.createElement('div');
+  message.className = 'planner-request-failure-message';
+  message.textContent = data.message || 'Planner request failed before a valid response was available.';
+
+  const actions = document.createElement('div');
+  actions.className = 'planner-request-failure-actions';
+
+  const retryBtn = document.createElement('button');
+  retryBtn.type = 'button';
+  retryBtn.className = 'planner-request-failure-action planner-request-failure-retry-btn';
+  retryBtn.textContent = t('sp.retry');
+  retryBtn.title = t('sp.retry');
+  retryBtn.setAttribute('aria-label', t('sp.retry'));
+  const retryReady = configureRetryButton(retryBtn, retryPayload);
+
+  const providerBtn = document.createElement('button');
+  providerBtn.type = 'button';
+  providerBtn.className = 'planner-request-failure-action planner-request-failure-provider-btn';
+  providerBtn.textContent = t('st.tab.providers');
+  providerBtn.title = `${t('sp.btn.settings')}: ${t('st.tab.providers')}`;
+  providerBtn.setAttribute('aria-label', providerBtn.title);
+  bindPlannerProviderSettingsButton(providerBtn);
+
+  const orderedActions = data.failureKind === 'auth'
+    ? [providerBtn, retryReady ? retryBtn : null]
+    : [retryReady ? retryBtn : null, providerBtn];
+  const visibleActions = orderedActions.filter(Boolean);
+  visibleActions[0]?.classList.add('primary');
+  visibleActions.forEach(btn => actions.appendChild(btn));
+
+  textEl.append(message, actions);
+  addMessageCopyButton(assistantEl);
+  scrollToBottom();
+  return true;
 }
 
 function clearActiveChatPayloadForTab(tabId) {
@@ -5099,6 +5183,7 @@ function rebindRestoredMessageControls() {
   rebindCopyButtons();
   rebindScreenshotSaveButtons();
   rebindRetryButtons();
+  rebindPlannerRequestFailureControls();
   rebindContinueButtons();
   rebindClarifyCards();
   rebindPlanReviewCards();
@@ -6721,6 +6806,14 @@ async function sendMessage(extraChatParams = {}) {
     accepted = true;
     completedSuccessfully = res?.successfulDone === true || updatesContainSuccessfulDone(res?.updates);
     promptEligibleCompletion = completedSuccessfully || isSuccessfulAskCompletion(modeForSend, res);
+    const returnedPlannerFailure = plannerRequestFailureUpdate(res?.updates);
+    if (returnedPlannerFailure
+        && renderToCurrentTab
+        && currentTabId === tabId
+        && !isTabAbortRequested(tabId)
+        && !clearedConversationRunRequestIds.has(requestId)) {
+      renderPlannerRequestFailure(assistantEl, returnedPlannerFailure.data, retryPayload);
+    }
     const returnedErrorUpdate = Array.isArray(res?.updates)
       ? res.updates.find(u => u?.type === 'error')
       : null;
@@ -7054,7 +7147,12 @@ function handleAgentUpdateMessage(msg) {
 
     case 'warning':
       hideActivity();
-      if (data?.code === 'ask_stream_fallback') {
+      if (data?.code === 'planner_request_failed') {
+        const targetAssistantEl = eventAssistantEl || currentAssistantEl;
+        const retryPayload = activeRetryPayloadForRequest(eventTabId, msg.requestId)
+          || retryPayloadForRunAssistant(targetAssistantEl);
+        renderPlannerRequestFailure(targetAssistantEl, data, retryPayload);
+      } else if (data?.code === 'ask_stream_fallback') {
         showComposerToast(t('sp.streaming.fallback'), { duration: 6000 });
       }
       break;

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -2745,6 +2745,72 @@ body {
   background: var(--accent-hover);
 }
 
+/* Planner transport/auth failure — actionable assistant card */
+.message.assistant.planner-request-failure .message-content {
+  background: rgba(244, 67, 54, 0.08);
+  border-color: rgba(244, 67, 54, 0.3);
+}
+
+.planner-request-failure-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.planner-request-failure-message {
+  color: var(--error-soft);
+}
+
+.planner-request-failure-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.planner-request-failure-action {
+  min-height: 30px;
+  padding: 5px 11px;
+  border: 1px solid rgba(244, 67, 54, 0.35);
+  border-radius: 6px;
+  background: rgba(244, 67, 54, 0.06);
+  color: var(--error-soft);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.planner-request-failure-action.primary {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #fff;
+}
+
+.planner-request-failure-action:hover:not(:disabled),
+.planner-request-failure-action:focus-visible {
+  border-color: rgba(244, 67, 54, 0.6);
+  background: rgba(244, 67, 54, 0.16);
+  color: var(--text-primary);
+}
+
+.planner-request-failure-action.primary:hover:not(:disabled),
+.planner-request-failure-action.primary:focus-visible {
+  border-color: var(--accent-hover);
+  background: var(--accent-hover);
+  color: #fff;
+}
+
+.planner-request-failure-action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.planner-request-failure-action:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
 /* Error messages */
 .message.error .message-content {
   background: rgba(244, 67, 54, 0.1);

--- a/test/run.js
+++ b/test/run.js
@@ -49084,8 +49084,8 @@ test('planner request errors stop accurately instead of masquerading as JSON rep
         calls += 1;
         throw new Error('401 invalid API key');
       };
-      let warning = '';
-      const onUpdate = (type, data) => { if (type === 'warning') warning = data?.message || ''; };
+      let warning = null;
+      const onUpdate = (type, data) => { if (type === 'warning') warning = data || null; };
 
       const intent = await agent._runPlannerIntentGate(
         tabId,
@@ -49099,10 +49099,15 @@ test('planner request errors stop accurately instead of masquerading as JSON rep
       assert.equal(intent.requestKind, 'respond', `${label}: provider failure was mislabeled as ambiguous intent`);
       assert.equal(intent.readOnlyFallback, undefined, `${label}: provider failure was treated as invalid JSON`);
       assert.match(intent.message || '', /Planner request failed.*401 invalid API key/i, `${label}: intent request error hid the provider failure`);
-      assert.equal(warning, intent.message, `${label}: intent request warning diverged from the terminal error`);
+      assert.match(intent.message || '', /No tools ran\.$/, `${label}: planner failure did not state that execution never began`);
+      assert.equal(intent.failureKind, 'auth', `${label}: 401 planner failure was not classified as an authentication problem`);
+      assert.equal(warning?.code, 'planner_request_failed', `${label}: planner request failure warning lacks a stable UI code`);
+      assert.equal(warning?.failureKind, 'auth', `${label}: planner request failure warning lost its authentication category`);
+      assert.equal(warning?.provider, 'broken-provider', `${label}: planner request failure warning lost its provider label`);
+      assert.equal(warning?.message, intent.message, `${label}: intent request warning diverged from the terminal error`);
 
       calls = 0;
-      warning = '';
+      warning = null;
       const full = await agent._runPlannerGate(
         tabId,
         { role: 'user', content: 'Perform this task.' },
@@ -49114,9 +49119,91 @@ test('planner request errors stop accurately instead of masquerading as JSON rep
       assert.equal(full.reason, 'planner_error', `${label}: full planner request error lost its planner status`);
       assert.equal(full.readOnlyFallback, undefined, `${label}: full planner provider failure was treated as invalid JSON`);
       assert.match(full.message || '', /Planner request failed.*401 invalid API key/i, `${label}: full planner request error hid the provider failure`);
-      assert.equal(warning, full.message, `${label}: full planner warning diverged from the terminal error`);
+      assert.equal(warning?.message, full.message, `${label}: full planner warning diverged from the terminal error`);
+
+      agent._chatWithCostAllowance = async () => {
+        throw new Error('openrouter error 503: temporarily unavailable');
+      };
+      warning = null;
+      const transient = await agent._runPlannerGate(
+        tabId,
+        { role: 'user', content: 'Perform this task later.' },
+        onUpdate,
+        null,
+      );
+      assert.equal(transient.failureKind, 'transient', `${label}: 503 planner failure was not classified as transient`);
+      assert.equal(warning?.failureKind, 'transient', `${label}: transient category was not exposed to the sidepanel`);
     }
   });
+});
+
+test('planner request failures expose provider settings and retry actions in both sidepanels', () => {
+  for (const [label, panelRel, backgroundRel, cssRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js', 'src/chrome/src/background.js', 'src/chrome/styles/sidepanel.css'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js', 'src/firefox/src/background.js', 'src/firefox/styles/sidepanel.css'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    const background = fs.readFileSync(path.join(ROOT, backgroundRel), 'utf8');
+    const css = fs.readFileSync(path.join(ROOT, cssRel), 'utf8');
+
+    assert.match(
+      background,
+      /function isPlannerRequestFailureUpdate\(update\) \{[\s\S]*?update\?\.type === 'warning'[\s\S]*?update\?\.data\?\.code === 'planner_request_failed';[\s\S]*?\}/,
+      `${label}: background cannot identify structured planner request failures`,
+    );
+    assert.match(
+      background,
+      /function runUpdatesSucceeded\(updates = \[\]\) \{[\s\S]*?isPlannerRequestFailureUpdate\(update\)[\s\S]*?\}/,
+      `${label}: planner request failure is still counted as a successful run`,
+    );
+    assert.match(
+      background,
+      /if \(updates\.some\(update => update\?\.type === 'error' \|\| isPlannerRequestFailureUpdate\(update\)\)\) return 'failed';/,
+      `${label}: planner request failure does not produce a failed terminal run status`,
+    );
+    assert.match(
+      panel,
+      /function renderPlannerRequestFailure\(assistantEl, data, retryPayload = null\) \{[\s\S]*?textEl\.append\(message, actions\);[\s\S]*?addMessageCopyButton\(assistantEl\);[\s\S]*?return true;[\s\S]*?\}/,
+      `${label}: planner request failure is not rendered as an actionable assistant card`,
+    );
+    assert.match(
+      panel,
+      /providerBtn\.textContent = t\('st\.tab\.providers'\);[\s\S]*?await openProvidersSettingsPage\(\);/,
+      `${label}: Providers action does not lead to the provider settings tab`,
+    );
+    assert.match(
+      panel,
+      /const orderedActions = data\.failureKind === 'auth'\s*\? \[providerBtn, retryReady \? retryBtn : null\]\s*: \[retryReady \? retryBtn : null, providerBtn\];/,
+      `${label}: authentication failures should prioritize Providers while transient failures prioritize Retry`,
+    );
+    assert.match(
+      panel,
+      /case 'warning':[\s\S]*?data\?\.code === 'planner_request_failed'[\s\S]*?const targetAssistantEl = eventAssistantEl \|\| currentAssistantEl;[\s\S]*?renderPlannerRequestFailure\(targetAssistantEl, data, retryPayload\);/,
+      `${label}: live planner request failures bypass the actionable renderer`,
+    );
+    assert.equal(
+      (panel.match(/plannerRequestFailureUpdate\(res\?\.updates\)/g) || []).length >= 2,
+      true,
+      `${label}: returned and restored run responses do not both recover planner failure actions`,
+    );
+    assert.match(
+      panel,
+      /document\.querySelectorAll\('\.error-retry-btn, \.planner-request-failure-retry-btn'\)\.forEach\(bindErrorRetryButton\);/,
+      `${label}: restored planner Retry buttons are not rebound`,
+    );
+    assert.match(
+      panel,
+      /planner-request-failure-retry-btn\[data-retry-id\]/,
+      `${label}: planner Retry attachment payloads are not released with the card`,
+    );
+    assert.match(
+      panel,
+      /function rebindPlannerRequestFailureControls\(\) \{[\s\S]*?planner-request-failure-provider-btn[\s\S]*?bindPlannerProviderSettingsButton/,
+      `${label}: restored Providers buttons are not rebound`,
+    );
+    assert.match(css, /\.planner-request-failure-actions \{/, `${label}: planner failure action row is not styled`);
+    assert.match(css, /\.planner-request-failure-action\.primary \{/, `${label}: planner failure primary action is not styled`);
+  }
 });
 
 test('planner read-only fallback applies Ask mode to runtime guards without changing the selected mode', async () => {


### PR DESCRIPTION
## Summary

- classify planner request failures as authentication, transient, or other provider failures
- render a mirrored Chrome/Firefox failure card with contextual **Providers** and **Retry** actions
- preserve retry payloads and rebind both actions after sidepanel history restoration
- mark structured planner request failures as failed runs instead of successful warning-only completions

## Why

Planner transport and authentication failures were emitted as warnings and returned as ordinary assistant text. That bypassed the existing actionable error/retry path, leaving users with a provider error such as a 401 but no direct route to fix the provider or repeat the original request.

## User impact

Authentication failures now prioritize **Providers**, while transient failures prioritize **Retry**. Retrying preserves the original prompt, mode, permissions, foreground state, and available attachments. The response also states that no tools ran.

## Validation

- `node test/run.js`: 1,354 passed; 1 pre-existing release-history mismatch (`package.json` 26.0.1 vs latest changelog 26.0.0)
- `node test/security/injection-corpus.mjs`: 60/60 passed
- `node --check` on changed JavaScript files
- `git diff --check`
