### PR TITLE
Add safe runtime settings to trace metadata

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -31,6 +31,7 @@ import {
   PDF_PASSTHROUGH_MAX_BYTES,
 } from './pdf-tools.js';
 import * as trace from '../trace/recorder.js';
+import { normalizeRuntimeTraceConfig } from '../trace/runtime-config.js';
 import { tracesToMarkdown } from './trace-export.js';
 import { solveCaptcha, detectCaptcha, injectToken, captchaParamError, captchaTypesMatch, captchaWebsiteUrl } from './captcha-solver.js';
 import { isCapsolverEnabled, normalizeCapsolverApiKey } from './capsolver-config.js';
@@ -724,6 +725,34 @@ export class Agent extends LoopDetector {
     return this.conversationIds.get(tabId) || null;
   }
 
+  _runtimeTraceConfig(provider, { tabId = null, mode = null } = {}) {
+    let extensionVersion = '';
+    let promptTier = 'full';
+    try { extensionVersion = chrome.runtime.getManifest().version || ''; } catch {}
+    try { promptTier = provider?.promptTier || 'full'; } catch {}
+    const effectiveMode = mode
+      || (tabId != null ? this._effectiveRunMode(tabId) : 'ask');
+    return normalizeRuntimeTraceConfig({
+      extension_version: extensionVersion,
+      browser_target: 'chrome',
+      mode: effectiveMode,
+      prompt_tier: promptTier,
+      screenshot_redaction: this.screenshotRedaction === true,
+      strict_secret_mode: this.strictSecretMode === true,
+      plan_before_act_mode: this._normalizePlanBeforeActMode(this.planBeforeActMode),
+      auto_screenshot: this.autoScreenshot,
+      use_site_adapters: this.useSiteAdapters === true,
+      web_mcp_enabled: this.webMcpEnabled === true,
+      api_mutations_allowed: tabId != null && this.apiAllowedTabs.has(tabId),
+      user_memory_enabled: this.userMemoryEnabled === true,
+      selection_grounded: tabId != null && this.selectionGroundingScopes.has(tabId),
+      image_detail: this.imageDetail,
+      max_agent_steps: this.maxSteps,
+      max_image_dimension: this.maxImageDimension,
+      max_screenshots_per_turn: this.maxScreenshotsPerTurn,
+    });
+  }
+
   _cloudGenerationOptions(provider, options = {}, { tabId = null, conversationId = null, generationName = 'main' } = {}) {
     if (String(provider?.config?.providerName || '').toLowerCase() !== 'webbrain-cloud') return options;
     const effectiveConversationId = conversationId || (tabId != null ? this.conversationIds.get(tabId) : null);
@@ -732,6 +761,7 @@ export class Agent extends LoopDetector {
       ...options,
       webbrainSessionId: String(effectiveConversationId),
       webbrainGenerationName: String(generationName || 'main'),
+      webbrainRuntimeConfig: this._runtimeTraceConfig(provider, { tabId }),
     };
   }
 
@@ -6749,6 +6779,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         providerId: provider?.name,
         providerClass: provider?.constructor?.name,
         webbrainVersion: chrome.runtime.getManifest().version || '',
+        runtimeConfig: this._runtimeTraceConfig(provider, { tabId, mode }),
         userMessage: typeof userMessage === 'string' ? userMessage : JSON.stringify(userMessage).slice(0, 2000),
         tabUrl,
         tabTitle,
@@ -13563,6 +13594,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       mode: 'act',
       model: this.providerManager?.getActive?.()?.model || '',
       providerId: this.providerManager?.activeProviderId || '',
+      runtimeConfig: this._runtimeTraceConfig(this.providerManager?.getActive?.(), {
+        tabId,
+        mode: 'act',
+      }),
     });
     let traceStatus = 'workflow_stopped';
     let finalContent = '';

--- a/src/chrome/src/providers/openai.js
+++ b/src/chrome/src/providers/openai.js
@@ -5,6 +5,7 @@ import {
   shouldUseOpenAIResponsesApi,
   supportsOpenAIAskStreaming,
 } from './provider-compatibility.js';
+import { normalizeRuntimeTraceConfig } from '../trace/runtime-config.js';
 
 const OPENAI_RESPONSES_MIN_MAX_OUTPUT_TOKENS = 16;
 const KIMI_CURRENT_TOOL_REASONING_MODELS = new Set([
@@ -235,11 +236,16 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     const sessionId = String(options.webbrainSessionId || '').trim();
     if (sessionId) body.session_id = sessionId.slice(0, 200);
     const generationName = String(options.webbrainGenerationName || '').trim().toLowerCase();
-    if (generationName) {
+    const runtimeConfig = normalizeRuntimeTraceConfig(options.webbrainRuntimeConfig);
+    if (generationName || runtimeConfig) {
       const trace = body.trace && typeof body.trace === 'object' && !Array.isArray(body.trace)
         ? body.trace
         : {};
-      body.trace = { ...trace, generation_name: generationName.slice(0, 64) };
+      body.trace = {
+        ...trace,
+        ...(generationName ? { generation_name: generationName.slice(0, 64) } : {}),
+        ...(runtimeConfig ? { runtime_config: runtimeConfig } : {}),
+      };
     }
   }
 

--- a/src/chrome/src/trace/recorder.js
+++ b/src/chrome/src/trace/recorder.js
@@ -1,3 +1,5 @@
+import { normalizeRuntimeTraceConfig } from './runtime-config.js';
+
 /**
  * Trace recorder — writes per-run traces (LLM requests/responses, tool calls,
  * screenshots) into IndexedDB for later inspection and cross-model comparison.
@@ -130,6 +132,7 @@ export async function startRun(meta = {}) {
       providerId: meta.providerId || '',
       providerClass: meta.providerClass || '',
       webbrainVersion: meta.webbrainVersion || '',
+      runtimeConfig: normalizeRuntimeTraceConfig(meta.runtimeConfig),
       userMessage: meta.userMessage || '',
       tabUrl: meta.tabUrl || '',
       tabTitle: meta.tabTitle || '',

--- a/src/chrome/src/trace/runtime-config.js
+++ b/src/chrome/src/trace/runtime-config.js
@@ -1,0 +1,59 @@
+const STRING_ENUMS = Object.freeze({
+  browser_target: new Set(['chrome', 'firefox']),
+  mode: new Set(['ask', 'act', 'dev']),
+  prompt_tier: new Set(['compact', 'mid', 'full']),
+  plan_before_act_mode: new Set(['off', 'try', 'strict']),
+  auto_screenshot: new Set(['off', 'navigation', 'state_change', 'every_step']),
+  image_detail: new Set(['auto', 'low', 'high']),
+});
+
+const BOOLEAN_FIELDS = Object.freeze([
+  'screenshot_redaction',
+  'strict_secret_mode',
+  'use_site_adapters',
+  'web_mcp_enabled',
+  'api_mutations_allowed',
+  'user_memory_enabled',
+  'selection_grounded',
+]);
+
+const INTEGER_RANGES = Object.freeze({
+  max_agent_steps: [0, 10_000],
+  max_image_dimension: [256, 16_384],
+  max_screenshots_per_turn: [0, 1_000],
+});
+
+function safeVersion(value) {
+  const version = String(value || '').trim();
+  return /^[0-9A-Za-z][0-9A-Za-z.+_-]{0,63}$/.test(version) ? version : '';
+}
+
+/**
+ * Runtime trace metadata crosses both a provider boundary and an export
+ * boundary. Keep it to a small, versioned allowlist of booleans, bounded
+ * integers, and enums so a caller can never smuggle credentials or profile
+ * contents into a trace by passing an arbitrary settings object.
+ */
+export function normalizeRuntimeTraceConfig(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+
+  const normalized = { schema_version: 1 };
+  const extensionVersion = safeVersion(value.extension_version);
+  if (extensionVersion) normalized.extension_version = extensionVersion;
+
+  for (const [field, allowed] of Object.entries(STRING_ENUMS)) {
+    const candidate = String(value[field] || '').trim().toLowerCase();
+    if (allowed.has(candidate)) normalized[field] = candidate;
+  }
+  for (const field of BOOLEAN_FIELDS) {
+    if (typeof value[field] === 'boolean') normalized[field] = value[field];
+  }
+  for (const [field, [min, max]] of Object.entries(INTEGER_RANGES)) {
+    const candidate = Number(value[field]);
+    if (Number.isInteger(candidate) && candidate >= min && candidate <= max) {
+      normalized[field] = candidate;
+    }
+  }
+
+  return normalized;
+}

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -33,6 +33,7 @@ import {
   PDF_PASSTHROUGH_MAX_BYTES,
 } from './pdf-tools.js';
 import * as trace from '../trace/recorder.js';
+import { normalizeRuntimeTraceConfig } from '../trace/runtime-config.js';
 import { tracesToMarkdown } from './trace-export.js';
 import { solveCaptcha, detectCaptcha, injectToken, captchaParamError, captchaTypesMatch, captchaWebsiteUrl } from './captcha-solver.js';
 import { isCapsolverEnabled, normalizeCapsolverApiKey } from './capsolver-config.js';
@@ -823,6 +824,34 @@ export class Agent extends LoopDetector {
     return this.conversationIds.get(tabId) || null;
   }
 
+  _runtimeTraceConfig(provider, { tabId = null, mode = null } = {}) {
+    let extensionVersion = '';
+    let promptTier = 'full';
+    try { extensionVersion = browser.runtime.getManifest().version || ''; } catch {}
+    try { promptTier = provider?.promptTier || 'full'; } catch {}
+    const effectiveMode = mode
+      || (tabId != null ? this._effectiveRunMode(tabId) : 'ask');
+    return normalizeRuntimeTraceConfig({
+      extension_version: extensionVersion,
+      browser_target: 'firefox',
+      mode: effectiveMode,
+      prompt_tier: promptTier,
+      screenshot_redaction: this.screenshotRedaction === true,
+      strict_secret_mode: this.strictSecretMode === true,
+      plan_before_act_mode: this._normalizePlanBeforeActMode(this.planBeforeActMode),
+      auto_screenshot: this.autoScreenshot,
+      use_site_adapters: this.useSiteAdapters === true,
+      web_mcp_enabled: this.webMcpEnabled === true,
+      api_mutations_allowed: tabId != null && this.apiAllowedTabs.has(tabId),
+      user_memory_enabled: this.userMemoryEnabled === true,
+      selection_grounded: tabId != null && this.selectionGroundingScopes.has(tabId),
+      image_detail: this.imageDetail,
+      max_agent_steps: this.maxSteps,
+      max_image_dimension: this.maxImageDimension,
+      max_screenshots_per_turn: this.maxScreenshotsPerTurn,
+    });
+  }
+
   _cloudGenerationOptions(provider, options = {}, { tabId = null, conversationId = null, generationName = 'main' } = {}) {
     if (String(provider?.config?.providerName || '').toLowerCase() !== 'webbrain-cloud') return options;
     const effectiveConversationId = conversationId || (tabId != null ? this.conversationIds.get(tabId) : null);
@@ -831,6 +860,7 @@ export class Agent extends LoopDetector {
       ...options,
       webbrainSessionId: String(effectiveConversationId),
       webbrainGenerationName: String(generationName || 'main'),
+      webbrainRuntimeConfig: this._runtimeTraceConfig(provider, { tabId }),
     };
   }
 
@@ -5693,6 +5723,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         providerId: provider?.name,
         providerClass: provider?.constructor?.name,
         webbrainVersion: browser.runtime.getManifest().version || '',
+        runtimeConfig: this._runtimeTraceConfig(provider, { tabId, mode }),
         userMessage: typeof userMessage === 'string' ? userMessage : JSON.stringify(userMessage).slice(0, 2000),
         tabUrl,
         tabTitle,
@@ -11833,6 +11864,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       mode: 'act',
       model: this.providerManager?.getActive?.()?.model || '',
       providerId: this.providerManager?.activeProviderId || '',
+      runtimeConfig: this._runtimeTraceConfig(this.providerManager?.getActive?.(), {
+        tabId,
+        mode: 'act',
+      }),
     });
     let traceStatus = 'workflow_stopped';
     let finalContent = '';

--- a/src/firefox/src/providers/openai.js
+++ b/src/firefox/src/providers/openai.js
@@ -5,6 +5,7 @@ import {
   shouldUseOpenAIResponsesApi,
   supportsOpenAIAskStreaming,
 } from './provider-compatibility.js';
+import { normalizeRuntimeTraceConfig } from '../trace/runtime-config.js';
 
 const OPENAI_RESPONSES_MIN_MAX_OUTPUT_TOKENS = 16;
 const KIMI_CURRENT_TOOL_REASONING_MODELS = new Set([
@@ -235,11 +236,16 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     const sessionId = String(options.webbrainSessionId || '').trim();
     if (sessionId) body.session_id = sessionId.slice(0, 200);
     const generationName = String(options.webbrainGenerationName || '').trim().toLowerCase();
-    if (generationName) {
+    const runtimeConfig = normalizeRuntimeTraceConfig(options.webbrainRuntimeConfig);
+    if (generationName || runtimeConfig) {
       const trace = body.trace && typeof body.trace === 'object' && !Array.isArray(body.trace)
         ? body.trace
         : {};
-      body.trace = { ...trace, generation_name: generationName.slice(0, 64) };
+      body.trace = {
+        ...trace,
+        ...(generationName ? { generation_name: generationName.slice(0, 64) } : {}),
+        ...(runtimeConfig ? { runtime_config: runtimeConfig } : {}),
+      };
     }
   }
 

--- a/src/firefox/src/trace/recorder.js
+++ b/src/firefox/src/trace/recorder.js
@@ -1,3 +1,5 @@
+import { normalizeRuntimeTraceConfig } from './runtime-config.js';
+
 /**
  * Trace recorder — writes per-run traces (LLM requests/responses, tool calls,
  * screenshots) into IndexedDB for later inspection and cross-model comparison.
@@ -114,6 +116,7 @@ export async function startRun(meta) {
       providerId: meta.providerId || '',
       providerClass: meta.providerClass || '',
       webbrainVersion: meta.webbrainVersion || '',
+      runtimeConfig: normalizeRuntimeTraceConfig(meta.runtimeConfig),
       userMessage: meta.userMessage || '',
       tabUrl: meta.tabUrl || '',
       tabTitle: meta.tabTitle || '',

--- a/src/firefox/src/trace/runtime-config.js
+++ b/src/firefox/src/trace/runtime-config.js
@@ -1,0 +1,59 @@
+const STRING_ENUMS = Object.freeze({
+  browser_target: new Set(['chrome', 'firefox']),
+  mode: new Set(['ask', 'act', 'dev']),
+  prompt_tier: new Set(['compact', 'mid', 'full']),
+  plan_before_act_mode: new Set(['off', 'try', 'strict']),
+  auto_screenshot: new Set(['off', 'navigation', 'state_change', 'every_step']),
+  image_detail: new Set(['auto', 'low', 'high']),
+});
+
+const BOOLEAN_FIELDS = Object.freeze([
+  'screenshot_redaction',
+  'strict_secret_mode',
+  'use_site_adapters',
+  'web_mcp_enabled',
+  'api_mutations_allowed',
+  'user_memory_enabled',
+  'selection_grounded',
+]);
+
+const INTEGER_RANGES = Object.freeze({
+  max_agent_steps: [0, 10_000],
+  max_image_dimension: [256, 16_384],
+  max_screenshots_per_turn: [0, 1_000],
+});
+
+function safeVersion(value) {
+  const version = String(value || '').trim();
+  return /^[0-9A-Za-z][0-9A-Za-z.+_-]{0,63}$/.test(version) ? version : '';
+}
+
+/**
+ * Runtime trace metadata crosses both a provider boundary and an export
+ * boundary. Keep it to a small, versioned allowlist of booleans, bounded
+ * integers, and enums so a caller can never smuggle credentials or profile
+ * contents into a trace by passing an arbitrary settings object.
+ */
+export function normalizeRuntimeTraceConfig(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+
+  const normalized = { schema_version: 1 };
+  const extensionVersion = safeVersion(value.extension_version);
+  if (extensionVersion) normalized.extension_version = extensionVersion;
+
+  for (const [field, allowed] of Object.entries(STRING_ENUMS)) {
+    const candidate = String(value[field] || '').trim().toLowerCase();
+    if (allowed.has(candidate)) normalized[field] = candidate;
+  }
+  for (const field of BOOLEAN_FIELDS) {
+    if (typeof value[field] === 'boolean') normalized[field] = value[field];
+  }
+  for (const [field, [min, max]] of Object.entries(INTEGER_RANGES)) {
+    const candidate = Number(value[field]);
+    if (Number.isInteger(candidate) && candidate >= min && candidate <= max) {
+      normalized[field] = candidate;
+    }
+  }
+
+  return normalized;
+}

--- a/test/run.js
+++ b/test/run.js
@@ -259,6 +259,12 @@ const ConfigTransferCh = await import(
 const ConfigTransferFx = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/config-transfer.js').replace(/\\/g, '/')
 );
+const RuntimeTraceConfigCh = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/trace/runtime-config.js').replace(/\\/g, '/')
+);
+const RuntimeTraceConfigFx = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/trace/runtime-config.js').replace(/\\/g, '/')
+);
 const DownloadDirectoryCh = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/download-directory.js').replace(/\\/g, '/')
 );
@@ -4062,10 +4068,70 @@ test('trace record and JSON exports carry WebBrain version metadata', () => {
     const traceUi = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/traces.js'), 'utf8');
     const agent = fs.readFileSync(path.join(ROOT, prefix, 'src/agent/agent.js'), 'utf8');
     assert.match(recorder, /webbrainVersion: meta\.webbrainVersion \|\| ''/, `${label}: run record should retain the recording version`);
+    assert.match(recorder, /runtimeConfig: normalizeRuntimeTraceConfig\(meta\.runtimeConfig\)/, `${label}: run record should retain only allowlisted runtime settings`);
     assert.match(agent, new RegExp(`webbrainVersion: ${runtimeName}\\.runtime\\.getManifest\\(\\)\\.version`), `${label}: trace start should read the runtime manifest`);
+    assert.match(agent, /runtimeConfig: this\._runtimeTraceConfig\(provider, \{ tabId, mode \}\)/, `${label}: trace start should snapshot effective runtime settings`);
     assert.match(traceUi, new RegExp(`exportedByWebBrainVersion: ${runtimeName}\\.runtime\\.getManifest\\(\\)\\.version`), `${label}: JSON export should identify the exporting build`);
     assert.match(traceUi, /schema: 'webbrain-trace\/1'/, `${label}: additive version metadata should retain the v1 schema`);
   }
+});
+
+test('runtime trace config is versioned, bounded, and secret-free in both browsers', () => {
+  const candidate = {
+    schema_version: 99,
+    extension_version: '24.7.0-beta.1',
+    browser_target: 'chrome',
+    mode: 'act',
+    prompt_tier: 'compact',
+    plan_before_act_mode: 'try',
+    auto_screenshot: 'state_change',
+    image_detail: 'low',
+    screenshot_redaction: true,
+    strict_secret_mode: false,
+    use_site_adapters: true,
+    web_mcp_enabled: false,
+    api_mutations_allowed: true,
+    user_memory_enabled: true,
+    selection_grounded: false,
+    max_agent_steps: 130,
+    max_image_dimension: 1568,
+    max_screenshots_per_turn: 4,
+    api_key: 'must-not-leak',
+    profile_text: 'must-not-leak',
+    arbitrary_nested_settings: { token: 'must-not-leak' },
+  };
+  const expected = {
+    schema_version: 1,
+    extension_version: '24.7.0-beta.1',
+    browser_target: 'chrome',
+    mode: 'act',
+    prompt_tier: 'compact',
+    plan_before_act_mode: 'try',
+    auto_screenshot: 'state_change',
+    image_detail: 'low',
+    screenshot_redaction: true,
+    strict_secret_mode: false,
+    use_site_adapters: true,
+    web_mcp_enabled: false,
+    api_mutations_allowed: true,
+    user_memory_enabled: true,
+    selection_grounded: false,
+    max_agent_steps: 130,
+    max_image_dimension: 1568,
+    max_screenshots_per_turn: 4,
+  };
+  assert.deepEqual(RuntimeTraceConfigCh.normalizeRuntimeTraceConfig(candidate), expected);
+  assert.deepEqual(RuntimeTraceConfigFx.normalizeRuntimeTraceConfig(candidate), expected);
+
+  const rejected = RuntimeTraceConfigCh.normalizeRuntimeTraceConfig({
+    extension_version: 'bad version with spaces',
+    browser_target: 'safari',
+    mode: 'admin',
+    max_agent_steps: Infinity,
+    max_image_dimension: 42,
+    screenshot_redaction: 'yes',
+  });
+  assert.deepEqual(rejected, { schema_version: 1 });
 });
 
 test('trace recorders normalize done only from explicit loop error evidence', () => {
@@ -32279,6 +32345,9 @@ test('WebBrain Cloud groups every generation in a stable conversation session wi
     const tabId = label === 'chrome' ? 731 : 732;
     const agent = new AgentClass({});
     agent.getConversation(tabId, 'ask');
+    agent.screenshotRedaction = true;
+    agent.strictSecretMode = true;
+    agent.apiAllowedTabs.add(tabId);
     const firstConversationId = agent.conversationIds.get(tabId);
     assert.match(firstConversationId, /^conv_/, `${label}: new conversation should mint an id`);
 
@@ -32288,6 +32357,13 @@ test('WebBrain Cloud groups every generation in a stable conversation session wi
     assert.equal(main.webbrainSessionId, firstConversationId, `${label}: main call should carry the conversation id`);
     assert.equal(planner.webbrainSessionId, firstConversationId, `${label}: planner call should share the main session`);
     assert.equal(planner.webbrainGenerationName, 'planner', `${label}: planner call should be labeled`);
+    assert.equal(main.webbrainRuntimeConfig?.schema_version, 1, `${label}: runtime trace schema missing`);
+    assert.equal(main.webbrainRuntimeConfig?.browser_target, label, `${label}: browser target missing`);
+    assert.equal(main.webbrainRuntimeConfig?.mode, 'ask', `${label}: effective mode missing`);
+    assert.equal(main.webbrainRuntimeConfig?.screenshot_redaction, true, `${label}: screenshot redaction setting missing`);
+    assert.equal(main.webbrainRuntimeConfig?.strict_secret_mode, true, `${label}: strict secret setting missing`);
+    assert.equal(main.webbrainRuntimeConfig?.api_mutations_allowed, true, `${label}: per-tab API authorization missing`);
+    assert.ok(!JSON.stringify(main.webbrainRuntimeConfig).includes('apiKey'), `${label}: runtime metadata must remain an allowlist`);
 
     const byoOptions = agent._cloudGenerationOptions({ config: { providerName: 'openai' } }, { temperature: 0 }, { tabId, generationName: 'memory' });
     assert.deepEqual(byoOptions, { temperature: 0 }, `${label}: BYO provider received Cloud collection fields`);
@@ -32304,9 +32380,16 @@ test('WebBrain Cloud groups every generation in a stable conversation session wi
     cloudProvider._addWebBrainCloudContext(cloudBody, {
       webbrainSessionId: firstConversationId,
       webbrainGenerationName: 'compaction',
+      webbrainRuntimeConfig: {
+        ...main.webbrainRuntimeConfig,
+        api_key: 'must-not-leak',
+        profile_text: 'must-not-leak',
+      },
     });
     assert.equal(cloudBody.session_id, firstConversationId, `${label}: Cloud request body should include session_id`);
     assert.equal(cloudBody.trace?.generation_name, 'compaction', `${label}: Cloud request body should include the generation label`);
+    assert.deepEqual(cloudBody.trace?.runtime_config, main.webbrainRuntimeConfig, `${label}: Cloud request body should include only allowlisted runtime settings`);
+    assert.ok(!JSON.stringify(cloudBody).includes('must-not-leak'), `${label}: arbitrary settings leaked into Cloud trace context`);
 
     const byoProvider = new Provider({ providerName: 'openai', apiKey: 'test-key' });
     const byoBody = {};


### PR DESCRIPTION
## What

- snapshot a versioned allowlist of effective runtime settings for Chrome and Firefox
- attach it to local trace run records and WebBrain Cloud generation context
- normalize the snapshot again at the provider boundary so arbitrary settings cannot leak
- cover version/build identity, browser target, mode/tier, screenshot redaction, secret handling, planner mode, screenshot policy, adapters, WebMCP, per-tab API authorization, memory/selection state, and bounded image/step limits

## Why

Cloud dumps currently show the model and generation type but not the extension build or relevant runtime/privacy settings. In particular, a dump containing account data could not tell us whether screenshot redaction was actually enabled, so the audit could not attribute the behavior correctly.

## Impact

No raw settings object, API key, token, profile text, hostname allowlist, prompt, or account identifier is included. Values are limited to booleans, bounded integers, and enums under schema version 1. BYO and local provider request bodies are unchanged.

Cloud forwarding counterpart: https://github.com/esokullu/webbrain-cloud/pull/4

## Checks

- `node test/run.js` — 1,354 passed; one pre-existing release metadata failure (`package.json` 26.0.1 vs latest changelog entry 26.0.0)
- `npm run test:security` — 60/60 passed
- `npm run test:ci` — passed
- `git diff --check`