### PR TITLE
Fix localized completion form classification

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -10,7 +10,7 @@ import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLe
 import { buildGithubStargazerProgressItems } from './observers/github-stargazers.js';
 import { analyzeMastodonPage, mastodonHandoffInstruction, mastodonProgressGuard } from './observers/mastodon.js';
 import { isProgressActionAllowed, isProgressIntentActive, normalizeProgressAction, normalizeProgressIntent } from './progress-intent.js';
-import { completionDoneBlock, completionPlainFinalBlock, consumeCompletionObservation, consumeCompletionObservationResult, createCompletionInvariantState, hasUnconsumedCompletionObservation, hasUnconsumedCompletionObservationResult, recordCompletionToolResult } from './completion-invariant.js';
+import { classifyCompletionForm, completionDoneBlock, completionPlainFinalBlock, consumeCompletionObservation, consumeCompletionObservationResult, createCompletionInvariantState, hasUnconsumedCompletionObservation, hasUnconsumedCompletionObservationResult, recordCompletionToolResult } from './completion-invariant.js';
 import { cdpClient } from '../cdp/cdp-client.js';
 import { getActiveAdapter, getFullPageCapturePolicy, UNIVERSAL_PREAMBLE } from './adapters.js';
 import {
@@ -659,6 +659,7 @@ export class Agent extends LoopDetector {
                 label: boundedText(form?.label, 80),
                 relevant: !!form?.relevant,
                 utility: !!form?.utility,
+                utilityReason: boundedText(form?.utilityReason, 40),
                 editableCount: Number(form?.editableCount || 0),
                 submitCount: Number(form?.submitCount || 0),
               }))
@@ -14973,18 +14974,36 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                     return true;
                   } catch (e) { return false; }
                 }
+                const classifyForm = ${classifyCompletionForm.toString()};
                 const dialogs = Array.from(document.querySelectorAll('[role=dialog],[role=alertdialog],[aria-modal="true"],dialog[open]')).filter(visible);
                 const forms = Array.from(document.querySelectorAll('form')).filter(visible);
+                const primaryContent = document.querySelector('main,[role=main]');
                 const formDescriptors = forms.map(form => {
                   const editable = Array.from(form.querySelectorAll('input:not([type=hidden]):not([type=button]):not([type=submit]):not([type=reset]):not([type=image]),textarea,select,[contenteditable=true]')).filter(visible);
                   const submits = Array.from(form.querySelectorAll('button,input[type=submit],input[type=image],[role=button]')).filter(visible);
                   const utilityRegion = !!form.closest('header,nav,footer,[role=banner],[role=navigation],[role=search],[role=contentinfo]') || form.getAttribute('role') === 'search';
-                  const searchOnly = editable.length > 0
-                    && editable.every(el => el.matches('input[type=search]') || /^(q|query|search|filter)$/i.test(el.getAttribute('name') || ''))
-                    && submits.every(el => /search|filter|go/i.test((el.innerText || el.value || el.getAttribute('aria-label') || '').trim()));
                   const label = (form.getAttribute('aria-label') || form.getAttribute('name') || form.id || (form.querySelector('h1,h2,h3,legend')?.innerText || '')).trim().slice(0, 80);
-                  const relevant = !utilityRegion && !searchOnly && (editable.length > 0 || submits.length > 0);
-                  return { label, relevant, utility: utilityRegion || searchOnly, editableCount: editable.length, submitCount: submits.length };
+                  return classifyForm({
+                    label,
+                    utilityRegion,
+                    outsidePrimaryContent: !!primaryContent && !form.closest('main,[role=main]'),
+                    insideDialog: !!form.closest('[role=dialog],[role=alertdialog],[aria-modal=true],dialog[open]'),
+                    method: form.getAttribute('method') || 'get',
+                    hiddenNamedCount: Array.from(form.querySelectorAll('input[type=hidden][name]'))
+                      .filter(el => (el.getAttribute('name') || '').trim()).length,
+                    editable: editable.map(el => ({
+                      tag: (el.tagName || '').toLowerCase(),
+                      type: el.getAttribute('type') || '',
+                      role: el.getAttribute('role') || '',
+                      name: el.getAttribute('name') || '',
+                      value: 'value' in el ? el.value : (el.innerText || ''),
+                      required: el.required === true || el.getAttribute('aria-required') === 'true',
+                      focused: document.activeElement === el,
+                    })),
+                    submits: submits.map(el => ({
+                      label: (el.innerText || el.value || el.getAttribute('aria-label') || '').trim(),
+                    })),
+                  });
                 });
                 const toasts = Array.from(document.querySelectorAll('[role=status],[role=alert],[aria-live]'))
                   .filter(visible)

--- a/src/chrome/src/agent/completion-invariant.js
+++ b/src/chrome/src/agent/completion-invariant.js
@@ -132,7 +132,8 @@ export function classifyCompletionForm({
   // Preserve the previous per-field semantic-or-conventional behavior so a
   // search input plus a named filter control remains utility UI. Task evidence
   // gates the whole shortcut: semantic markup alone must not hide an assignee
-  // picker, dialog, POST form, populated draft, or non-search submission.
+  // picker, dialog, POST form, or non-search submission. A retained value is
+  // normal search-results state and is not task evidence by itself.
   const searchFieldsOnly = normalizedFields.length > 0
     && normalizedFields.every(field => semanticSearchField(field) || conventionalSearchField(field));
   const searchSubmitsOnly = normalizedSubmits.every(control => /search|filter|go/i.test(control.label));
@@ -144,7 +145,6 @@ export function classifyCompletionForm({
     || normalizedFields.some(field => (
       field.required
       || field.focused
-      || !!field.value
       || (!!field.name && !conventionalSearchField(field))
     ))
   );

--- a/src/chrome/src/agent/completion-invariant.js
+++ b/src/chrome/src/agent/completion-invariant.js
@@ -127,15 +127,31 @@ export function classifyCompletionForm({
     label: String(control?.label || '').trim(),
   }));
 
-  const semanticSearchOnly = normalizedFields.length > 0
-    && normalizedFields.every(field => field.type === 'search' || field.role === 'searchbox');
-  // Preserve compatibility with conventional query field names. Unlike the
-  // structural branches, this legacy fallback intentionally requires a
-  // search-like submit label so an unrelated named field cannot hide a task
-  // form merely because its name happens to be short.
-  const conventionalSearchOnly = normalizedFields.length > 0
-    && normalizedFields.every(field => /^(q|query|search|filter)$/i.test(field.name))
-    && normalizedSubmits.every(control => /search|filter|go/i.test(control.label));
+  const semanticSearchField = field => field.type === 'search' || field.role === 'searchbox';
+  const conventionalSearchField = field => /^(q|query|search|filter)$/i.test(field.name);
+  // Preserve the previous per-field semantic-or-conventional behavior so a
+  // search input plus a named filter control remains utility UI. Task evidence
+  // gates the whole shortcut: semantic markup alone must not hide an assignee
+  // picker, dialog, POST form, populated draft, or non-search submission.
+  const searchFieldsOnly = normalizedFields.length > 0
+    && normalizedFields.every(field => semanticSearchField(field) || conventionalSearchField(field));
+  const searchSubmitsOnly = normalizedSubmits.every(control => /search|filter|go/i.test(control.label));
+  const searchHasTaskEvidence = !!(
+    insideDialog
+    || normalizedMethod !== 'get'
+    || Number(hiddenNamedCount || 0) !== 0
+    || !searchSubmitsOnly
+    || normalizedFields.some(field => (
+      field.required
+      || field.focused
+      || !!field.value
+      || (!!field.name && !conventionalSearchField(field))
+    ))
+  );
+  // Primary content alone is not task evidence: result pages commonly place
+  // genuine search/filter forms there.
+  const safeSearchOnly = searchFieldsOnly && !searchHasTaskEvidence;
+  const hasSemanticSearchField = normalizedFields.some(semanticSearchField);
 
   const onlyField = normalizedFields.length === 1 ? normalizedFields[0] : null;
   const passiveUtilityShell = !!(
@@ -155,10 +171,10 @@ export function classifyCompletionForm({
 
   const utilityReason = utilityRegion
     ? 'utility_region'
-    : semanticSearchOnly
-      ? 'semantic_search'
-      : conventionalSearchOnly
-        ? 'conventional_search'
+    : safeSearchOnly
+      ? hasSemanticSearchField
+        ? 'semantic_search'
+        : 'conventional_search'
         : passiveUtilityShell
           ? 'passive_utility_shell'
           : null;

--- a/src/chrome/src/agent/completion-invariant.js
+++ b/src/chrome/src/agent/completion-invariant.js
@@ -94,6 +94,85 @@ function isSelfVerifyingActionResult(name, result) {
   );
 }
 
+/**
+ * Classify one visible form from browser-neutral structural facts.
+ *
+ * Completion probes run inside the page, so Agent serializes this function
+ * with toString() and supplies plain facts rather than DOM nodes. Keep this
+ * function self-contained and language-independent for structural fallbacks.
+ */
+export function classifyCompletionForm({
+  label = '',
+  utilityRegion = false,
+  outsidePrimaryContent = false,
+  insideDialog = false,
+  method = 'get',
+  hiddenNamedCount = 0,
+  editable = [],
+  submits = [],
+} = {}) {
+  const fields = Array.isArray(editable) ? editable : [];
+  const submitControls = Array.isArray(submits) ? submits : [];
+  const normalizedMethod = String(method || 'get').trim().toLowerCase() || 'get';
+  const normalizedFields = fields.map(field => ({
+    tag: String(field?.tag || '').trim().toLowerCase(),
+    type: String(field?.type || '').trim().toLowerCase(),
+    role: String(field?.role || '').trim().toLowerCase(),
+    name: String(field?.name || '').trim(),
+    value: String(field?.value || '').trim(),
+    required: field?.required === true,
+    focused: field?.focused === true,
+  }));
+  const normalizedSubmits = submitControls.map(control => ({
+    label: String(control?.label || '').trim(),
+  }));
+
+  const semanticSearchOnly = normalizedFields.length > 0
+    && normalizedFields.every(field => field.type === 'search' || field.role === 'searchbox');
+  // Preserve compatibility with conventional query field names. Unlike the
+  // structural branches, this legacy fallback intentionally requires a
+  // search-like submit label so an unrelated named field cannot hide a task
+  // form merely because its name happens to be short.
+  const conventionalSearchOnly = normalizedFields.length > 0
+    && normalizedFields.every(field => /^(q|query|search|filter)$/i.test(field.name))
+    && normalizedSubmits.every(control => /search|filter|go/i.test(control.label));
+
+  const onlyField = normalizedFields.length === 1 ? normalizedFields[0] : null;
+  const passiveUtilityShell = !!(
+    onlyField
+    && outsidePrimaryContent
+    && !insideDialog
+    && normalizedMethod === 'get'
+    && Number(hiddenNamedCount || 0) === 0
+    && normalizedSubmits.length === 0
+    && onlyField.tag === 'input'
+    && (onlyField.type === '' || onlyField.type === 'text' || onlyField.type === 'search')
+    && !onlyField.name
+    && !onlyField.value
+    && !onlyField.required
+    && !onlyField.focused
+  );
+
+  const utilityReason = utilityRegion
+    ? 'utility_region'
+    : semanticSearchOnly
+      ? 'semantic_search'
+      : conventionalSearchOnly
+        ? 'conventional_search'
+        : passiveUtilityShell
+          ? 'passive_utility_shell'
+          : null;
+  const utility = utilityReason !== null;
+  return {
+    label: String(label || '').trim().slice(0, 80),
+    relevant: !utility && (normalizedFields.length > 0 || normalizedSubmits.length > 0),
+    utility,
+    utilityReason,
+    editableCount: normalizedFields.length,
+    submitCount: normalizedSubmits.length,
+  };
+}
+
 export function isCompletionActionTool(name, args = {}) {
   if (name === 'execute_webmcp_tool') return true;
   if (

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -10,7 +10,7 @@ import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLe
 import { buildGithubStargazerProgressItems } from './observers/github-stargazers.js';
 import { analyzeMastodonPage, mastodonHandoffInstruction, mastodonProgressGuard } from './observers/mastodon.js';
 import { isProgressActionAllowed, isProgressIntentActive, normalizeProgressAction, normalizeProgressIntent } from './progress-intent.js';
-import { completionDoneBlock, completionPlainFinalBlock, consumeCompletionObservation, consumeCompletionObservationResult, createCompletionInvariantState, hasUnconsumedCompletionObservation, hasUnconsumedCompletionObservationResult, recordCompletionToolResult } from './completion-invariant.js';
+import { classifyCompletionForm, completionDoneBlock, completionPlainFinalBlock, consumeCompletionObservation, consumeCompletionObservationResult, createCompletionInvariantState, hasUnconsumedCompletionObservation, hasUnconsumedCompletionObservationResult, recordCompletionToolResult } from './completion-invariant.js';
 import { getActiveAdapter, UNIVERSAL_PREAMBLE } from './adapters.js';
 import {
   fetchUrl,
@@ -594,6 +594,7 @@ export class Agent extends LoopDetector {
                 label: boundedText(form?.label, 80),
                 relevant: !!form?.relevant,
                 utility: !!form?.utility,
+                utilityReason: boundedText(form?.utilityReason, 40),
                 editableCount: Number(form?.editableCount || 0),
                 submitCount: Number(form?.submitCount || 0),
               }))
@@ -12841,18 +12842,36 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                     return true;
                   } catch (e) { return false; }
                 }
+                const classifyForm = ${classifyCompletionForm.toString()};
                 const dialogs = Array.from(document.querySelectorAll('[role=dialog],[role=alertdialog],[aria-modal="true"],dialog[open]')).filter(visible);
                 const forms = Array.from(document.querySelectorAll('form')).filter(visible);
+                const primaryContent = document.querySelector('main,[role=main]');
                 const formDescriptors = forms.map(form => {
                   const editable = Array.from(form.querySelectorAll('input:not([type=hidden]):not([type=button]):not([type=submit]):not([type=reset]):not([type=image]),textarea,select,[contenteditable=true]')).filter(visible);
                   const submits = Array.from(form.querySelectorAll('button,input[type=submit],input[type=image],[role=button]')).filter(visible);
                   const utilityRegion = !!form.closest('header,nav,footer,[role=banner],[role=navigation],[role=search],[role=contentinfo]') || form.getAttribute('role') === 'search';
-                  const searchOnly = editable.length > 0
-                    && editable.every(el => el.matches('input[type=search]') || /^(q|query|search|filter)$/i.test(el.getAttribute('name') || ''))
-                    && submits.every(el => /search|filter|go/i.test((el.innerText || el.value || el.getAttribute('aria-label') || '').trim()));
                   const label = (form.getAttribute('aria-label') || form.getAttribute('name') || form.id || (form.querySelector('h1,h2,h3,legend')?.innerText || '')).trim().slice(0, 80);
-                  const relevant = !utilityRegion && !searchOnly && (editable.length > 0 || submits.length > 0);
-                  return { label, relevant, utility: utilityRegion || searchOnly, editableCount: editable.length, submitCount: submits.length };
+                  return classifyForm({
+                    label,
+                    utilityRegion,
+                    outsidePrimaryContent: !!primaryContent && !form.closest('main,[role=main]'),
+                    insideDialog: !!form.closest('[role=dialog],[role=alertdialog],[aria-modal=true],dialog[open]'),
+                    method: form.getAttribute('method') || 'get',
+                    hiddenNamedCount: Array.from(form.querySelectorAll('input[type=hidden][name]'))
+                      .filter(el => (el.getAttribute('name') || '').trim()).length,
+                    editable: editable.map(el => ({
+                      tag: (el.tagName || '').toLowerCase(),
+                      type: el.getAttribute('type') || '',
+                      role: el.getAttribute('role') || '',
+                      name: el.getAttribute('name') || '',
+                      value: 'value' in el ? el.value : (el.innerText || ''),
+                      required: el.required === true || el.getAttribute('aria-required') === 'true',
+                      focused: document.activeElement === el,
+                    })),
+                    submits: submits.map(el => ({
+                      label: (el.innerText || el.value || el.getAttribute('aria-label') || '').trim(),
+                    })),
+                  });
                 });
                 const toasts = Array.from(document.querySelectorAll('[role=status],[role=alert],[aria-live]'))
                   .filter(visible)

--- a/src/firefox/src/agent/completion-invariant.js
+++ b/src/firefox/src/agent/completion-invariant.js
@@ -132,7 +132,8 @@ export function classifyCompletionForm({
   // Preserve the previous per-field semantic-or-conventional behavior so a
   // search input plus a named filter control remains utility UI. Task evidence
   // gates the whole shortcut: semantic markup alone must not hide an assignee
-  // picker, dialog, POST form, populated draft, or non-search submission.
+  // picker, dialog, POST form, or non-search submission. A retained value is
+  // normal search-results state and is not task evidence by itself.
   const searchFieldsOnly = normalizedFields.length > 0
     && normalizedFields.every(field => semanticSearchField(field) || conventionalSearchField(field));
   const searchSubmitsOnly = normalizedSubmits.every(control => /search|filter|go/i.test(control.label));
@@ -144,7 +145,6 @@ export function classifyCompletionForm({
     || normalizedFields.some(field => (
       field.required
       || field.focused
-      || !!field.value
       || (!!field.name && !conventionalSearchField(field))
     ))
   );

--- a/src/firefox/src/agent/completion-invariant.js
+++ b/src/firefox/src/agent/completion-invariant.js
@@ -127,15 +127,31 @@ export function classifyCompletionForm({
     label: String(control?.label || '').trim(),
   }));
 
-  const semanticSearchOnly = normalizedFields.length > 0
-    && normalizedFields.every(field => field.type === 'search' || field.role === 'searchbox');
-  // Preserve compatibility with conventional query field names. Unlike the
-  // structural branches, this legacy fallback intentionally requires a
-  // search-like submit label so an unrelated named field cannot hide a task
-  // form merely because its name happens to be short.
-  const conventionalSearchOnly = normalizedFields.length > 0
-    && normalizedFields.every(field => /^(q|query|search|filter)$/i.test(field.name))
-    && normalizedSubmits.every(control => /search|filter|go/i.test(control.label));
+  const semanticSearchField = field => field.type === 'search' || field.role === 'searchbox';
+  const conventionalSearchField = field => /^(q|query|search|filter)$/i.test(field.name);
+  // Preserve the previous per-field semantic-or-conventional behavior so a
+  // search input plus a named filter control remains utility UI. Task evidence
+  // gates the whole shortcut: semantic markup alone must not hide an assignee
+  // picker, dialog, POST form, populated draft, or non-search submission.
+  const searchFieldsOnly = normalizedFields.length > 0
+    && normalizedFields.every(field => semanticSearchField(field) || conventionalSearchField(field));
+  const searchSubmitsOnly = normalizedSubmits.every(control => /search|filter|go/i.test(control.label));
+  const searchHasTaskEvidence = !!(
+    insideDialog
+    || normalizedMethod !== 'get'
+    || Number(hiddenNamedCount || 0) !== 0
+    || !searchSubmitsOnly
+    || normalizedFields.some(field => (
+      field.required
+      || field.focused
+      || !!field.value
+      || (!!field.name && !conventionalSearchField(field))
+    ))
+  );
+  // Primary content alone is not task evidence: result pages commonly place
+  // genuine search/filter forms there.
+  const safeSearchOnly = searchFieldsOnly && !searchHasTaskEvidence;
+  const hasSemanticSearchField = normalizedFields.some(semanticSearchField);
 
   const onlyField = normalizedFields.length === 1 ? normalizedFields[0] : null;
   const passiveUtilityShell = !!(
@@ -155,10 +171,10 @@ export function classifyCompletionForm({
 
   const utilityReason = utilityRegion
     ? 'utility_region'
-    : semanticSearchOnly
-      ? 'semantic_search'
-      : conventionalSearchOnly
-        ? 'conventional_search'
+    : safeSearchOnly
+      ? hasSemanticSearchField
+        ? 'semantic_search'
+        : 'conventional_search'
         : passiveUtilityShell
           ? 'passive_utility_shell'
           : null;

--- a/src/firefox/src/agent/completion-invariant.js
+++ b/src/firefox/src/agent/completion-invariant.js
@@ -94,6 +94,85 @@ function isSelfVerifyingActionResult(name, result) {
   );
 }
 
+/**
+ * Classify one visible form from browser-neutral structural facts.
+ *
+ * Completion probes run inside the page, so Agent serializes this function
+ * with toString() and supplies plain facts rather than DOM nodes. Keep this
+ * function self-contained and language-independent for structural fallbacks.
+ */
+export function classifyCompletionForm({
+  label = '',
+  utilityRegion = false,
+  outsidePrimaryContent = false,
+  insideDialog = false,
+  method = 'get',
+  hiddenNamedCount = 0,
+  editable = [],
+  submits = [],
+} = {}) {
+  const fields = Array.isArray(editable) ? editable : [];
+  const submitControls = Array.isArray(submits) ? submits : [];
+  const normalizedMethod = String(method || 'get').trim().toLowerCase() || 'get';
+  const normalizedFields = fields.map(field => ({
+    tag: String(field?.tag || '').trim().toLowerCase(),
+    type: String(field?.type || '').trim().toLowerCase(),
+    role: String(field?.role || '').trim().toLowerCase(),
+    name: String(field?.name || '').trim(),
+    value: String(field?.value || '').trim(),
+    required: field?.required === true,
+    focused: field?.focused === true,
+  }));
+  const normalizedSubmits = submitControls.map(control => ({
+    label: String(control?.label || '').trim(),
+  }));
+
+  const semanticSearchOnly = normalizedFields.length > 0
+    && normalizedFields.every(field => field.type === 'search' || field.role === 'searchbox');
+  // Preserve compatibility with conventional query field names. Unlike the
+  // structural branches, this legacy fallback intentionally requires a
+  // search-like submit label so an unrelated named field cannot hide a task
+  // form merely because its name happens to be short.
+  const conventionalSearchOnly = normalizedFields.length > 0
+    && normalizedFields.every(field => /^(q|query|search|filter)$/i.test(field.name))
+    && normalizedSubmits.every(control => /search|filter|go/i.test(control.label));
+
+  const onlyField = normalizedFields.length === 1 ? normalizedFields[0] : null;
+  const passiveUtilityShell = !!(
+    onlyField
+    && outsidePrimaryContent
+    && !insideDialog
+    && normalizedMethod === 'get'
+    && Number(hiddenNamedCount || 0) === 0
+    && normalizedSubmits.length === 0
+    && onlyField.tag === 'input'
+    && (onlyField.type === '' || onlyField.type === 'text' || onlyField.type === 'search')
+    && !onlyField.name
+    && !onlyField.value
+    && !onlyField.required
+    && !onlyField.focused
+  );
+
+  const utilityReason = utilityRegion
+    ? 'utility_region'
+    : semanticSearchOnly
+      ? 'semantic_search'
+      : conventionalSearchOnly
+        ? 'conventional_search'
+        : passiveUtilityShell
+          ? 'passive_utility_shell'
+          : null;
+  const utility = utilityReason !== null;
+  return {
+    label: String(label || '').trim().slice(0, 80),
+    relevant: !utility && (normalizedFields.length > 0 || normalizedSubmits.length > 0),
+    utility,
+    utilityReason,
+    editableCount: normalizedFields.length,
+    submitCount: normalizedSubmits.length,
+  };
+}
+
 export function isCompletionActionTool(name, args = {}) {
   if (name === 'execute_webmcp_tool') return true;
   if (

--- a/test/run.js
+++ b/test/run.js
@@ -10184,6 +10184,25 @@ test('completion form classification ignores passive localized utility shells wi
       },
       `${label}: mixed semantic and conventional search fields regressed`,
     );
+    assert.deepEqual(
+      classify({
+        outsidePrimaryContent: false,
+        editable: [
+          { tag: 'input', type: 'search', role: '', name: 'q', value: 'webbrain' },
+          { tag: 'select', type: '', role: '', name: 'filter', value: 'recent' },
+        ],
+        submits: [{ label: 'Search' }],
+      }),
+      {
+        label: '',
+        relevant: false,
+        utility: true,
+        utilityReason: 'semantic_search',
+        editableCount: 2,
+        submitCount: 1,
+      },
+      `${label}: retained search query and filter values were treated as task drafts`,
+    );
 
     for (const [caseName, override] of [
       ['primary-content form', { outsidePrimaryContent: false }],
@@ -10223,7 +10242,6 @@ test('completion form classification ignores passive localized utility shells wi
       ['search selector with hidden submitted state', { hiddenNamedCount: 1 }],
       ['required search selector', { editable: [{ ...semanticTaskSelector.editable[0], required: true }] }],
       ['focused search selector', { editable: [{ ...semanticTaskSelector.editable[0], focused: true }] }],
-      ['draft-bearing search selector', { editable: [{ ...semanticTaskSelector.editable[0], value: 'alice' }] }],
       ['named task search selector', { editable: [{ ...semanticTaskSelector.editable[0], name: 'assignee' }] }],
       ['search selector with non-search submit', { submits: [{ label: 'Add' }] }],
     ]) {

--- a/test/run.js
+++ b/test/run.js
@@ -10153,7 +10153,7 @@ test('completion form classification ignores passive localized utility shells wi
     assert.deepEqual(
       classify({
         editable: [{ tag: 'input', type: 'search', role: '', name: '', value: '' }],
-        submits: [{ label: 'Buscar' }],
+        submits: [],
       }),
       {
         label: '',
@@ -10161,9 +10161,28 @@ test('completion form classification ignores passive localized utility shells wi
         utility: true,
         utilityReason: 'semantic_search',
         editableCount: 1,
+        submitCount: 0,
+      },
+      `${label}: semantic search input without a submit control was not recognized structurally`,
+    );
+    assert.deepEqual(
+      classify({
+        outsidePrimaryContent: false,
+        editable: [
+          { tag: 'input', type: 'search', role: '', name: '', value: '' },
+          { tag: 'select', type: '', role: '', name: 'filter', value: '' },
+        ],
+        submits: [{ label: 'Filter' }],
+      }),
+      {
+        label: '',
+        relevant: false,
+        utility: true,
+        utilityReason: 'semantic_search',
+        editableCount: 2,
         submitCount: 1,
       },
-      `${label}: semantic search input depended on an English submit label`,
+      `${label}: mixed semantic and conventional search fields regressed`,
     );
 
     for (const [caseName, override] of [
@@ -10180,6 +10199,37 @@ test('completion form classification ignores passive localized utility shells wi
       const result = classify({ ...passiveSidebarSearch, ...override });
       assert.equal(result.relevant, true, `${label}: ${caseName} was hidden as utility UI`);
       assert.equal(result.utility, false, `${label}: ${caseName} received a utility classification`);
+    }
+
+    const semanticTaskSelector = {
+      outsidePrimaryContent: true,
+      insideDialog: false,
+      method: 'get',
+      hiddenNamedCount: 0,
+      editable: [{
+        tag: 'input',
+        type: 'search',
+        role: 'searchbox',
+        name: '',
+        value: '',
+        required: false,
+        focused: false,
+      }],
+      submits: [],
+    };
+    for (const [caseName, override] of [
+      ['dialog search selector', { insideDialog: true }],
+      ['POST search selector', { method: 'post' }],
+      ['search selector with hidden submitted state', { hiddenNamedCount: 1 }],
+      ['required search selector', { editable: [{ ...semanticTaskSelector.editable[0], required: true }] }],
+      ['focused search selector', { editable: [{ ...semanticTaskSelector.editable[0], focused: true }] }],
+      ['draft-bearing search selector', { editable: [{ ...semanticTaskSelector.editable[0], value: 'alice' }] }],
+      ['named task search selector', { editable: [{ ...semanticTaskSelector.editable[0], name: 'assignee' }] }],
+      ['search selector with non-search submit', { submits: [{ label: 'Add' }] }],
+    ]) {
+      const result = classify({ ...semanticTaskSelector, ...override });
+      assert.equal(result.relevant, true, `${label}: ${caseName} was hidden as semantic search UI`);
+      assert.equal(result.utility, false, `${label}: ${caseName} received a semantic utility classification`);
     }
 
     const agentSource = fs.readFileSync(path.join(ROOT, agentRel), 'utf8');

--- a/test/run.js
+++ b/test/run.js
@@ -10108,6 +10108,89 @@ test('getToolsForMode: `done` outcome is required in every supported Act and Dev
   }
 });
 
+test('completion form classification ignores passive localized utility shells without weakening real form guards', () => {
+  const passiveSidebarSearch = {
+    label: '',
+    outsidePrimaryContent: true,
+    insideDialog: false,
+    method: 'get',
+    hiddenNamedCount: 0,
+    editable: [{
+      tag: 'input',
+      type: 'text',
+      role: '',
+      name: '',
+      value: '',
+      required: false,
+      focused: false,
+    }],
+    submits: [],
+  };
+
+  for (const [label, invariant, agentRel] of [
+    ['chrome', CompletionInvariantCh, 'src/chrome/src/agent/agent.js'],
+    ['firefox', CompletionInvariantFx, 'src/firefox/src/agent/agent.js'],
+  ]) {
+    const classify = invariant.classifyCompletionForm;
+    const reconstructed = Function(`return (${classify.toString()});`)();
+    assert.deepEqual(
+      reconstructed(passiveSidebarSearch),
+      classify(passiveSidebarSearch),
+      `${label}: completion form classifier is not self-contained for page injection`,
+    );
+    assert.deepEqual(
+      classify(passiveSidebarSearch),
+      {
+        label: '',
+        relevant: false,
+        utility: true,
+        utilityReason: 'passive_utility_shell',
+        editableCount: 1,
+        submitCount: 0,
+      },
+      `${label}: Mastodon-shaped localized sidebar search still blocked completion`,
+    );
+    assert.deepEqual(
+      classify({
+        editable: [{ tag: 'input', type: 'search', role: '', name: '', value: '' }],
+        submits: [{ label: 'Buscar' }],
+      }),
+      {
+        label: '',
+        relevant: false,
+        utility: true,
+        utilityReason: 'semantic_search',
+        editableCount: 1,
+        submitCount: 1,
+      },
+      `${label}: semantic search input depended on an English submit label`,
+    );
+
+    for (const [caseName, override] of [
+      ['primary-content form', { outsidePrimaryContent: false }],
+      ['dialog form', { insideDialog: true }],
+      ['POST form', { method: 'post' }],
+      ['form with hidden submitted state', { hiddenNamedCount: 1 }],
+      ['required field', { editable: [{ ...passiveSidebarSearch.editable[0], required: true }] }],
+      ['focused field', { editable: [{ ...passiveSidebarSearch.editable[0], focused: true }] }],
+      ['draft-bearing field', { editable: [{ ...passiveSidebarSearch.editable[0], value: 'draft' }] }],
+      ['named task field', { editable: [{ ...passiveSidebarSearch.editable[0], name: 'title' }] }],
+      ['form with a submit control', { submits: [{ label: 'Gönder' }] }],
+    ]) {
+      const result = classify({ ...passiveSidebarSearch, ...override });
+      assert.equal(result.relevant, true, `${label}: ${caseName} was hidden as utility UI`);
+      assert.equal(result.utility, false, `${label}: ${caseName} received a utility classification`);
+    }
+
+    const agentSource = fs.readFileSync(path.join(ROOT, agentRel), 'utf8');
+    assert.match(
+      agentSource,
+      /const classifyForm = \$\{classifyCompletionForm\.toString\(\)\}/,
+      `${label}: done verification probe is not wired to the shared form classifier`,
+    );
+  }
+});
+
 test('completion invariant state machine enforces post-action observation with Chrome/Firefox parity', () => {
   assert.equal(
     fs.readFileSync(path.join(ROOT, 'src/chrome/src/agent/completion-invariant.js'), 'utf8'),


### PR DESCRIPTION
## Summary

- extract a browser-neutral completion-form classifier shared by the Chrome and Firefox probes
- recognize narrow passive utility shells without relying on English labels
- preserve mixed semantic and conventionally named search/filter forms through per-field matching
- preserve retained search query and filter values on results pages as utility state
- gate semantic search classification on stronger task evidence, including dialogs, POST forms, hidden state, required/focused fields, task-specific names, and non-search submits
- include the utility classification reason in bounded completion diagnostics

## Why

The completion probe treated an empty, unnamed, localized sidebar search form as unfinished task UI. That could prevent an otherwise valid `done` result on Mastodon-shaped pages even though the search box was unrelated to the task.

## Impact

Passive utility searches no longer trap completed runs, mixed and populated search/filter forms retain their expected behavior, and semantic search markup cannot hide genuine unfinished task forms. The classifier and its page-injection wiring are mirrored across Chrome and Firefox.

## Validation

- `node test/run.js` — 1,367 passed; the sole failure is the pre-existing `package.json` 26.0.1 versus changelog 26.0.0 mismatch
- `npm run test:security` — 60/60 passed
- `node --check` on both changed agent and completion-invariant modules plus the test runner
- Chrome/Firefox completion-invariant byte parity
- `git diff --check`