### PR TITLE
Paginate read_page article text

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1,5 +1,6 @@
 import { AGENT_TOOLS, AGENT_TOOL_NAMES, RESERVED_AGENT_TOOL_NAMES, getToolsForMode, SYSTEM_PROMPT_ASK, SYSTEM_PROMPT_ACT, SYSTEM_PROMPT_ACT_COMPACT, SYSTEM_PROMPT_ACT_MID, SYSTEM_PROMPT_DEV_APPENDIX, SYSTEM_PROMPT_WEBMCP_ASK, SYSTEM_PROMPT_WEBMCP_ACT } from './tools.js';
 import { handleDoneJson } from './cloud-output.js';
+import { applyReadPageWindow, fitReadPageWindowResult, isReadPageWindowResult } from './read-page-window.js';
 import { LoopDetector } from './loop-detector.js';
 import { parseToolCallsFromText } from './tool-call-parser.js';
 import { IMAGE_BUDGET, estimateImageTokens, fitImageDimensions } from './image-budget.js';
@@ -12645,13 +12646,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    */
   _limitToolResult(result) {
     const maxResultChars = 8000; // ~2k tokens
-    const safeResult = result == null ? {
+    const windowSafeResult = isReadPageWindowResult(result)
+      ? fitReadPageWindowResult(result, maxResultChars)
+      : result;
+    const safeResult = windowSafeResult == null ? {
       success: false,
       errorCode: 'missing_tool_response',
       missingToolResponse: true,
       outcomeUnknown: false,
       error: 'Tool returned no result.',
-    } : result;
+    } : windowSafeResult;
     let json;
     try {
       json = JSON.stringify(safeResult);
@@ -12668,14 +12672,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (json.length <= maxResultChars) return json;
 
     // Try to trim the 'text' field specifically (page content)
-    if (result && typeof result.text === 'string' && result.text.length > 4000) {
-      const trimmed = { ...result, text: result.text.slice(0, 4000) + '\n[...page text truncated]' };
+    if (safeResult && typeof safeResult.text === 'string' && safeResult.text.length > 4000) {
+      const trimmed = { ...safeResult, text: safeResult.text.slice(0, 4000) + '\n[...page text truncated]' };
       json = JSON.stringify(trimmed);
       if (json.length <= maxResultChars) return json;
     }
 
-    if (result && result.data && typeof result.data === 'object' && !Array.isArray(result.data)) {
-      const originalData = result.data;
+    if (safeResult && safeResult.data && typeof safeResult.data === 'object' && !Array.isArray(safeResult.data)) {
+      const originalData = safeResult.data;
       const originalText = typeof originalData.text === 'string' ? originalData.text : null;
       const originalSegments = Array.isArray(originalData.segments) ? originalData.segments : null;
       if (originalText || originalSegments) {
@@ -12710,7 +12714,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               data.segmentsTruncated = true;
               data.originalSegmentCount = data.originalSegmentCount ?? originalSegments.length;
             }
-            const trimmed = { ...result, data };
+            const trimmed = { ...safeResult, data };
             json = JSON.stringify(trimmed);
             if (json.length <= maxResultChars) return json;
           }
@@ -18067,6 +18071,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       );
       this._recordInteractionRect(tabId, name, response, interactionUrl);
       this._annotateCredentialField(name, response);
+      if (name === 'read_page') {
+        response = applyReadPageWindow(response, args);
+      }
       return response;
     } finally {
       clickAxSideEffectWatch?.stop();

--- a/src/chrome/src/agent/read-page-window.js
+++ b/src/chrome/src/agent/read-page-window.js
@@ -16,6 +16,13 @@ function withDeliveredText(result, text) {
   const deliveredEnd = Math.min(originalLength, textOffset + returnedLength);
   const hasMore = deliveredEnd < originalLength;
   const textTruncated = textOffset > 0 || hasMore;
+  const continuationArgs = hasMore
+    ? {
+      offset: deliveredEnd,
+      limit: Number(result.textLimit) || READ_PAGE_DEFAULT_LIMIT,
+      includeChrome: result.includeChrome === true,
+    }
+    : null;
   return {
     ...result,
     text,
@@ -23,6 +30,7 @@ function withDeliveredText(result, text) {
     textTruncated,
     hasMore,
     nextOffset: hasMore ? deliveredEnd : null,
+    continuationArgs,
     truncationReason: textTruncated ? 'tool_output_window' : null,
   };
 }

--- a/src/chrome/src/agent/read-page-window.js
+++ b/src/chrome/src/agent/read-page-window.js
@@ -1,0 +1,190 @@
+export const READ_PAGE_DEFAULT_LIMIT = 4000;
+export const READ_PAGE_MIN_LIMIT = 500;
+export const READ_PAGE_MAX_LIMIT = 6000;
+
+function boundedInteger(value, fallback, min, max) {
+  if (value == null || value === '') return fallback;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return fallback;
+  return Math.min(max, Math.max(min, Math.floor(numeric)));
+}
+
+function withDeliveredText(result, text) {
+  const originalLength = Number(result.originalLength) || 0;
+  const textOffset = Number(result.textOffset) || 0;
+  const returnedLength = text.length;
+  const deliveredEnd = Math.min(originalLength, textOffset + returnedLength);
+  const hasMore = deliveredEnd < originalLength;
+  const textTruncated = textOffset > 0 || hasMore;
+  return {
+    ...result,
+    text,
+    returnedLength,
+    textTruncated,
+    hasMore,
+    nextOffset: hasMore ? deliveredEnd : null,
+    truncationReason: textTruncated ? 'tool_output_window' : null,
+  };
+}
+
+function compactForm(form, inputLimit) {
+  if (!form || typeof form !== 'object' || !Array.isArray(form.inputs)) return form;
+  if (form.inputs.length <= inputLimit) return form;
+  return {
+    ...form,
+    inputs: form.inputs.slice(0, inputLimit),
+    inputsTruncated: true,
+    originalInputCount: form.inputs.length,
+  };
+}
+
+function compactAuxiliaryContent(result, {
+  linkLimit,
+  formLimit,
+  inputLimit,
+  shadowLimit,
+  mediaLimit,
+}) {
+  const links = Array.isArray(result.links) ? result.links : null;
+  const forms = Array.isArray(result.forms) ? result.forms : null;
+  const shadowDOM = Array.isArray(result.shadowDOM) ? result.shadowDOM : null;
+  const media = result.media && typeof result.media === 'object' ? result.media : null;
+  const videos = Array.isArray(media?.videos) ? media.videos : null;
+  const images = Array.isArray(media?.images) ? media.images : null;
+  return {
+    ...result,
+    ...(links ? {
+      links: links.slice(0, linkLimit),
+      originalLinkCount: links.length,
+    } : {}),
+    ...(forms ? {
+      forms: forms.slice(0, formLimit).map(form => compactForm(form, inputLimit)),
+      originalFormCount: forms.length,
+    } : {}),
+    ...(shadowDOM ? {
+      shadowDOM: shadowDOM.slice(0, shadowLimit),
+      originalShadowRootCount: shadowDOM.length,
+    } : {}),
+    ...(media ? {
+      media: {
+        ...media,
+        ...(videos ? { videos: videos.slice(0, mediaLimit) } : {}),
+        ...(images ? { images: images.slice(0, mediaLimit) } : {}),
+      },
+    } : {}),
+    auxiliaryContentTruncated: true,
+  };
+}
+
+function compactCoreResult(result) {
+  const shortString = (value, limit) => (
+    typeof value === 'string' ? value.slice(0, limit) : value
+  );
+  const pageGate = result.pageGate && typeof result.pageGate === 'object'
+    ? {
+      type: shortString(result.pageGate.type, 100),
+      blocking: result.pageGate.blocking === true,
+      surface: shortString(result.pageGate.surface, 100),
+      label: shortString(result.pageGate.label, 500),
+    }
+    : undefined;
+  return withDeliveredText({
+    url: shortString(result.url, 1000),
+    title: shortString(result.title, 500),
+    text: result.text,
+    textSource: shortString(result.textSource, 200),
+    isArticlePage: result.isArticlePage === true,
+    includeChrome: result.includeChrome === true,
+    originalLength: result.originalLength,
+    textOffset: result.textOffset,
+    textLimit: result.textLimit,
+    accessState: result.accessState,
+    accessGateEvidence: result.accessGateEvidence,
+    ...(pageGate ? { pageGate } : {}),
+    auxiliaryContentTruncated: true,
+  }, result.text);
+}
+
+export function isReadPageWindowResult(result) {
+  return !!result
+    && typeof result === 'object'
+    && typeof result.text === 'string'
+    && Number.isFinite(Number(result.originalLength))
+    && Number.isFinite(Number(result.textOffset))
+    && typeof result.accessState === 'string';
+}
+
+export function applyReadPageWindow(result, args = {}) {
+  if (!result || typeof result !== 'object' || typeof result.text !== 'string') return result;
+
+  const originalText = result.text;
+  const originalLength = originalText.length;
+  const requestedOffset = boundedInteger(args.offset, 0, 0, Number.MAX_SAFE_INTEGER);
+  const textOffset = Math.min(requestedOffset, originalLength);
+  const textLimit = boundedInteger(
+    args.limit,
+    READ_PAGE_DEFAULT_LIMIT,
+    READ_PAGE_MIN_LIMIT,
+    READ_PAGE_MAX_LIMIT,
+  );
+  const text = originalText.slice(textOffset, textOffset + textLimit);
+  const blockingPageGate = result.pageGate?.blocking === true;
+  const {
+    media,
+    activeElement,
+    links,
+    forms,
+    shadowDOM,
+    ...core
+  } = result;
+
+  return withDeliveredText({
+    ...core,
+    text,
+    originalLength,
+    textOffset,
+    textLimit,
+    accessState: blockingPageGate ? 'blocked_by_page_gate' : 'no_blocking_page_gate',
+    accessGateEvidence: blockingPageGate ? 'pageGate' : 'none',
+    ...(media !== undefined ? { media } : {}),
+    ...(activeElement !== undefined ? { activeElement } : {}),
+    ...(links !== undefined ? { links } : {}),
+    ...(forms !== undefined ? { forms } : {}),
+    ...(shadowDOM !== undefined ? { shadowDOM } : {}),
+  }, text);
+}
+
+export function fitReadPageWindowResult(result, maxChars = 8000) {
+  if (!isReadPageWindowResult(result)) return result;
+  const fits = candidate => JSON.stringify(candidate).length <= maxChars;
+  if (fits(result)) return result;
+
+  const profiles = [
+    { linkLimit: 20, formLimit: 5, inputLimit: 10, shadowLimit: 5, mediaLimit: 5 },
+    { linkLimit: 10, formLimit: 3, inputLimit: 5, shadowLimit: 2, mediaLimit: 2 },
+    { linkLimit: 0, formLimit: 0, inputLimit: 0, shadowLimit: 0, mediaLimit: 0 },
+  ];
+  let compact = result;
+  for (const profile of profiles) {
+    compact = compactAuxiliaryContent(result, profile);
+    if (fits(compact)) return compact;
+  }
+  if (!fits(withDeliveredText(compact, ''))) {
+    compact = compactCoreResult(result);
+  }
+
+  let low = 0;
+  let high = compact.text.length;
+  let best = withDeliveredText(compact, '');
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const candidate = withDeliveredText(compact, compact.text.slice(0, mid));
+    if (fits(candidate)) {
+      best = candidate;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return best;
+}

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -129,7 +129,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'read_page',
-      description: 'Read the current page as a bounded PROSE window — title, URL, visible text, links, and forms. LEGACY read path; prefer get_accessibility_tree for UI tasks. Use read_page only for long-form text content (articles, READMEs, documentation). Continue long text with `offset: nextOffset` while `hasMore:true`; do not scroll and reread the same document prefix. RESULT SHAPE: `text`, `originalLength`, `textOffset`, `textLimit`, `returnedLength`, `textTruncated`, `hasMore`, and `nextOffset` describe the tool-output window. `truncationReason:"tool_output_window"` is a context-window boundary, never evidence of a paywall. `accessState:"blocked_by_page_gate"` plus `accessGateEvidence:"pageGate"` is the structured access-block signal; `accessState:"no_blocking_page_gate"` means tool truncation must not be described as an access restriction. `pageGate`, when present, describes the rendered blocking surface; `textSource` identifies the article selector or bounded pre-gate/gate text; `isArticlePage` reports article markup. NOTE: PDF tabs auto-redirect to read_pdf because Chrome\'s PDF viewer is a chrome-extension:// page that content scripts cannot scrape.',
+      description: 'Read the current page as a bounded PROSE window — title, URL, visible text, links, and forms. LEGACY read path; prefer get_accessibility_tree for UI tasks. Use read_page only for long-form text content (articles, READMEs, documentation). While `hasMore:true`, continue with the exact returned `continuationArgs`; it carries `offset:nextOffset`, `limit`, and extraction options such as `includeChrome`. Do not scroll and reread the same document prefix. RESULT SHAPE: `text`, `originalLength`, `textOffset`, `textLimit`, `returnedLength`, `textTruncated`, `hasMore`, `nextOffset`, and `continuationArgs` describe the tool-output window. `truncationReason:"tool_output_window"` is a context-window boundary, never evidence of a paywall. `accessState:"blocked_by_page_gate"` plus `accessGateEvidence:"pageGate"` is the structured access-block signal; `accessState:"no_blocking_page_gate"` means tool truncation must not be described as an access restriction. `pageGate`, when present, describes the rendered blocking surface; `textSource` identifies the article selector or bounded pre-gate/gate text; `isArticlePage` reports article markup. NOTE: PDF tabs auto-redirect to read_pdf because Chrome\'s PDF viewer is a chrome-extension:// page that content scripts cannot scrape.',
       parameters: {
         type: 'object',
         properties: {
@@ -140,7 +140,7 @@ export const AGENT_TOOLS = [
           offset: {
             type: 'integer',
             minimum: 0,
-            description: 'Character offset into the extracted prose. Default 0. When hasMore is true, call read_page again with offset set exactly to nextOffset.',
+            description: 'Character offset into the extracted prose. Default 0. When hasMore is true, pass the exact returned continuationArgs so extraction options stay stable.',
           },
           limit: {
             type: 'integer',
@@ -1414,7 +1414,7 @@ READING THE CURRENT TAB vs. FETCHING URLS — read this:
 - DO NOT call \`fetch_url\` or \`research_url\` against the URL of the active tab, the API equivalent of the active tab, or a "renderable" / "raw" / "amp" / "mobile" variant of the active tab's URL. Re-fetching content the user is already looking at is the most common wasted step. Symptom of this antipattern: you fetch a Wikipedia/MediaWiki API URL for the same page the user is on, get a truncated result, then fetch a slightly different variant hoping for more content. Stop and call \`read_page\` instead.
 - \`fetch_url\` and \`research_url\` are for content on OTHER URLs — a referenced article, an API the page links to, a sibling page, a different site entirely.
 - If \`get_accessibility_tree({filter:"visible"})\` returns \`truncated:true\` / \`hasMore:true\`, call \`get_accessibility_tree({filter:"visible", page: nextPage})\` before scrolling to find a control that may already be visible but omitted from the first chunk.
-- If \`read_page\` returns \`hasMore:true\`, continue deterministically with \`read_page({offset: nextOffset})\` until enough article text is covered. Do not scroll and reread the same prefix. \`truncationReason:"tool_output_window"\` with \`accessState:"no_blocking_page_gate"\` is NOT a paywall or access restriction; only a structured blocking \`pageGate\` supports that claim.
+- If \`read_page\` returns \`hasMore:true\`, continue deterministically with the exact returned \`continuationArgs\` (equivalent to \`{offset: nextOffset, limit: textLimit, includeChrome}\`) until enough article text is covered. Preserve every extraction option across windows; do not scroll and reread the same prefix. \`truncationReason:"tool_output_window"\` with \`accessState:"no_blocking_page_gate"\` is NOT a paywall or access restriction; only a structured blocking \`pageGate\` supports that claim.
 
 Guidelines:
 1. Read the page first (a11y tree by default) to understand the context, then answer the user's question.

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -129,13 +129,24 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'read_page',
-      description: 'Read the current page as PROSE — title, URL, visible text, links, forms. LEGACY read path; prefer get_accessibility_tree for UI tasks. Use read_page only when the user is asking about long-form text content (articles, READMEs, documentation). RESULT SHAPE: `pageGate`, when present, describes a rendered blocking login/registration/subscription surface and means text behind that gate was deliberately excluded; `text` is the readable article body or bounded pre-gate/gate text; `textSource` is the CSS selector that produced the body, "page-gate", or a "(pre-gate)" selector; `isArticlePage` reports article markup. Only treat the article body as complete when no blocking `pageGate` is present and `isArticlePage:true` with a real article selector. NOTE: PDF tabs auto-redirect to read_pdf because Chrome\'s PDF viewer is a chrome-extension:// page that content scripts cannot scrape.',
+      description: 'Read the current page as a bounded PROSE window — title, URL, visible text, links, and forms. LEGACY read path; prefer get_accessibility_tree for UI tasks. Use read_page only for long-form text content (articles, READMEs, documentation). Continue long text with `offset: nextOffset` while `hasMore:true`; do not scroll and reread the same document prefix. RESULT SHAPE: `text`, `originalLength`, `textOffset`, `textLimit`, `returnedLength`, `textTruncated`, `hasMore`, and `nextOffset` describe the tool-output window. `truncationReason:"tool_output_window"` is a context-window boundary, never evidence of a paywall. `accessState:"blocked_by_page_gate"` plus `accessGateEvidence:"pageGate"` is the structured access-block signal; `accessState:"no_blocking_page_gate"` means tool truncation must not be described as an access restriction. `pageGate`, when present, describes the rendered blocking surface; `textSource` identifies the article selector or bounded pre-gate/gate text; `isArticlePage` reports article markup. NOTE: PDF tabs auto-redirect to read_pdf because Chrome\'s PDF viewer is a chrome-extension:// page that content scripts cannot scrape.',
       parameters: {
         type: 'object',
         properties: {
           includeChrome: {
             type: 'boolean',
             description: 'Include nav / header / footer / aside / ad-slot text in the body. Default false — when the user asks about article/README content you almost never want this. Set true only when the user is asking ABOUT the navigation menu, footer links, cookie banner, advertisement, etc.',
+          },
+          offset: {
+            type: 'integer',
+            minimum: 0,
+            description: 'Character offset into the extracted prose. Default 0. When hasMore is true, call read_page again with offset set exactly to nextOffset.',
+          },
+          limit: {
+            type: 'integer',
+            minimum: 500,
+            maximum: 6000,
+            description: 'Maximum prose characters to return. Default 4000; bounded to 500..6000.',
           },
         },
         required: [],
@@ -1403,7 +1414,7 @@ READING THE CURRENT TAB vs. FETCHING URLS — read this:
 - DO NOT call \`fetch_url\` or \`research_url\` against the URL of the active tab, the API equivalent of the active tab, or a "renderable" / "raw" / "amp" / "mobile" variant of the active tab's URL. Re-fetching content the user is already looking at is the most common wasted step. Symptom of this antipattern: you fetch a Wikipedia/MediaWiki API URL for the same page the user is on, get a truncated result, then fetch a slightly different variant hoping for more content. Stop and call \`read_page\` instead.
 - \`fetch_url\` and \`research_url\` are for content on OTHER URLs — a referenced article, an API the page links to, a sibling page, a different site entirely.
 - If \`get_accessibility_tree({filter:"visible"})\` returns \`truncated:true\` / \`hasMore:true\`, call \`get_accessibility_tree({filter:"visible", page: nextPage})\` before scrolling to find a control that may already be visible but omitted from the first chunk.
-- If \`read_page\` truncates or doesn't surface what you need, scroll the tab and re-read; or use \`get_accessibility_tree({ref_id: ...})\` to read a specific subtree. Don't escape to fetch_url to retrieve what's already in the DOM.
+- If \`read_page\` returns \`hasMore:true\`, continue deterministically with \`read_page({offset: nextOffset})\` until enough article text is covered. Do not scroll and reread the same prefix. \`truncationReason:"tool_output_window"\` with \`accessState:"no_blocking_page_gate"\` is NOT a paywall or access restriction; only a structured blocking \`pageGate\` supports that claim.
 
 Guidelines:
 1. Read the page first (a11y tree by default) to understand the context, then answer the user's question.

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1,5 +1,6 @@
 import { AGENT_TOOLS, AGENT_TOOL_NAMES, RESERVED_AGENT_TOOL_NAMES, getToolsForMode, SYSTEM_PROMPT_ASK, SYSTEM_PROMPT_ACT, SYSTEM_PROMPT_ACT_COMPACT, SYSTEM_PROMPT_ACT_MID, SYSTEM_PROMPT_DEV_APPENDIX } from './tools.js';
 import { handleDoneJson } from './cloud-output.js';
+import { applyReadPageWindow, fitReadPageWindowResult, isReadPageWindowResult } from './read-page-window.js';
 import { LoopDetector } from './loop-detector.js';
 import { parseToolCallsFromText } from './tool-call-parser.js';
 import { IMAGE_BUDGET, estimateImageTokens, fitImageDimensions } from './image-budget.js';
@@ -11217,13 +11218,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    */
   _limitToolResult(result) {
     const maxResultChars = 8000; // ~2k tokens
-    const safeResult = result == null ? {
+    const windowSafeResult = isReadPageWindowResult(result)
+      ? fitReadPageWindowResult(result, maxResultChars)
+      : result;
+    const safeResult = windowSafeResult == null ? {
       success: false,
       errorCode: 'missing_tool_response',
       missingToolResponse: true,
       outcomeUnknown: false,
       error: 'Tool returned no result.',
-    } : result;
+    } : windowSafeResult;
     let json;
     try {
       json = JSON.stringify(safeResult);
@@ -11240,14 +11244,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (json.length <= maxResultChars) return json;
 
     // Try to trim the 'text' field specifically (page content)
-    if (result && typeof result.text === 'string' && result.text.length > 4000) {
-      const trimmed = { ...result, text: result.text.slice(0, 4000) + '\n[...page text truncated]' };
+    if (safeResult && typeof safeResult.text === 'string' && safeResult.text.length > 4000) {
+      const trimmed = { ...safeResult, text: safeResult.text.slice(0, 4000) + '\n[...page text truncated]' };
       json = JSON.stringify(trimmed);
       if (json.length <= maxResultChars) return json;
     }
 
-    if (result && result.data && typeof result.data === 'object' && !Array.isArray(result.data)) {
-      const originalData = result.data;
+    if (safeResult && safeResult.data && typeof safeResult.data === 'object' && !Array.isArray(safeResult.data)) {
+      const originalData = safeResult.data;
       const originalText = typeof originalData.text === 'string' ? originalData.text : null;
       const originalSegments = Array.isArray(originalData.segments) ? originalData.segments : null;
       if (originalText || originalSegments) {
@@ -11282,7 +11286,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               data.segmentsTruncated = true;
               data.originalSegmentCount = data.originalSegmentCount ?? originalSegments.length;
             }
-            const trimmed = { ...result, data };
+            const trimmed = { ...safeResult, data };
             json = JSON.stringify(trimmed);
             if (json.length <= maxResultChars) return json;
           }
@@ -14224,6 +14228,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }
       }
       this._annotateCredentialField(name, response);
+      if (name === 'read_page') {
+        response = applyReadPageWindow(response, args);
+      }
       return response;
     } catch (e) {
       // Content script might not be injected — try injecting it
@@ -14250,6 +14257,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           }
         }
         this._annotateCredentialField(name, response);
+        if (name === 'read_page') {
+          response = applyReadPageWindow(response, args);
+        }
         return response;
       } catch (e2) {
         let pageUrl = '';

--- a/src/firefox/src/agent/read-page-window.js
+++ b/src/firefox/src/agent/read-page-window.js
@@ -16,6 +16,13 @@ function withDeliveredText(result, text) {
   const deliveredEnd = Math.min(originalLength, textOffset + returnedLength);
   const hasMore = deliveredEnd < originalLength;
   const textTruncated = textOffset > 0 || hasMore;
+  const continuationArgs = hasMore
+    ? {
+      offset: deliveredEnd,
+      limit: Number(result.textLimit) || READ_PAGE_DEFAULT_LIMIT,
+      includeChrome: result.includeChrome === true,
+    }
+    : null;
   return {
     ...result,
     text,
@@ -23,6 +30,7 @@ function withDeliveredText(result, text) {
     textTruncated,
     hasMore,
     nextOffset: hasMore ? deliveredEnd : null,
+    continuationArgs,
     truncationReason: textTruncated ? 'tool_output_window' : null,
   };
 }

--- a/src/firefox/src/agent/read-page-window.js
+++ b/src/firefox/src/agent/read-page-window.js
@@ -1,0 +1,190 @@
+export const READ_PAGE_DEFAULT_LIMIT = 4000;
+export const READ_PAGE_MIN_LIMIT = 500;
+export const READ_PAGE_MAX_LIMIT = 6000;
+
+function boundedInteger(value, fallback, min, max) {
+  if (value == null || value === '') return fallback;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return fallback;
+  return Math.min(max, Math.max(min, Math.floor(numeric)));
+}
+
+function withDeliveredText(result, text) {
+  const originalLength = Number(result.originalLength) || 0;
+  const textOffset = Number(result.textOffset) || 0;
+  const returnedLength = text.length;
+  const deliveredEnd = Math.min(originalLength, textOffset + returnedLength);
+  const hasMore = deliveredEnd < originalLength;
+  const textTruncated = textOffset > 0 || hasMore;
+  return {
+    ...result,
+    text,
+    returnedLength,
+    textTruncated,
+    hasMore,
+    nextOffset: hasMore ? deliveredEnd : null,
+    truncationReason: textTruncated ? 'tool_output_window' : null,
+  };
+}
+
+function compactForm(form, inputLimit) {
+  if (!form || typeof form !== 'object' || !Array.isArray(form.inputs)) return form;
+  if (form.inputs.length <= inputLimit) return form;
+  return {
+    ...form,
+    inputs: form.inputs.slice(0, inputLimit),
+    inputsTruncated: true,
+    originalInputCount: form.inputs.length,
+  };
+}
+
+function compactAuxiliaryContent(result, {
+  linkLimit,
+  formLimit,
+  inputLimit,
+  shadowLimit,
+  mediaLimit,
+}) {
+  const links = Array.isArray(result.links) ? result.links : null;
+  const forms = Array.isArray(result.forms) ? result.forms : null;
+  const shadowDOM = Array.isArray(result.shadowDOM) ? result.shadowDOM : null;
+  const media = result.media && typeof result.media === 'object' ? result.media : null;
+  const videos = Array.isArray(media?.videos) ? media.videos : null;
+  const images = Array.isArray(media?.images) ? media.images : null;
+  return {
+    ...result,
+    ...(links ? {
+      links: links.slice(0, linkLimit),
+      originalLinkCount: links.length,
+    } : {}),
+    ...(forms ? {
+      forms: forms.slice(0, formLimit).map(form => compactForm(form, inputLimit)),
+      originalFormCount: forms.length,
+    } : {}),
+    ...(shadowDOM ? {
+      shadowDOM: shadowDOM.slice(0, shadowLimit),
+      originalShadowRootCount: shadowDOM.length,
+    } : {}),
+    ...(media ? {
+      media: {
+        ...media,
+        ...(videos ? { videos: videos.slice(0, mediaLimit) } : {}),
+        ...(images ? { images: images.slice(0, mediaLimit) } : {}),
+      },
+    } : {}),
+    auxiliaryContentTruncated: true,
+  };
+}
+
+function compactCoreResult(result) {
+  const shortString = (value, limit) => (
+    typeof value === 'string' ? value.slice(0, limit) : value
+  );
+  const pageGate = result.pageGate && typeof result.pageGate === 'object'
+    ? {
+      type: shortString(result.pageGate.type, 100),
+      blocking: result.pageGate.blocking === true,
+      surface: shortString(result.pageGate.surface, 100),
+      label: shortString(result.pageGate.label, 500),
+    }
+    : undefined;
+  return withDeliveredText({
+    url: shortString(result.url, 1000),
+    title: shortString(result.title, 500),
+    text: result.text,
+    textSource: shortString(result.textSource, 200),
+    isArticlePage: result.isArticlePage === true,
+    includeChrome: result.includeChrome === true,
+    originalLength: result.originalLength,
+    textOffset: result.textOffset,
+    textLimit: result.textLimit,
+    accessState: result.accessState,
+    accessGateEvidence: result.accessGateEvidence,
+    ...(pageGate ? { pageGate } : {}),
+    auxiliaryContentTruncated: true,
+  }, result.text);
+}
+
+export function isReadPageWindowResult(result) {
+  return !!result
+    && typeof result === 'object'
+    && typeof result.text === 'string'
+    && Number.isFinite(Number(result.originalLength))
+    && Number.isFinite(Number(result.textOffset))
+    && typeof result.accessState === 'string';
+}
+
+export function applyReadPageWindow(result, args = {}) {
+  if (!result || typeof result !== 'object' || typeof result.text !== 'string') return result;
+
+  const originalText = result.text;
+  const originalLength = originalText.length;
+  const requestedOffset = boundedInteger(args.offset, 0, 0, Number.MAX_SAFE_INTEGER);
+  const textOffset = Math.min(requestedOffset, originalLength);
+  const textLimit = boundedInteger(
+    args.limit,
+    READ_PAGE_DEFAULT_LIMIT,
+    READ_PAGE_MIN_LIMIT,
+    READ_PAGE_MAX_LIMIT,
+  );
+  const text = originalText.slice(textOffset, textOffset + textLimit);
+  const blockingPageGate = result.pageGate?.blocking === true;
+  const {
+    media,
+    activeElement,
+    links,
+    forms,
+    shadowDOM,
+    ...core
+  } = result;
+
+  return withDeliveredText({
+    ...core,
+    text,
+    originalLength,
+    textOffset,
+    textLimit,
+    accessState: blockingPageGate ? 'blocked_by_page_gate' : 'no_blocking_page_gate',
+    accessGateEvidence: blockingPageGate ? 'pageGate' : 'none',
+    ...(media !== undefined ? { media } : {}),
+    ...(activeElement !== undefined ? { activeElement } : {}),
+    ...(links !== undefined ? { links } : {}),
+    ...(forms !== undefined ? { forms } : {}),
+    ...(shadowDOM !== undefined ? { shadowDOM } : {}),
+  }, text);
+}
+
+export function fitReadPageWindowResult(result, maxChars = 8000) {
+  if (!isReadPageWindowResult(result)) return result;
+  const fits = candidate => JSON.stringify(candidate).length <= maxChars;
+  if (fits(result)) return result;
+
+  const profiles = [
+    { linkLimit: 20, formLimit: 5, inputLimit: 10, shadowLimit: 5, mediaLimit: 5 },
+    { linkLimit: 10, formLimit: 3, inputLimit: 5, shadowLimit: 2, mediaLimit: 2 },
+    { linkLimit: 0, formLimit: 0, inputLimit: 0, shadowLimit: 0, mediaLimit: 0 },
+  ];
+  let compact = result;
+  for (const profile of profiles) {
+    compact = compactAuxiliaryContent(result, profile);
+    if (fits(compact)) return compact;
+  }
+  if (!fits(withDeliveredText(compact, ''))) {
+    compact = compactCoreResult(result);
+  }
+
+  let low = 0;
+  let high = compact.text.length;
+  let best = withDeliveredText(compact, '');
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const candidate = withDeliveredText(compact, compact.text.slice(0, mid));
+    if (fits(candidate)) {
+      best = candidate;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return best;
+}

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -129,13 +129,24 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'read_page',
-      description: 'Read the current page content including title, URL, visible text, links, and forms. RESULT SHAPE: `pageGate`, when present, describes a rendered blocking login/registration/subscription surface and means text behind that gate was deliberately excluded; `text` is the readable article body or bounded pre-gate/gate text; `textSource` is the CSS selector that produced the body, "page-gate", or a "(pre-gate)" selector; `isArticlePage` reports article markup. Only treat the article body as complete when no blocking `pageGate` is present and `isArticlePage:true` with a real article selector. NOTE: PDF tabs auto-redirect to read_pdf because Firefox\'s built-in viewer is a privileged page that content scripts cannot scrape.',
+      description: 'Read the current page as a bounded PROSE window — title, URL, visible text, links, and forms. LEGACY read path; prefer get_accessibility_tree for UI tasks. Use read_page only for long-form text content (articles, READMEs, documentation). Continue long text with `offset: nextOffset` while `hasMore:true`; do not scroll and reread the same document prefix. RESULT SHAPE: `text`, `originalLength`, `textOffset`, `textLimit`, `returnedLength`, `textTruncated`, `hasMore`, and `nextOffset` describe the tool-output window. `truncationReason:"tool_output_window"` is a context-window boundary, never evidence of a paywall. `accessState:"blocked_by_page_gate"` plus `accessGateEvidence:"pageGate"` is the structured access-block signal; `accessState:"no_blocking_page_gate"` means tool truncation must not be described as an access restriction. `pageGate`, when present, describes the rendered blocking surface; `textSource` identifies the article selector or bounded pre-gate/gate text; `isArticlePage` reports article markup. NOTE: PDF tabs auto-redirect to read_pdf because Firefox\'s built-in viewer is a privileged page that content scripts cannot scrape.',
       parameters: {
         type: 'object',
         properties: {
           includeChrome: {
             type: 'boolean',
             description: 'Include nav / header / footer / aside / ad-slot text in the body. Default false — when the user asks about article/README content you almost never want this. Set true only when the user is asking ABOUT the navigation menu, footer links, cookie banner, advertisement, etc.',
+          },
+          offset: {
+            type: 'integer',
+            minimum: 0,
+            description: 'Character offset into the extracted prose. Default 0. When hasMore is true, call read_page again with offset set exactly to nextOffset.',
+          },
+          limit: {
+            type: 'integer',
+            minimum: 500,
+            maximum: 6000,
+            description: 'Maximum prose characters to return. Default 4000; bounded to 500..6000.',
           },
         },
         required: [],
@@ -1278,7 +1289,7 @@ READING THE CURRENT TAB vs. FETCHING URLS — read this:
 - DO NOT call \`fetch_url\` or \`research_url\` against the URL of the active tab, the API equivalent of the active tab, or a "renderable" / "raw" / "amp" / "mobile" variant of the active tab's URL. Re-fetching content the user is already looking at is the most common wasted step. Symptom of this antipattern: you fetch a Wikipedia/MediaWiki API URL for the same page the user is on, get a truncated result, then fetch a slightly different variant hoping for more content. Stop and call \`read_page\` instead.
 - \`fetch_url\` and \`research_url\` are for content on OTHER URLs — a referenced article, an API the page links to, a sibling page, a different site entirely.
 - If \`get_accessibility_tree({filter:"visible"})\` returns \`truncated:true\` / \`hasMore:true\`, call \`get_accessibility_tree({filter:"visible", page: nextPage})\` before scrolling to find a control that may already be visible but omitted from the first chunk.
-- If \`read_page\` truncates or doesn't surface what you need, scroll the tab and re-read; or use \`get_accessibility_tree({ref_id: ...})\` to read a specific subtree. Don't escape to fetch_url to retrieve what's already in the DOM.
+- If \`read_page\` returns \`hasMore:true\`, continue deterministically with \`read_page({offset: nextOffset})\` until enough article text is covered. Do not scroll and reread the same prefix. \`truncationReason:"tool_output_window"\` with \`accessState:"no_blocking_page_gate"\` is NOT a paywall or access restriction; only a structured blocking \`pageGate\` supports that claim.
 
 Guidelines:
 1. Read the page first to understand the context, then answer the user's question.

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -129,7 +129,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'read_page',
-      description: 'Read the current page as a bounded PROSE window — title, URL, visible text, links, and forms. LEGACY read path; prefer get_accessibility_tree for UI tasks. Use read_page only for long-form text content (articles, READMEs, documentation). Continue long text with `offset: nextOffset` while `hasMore:true`; do not scroll and reread the same document prefix. RESULT SHAPE: `text`, `originalLength`, `textOffset`, `textLimit`, `returnedLength`, `textTruncated`, `hasMore`, and `nextOffset` describe the tool-output window. `truncationReason:"tool_output_window"` is a context-window boundary, never evidence of a paywall. `accessState:"blocked_by_page_gate"` plus `accessGateEvidence:"pageGate"` is the structured access-block signal; `accessState:"no_blocking_page_gate"` means tool truncation must not be described as an access restriction. `pageGate`, when present, describes the rendered blocking surface; `textSource` identifies the article selector or bounded pre-gate/gate text; `isArticlePage` reports article markup. NOTE: PDF tabs auto-redirect to read_pdf because Firefox\'s built-in viewer is a privileged page that content scripts cannot scrape.',
+      description: 'Read the current page as a bounded PROSE window — title, URL, visible text, links, and forms. LEGACY read path; prefer get_accessibility_tree for UI tasks. Use read_page only for long-form text content (articles, READMEs, documentation). While `hasMore:true`, continue with the exact returned `continuationArgs`; it carries `offset:nextOffset`, `limit`, and extraction options such as `includeChrome`. Do not scroll and reread the same document prefix. RESULT SHAPE: `text`, `originalLength`, `textOffset`, `textLimit`, `returnedLength`, `textTruncated`, `hasMore`, `nextOffset`, and `continuationArgs` describe the tool-output window. `truncationReason:"tool_output_window"` is a context-window boundary, never evidence of a paywall. `accessState:"blocked_by_page_gate"` plus `accessGateEvidence:"pageGate"` is the structured access-block signal; `accessState:"no_blocking_page_gate"` means tool truncation must not be described as an access restriction. `pageGate`, when present, describes the rendered blocking surface; `textSource` identifies the article selector or bounded pre-gate/gate text; `isArticlePage` reports article markup. NOTE: PDF tabs auto-redirect to read_pdf because Firefox\'s built-in viewer is a privileged page that content scripts cannot scrape.',
       parameters: {
         type: 'object',
         properties: {
@@ -140,7 +140,7 @@ export const AGENT_TOOLS = [
           offset: {
             type: 'integer',
             minimum: 0,
-            description: 'Character offset into the extracted prose. Default 0. When hasMore is true, call read_page again with offset set exactly to nextOffset.',
+            description: 'Character offset into the extracted prose. Default 0. When hasMore is true, pass the exact returned continuationArgs so extraction options stay stable.',
           },
           limit: {
             type: 'integer',
@@ -1289,7 +1289,7 @@ READING THE CURRENT TAB vs. FETCHING URLS — read this:
 - DO NOT call \`fetch_url\` or \`research_url\` against the URL of the active tab, the API equivalent of the active tab, or a "renderable" / "raw" / "amp" / "mobile" variant of the active tab's URL. Re-fetching content the user is already looking at is the most common wasted step. Symptom of this antipattern: you fetch a Wikipedia/MediaWiki API URL for the same page the user is on, get a truncated result, then fetch a slightly different variant hoping for more content. Stop and call \`read_page\` instead.
 - \`fetch_url\` and \`research_url\` are for content on OTHER URLs — a referenced article, an API the page links to, a sibling page, a different site entirely.
 - If \`get_accessibility_tree({filter:"visible"})\` returns \`truncated:true\` / \`hasMore:true\`, call \`get_accessibility_tree({filter:"visible", page: nextPage})\` before scrolling to find a control that may already be visible but omitted from the first chunk.
-- If \`read_page\` returns \`hasMore:true\`, continue deterministically with \`read_page({offset: nextOffset})\` until enough article text is covered. Do not scroll and reread the same prefix. \`truncationReason:"tool_output_window"\` with \`accessState:"no_blocking_page_gate"\` is NOT a paywall or access restriction; only a structured blocking \`pageGate\` supports that claim.
+- If \`read_page\` returns \`hasMore:true\`, continue deterministically with the exact returned \`continuationArgs\` (equivalent to \`{offset: nextOffset, limit: textLimit, includeChrome}\`) until enough article text is covered. Preserve every extraction option across windows; do not scroll and reread the same prefix. \`truncationReason:"tool_output_window"\` with \`accessState:"no_blocking_page_gate"\` is NOT a paywall or access restriction; only a structured blocking \`pageGate\` supports that claim.
 
 Guidelines:
 1. Read the page first to understand the context, then answer the user's question.

--- a/test/run.js
+++ b/test/run.js
@@ -3339,12 +3339,30 @@ test('read_page paginates a long friend-link article without inventing a paywall
       assert.equal(page.accessState, 'no_blocking_page_gate', `${label}: readable friend link was treated as blocked`);
       assert.equal(page.accessGateEvidence, 'none', `${label}: tool truncation invented access-gate evidence`);
       assert.equal(page.truncationReason, 'tool_output_window', `${label}: long page lacks a structured tool-window reason`);
+      if (page.hasMore) {
+        assert.deepEqual(page.continuationArgs, {
+          offset: page.nextOffset,
+          limit: 3000,
+          includeChrome: false,
+        }, `${label}: continuation does not preserve extraction options`);
+      }
       offset = page.nextOffset;
     } while (offset !== null);
 
     assert.equal(pages.map(page => page.text).join(''), longText, `${label}: continuation skipped or duplicated article text`);
     assert.equal(pages.at(-1).hasMore, false, `${label}: final window still claims more text`);
     assert.equal(pages.at(-1).nextOffset, null, `${label}: final window exposed a stale continuation`);
+    assert.equal(pages.at(-1).continuationArgs, null, `${label}: final window exposed stale continuation arguments`);
+
+    const chromeIncluded = runtime.applyReadPageWindow({
+      ...friendLinkArticle,
+      includeChrome: true,
+    }, { includeChrome: true, limit: 3000 });
+    assert.deepEqual(chromeIncluded.continuationArgs, {
+      offset: 3000,
+      limit: 3000,
+      includeChrome: true,
+    }, `${label}: includeChrome was lost across continuation`);
 
     const blocked = runtime.applyReadPageWindow({
       ...friendLinkArticle,
@@ -3376,9 +3394,9 @@ test('read_page schema and prompts require nextOffset continuation in both brows
     assert.equal(properties.offset.minimum, 0, `${label}: offset accepts negative values`);
     assert.equal(properties.limit.minimum, 500, `${label}: limit minimum drifted`);
     assert.equal(properties.limit.maximum, 6000, `${label}: limit maximum drifted`);
-    assert.match(tool.function.description, /offset: nextOffset[\s\S]*hasMore:true/i, `${label}: tool does not teach continuation`);
+    assert.match(tool.function.description, /hasMore:true[\s\S]*continuationArgs[\s\S]*offset:nextOffset/i, `${label}: tool does not teach stable continuation`);
     assert.match(tool.function.description, /tool_output_window[\s\S]*never evidence of a paywall/i, `${label}: tool truncation can be mistaken for a paywall`);
-    assert.match(prompt, /read_page\(\{offset: nextOffset\}\)/, `${label}: Ask prompt does not continue the returned window`);
+    assert.match(prompt, /continuationArgs[\s\S]*offset: nextOffset[\s\S]*includeChrome/, `${label}: Ask prompt does not preserve continuation options`);
     assert.match(prompt, /no_blocking_page_gate[\s\S]*NOT a paywall/i, `${label}: Ask prompt lacks the structural access distinction`);
     assert.doesNotMatch(prompt, /scroll the tab and re-read/i, `${label}: stale scroll-and-reread guidance survived`);
   }

--- a/test/run.js
+++ b/test/run.js
@@ -536,6 +536,12 @@ const CompletionInvariantCh = await import(
 const CompletionInvariantFx = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/agent/completion-invariant.js').replace(/\\/g, '/')
 );
+const ReadPageWindowCh = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/agent/read-page-window.js').replace(/\\/g, '/')
+);
+const ReadPageWindowFx = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/agent/read-page-window.js').replace(/\\/g, '/')
+);
 const {
   buildGithubStargazerProgressItems,
   parseGithubStargazerFollowButtons,
@@ -3293,6 +3299,89 @@ test('trace export: preserves structured pageGate before truncated article text 
   assert.match(markdown, /read_page[^\n]*pageGate[^\n]*subscription[^\n]*blocking[^\n]*true/i);
   assert.ok(markdown.indexOf('pageGate') < markdown.indexOf('truncated'), 'pageGate should survive before result truncation');
   assert.ok(markdown.indexOf('read_page') < markdown.indexOf('fetch_nytimes_article'), 'fallback tool should follow the blocked browser read');
+});
+
+test('read_page paginates a long friend-link article without inventing a paywall', () => {
+  const chromeSource = fs.readFileSync(path.join(ROOT, 'src/chrome/src/agent/read-page-window.js'), 'utf8');
+  const firefoxSource = fs.readFileSync(path.join(ROOT, 'src/firefox/src/agent/read-page-window.js'), 'utf8');
+  assert.equal(chromeSource, firefoxSource, 'Chrome/Firefox read_page window helpers drifted');
+
+  const longText = Array.from(
+    { length: 12 },
+    (_, index) => `SECTION-${String(index + 1).padStart(2, '0')}:`.padEnd(1000, String(index % 10)),
+  ).join('');
+  const friendLinkArticle = {
+    url: 'https://medium.example/long-article?source=friend_link',
+    title: 'A long article available through the author friend link',
+    text: longText,
+    textSource: 'article',
+    isArticlePage: true,
+    includeChrome: false,
+    links: Array.from({ length: 100 }, (_, index) => ({
+      text: `Reference ${index}`,
+      href: `https://medium.example/reference/${index}`,
+    })),
+    forms: [],
+    media: { videoCount: 0, imageCount: 0, videos: [], images: [] },
+  };
+
+  for (const [label, runtime] of [
+    ['chrome', ReadPageWindowCh],
+    ['firefox', ReadPageWindowFx],
+  ]) {
+    const pages = [];
+    let offset = 0;
+    do {
+      const page = runtime.applyReadPageWindow(friendLinkArticle, { offset, limit: 3000 });
+      pages.push(page);
+      assert.equal(page.originalLength, longText.length, `${label}: originalLength drifted`);
+      assert.equal(page.textOffset, offset, `${label}: textOffset drifted`);
+      assert.equal(page.accessState, 'no_blocking_page_gate', `${label}: readable friend link was treated as blocked`);
+      assert.equal(page.accessGateEvidence, 'none', `${label}: tool truncation invented access-gate evidence`);
+      assert.equal(page.truncationReason, 'tool_output_window', `${label}: long page lacks a structured tool-window reason`);
+      offset = page.nextOffset;
+    } while (offset !== null);
+
+    assert.equal(pages.map(page => page.text).join(''), longText, `${label}: continuation skipped or duplicated article text`);
+    assert.equal(pages.at(-1).hasMore, false, `${label}: final window still claims more text`);
+    assert.equal(pages.at(-1).nextOffset, null, `${label}: final window exposed a stale continuation`);
+
+    const blocked = runtime.applyReadPageWindow({
+      ...friendLinkArticle,
+      pageGate: { type: 'subscription', blocking: true, surface: 'dialog', label: 'Subscribe to continue' },
+    }, { limit: 3000 });
+    assert.equal(blocked.accessState, 'blocked_by_page_gate', `${label}: blocking pageGate was not preserved`);
+    assert.equal(blocked.accessGateEvidence, 'pageGate', `${label}: blocking pageGate lacks structured evidence`);
+
+    const fitted = runtime.fitReadPageWindowResult(pages[0], 8000);
+    assert.ok(JSON.stringify(fitted).length <= 8000, `${label}: model-facing read_page window exceeds the tool-result cap`);
+    assert.equal(fitted.nextOffset, fitted.textOffset + fitted.returnedLength, `${label}: compaction would skip unseen prose`);
+    const serialized = new (label === 'chrome' ? AgentCh : AgentFx)({})._limitToolResult(pages[0]);
+    const parsed = JSON.parse(serialized);
+    assert.equal(parsed.truncationReason, 'tool_output_window', `${label}: limiter discarded structured truncation metadata`);
+    assert.equal(parsed.accessState, 'no_blocking_page_gate', `${label}: limiter discarded structured access state`);
+    assert.doesNotMatch(serialized, /page text truncated/, `${label}: legacy prose-only truncation marker survived`);
+  }
+});
+
+test('read_page schema and prompts require nextOffset continuation in both browsers', () => {
+  for (const [label, getTools, prompt] of [
+    ['chrome', getToolsForModeCh, SYSTEM_PROMPT_ASK_CH],
+    ['firefox', getToolsForModeFx, SYSTEM_PROMPT_ASK_FX],
+  ]) {
+    const tool = getTools('ask').find(item => item.function.name === 'read_page');
+    assert.ok(tool, `${label}: read_page missing from Ask mode`);
+    const properties = tool.function.parameters.properties;
+    assert.equal(properties.offset.type, 'integer', `${label}: offset is not an integer`);
+    assert.equal(properties.offset.minimum, 0, `${label}: offset accepts negative values`);
+    assert.equal(properties.limit.minimum, 500, `${label}: limit minimum drifted`);
+    assert.equal(properties.limit.maximum, 6000, `${label}: limit maximum drifted`);
+    assert.match(tool.function.description, /offset: nextOffset[\s\S]*hasMore:true/i, `${label}: tool does not teach continuation`);
+    assert.match(tool.function.description, /tool_output_window[\s\S]*never evidence of a paywall/i, `${label}: tool truncation can be mistaken for a paywall`);
+    assert.match(prompt, /read_page\(\{offset: nextOffset\}\)/, `${label}: Ask prompt does not continue the returned window`);
+    assert.match(prompt, /no_blocking_page_gate[\s\S]*NOT a paywall/i, `${label}: Ask prompt lacks the structural access distinction`);
+    assert.doesNotMatch(prompt, /scroll the tab and re-read/i, `${label}: stale scroll-and-reread guidance survived`);
+  }
 });
 
 test('trace export: empty input → empty transcript, zero counts', () => {


### PR DESCRIPTION
## Summary

- return deterministic read-page window metadata: `textTruncated`, `originalLength`, `hasMore`, and `nextOffset`
- add bounded `offset` / `limit` continuation parameters and preserve the offset of the text actually delivered to the model
- distinguish `tool_output_window` from structured `pageGate` access-block evidence
- keep Chrome and Firefox behavior byte-identical and cover a long readable friend-link article

## Root cause

`read_page` returned an unstructured clipped string after the generic tool-result limiter ran. The model could neither continue from the omitted text nor distinguish a context window boundary from an actual paywall, so long readable friend-link articles could be misreported as access-restricted.

## Validation

- `git diff --check`
- Chrome/Firefox helper parity and Node syntax checks
- `npm run test:security` — 60/60 passed
- `npm test` — 1376 passed, 1 unrelated baseline failure: package version is 26.0.1 while the latest changelog section is 26.0.0