### PR TITLE
Fix false run replay compaction notices

### DIFF
--- a/src/chrome/src/run-ui-journal.js
+++ b/src/chrome/src/run-ui-journal.js
@@ -2,6 +2,34 @@ export const RUN_UI_EVENT_LIMIT = 256;
 export const RUN_UI_TEXT_DELTA_PERSIST_DELAY_MS = 200;
 export const RUN_UI_STREAM_TEXT_LIMIT = 100000;
 
+/**
+ * Highest sequence number that was genuinely evicted from the bounded replay
+ * journal. Older snapshots used `truncatedBeforeSeq` for both eviction and
+ * ordinary acknowledgements, so only treat that legacy value as a replay gap
+ * when it extends beyond the acknowledged boundary.
+ */
+export function runUiDiscardedBeforeSeq(snapshot = {}) {
+  if (Object.prototype.hasOwnProperty.call(snapshot, 'discardedBeforeSeq')) {
+    const explicit = Number(snapshot.discardedBeforeSeq);
+    return Number.isFinite(explicit) ? Math.max(0, explicit) : 0;
+  }
+  const legacy = Number(snapshot.truncatedBeforeSeq || 0);
+  const acknowledged = Number(snapshot.ackedSeq || 0);
+  if (!Number.isFinite(legacy) || legacy <= acknowledged) return 0;
+  return Math.max(0, legacy);
+}
+
+/**
+ * Events at or below this boundary are no longer available to a sidepanel
+ * replay. They may have been rendered and acknowledged by another panel copy,
+ * or genuinely evicted by the bounded journal.
+ */
+export function runUiUnavailableBeforeSeq(snapshot = {}) {
+  const acknowledged = Number(snapshot.ackedSeq || 0);
+  const acknowledgedBoundary = Number.isFinite(acknowledged) ? Math.max(0, acknowledged) : 0;
+  return Math.max(acknowledgedBoundary, runUiDiscardedBeforeSeq(snapshot));
+}
+
 export function createRunRequestId(tabId, supplied = '') {
   const clean = String(supplied || '').trim();
   return clean || `req_${tabId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
@@ -121,6 +149,8 @@ export class RunUiJournal {
       status: 'running',
       seq: 0,
       ackedSeq: 0,
+      discardedBeforeSeq: 0,
+      // Legacy alias retained for persisted snapshots and older callers.
       truncatedBeforeSeq: 0,
       events: [],
       pendingPlanId: null,
@@ -192,7 +222,9 @@ export class RunUiJournal {
     }
     while (snapshot.events.length > this.eventLimit) {
       const removed = snapshot.events.shift();
-      snapshot.truncatedBeforeSeq = removed?.seq || snapshot.truncatedBeforeSeq;
+      const removedSeq = Number(removed?.seq || 0);
+      snapshot.discardedBeforeSeq = removedSeq || snapshot.discardedBeforeSeq;
+      snapshot.truncatedBeforeSeq = snapshot.discardedBeforeSeq;
     }
     if (type === 'plan_review') {
       snapshot.status = 'awaiting_plan';
@@ -260,13 +292,19 @@ export class RunUiJournal {
     snapshot.events.push(event);
     while (snapshot.events.length > this.eventLimit) {
       const removed = snapshot.events.shift();
-      snapshot.truncatedBeforeSeq = removed?.seq || snapshot.truncatedBeforeSeq;
+      const removedSeq = Number(removed?.seq || 0);
+      snapshot.discardedBeforeSeq = removedSeq || snapshot.discardedBeforeSeq;
+      snapshot.truncatedBeforeSeq = snapshot.discardedBeforeSeq;
     }
     return this._changed(tabId, snapshot);
   }
 
   restore(tabId, snapshot) {
     if (!snapshot || typeof snapshot !== 'object') return null;
+    snapshot.discardedBeforeSeq = runUiDiscardedBeforeSeq(snapshot);
+    // From this point on, keep the legacy field aligned with real eviction
+    // only. Acknowledged events are intentionally released, not lost.
+    snapshot.truncatedBeforeSeq = snapshot.discardedBeforeSeq;
     if (snapshot.successfulDone !== true) snapshot.successfulDone = false;
     if (snapshot.hadError !== true) snapshot.hadError = false;
     if (typeof snapshot.lastError !== 'string') snapshot.lastError = '';
@@ -300,7 +338,6 @@ export class RunUiJournal {
     if (!snapshot || snapshot.requestId !== requestId || !Number.isFinite(numericSeq)) return null;
     snapshot.ackedSeq = Math.max(Number(snapshot.ackedSeq || 0), numericSeq);
     snapshot.events = snapshot.events.filter(event => Number(event?.seq || 0) > snapshot.ackedSeq);
-    snapshot.truncatedBeforeSeq = Math.max(Number(snapshot.truncatedBeforeSeq || 0), snapshot.ackedSeq);
     return this._changed(tabId, snapshot);
   }
 

--- a/src/chrome/src/ui/locales/ar.js
+++ b/src/chrome/src/ui/locales/ar.js
@@ -932,4 +932,5 @@ export default {
   'st.skills.cws.package_cleared': 'تمت إزالة ملف ZIP للإصدار من التخزين المحلي.',
   'st.skills.cws.package_zip_only': 'اختر ملف إصدار بصيغة .zip.',
   'st.skills.cws.package_too_large': 'يجب أن يكون حجم الملف بين 1 بايت و100 ميجابايت.',
+  'sp.run_progress_replay_gap': 'تعذّر إعادة عرض بعض تقدّم التشغيل السابق',
 };

--- a/src/chrome/src/ui/locales/bn.js
+++ b/src/chrome/src/ui/locales/bn.js
@@ -930,4 +930,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "আনুমানিক ক্যাশে পড়ার খরচ ($ / 1M টোকেন)",
   'st.provider.field.cache_write_cost_per_million': "আনুমানিক 5-মিনিট ক্যাশে লেখার খরচ ($ / 1M টোকেন)",
   'st.provider.field.cache_write_1h_cost_per_million': "আনুমানিক 1-ঘন্টা ক্যাশে লেখার খরচ ($ / 1M টোকেন)",
+  'sp.run_progress_replay_gap': 'আগের কিছু রান অগ্রগতি পুনরায় দেখানো যায়নি',
 };

--- a/src/chrome/src/ui/locales/de.js
+++ b/src/chrome/src/ui/locales/de.js
@@ -903,4 +903,5 @@ export default {
   'tr.event.args': 'Argumente',
   'tr.event.result': 'Ergebnis',
   'tr.event.step': 'Schritt {step}',
+  'sp.run_progress_replay_gap': 'Ein Teil des früheren Ausführungsverlaufs konnte nicht erneut angezeigt werden',
 };

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -934,4 +934,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Estimated cache read cost ($ / 1M tokens)",
   'st.provider.field.cache_write_cost_per_million': "Estimated 5-minute cache write cost ($ / 1M tokens)",
   'st.provider.field.cache_write_1h_cost_per_million': "Estimated 1-hour cache write cost ($ / 1M tokens)",
+  'sp.run_progress_replay_gap': 'Some earlier run progress could not be replayed',
 };

--- a/src/chrome/src/ui/locales/es.js
+++ b/src/chrome/src/ui/locales/es.js
@@ -932,4 +932,5 @@ export default {
   'st.skills.cws.package_cleared': 'ZIP de publicación seleccionado eliminado del almacenamiento local.',
   'st.skills.cws.package_zip_only': 'Elige un paquete de publicación en formato .zip.',
   'st.skills.cws.package_too_large': 'El archivo ZIP debe tener entre 1 byte y 100 MB.',
+  'sp.run_progress_replay_gap': 'No se pudo volver a mostrar parte del progreso anterior de la ejecución',
 };

--- a/src/chrome/src/ui/locales/fa.js
+++ b/src/chrome/src/ui/locales/fa.js
@@ -930,4 +930,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "تخمینی هزینه خواندن حافظه پنهان ($ / 1 میلیون توکن)",
   'st.provider.field.cache_write_cost_per_million': "تخمینی هزینه نوشتن 5 دقیقه ای کش ($ / 1 میلیون توکن)",
   'st.provider.field.cache_write_1h_cost_per_million': "تخمینی هزینه نوشتن حافظه پنهان 1 ساعته ($ / 1 میلیون توکن)",
+  'sp.run_progress_replay_gap': 'بخشی از پیشرفت پیشین اجرا قابل بازپخش نبود',
 };

--- a/src/chrome/src/ui/locales/fr.js
+++ b/src/chrome/src/ui/locales/fr.js
@@ -932,4 +932,5 @@ export default {
   'st.skills.cws.package_cleared': "ZIP de publication sélectionné supprimé du stockage local.",
   'st.skills.cws.package_zip_only': "Choisissez un package de publication au format .zip.",
   'st.skills.cws.package_too_large': "Le fichier ZIP doit faire entre 1 octet et 100 Mo.",
+  'sp.run_progress_replay_gap': 'Une partie de la progression précédente de l’exécution n’a pas pu être réaffichée',
 };

--- a/src/chrome/src/ui/locales/he.js
+++ b/src/chrome/src/ui/locales/he.js
@@ -885,4 +885,5 @@ export default {
   'st.skills.cws.package_cleared': 'קובץ ZIP ל פרסום נבחר הוסר מהאחסון המקומי.',
   'st.skills.cws.package_zip_only': 'בחר חבילת פרסום בפורמט .zip.',
   'st.skills.cws.package_too_large': 'קובץ ZIP חייב להיות בין 1 bait ל-100 MB.',
+  'sp.run_progress_replay_gap': 'לא ניתן היה להציג מחדש חלק מהתקדמות ההרצה הקודמת',
 };

--- a/src/chrome/src/ui/locales/hi.js
+++ b/src/chrome/src/ui/locales/hi.js
@@ -930,4 +930,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "अनुमानित कैश पढ़ने की लागत ($ / 1M टोकन)",
   'st.provider.field.cache_write_cost_per_million': "अनुमानित 5-मिनट कैश लिखने की लागत ($ / 1M टोकन)",
   'st.provider.field.cache_write_1h_cost_per_million': "अनुमानित 1-घंटे कैश लिखने की लागत ($ / 1M टोकन)",
+  'sp.run_progress_replay_gap': 'पहले की कुछ रन प्रगति दोबारा नहीं दिखाई जा सकी',
 };

--- a/src/chrome/src/ui/locales/id.js
+++ b/src/chrome/src/ui/locales/id.js
@@ -932,4 +932,5 @@ export default {
   'st.skills.cws.package_cleared': 'ZIP rilis yang dipilih dihapus dari penyimpanan lokal.',
   'st.skills.cws.package_zip_only': 'Pilih paket rilis berekstensi .zip.',
   'st.skills.cws.package_too_large': 'ZIP harus berukuran antara 1 byte hingga 100 MB.',
+  'sp.run_progress_replay_gap': 'Sebagian kemajuan proses sebelumnya tidak dapat ditampilkan ulang',
 };

--- a/src/chrome/src/ui/locales/ja.js
+++ b/src/chrome/src/ui/locales/ja.js
@@ -932,4 +932,5 @@ export default {
   'st.skills.cws.package_cleared': '選択したリリース ZIP がローカルストレージから削除されました。',
   'st.skills.cws.package_zip_only': '.zip リリースパッケージを選択してください。',
   'st.skills.cws.package_too_large': 'ZIP は 1 バイトから 100 MB の間でなければなりません。',
+  'sp.run_progress_replay_gap': '以前の実行進捗の一部を再表示できませんでした',
 };

--- a/src/chrome/src/ui/locales/ko.js
+++ b/src/chrome/src/ui/locales/ko.js
@@ -932,4 +932,5 @@ export default {
   'st.skills.cws.package_cleared': '선택된 릴리스 ZIP이 로컬 스토리지에서 제거되었습니다.',
   'st.skills.cws.package_zip_only': '.zip 릴리스 패키지를 선택하세요.',
   'st.skills.cws.package_too_large': 'ZIP은 1바이트에서 100MB 사이여야 합니다.',
+  'sp.run_progress_replay_gap': '이전 실행 진행 상황 일부를 다시 표시할 수 없습니다',
 };

--- a/src/chrome/src/ui/locales/ms.js
+++ b/src/chrome/src/ui/locales/ms.js
@@ -932,4 +932,5 @@ export default {
   'st.skills.cws.package_cleared': 'ZIP pelepasan yang dipilih dibuang daripada storan tempatan.',
   'st.skills.cws.package_zip_only': 'Pilih pakej pelepasan berformat .zip.',
   'st.skills.cws.package_too_large': 'ZIP mesti antara 1 bait hingga 100 MB.',
+  'sp.run_progress_replay_gap': 'Sebahagian kemajuan larian terdahulu tidak dapat dipaparkan semula',
 };

--- a/src/chrome/src/ui/locales/nl.js
+++ b/src/chrome/src/ui/locales/nl.js
@@ -883,4 +883,5 @@ export default {
   'st.skills.cws.package_cleared': 'Geselecteerde release-ZIP verwijderd uit lokale opslag.',
   'st.skills.cws.package_zip_only': 'Kies een .zip release-pakket.',
   'st.skills.cws.package_too_large': 'De ZIP moet tussen 1 byte en 100 MB zijn.',
+  'sp.run_progress_replay_gap': 'Een deel van de eerdere uitvoeringsvoortgang kon niet opnieuw worden weergegeven',
 };

--- a/src/chrome/src/ui/locales/pl.js
+++ b/src/chrome/src/ui/locales/pl.js
@@ -892,4 +892,5 @@ export default {
   'st.skills.cws.package_cleared': 'Wybrany ZIP publikacji usunięty z pamięci lokalnej.',
   'st.skills.cws.package_zip_only': 'Wybierz pakiet publikacji w formacie .zip.',
   'st.skills.cws.package_too_large': 'ZIP musi mieć rozmiar od 1 bajta do 100 MB.',
+  'sp.run_progress_replay_gap': 'Nie udało się ponownie wyświetlić części wcześniejszego postępu wykonania',
 };

--- a/src/chrome/src/ui/locales/pt.js
+++ b/src/chrome/src/ui/locales/pt.js
@@ -930,4 +930,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Custo estimado de leitura de cache ($/1 milhão de tokens)",
   'st.provider.field.cache_write_cost_per_million': "Custo estimado de gravação em cache de 5 minutos ($/1 milhão de tokens)",
   'st.provider.field.cache_write_1h_cost_per_million': "Custo estimado de gravação de cache em 1 hora ($/1 milhão de tokens)",
+  'sp.run_progress_replay_gap': 'Não foi possível reexibir parte do progresso anterior da execução',
 };

--- a/src/chrome/src/ui/locales/ru.js
+++ b/src/chrome/src/ui/locales/ru.js
@@ -932,4 +932,5 @@ export default {
   'st.skills.cws.package_cleared': 'Выбранный ZIP-файл публикации удалён из локального хранилища.',
   'st.skills.cws.package_zip_only': 'Выберите пакет публикации в формате .zip.',
   'st.skills.cws.package_too_large': 'ZIP-файл должен быть от 1 байта до 100 МБ.',
+  'sp.run_progress_replay_gap': 'Не удалось повторно показать часть предыдущего хода выполнения',
 };

--- a/src/chrome/src/ui/locales/th.js
+++ b/src/chrome/src/ui/locales/th.js
@@ -932,4 +932,5 @@ export default {
   'st.skills.cws.package_cleared': 'ลบ ZIP การเผยแพร่ที่เลือกออกจากที่จัดเก็บในเครื่องแล้ว',
   'st.skills.cws.package_zip_only': 'เลือกแพ็คเกจการเผยแพร่รูปแบบ .zip',
   'st.skills.cws.package_too_large': 'ZIP ต้องมีขนาดระหว่าง 1 ไบต์ถึง 100 MB',
+  'sp.run_progress_replay_gap': 'ไม่สามารถแสดงความคืบหน้าก่อนหน้านี้บางส่วนของการทำงานซ้ำได้',
 };

--- a/src/chrome/src/ui/locales/tl.js
+++ b/src/chrome/src/ui/locales/tl.js
@@ -932,4 +932,5 @@ export default {
   'st.skills.cws.package_cleared': 'Na-remove ang napiling release ZIP mula sa local storage.',
   'st.skills.cws.package_zip_only': 'Pumili ng .zip release package.',
   'st.skills.cws.package_too_large': 'Ang ZIP ay dapat nasa pagitan ng 1 byte hanggang 100 MB.',
+  'sp.run_progress_replay_gap': 'Hindi maipakita muli ang ilang naunang progreso ng run',
 };

--- a/src/chrome/src/ui/locales/tr.js
+++ b/src/chrome/src/ui/locales/tr.js
@@ -931,4 +931,5 @@ export default {
   'st.skills.cws.package_cleared': 'Seçili sürüm ZIP\'i yerel depodan kaldırıldı.',
   'st.skills.cws.package_zip_only': '.zip biçiminde bir sürüm paketi seçin.',
   'st.skills.cws.package_too_large': 'ZIP 1 bayt ile 100 MB arasında olmalıdır.',
+  'sp.run_progress_replay_gap': 'Önceki çalışma ilerlemesinin bir kısmı yeniden gösterilemedi',
 };

--- a/src/chrome/src/ui/locales/uk.js
+++ b/src/chrome/src/ui/locales/uk.js
@@ -932,4 +932,5 @@ export default {
   'st.skills.cws.package_cleared': 'Вибраний ZIP-файл публікації видалено з локального сховища.',
   'st.skills.cws.package_zip_only': 'Виберіть пакет публікації у форматі .zip.',
   'st.skills.cws.package_too_large': 'ZIP-файл повинен бути від 1 байта до 100 МБ.',
+  'sp.run_progress_replay_gap': 'Не вдалося повторно показати частину попереднього перебігу виконання',
 };

--- a/src/chrome/src/ui/locales/vi.js
+++ b/src/chrome/src/ui/locales/vi.js
@@ -930,4 +930,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Chi phí đọc bộ nhớ đệm ước tính ($ / 1 triệu token)",
   'st.provider.field.cache_write_cost_per_million': "Ước tính chi phí ghi vào bộ nhớ đệm trong 5 phút ($ / 1 triệu token)",
   'st.provider.field.cache_write_1h_cost_per_million': "Chi phí ghi bộ nhớ đệm trong 1 giờ ước tính ($ / 1 triệu token)",
+  'sp.run_progress_replay_gap': 'Không thể hiển thị lại một phần tiến trình chạy trước đó',
 };

--- a/src/chrome/src/ui/locales/zh.js
+++ b/src/chrome/src/ui/locales/zh.js
@@ -932,4 +932,5 @@ export default {
   'st.skills.cws.package_cleared': '已从本地存储中移除选中的发布 ZIP。',
   'st.skills.cws.package_zip_only': '请选择 .zip 格式的发布包。',
   'st.skills.cws.package_too_large': 'ZIP 文件大小必须在 1 字节到 100 MB 之间。',
+  'sp.run_progress_replay_gap': '部分较早的运行进度无法重新显示',
 };

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -9347,7 +9347,7 @@ function addContextCompactedNote(data) {
 function addRunProgressReplayGapNote() {
   const note = document.createElement('div');
   note.className = 'context-compacted-note run-progress-replay-gap-note';
-  note.textContent = 'Some earlier run progress could not be replayed';
+  note.textContent = t('sp.run_progress_replay_gap');
   const stepsContainer = getOrCreateStepsContainer();
   if (stepsContainer) {
     stepsContainer.appendChild(note);

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -4005,13 +4005,14 @@ async function applyActiveRunState(numericTabId, state) {
     };
     if (!hasReplayableStreamStart) restoreSnapshotStream();
     const unavailableBeforeSeq = runUiUnavailableBeforeSeq(runUi);
-    if (unavailableBeforeSeq > lastRenderedSeq) {
+    const replayGapBeforeSeq = Number(runAssistantEl.dataset.replayGapBeforeSeq || 0);
+    if (unavailableBeforeSeq > lastRenderedSeq
+        && unavailableBeforeSeq > replayGapBeforeSeq) {
       addRunProgressReplayGapNote();
-      // The discarded range has now been represented by the one gap marker.
-      // Advance the local cursor so the 1.2s run-state poll cannot append the
-      // same notice again when there are no replayable events after the gap.
-      lastRenderedSeq = unavailableBeforeSeq;
-      runAssistantEl.dataset.lastRenderedSeq = String(lastRenderedSeq);
+      // Keep replay-loss notice deduplication separate from the rendered-event
+      // cursor. A terminal snapshot can be fully acknowledged (and therefore
+      // absent from events) while finalContent still needs to be restored.
+      runAssistantEl.dataset.replayGapBeforeSeq = String(unavailableBeforeSeq);
     }
     for (const event of replayEvents) {
       if (Number(event?.seq || 0) <= lastRenderedSeq) continue;

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -16,6 +16,7 @@ import {
 import { deleteChatHistoryRecord, saveChatHistoryRecord } from './chat-history-store.js';
 import { claimRunError } from './run-error-dedupe.js';
 import { RUN_CAPTURE_START_ERROR_PREFIX } from '../run-capture.js';
+import { runUiUnavailableBeforeSeq } from '../run-ui-journal.js';
 import { escapeHtml } from './utils.js';
 import {
   isBackgroundConnectionError,
@@ -3973,7 +3974,7 @@ async function applyActiveRunState(numericTabId, state) {
     runAssistantEl.dataset.runRequestId = String(runUi.requestId);
     runAssistantEl.dataset.retryForeground = runUi.foreground === true ? 'true' : 'false';
     if (runUi.runId) runAssistantEl.dataset.runId = String(runUi.runId);
-    const lastRenderedSeq = Number(runAssistantEl.dataset.lastRenderedSeq || 0);
+    let lastRenderedSeq = Number(runAssistantEl.dataset.lastRenderedSeq || 0);
     const replayEvents = Array.isArray(runUi.events) ? runUi.events : [];
     const snapshotStreamedText = runUi.streamedTextTruncated === true
       ? ''
@@ -4003,8 +4004,14 @@ async function applyActiveRunState(numericTabId, state) {
       restoredSnapshotStream = true;
     };
     if (!hasReplayableStreamStart) restoreSnapshotStream();
-    if (runUi.truncatedBeforeSeq > lastRenderedSeq) {
-      addContextCompactedNote({ message: 'Some hidden-tab progress was compacted.' });
+    const unavailableBeforeSeq = runUiUnavailableBeforeSeq(runUi);
+    if (unavailableBeforeSeq > lastRenderedSeq) {
+      addRunProgressReplayGapNote();
+      // The discarded range has now been represented by the one gap marker.
+      // Advance the local cursor so the 1.2s run-state poll cannot append the
+      // same notice again when there are no replayable events after the gap.
+      lastRenderedSeq = unavailableBeforeSeq;
+      runAssistantEl.dataset.lastRenderedSeq = String(lastRenderedSeq);
     }
     for (const event of replayEvents) {
       if (Number(event?.seq || 0) <= lastRenderedSeq) continue;
@@ -9324,6 +9331,23 @@ function addContextCompactedNote(data) {
   // at the actual compaction point, interleaved with the tool steps. Appending
   // to messagesEl would drop it *after* the still-open bubble — i.e. before the
   // text/tool output that the same bubble keeps receiving post-compaction.
+  const stepsContainer = getOrCreateStepsContainer();
+  if (stepsContainer) {
+    stepsContainer.appendChild(note);
+  } else {
+    messagesEl.appendChild(note);
+  }
+  scrollToBottom();
+}
+
+/**
+ * Run-journal replay loss is UI history loss, not model-context compaction.
+ * Keep the styling subtle but use a distinct class and unambiguous copy.
+ */
+function addRunProgressReplayGapNote() {
+  const note = document.createElement('div');
+  note.className = 'context-compacted-note run-progress-replay-gap-note';
+  note.textContent = 'Some earlier run progress could not be replayed';
   const stepsContainer = getOrCreateStepsContainer();
   if (stepsContainer) {
     stepsContainer.appendChild(note);

--- a/src/firefox/src/run-ui-journal.js
+++ b/src/firefox/src/run-ui-journal.js
@@ -2,6 +2,34 @@ export const RUN_UI_EVENT_LIMIT = 256;
 export const RUN_UI_TEXT_DELTA_PERSIST_DELAY_MS = 200;
 export const RUN_UI_STREAM_TEXT_LIMIT = 100000;
 
+/**
+ * Highest sequence number that was genuinely evicted from the bounded replay
+ * journal. Older snapshots used `truncatedBeforeSeq` for both eviction and
+ * ordinary acknowledgements, so only treat that legacy value as a replay gap
+ * when it extends beyond the acknowledged boundary.
+ */
+export function runUiDiscardedBeforeSeq(snapshot = {}) {
+  if (Object.prototype.hasOwnProperty.call(snapshot, 'discardedBeforeSeq')) {
+    const explicit = Number(snapshot.discardedBeforeSeq);
+    return Number.isFinite(explicit) ? Math.max(0, explicit) : 0;
+  }
+  const legacy = Number(snapshot.truncatedBeforeSeq || 0);
+  const acknowledged = Number(snapshot.ackedSeq || 0);
+  if (!Number.isFinite(legacy) || legacy <= acknowledged) return 0;
+  return Math.max(0, legacy);
+}
+
+/**
+ * Events at or below this boundary are no longer available to a sidepanel
+ * replay. They may have been rendered and acknowledged by another panel copy,
+ * or genuinely evicted by the bounded journal.
+ */
+export function runUiUnavailableBeforeSeq(snapshot = {}) {
+  const acknowledged = Number(snapshot.ackedSeq || 0);
+  const acknowledgedBoundary = Number.isFinite(acknowledged) ? Math.max(0, acknowledged) : 0;
+  return Math.max(acknowledgedBoundary, runUiDiscardedBeforeSeq(snapshot));
+}
+
 export function createRunRequestId(tabId, supplied = '') {
   const clean = String(supplied || '').trim();
   return clean || `req_${tabId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
@@ -121,6 +149,8 @@ export class RunUiJournal {
       status: 'running',
       seq: 0,
       ackedSeq: 0,
+      discardedBeforeSeq: 0,
+      // Legacy alias retained for persisted snapshots and older callers.
       truncatedBeforeSeq: 0,
       events: [],
       pendingPlanId: null,
@@ -192,7 +222,9 @@ export class RunUiJournal {
     }
     while (snapshot.events.length > this.eventLimit) {
       const removed = snapshot.events.shift();
-      snapshot.truncatedBeforeSeq = removed?.seq || snapshot.truncatedBeforeSeq;
+      const removedSeq = Number(removed?.seq || 0);
+      snapshot.discardedBeforeSeq = removedSeq || snapshot.discardedBeforeSeq;
+      snapshot.truncatedBeforeSeq = snapshot.discardedBeforeSeq;
     }
     if (type === 'plan_review') {
       snapshot.status = 'awaiting_plan';
@@ -260,13 +292,19 @@ export class RunUiJournal {
     snapshot.events.push(event);
     while (snapshot.events.length > this.eventLimit) {
       const removed = snapshot.events.shift();
-      snapshot.truncatedBeforeSeq = removed?.seq || snapshot.truncatedBeforeSeq;
+      const removedSeq = Number(removed?.seq || 0);
+      snapshot.discardedBeforeSeq = removedSeq || snapshot.discardedBeforeSeq;
+      snapshot.truncatedBeforeSeq = snapshot.discardedBeforeSeq;
     }
     return this._changed(tabId, snapshot);
   }
 
   restore(tabId, snapshot) {
     if (!snapshot || typeof snapshot !== 'object') return null;
+    snapshot.discardedBeforeSeq = runUiDiscardedBeforeSeq(snapshot);
+    // From this point on, keep the legacy field aligned with real eviction
+    // only. Acknowledged events are intentionally released, not lost.
+    snapshot.truncatedBeforeSeq = snapshot.discardedBeforeSeq;
     if (snapshot.successfulDone !== true) snapshot.successfulDone = false;
     if (snapshot.hadError !== true) snapshot.hadError = false;
     if (typeof snapshot.lastError !== 'string') snapshot.lastError = '';
@@ -300,7 +338,6 @@ export class RunUiJournal {
     if (!snapshot || snapshot.requestId !== requestId || !Number.isFinite(numericSeq)) return null;
     snapshot.ackedSeq = Math.max(Number(snapshot.ackedSeq || 0), numericSeq);
     snapshot.events = snapshot.events.filter(event => Number(event?.seq || 0) > snapshot.ackedSeq);
-    snapshot.truncatedBeforeSeq = Math.max(Number(snapshot.truncatedBeforeSeq || 0), snapshot.ackedSeq);
     return this._changed(tabId, snapshot);
   }
 

--- a/src/firefox/src/ui/locales/ar.js
+++ b/src/firefox/src/ui/locales/ar.js
@@ -905,4 +905,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "تكلفة قراءة ذاكرة التخزين المؤقت المقدّرة ($ / مليون رمز)",
   'st.provider.field.cache_write_cost_per_million': "تكلفة كتابة ذاكرة التخزين المؤقت لمدة 5 دقائق ($ / مليون رمز)",
   'st.provider.field.cache_write_1h_cost_per_million': "تكلفة كتابة ذاكرة التخزين المؤقت لمدة ساعة واحدة ($ / مليون رمز)",
+  'sp.run_progress_replay_gap': 'تعذّر إعادة عرض بعض تقدّم التشغيل السابق',
 };

--- a/src/firefox/src/ui/locales/bn.js
+++ b/src/firefox/src/ui/locales/bn.js
@@ -925,4 +925,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "আনুমানিক ক্যাশে পড়ার খরচ ($ / 1M টোকেন)",
   'st.provider.field.cache_write_cost_per_million': "আনুমানিক 5-মিনিট ক্যাশে লেখার খরচ ($ / 1M টোকেন)",
   'st.provider.field.cache_write_1h_cost_per_million': "আনুমানিক 1-ঘন্টা ক্যাশে লেখার খরচ ($ / 1M টোকেন)",
+  'sp.run_progress_replay_gap': 'আগের কিছু রান অগ্রগতি পুনরায় দেখানো যায়নি',
 };

--- a/src/firefox/src/ui/locales/de.js
+++ b/src/firefox/src/ui/locales/de.js
@@ -898,4 +898,5 @@ export default {
   'tr.event.args': 'Argumente',
   'tr.event.result': 'Ergebnis',
   'tr.event.step': 'Schritt {step}',
+  'sp.run_progress_replay_gap': 'Ein Teil des früheren Ausführungsverlaufs konnte nicht erneut angezeigt werden',
 };

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -927,4 +927,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Estimated cache read cost ($ / 1M tokens)",
   'st.provider.field.cache_write_cost_per_million': "Estimated 5-minute cache write cost ($ / 1M tokens)",
   'st.provider.field.cache_write_1h_cost_per_million': "Estimated 1-hour cache write cost ($ / 1M tokens)",
+  'sp.run_progress_replay_gap': 'Some earlier run progress could not be replayed',
 };

--- a/src/firefox/src/ui/locales/es.js
+++ b/src/firefox/src/ui/locales/es.js
@@ -905,4 +905,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Coste estimado de lectura de caché ($ / 1M tokens)",
   'st.provider.field.cache_write_cost_per_million': "Coste estimado de escritura en caché de 5 min ($ / 1M tokens)",
   'st.provider.field.cache_write_1h_cost_per_million': "Coste estimado de escritura en caché de 1 h ($ / 1M tokens)",
+  'sp.run_progress_replay_gap': 'No se pudo volver a mostrar parte del progreso anterior de la ejecución',
 };

--- a/src/firefox/src/ui/locales/fa.js
+++ b/src/firefox/src/ui/locales/fa.js
@@ -925,4 +925,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "تخمینی هزینه خواندن حافظه پنهان ($ / 1 میلیون توکن)",
   'st.provider.field.cache_write_cost_per_million': "تخمینی هزینه نوشتن 5 دقیقه ای کش ($ / 1 میلیون توکن)",
   'st.provider.field.cache_write_1h_cost_per_million': "تخمینی هزینه نوشتن حافظه پنهان 1 ساعته ($ / 1 میلیون توکن)",
+  'sp.run_progress_replay_gap': 'بخشی از پیشرفت پیشین اجرا قابل بازپخش نبود',
 };

--- a/src/firefox/src/ui/locales/fr.js
+++ b/src/firefox/src/ui/locales/fr.js
@@ -905,4 +905,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Coût estimé de lecture du cache ($ / 1M tokens)",
   'st.provider.field.cache_write_cost_per_million': "Coût estimé d’écriture du cache (5 min) ($ / 1M tokens)",
   'st.provider.field.cache_write_1h_cost_per_million': "Coût estimé d’écriture du cache (1 h) ($ / 1M tokens)",
+  'sp.run_progress_replay_gap': 'Une partie de la progression précédente de l’exécution n’a pas pu être réaffichée',
 };

--- a/src/firefox/src/ui/locales/he.js
+++ b/src/firefox/src/ui/locales/he.js
@@ -858,4 +858,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "עלות משוערת לקריאה מהמטמון ($ / מיליון אסימונים)",
   'st.provider.field.cache_write_cost_per_million': "עלות משוערת לכתיבה למטמון ל-5 דקות ($ / מיליון אסימונים)",
   'st.provider.field.cache_write_1h_cost_per_million': "עלות משוערת לכתיבה למטמון לשעה ($ / מיליון אסימונים)",
+  'sp.run_progress_replay_gap': 'לא ניתן היה להציג מחדש חלק מהתקדמות ההרצה הקודמת',
 };

--- a/src/firefox/src/ui/locales/hi.js
+++ b/src/firefox/src/ui/locales/hi.js
@@ -925,4 +925,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "अनुमानित कैश पढ़ने की लागत ($ / 1M टोकन)",
   'st.provider.field.cache_write_cost_per_million': "अनुमानित 5-मिनट कैश लिखने की लागत ($ / 1M टोकन)",
   'st.provider.field.cache_write_1h_cost_per_million': "अनुमानित 1-घंटे कैश लिखने की लागत ($ / 1M टोकन)",
+  'sp.run_progress_replay_gap': 'पहले की कुछ रन प्रगति दोबारा नहीं दिखाई जा सकी',
 };

--- a/src/firefox/src/ui/locales/id.js
+++ b/src/firefox/src/ui/locales/id.js
@@ -905,4 +905,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Perkiraan biaya baca cache ($ / 1 juta token)",
   'st.provider.field.cache_write_cost_per_million': "Perkiraan biaya tulis cache 5 menit ($ / 1 juta token)",
   'st.provider.field.cache_write_1h_cost_per_million': "Perkiraan biaya tulis cache 1 jam ($ / 1 juta token)",
+  'sp.run_progress_replay_gap': 'Sebagian kemajuan proses sebelumnya tidak dapat ditampilkan ulang',
 };

--- a/src/firefox/src/ui/locales/ja.js
+++ b/src/firefox/src/ui/locales/ja.js
@@ -905,4 +905,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "キャッシュ読み取りの推定費用（$ / 100万トークン）",
   'st.provider.field.cache_write_cost_per_million': "5分キャッシュ書き込みの推定費用（$ / 100万トークン）",
   'st.provider.field.cache_write_1h_cost_per_million': "1時間キャッシュ書き込みの推定費用（$ / 100万トークン）",
+  'sp.run_progress_replay_gap': '以前の実行進捗の一部を再表示できませんでした',
 };

--- a/src/firefox/src/ui/locales/ko.js
+++ b/src/firefox/src/ui/locales/ko.js
@@ -905,4 +905,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "캐시 읽기 예상 비용($ / 100만 토큰)",
   'st.provider.field.cache_write_cost_per_million': "5분 캐시 쓰기 예상 비용($ / 100만 토큰)",
   'st.provider.field.cache_write_1h_cost_per_million': "1시간 캐시 쓰기 예상 비용($ / 100만 토큰)",
+  'sp.run_progress_replay_gap': '이전 실행 진행 상황 일부를 다시 표시할 수 없습니다',
 };

--- a/src/firefox/src/ui/locales/ms.js
+++ b/src/firefox/src/ui/locales/ms.js
@@ -905,4 +905,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Anggaran kos bacaan cache ($ / 1 juta token)",
   'st.provider.field.cache_write_cost_per_million': "Anggaran kos tulis cache 5 minit ($ / 1 juta token)",
   'st.provider.field.cache_write_1h_cost_per_million': "Anggaran kos tulis cache 1 jam ($ / 1 juta token)",
+  'sp.run_progress_replay_gap': 'Sebahagian kemajuan larian terdahulu tidak dapat dipaparkan semula',
 };

--- a/src/firefox/src/ui/locales/nl.js
+++ b/src/firefox/src/ui/locales/nl.js
@@ -878,4 +878,5 @@ export default {
   'st.skills.cws.package_cleared': 'Geselecteerde release-ZIP verwijderd uit lokale opslag.',
   'st.skills.cws.package_zip_only': 'Kies een .zip release-pakket.',
   'st.skills.cws.package_too_large': 'De ZIP moet tussen 1 byte en 100 MB zijn.',
+  'sp.run_progress_replay_gap': 'Een deel van de eerdere uitvoeringsvoortgang kon niet opnieuw worden weergegeven',
 };

--- a/src/firefox/src/ui/locales/pl.js
+++ b/src/firefox/src/ui/locales/pl.js
@@ -865,4 +865,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Szacowany koszt odczytu z pamięci podręcznej ($ / 1M tokenów)",
   'st.provider.field.cache_write_cost_per_million': "Szacowany koszt zapisu do pamięci podręcznej (5 min) ($ / 1M tokenów)",
   'st.provider.field.cache_write_1h_cost_per_million': "Szacowany koszt zapisu do pamięci podręcznej (1 godz.) ($ / 1M tokenów)",
+  'sp.run_progress_replay_gap': 'Nie udało się ponownie wyświetlić części wcześniejszego postępu wykonania',
 };

--- a/src/firefox/src/ui/locales/pt.js
+++ b/src/firefox/src/ui/locales/pt.js
@@ -925,4 +925,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Custo estimado de leitura de cache ($/1 milhão de tokens)",
   'st.provider.field.cache_write_cost_per_million': "Custo estimado de gravação em cache de 5 minutos ($/1 milhão de tokens)",
   'st.provider.field.cache_write_1h_cost_per_million': "Custo estimado de gravação de cache em 1 hora ($/1 milhão de tokens)",
+  'sp.run_progress_replay_gap': 'Não foi possível reexibir parte do progresso anterior da execução',
 };

--- a/src/firefox/src/ui/locales/ru.js
+++ b/src/firefox/src/ui/locales/ru.js
@@ -905,4 +905,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Расчётная стоимость чтения из кэша ($ / 1 млн токенов)",
   'st.provider.field.cache_write_cost_per_million': "Расчётная стоимость записи в кэш на 5 минут ($ / 1 млн токенов)",
   'st.provider.field.cache_write_1h_cost_per_million': "Расчётная стоимость записи в кэш на 1 час ($ / 1 млн токенов)",
+  'sp.run_progress_replay_gap': 'Не удалось повторно показать часть предыдущего хода выполнения',
 };

--- a/src/firefox/src/ui/locales/th.js
+++ b/src/firefox/src/ui/locales/th.js
@@ -905,4 +905,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "ค่าอ่านแคชโดยประมาณ ($ / 1 ล้านโทเค็น)",
   'st.provider.field.cache_write_cost_per_million': "ค่าการเขียนแคช 5 นาทีโดยประมาณ ($ / 1 ล้านโทเค็น)",
   'st.provider.field.cache_write_1h_cost_per_million': "ค่าการเขียนแคช 1 ชั่วโมงโดยประมาณ ($ / 1 ล้านโทเค็น)",
+  'sp.run_progress_replay_gap': 'ไม่สามารถแสดงความคืบหน้าก่อนหน้านี้บางส่วนของการทำงานซ้ำได้',
 };

--- a/src/firefox/src/ui/locales/tl.js
+++ b/src/firefox/src/ui/locales/tl.js
@@ -905,4 +905,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Tinatayang gastos sa pagbasa ng cache ($ / 1M token)",
   'st.provider.field.cache_write_cost_per_million': "Tinatayang gastos sa 5 minutong pagsulat ng cache ($ / 1M token)",
   'st.provider.field.cache_write_1h_cost_per_million': "Tinatayang gastos sa 1 oras na pagsulat ng cache ($ / 1M token)",
+  'sp.run_progress_replay_gap': 'Hindi maipakita muli ang ilang naunang progreso ng run',
 };

--- a/src/firefox/src/ui/locales/tr.js
+++ b/src/firefox/src/ui/locales/tr.js
@@ -904,4 +904,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Tahmini önbellek okuma maliyeti ($ / 1M token)",
   'st.provider.field.cache_write_cost_per_million': "Tahmini 5 dakikalık önbellek yazma maliyeti ($ / 1M token)",
   'st.provider.field.cache_write_1h_cost_per_million': "Tahmini 1 saatlik önbellek yazma maliyeti ($ / 1M token)",
+  'sp.run_progress_replay_gap': 'Önceki çalışma ilerlemesinin bir kısmı yeniden gösterilemedi',
 };

--- a/src/firefox/src/ui/locales/uk.js
+++ b/src/firefox/src/ui/locales/uk.js
@@ -905,4 +905,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Орієнтовна вартість читання з кешу ($ / 1 млн токенів)",
   'st.provider.field.cache_write_cost_per_million': "Орієнтовна вартість запису в кеш на 5 хвилин ($ / 1 млн токенів)",
   'st.provider.field.cache_write_1h_cost_per_million': "Орієнтовна вартість запису в кеш на 1 годину ($ / 1 млн токенів)",
+  'sp.run_progress_replay_gap': 'Не вдалося повторно показати частину попереднього перебігу виконання',
 };

--- a/src/firefox/src/ui/locales/vi.js
+++ b/src/firefox/src/ui/locales/vi.js
@@ -925,4 +925,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "Chi phí đọc bộ nhớ đệm ước tính ($ / 1 triệu token)",
   'st.provider.field.cache_write_cost_per_million': "Ước tính chi phí ghi vào bộ nhớ đệm trong 5 phút ($ / 1 triệu token)",
   'st.provider.field.cache_write_1h_cost_per_million': "Chi phí ghi bộ nhớ đệm trong 1 giờ ước tính ($ / 1 triệu token)",
+  'sp.run_progress_replay_gap': 'Không thể hiển thị lại một phần tiến trình chạy trước đó',
 };

--- a/src/firefox/src/ui/locales/zh.js
+++ b/src/firefox/src/ui/locales/zh.js
@@ -905,4 +905,5 @@ export default {
   'st.provider.field.cache_read_cost_per_million': "估算缓存读取费用（$ / 100 万 token）",
   'st.provider.field.cache_write_cost_per_million': "估算 5 分钟缓存写入费用（$ / 100 万 token）",
   'st.provider.field.cache_write_1h_cost_per_million': "估算 1 小时缓存写入费用（$ / 100 万 token）",
+  'sp.run_progress_replay_gap': '部分较早的运行进度无法重新显示',
 };

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -16,6 +16,7 @@ import {
 import { deleteChatHistoryRecord, saveChatHistoryRecord } from './chat-history-store.js';
 import { claimRunError } from './run-error-dedupe.js';
 import { RUN_CAPTURE_START_ERROR_PREFIX } from '../run-capture.js';
+import { runUiUnavailableBeforeSeq } from '../run-ui-journal.js';
 import { escapeHtml } from './utils.js';
 import {
   isBackgroundConnectionError,
@@ -3827,7 +3828,7 @@ async function applyActiveRunState(numericTabId, state) {
     runAssistantEl.dataset.runRequestId = String(runUi.requestId);
     runAssistantEl.dataset.retryForeground = runUi.foreground === true ? 'true' : 'false';
     if (runUi.runId) runAssistantEl.dataset.runId = String(runUi.runId);
-    const lastRenderedSeq = Number(runAssistantEl.dataset.lastRenderedSeq || 0);
+    let lastRenderedSeq = Number(runAssistantEl.dataset.lastRenderedSeq || 0);
     const replayEvents = Array.isArray(runUi.events) ? runUi.events : [];
     const snapshotStreamedText = runUi.streamedTextTruncated === true
       ? ''
@@ -3857,8 +3858,14 @@ async function applyActiveRunState(numericTabId, state) {
       restoredSnapshotStream = true;
     };
     if (!hasReplayableStreamStart) restoreSnapshotStream();
-    if (runUi.truncatedBeforeSeq > lastRenderedSeq) {
-      addContextCompactedNote({ message: 'Some hidden-tab progress was compacted.' });
+    const unavailableBeforeSeq = runUiUnavailableBeforeSeq(runUi);
+    if (unavailableBeforeSeq > lastRenderedSeq) {
+      addRunProgressReplayGapNote();
+      // The discarded range has now been represented by the one gap marker.
+      // Advance the local cursor so the 1.2s run-state poll cannot append the
+      // same notice again when there are no replayable events after the gap.
+      lastRenderedSeq = unavailableBeforeSeq;
+      runAssistantEl.dataset.lastRenderedSeq = String(lastRenderedSeq);
     }
     for (const event of replayEvents) {
       if (Number(event?.seq || 0) <= lastRenderedSeq) continue;
@@ -8976,6 +8983,23 @@ function addContextCompactedNote(data) {
   // at the actual compaction point, interleaved with the tool steps. Appending
   // to messagesEl would drop it *after* the still-open bubble — i.e. before the
   // text/tool output that the same bubble keeps receiving post-compaction.
+  const stepsContainer = getOrCreateStepsContainer();
+  if (stepsContainer) {
+    stepsContainer.appendChild(note);
+  } else {
+    messagesEl.appendChild(note);
+  }
+  scrollToBottom();
+}
+
+/**
+ * Run-journal replay loss is UI history loss, not model-context compaction.
+ * Keep the styling subtle but use a distinct class and unambiguous copy.
+ */
+function addRunProgressReplayGapNote() {
+  const note = document.createElement('div');
+  note.className = 'context-compacted-note run-progress-replay-gap-note';
+  note.textContent = 'Some earlier run progress could not be replayed';
   const stepsContainer = getOrCreateStepsContainer();
   if (stepsContainer) {
     stepsContainer.appendChild(note);

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -3859,13 +3859,14 @@ async function applyActiveRunState(numericTabId, state) {
     };
     if (!hasReplayableStreamStart) restoreSnapshotStream();
     const unavailableBeforeSeq = runUiUnavailableBeforeSeq(runUi);
-    if (unavailableBeforeSeq > lastRenderedSeq) {
+    const replayGapBeforeSeq = Number(runAssistantEl.dataset.replayGapBeforeSeq || 0);
+    if (unavailableBeforeSeq > lastRenderedSeq
+        && unavailableBeforeSeq > replayGapBeforeSeq) {
       addRunProgressReplayGapNote();
-      // The discarded range has now been represented by the one gap marker.
-      // Advance the local cursor so the 1.2s run-state poll cannot append the
-      // same notice again when there are no replayable events after the gap.
-      lastRenderedSeq = unavailableBeforeSeq;
-      runAssistantEl.dataset.lastRenderedSeq = String(lastRenderedSeq);
+      // Keep replay-loss notice deduplication separate from the rendered-event
+      // cursor. A terminal snapshot can be fully acknowledged (and therefore
+      // absent from events) while finalContent still needs to be restored.
+      runAssistantEl.dataset.replayGapBeforeSeq = String(unavailableBeforeSeq);
     }
     for (const event of replayEvents) {
       if (Number(event?.seq || 0) <= lastRenderedSeq) continue;

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -8999,7 +8999,7 @@ function addContextCompactedNote(data) {
 function addRunProgressReplayGapNote() {
   const note = document.createElement('div');
   note.className = 'context-compacted-note run-progress-replay-gap-note';
-  note.textContent = 'Some earlier run progress could not be replayed';
+  note.textContent = t('sp.run_progress_replay_gap');
   const stepsContainer = getOrCreateStepsContainer();
   if (stepsContainer) {
     stepsContainer.appendChild(note);

--- a/test/run.js
+++ b/test/run.js
@@ -317,6 +317,8 @@ const { renderSkillMarkdown } = await import(
 const {
   RunUiJournal: RunUiJournalCh,
   RunUiPersistenceScheduler: RunUiPersistenceSchedulerCh,
+  runUiDiscardedBeforeSeq: runUiDiscardedBeforeSeqCh,
+  runUiUnavailableBeforeSeq: runUiUnavailableBeforeSeqCh,
   runUiSnapshotForRequest: runUiSnapshotForRequestCh,
 } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/run-ui-journal.js').replace(/\\/g, '/')
@@ -324,6 +326,8 @@ const {
 const {
   RunUiJournal: RunUiJournalFx,
   RunUiPersistenceScheduler: RunUiPersistenceSchedulerFx,
+  runUiDiscardedBeforeSeq: runUiDiscardedBeforeSeqFx,
+  runUiUnavailableBeforeSeq: runUiUnavailableBeforeSeqFx,
   runUiSnapshotForRequest: runUiSnapshotForRequestFx,
 } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/run-ui-journal.js').replace(/\\/g, '/')
@@ -53801,6 +53805,7 @@ test('run UI journal: concurrent tabs, bounded replay, terminal snapshots, and s
     journal.record(1, 'request-a', 'thinking', { content: 'a4' }, 'run-a');
 
     assert.equal(journal.get(1).events.length, 3, `${label}: replay journal should remain bounded`);
+    assert.equal(journal.get(1).discardedBeforeSeq, 1, `${label}: eviction should expose the genuine replay-gap boundary`);
     assert.equal(journal.get(1).truncatedBeforeSeq, 1, `${label}: compaction should expose the missing sequence boundary`);
     assert.deepEqual(journal.get(2).events.map(event => event.data.content), ['b1'], `${label}: tab B events must remain independent`);
     assert.equal(journal.record(1, 'stale-request', 'plan_review', { planId: 'stale' }, 'run-stale'), null, `${label}: stale request events must be rejected`);
@@ -53814,6 +53819,7 @@ test('run UI journal: concurrent tabs, bounded replay, terminal snapshots, and s
     const terminalSeq = journal.get(1).seq;
     assert.ok(journal.acknowledge(1, 'request-a', terminalSeq), `${label}: the rendered tab should acknowledge replay`);
     assert.equal(journal.get(1).events.length, 0, `${label}: acknowledged replay events should be released`);
+    assert.equal(journal.get(1).discardedBeforeSeq, 2, `${label}: acknowledgement must not turn rendered events into replay loss`);
     assert.equal(journal.get(1).finalContent, 'A finished', `${label}: acknowledgement must retain the terminal snapshot`);
 
     const remounted = new Journal();
@@ -53842,7 +53848,8 @@ test('run UI journal: resumed requests preserve sequence and replay boundaries',
     assert.equal(resumed.foreground, true, `${label}: restored continuations should retain foreground mode`);
     assert.equal(resumed.seq, 2, `${label}: resume must preserve the prior sequence`);
     assert.equal(resumed.ackedSeq, 1, `${label}: resume must preserve the acknowledged replay boundary`);
-    assert.equal(resumed.truncatedBeforeSeq, 1, `${label}: resume must preserve the compaction boundary`);
+    assert.equal(resumed.discardedBeforeSeq, 0, `${label}: acknowledged events must not become replay gaps`);
+    assert.equal(resumed.truncatedBeforeSeq, 0, `${label}: legacy truncation state should represent eviction only`);
     assert.equal(resumed.status, 'running', `${label}: resumed journal should return to running`);
     assert.equal(resumed.pendingPlanId, null, `${label}: stale pre-restart plan ownership should be cleared`);
     assert.deepEqual(
@@ -53862,6 +53869,58 @@ test('run UI journal: resumed requests preserve sequence and replay boundaries',
       `${label}: resumed events should not collide with prior replay sequence numbers`,
     );
     assert.equal(restarted.resume(7, 'different-request'), null, `${label}: a manual continuation must not reuse another request journal`);
+  }
+});
+
+test('run UI journal: replay gaps distinguish acknowledgements and dedupe repeated polls', () => {
+  for (const [label, Journal, discardedBeforeSeq, unavailableBeforeSeq] of [
+    ['chrome', RunUiJournalCh, runUiDiscardedBeforeSeqCh, runUiUnavailableBeforeSeqCh],
+    ['firefox', RunUiJournalFx, runUiDiscardedBeforeSeqFx, runUiUnavailableBeforeSeqFx],
+  ]) {
+    const acknowledged = new Journal();
+    acknowledged.begin(9, `${label}-ack-only`);
+    acknowledged.record(9, `${label}-ack-only`, 'thinking', { step: 1 });
+    acknowledged.acknowledge(9, `${label}-ack-only`, 1);
+    assert.equal(discardedBeforeSeq(acknowledged.get(9)), 0, `${label}: normal acknowledgement must not report replay loss`);
+    assert.equal(unavailableBeforeSeq(acknowledged.get(9)), 1, `${label}: another panel should still know acknowledged events are unavailable for replay`);
+
+    const evicted = new Journal({ eventLimit: 1 });
+    evicted.begin(10, `${label}-evicted`);
+    evicted.record(10, `${label}-evicted`, 'thinking', { step: 1 });
+    evicted.record(10, `${label}-evicted`, 'thinking', { step: 2 });
+    const snapshot = evicted.get(10);
+    let lastRenderedSeq = 0;
+    let notices = 0;
+    for (let poll = 0; poll < 6; poll++) {
+      const boundary = unavailableBeforeSeq(snapshot);
+      if (boundary > lastRenderedSeq) {
+        notices += 1;
+        lastRenderedSeq = boundary;
+      }
+    }
+    assert.equal(notices, 1, `${label}: repeated state polls should render one replay-gap notice`);
+
+    assert.equal(
+      discardedBeforeSeq({ ackedSeq: 4, truncatedBeforeSeq: 4 }),
+      0,
+      `${label}: legacy ack-only snapshots should migrate without a false replay gap`,
+    );
+    assert.equal(
+      discardedBeforeSeq({ ackedSeq: 1, truncatedBeforeSeq: 3 }),
+      3,
+      `${label}: legacy snapshots should preserve a genuine unacknowledged eviction boundary`,
+    );
+
+    lastRenderedSeq = 0;
+    notices = 0;
+    for (let poll = 0; poll < 6; poll++) {
+      const boundary = unavailableBeforeSeq(acknowledged.get(9));
+      if (boundary > lastRenderedSeq) {
+        notices += 1;
+        lastRenderedSeq = boundary;
+      }
+    }
+    assert.equal(notices, 1, `${label}: acknowledged events from another panel should produce one replay-gap notice, not one per poll`);
   }
 });
 
@@ -54806,6 +54865,9 @@ test('reconnect protocol is wired through both sidepanels and backgrounds', () =
     assert.match(panel, /sendPlanReviewDecisionWithReconnect\(/, `${label}: plan decisions should survive a lost response channel`);
     assert.match(panel, /showActivity\('Reconnecting…'\)/, `${label}: reconnect attempts should be visible`);
     assert.match(panel, /onState: state => applyActiveRunState\(tabId, state\)/, `${label}: reconnect probes should replay missed UI journal events`);
+    assert.match(panel, /const unavailableBeforeSeq = runUiUnavailableBeforeSeq\(runUi\);[\s\S]*?addRunProgressReplayGapNote\(\);[\s\S]*?lastRenderedSeq = unavailableBeforeSeq;[\s\S]*?dataset\.lastRenderedSeq = String\(lastRenderedSeq\)/, `${label}: replay gaps should render once and advance the local replay cursor`);
+    assert.match(panel, /function addRunProgressReplayGapNote\(\)[\s\S]*?run-progress-replay-gap-note[\s\S]*?Some earlier run progress could not be replayed/, `${label}: replay loss needs distinct non-context-compaction copy`);
+    assert.doesNotMatch(panel, /addContextCompactedNote\(\{ message: 'Some hidden-tab progress was compacted\.' \}\)/, `${label}: replay loss must not masquerade as model-context compaction`);
     assert.match(panel, /void adoptRestoredRunState\(numericTabId, state\)/, `${label}: remounted sidepanels should adopt orphaned run monitors`);
     assert.match(panel, /probeFirst: true,[\s\S]*?requireDurableSubmittedTurn:/, `${label}: remount adoption should probe before any safe continuation`);
     assert.match(panel, /if \(state\?\.running \|\| state\?\.starting\)/, `${label}: a reserved detached start should keep the composer and Stop UI in their active state`);

--- a/test/run.js
+++ b/test/run.js
@@ -53924,6 +53924,30 @@ test('run UI journal: replay gaps distinguish acknowledgements and dedupe repeat
   }
 });
 
+test('all locales translate the run-progress replay-gap notice', async () => {
+  for (const [label, panelRel, localeDir] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js', 'src/chrome/src/ui/locales'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js', 'src/firefox/src/ui/locales'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    assert.match(
+      panel,
+      /function addRunProgressReplayGapNote\(\) \{[\s\S]*?note\.textContent = t\('sp\.run_progress_replay_gap'\)/,
+      `${label}: replay-gap notice should render through the locale layer`,
+    );
+    for (const filename of fs.readdirSync(path.join(ROOT, localeDir)).filter((name) => name.endsWith('.js'))) {
+      const locale = (await import('file://' + path.join(ROOT, localeDir, filename).replace(/\\/g, '/'))).default;
+      const message = locale['sp.run_progress_replay_gap'];
+      assert.equal(typeof message, 'string', `${label}/${filename}: missing translated run-progress replay-gap notice`);
+      assert.ok(message.trim().length > 0, `${label}/${filename}: replay-gap notice must not be empty`);
+      // The whole point of the separate notice: replay loss is UI history loss,
+      // so no locale may reuse its context-compaction copy for it.
+      assert.notEqual(message, locale['sp.context_compacted'], `${label}/${filename}: replay loss needs copy distinct from context compaction`);
+      assert.notEqual(message, locale['sp.context_compacted_manual'], `${label}/${filename}: replay loss needs copy distinct from manual context compaction`);
+    }
+  }
+});
+
 test('run UI journal: consequential tool checkpoints stay pending until conversation durability is confirmed', () => {
   for (const [label, Journal] of [['chrome', RunUiJournalCh], ['firefox', RunUiJournalFx]]) {
     const journal = new Journal();
@@ -54866,7 +54890,7 @@ test('reconnect protocol is wired through both sidepanels and backgrounds', () =
     assert.match(panel, /showActivity\('Reconnecting…'\)/, `${label}: reconnect attempts should be visible`);
     assert.match(panel, /onState: state => applyActiveRunState\(tabId, state\)/, `${label}: reconnect probes should replay missed UI journal events`);
     assert.match(panel, /const unavailableBeforeSeq = runUiUnavailableBeforeSeq\(runUi\);[\s\S]*?addRunProgressReplayGapNote\(\);[\s\S]*?lastRenderedSeq = unavailableBeforeSeq;[\s\S]*?dataset\.lastRenderedSeq = String\(lastRenderedSeq\)/, `${label}: replay gaps should render once and advance the local replay cursor`);
-    assert.match(panel, /function addRunProgressReplayGapNote\(\)[\s\S]*?run-progress-replay-gap-note[\s\S]*?Some earlier run progress could not be replayed/, `${label}: replay loss needs distinct non-context-compaction copy`);
+    assert.match(panel, /function addRunProgressReplayGapNote\(\)[\s\S]*?run-progress-replay-gap-note[\s\S]*?t\('sp\.run_progress_replay_gap'\)/, `${label}: replay loss needs distinct non-context-compaction copy`);
     assert.doesNotMatch(panel, /addContextCompactedNote\(\{ message: 'Some hidden-tab progress was compacted\.' \}\)/, `${label}: replay loss must not masquerade as model-context compaction`);
     assert.match(panel, /void adoptRestoredRunState\(numericTabId, state\)/, `${label}: remounted sidepanels should adopt orphaned run monitors`);
     assert.match(panel, /probeFirst: true,[\s\S]*?requireDurableSubmittedTurn:/, `${label}: remount adoption should probe before any safe continuation`);

--- a/test/run.js
+++ b/test/run.js
@@ -53890,15 +53890,17 @@ test('run UI journal: replay gaps distinguish acknowledgements and dedupe repeat
     evicted.record(10, `${label}-evicted`, 'thinking', { step: 2 });
     const snapshot = evicted.get(10);
     let lastRenderedSeq = 0;
+    let replayGapBeforeSeq = 0;
     let notices = 0;
     for (let poll = 0; poll < 6; poll++) {
       const boundary = unavailableBeforeSeq(snapshot);
-      if (boundary > lastRenderedSeq) {
+      if (boundary > lastRenderedSeq && boundary > replayGapBeforeSeq) {
         notices += 1;
-        lastRenderedSeq = boundary;
+        replayGapBeforeSeq = boundary;
       }
     }
     assert.equal(notices, 1, `${label}: repeated state polls should render one replay-gap notice`);
+    assert.equal(lastRenderedSeq, 0, `${label}: a replay-gap notice must not claim that unavailable events were rendered`);
 
     assert.equal(
       discardedBeforeSeq({ ackedSeq: 4, truncatedBeforeSeq: 4 }),
@@ -53912,15 +53914,48 @@ test('run UI journal: replay gaps distinguish acknowledgements and dedupe repeat
     );
 
     lastRenderedSeq = 0;
+    replayGapBeforeSeq = 0;
     notices = 0;
     for (let poll = 0; poll < 6; poll++) {
       const boundary = unavailableBeforeSeq(acknowledged.get(9));
-      if (boundary > lastRenderedSeq) {
+      if (boundary > lastRenderedSeq && boundary > replayGapBeforeSeq) {
         notices += 1;
-        lastRenderedSeq = boundary;
+        replayGapBeforeSeq = boundary;
       }
     }
     assert.equal(notices, 1, `${label}: acknowledged events from another panel should produce one replay-gap notice, not one per poll`);
+
+    const completed = new Journal();
+    completed.begin(11, `${label}-acknowledged-terminal`);
+    completed.record(11, `${label}-acknowledged-terminal`, 'thinking', { step: 1 });
+    const terminal = completed.finish(
+      11,
+      `${label}-acknowledged-terminal`,
+      'completed',
+      'Recovered terminal answer',
+    );
+    completed.acknowledge(11, `${label}-acknowledged-terminal`, terminal.seq);
+    const terminalSnapshot = completed.get(11);
+    lastRenderedSeq = 0;
+    replayGapBeforeSeq = 0;
+    notices = 0;
+    let terminalRenders = 0;
+    let renderedTerminalContent = '';
+    for (let poll = 0; poll < 6; poll++) {
+      const boundary = unavailableBeforeSeq(terminalSnapshot);
+      if (boundary > lastRenderedSeq && boundary > replayGapBeforeSeq) {
+        notices += 1;
+        replayGapBeforeSeq = boundary;
+      }
+      if (lastRenderedSeq < terminalSnapshot.seq) {
+        terminalRenders += 1;
+        renderedTerminalContent = terminalSnapshot.finalContent;
+        lastRenderedSeq = terminalSnapshot.seq;
+      }
+    }
+    assert.equal(notices, 1, `${label}: acknowledged terminal replay loss should still render one gap notice`);
+    assert.equal(terminalRenders, 1, `${label}: gap deduplication must leave the acknowledged terminal snapshot renderable`);
+    assert.equal(renderedTerminalContent, 'Recovered terminal answer', `${label}: terminal fallback content should survive acknowledgement`);
   }
 });
 
@@ -54889,7 +54924,7 @@ test('reconnect protocol is wired through both sidepanels and backgrounds', () =
     assert.match(panel, /sendPlanReviewDecisionWithReconnect\(/, `${label}: plan decisions should survive a lost response channel`);
     assert.match(panel, /showActivity\('Reconnecting…'\)/, `${label}: reconnect attempts should be visible`);
     assert.match(panel, /onState: state => applyActiveRunState\(tabId, state\)/, `${label}: reconnect probes should replay missed UI journal events`);
-    assert.match(panel, /const unavailableBeforeSeq = runUiUnavailableBeforeSeq\(runUi\);[\s\S]*?addRunProgressReplayGapNote\(\);[\s\S]*?lastRenderedSeq = unavailableBeforeSeq;[\s\S]*?dataset\.lastRenderedSeq = String\(lastRenderedSeq\)/, `${label}: replay gaps should render once and advance the local replay cursor`);
+    assert.match(panel, /const unavailableBeforeSeq = runUiUnavailableBeforeSeq\(runUi\);[\s\S]*?const replayGapBeforeSeq = Number\(runAssistantEl\.dataset\.replayGapBeforeSeq \|\| 0\);[\s\S]*?unavailableBeforeSeq > lastRenderedSeq[\s\S]*?unavailableBeforeSeq > replayGapBeforeSeq[\s\S]*?addRunProgressReplayGapNote\(\);[\s\S]*?dataset\.replayGapBeforeSeq = String\(unavailableBeforeSeq\)/, `${label}: replay-gap notices should dedupe without advancing the rendered-event cursor`);
     assert.match(panel, /function addRunProgressReplayGapNote\(\)[\s\S]*?run-progress-replay-gap-note[\s\S]*?t\('sp\.run_progress_replay_gap'\)/, `${label}: replay loss needs distinct non-context-compaction copy`);
     assert.doesNotMatch(panel, /addContextCompactedNote\(\{ message: 'Some hidden-tab progress was compacted\.' \}\)/, `${label}: replay loss must not masquerade as model-context compaction`);
     assert.match(panel, /void adoptRestoredRunState\(numericTabId, state\)/, `${label}: remounted sidepanels should adopt orphaned run monitors`);


### PR DESCRIPTION
## Summary

- separate genuine bounded-journal eviction from ordinary acknowledged replay events
- migrate legacy replay snapshots without manufacturing false replay-loss state
- show one dedicated replay-gap notice during reconnect polling while preserving genuine model-context compaction notices
- keep Chrome and Firefox implementations mirrored and add regression coverage

## Root cause

`truncatedBeforeSeq` was advanced both when replay events were truly evicted and when a panel normally acknowledged rendered events. The sidepanel treated either condition as model-context compaction and did not advance its local replay cursor, so the reconnect state poll could append the same misleading compaction notice repeatedly.

## User impact

Reconnects and remounted sidepanels now distinguish unavailable UI progress from actual model-context compaction. If progress cannot be replayed, the UI shows one accurate notice instead of flooding the run with repeated compaction messages.

## Validation

- `node --check` on the modified Chrome and Firefox journal and sidepanel files
- Chrome/Firefox run-journal parity check
- `git diff --check origin/main...HEAD`
- `node test/run.js`: 1,412 passed; 1 unrelated baseline failure because `package.json` is `26.0.4` while the newest `CHANGELOG.md` entry is `26.0.0`
- `npm run test:security`: 60/60 passed