### PR TITLE
Avoid duplicate planner failure cards

### DIFF
--- a/src/chrome/src/run-reconnect.js
+++ b/src/chrome/src/run-reconnect.js
@@ -13,6 +13,13 @@ function requestMatches(value, requestId) {
   return value != null && String(value) === String(requestId);
 }
 
+function hasPlannerRequestFailure(updates) {
+  return updates.some(update => (
+    update?.type === 'warning'
+    && update?.data?.code === 'planner_request_failed'
+  ));
+}
+
 function runResponseFromSnapshot(snapshot, {
   reconnected = false,
   resumed = false,
@@ -21,7 +28,12 @@ function runResponseFromSnapshot(snapshot, {
   const updates = (Array.isArray(snapshot?.events) ? snapshot.events : [])
     .filter(event => event?.type && event.type !== 'run_complete')
     .map(event => ({ type: event.type, data: event.data }));
-  if (snapshot?.status === 'failed' && !updates.some(update => update.type === 'error')) {
+  // Planner request failures already render an actionable Retry/Providers card.
+  // Treat that warning as the terminal presentation so recovery cannot append
+  // a second generic error card for the same failed snapshot.
+  if (snapshot?.status === 'failed'
+      && !updates.some(update => update.type === 'error')
+      && !hasPlannerRequestFailure(updates)) {
     updates.push({
       type: 'error',
       data: {

--- a/src/firefox/src/run-reconnect.js
+++ b/src/firefox/src/run-reconnect.js
@@ -13,6 +13,13 @@ function requestMatches(value, requestId) {
   return value != null && String(value) === String(requestId);
 }
 
+function hasPlannerRequestFailure(updates) {
+  return updates.some(update => (
+    update?.type === 'warning'
+    && update?.data?.code === 'planner_request_failed'
+  ));
+}
+
 function runResponseFromSnapshot(snapshot, {
   reconnected = false,
   resumed = false,
@@ -21,7 +28,12 @@ function runResponseFromSnapshot(snapshot, {
   const updates = (Array.isArray(snapshot?.events) ? snapshot.events : [])
     .filter(event => event?.type && event.type !== 'run_complete')
     .map(event => ({ type: event.type, data: event.data }));
-  if (snapshot?.status === 'failed' && !updates.some(update => update.type === 'error')) {
+  // Planner request failures already render an actionable Retry/Providers card.
+  // Treat that warning as the terminal presentation so recovery cannot append
+  // a second generic error card for the same failed snapshot.
+  if (snapshot?.status === 'failed'
+      && !updates.some(update => update.type === 'error')
+      && !hasPlannerRequestFailure(updates)) {
     updates.push({
       type: 'error',
       data: {

--- a/test/run.js
+++ b/test/run.js
@@ -377,6 +377,7 @@ const {
 const {
   isBackgroundConnectionError: isBackgroundConnectionErrorCh,
   runDetachedWithReconnect: runDetachedWithReconnectCh,
+  runResponseFromSnapshot: runResponseFromSnapshotCh,
   sendPlanResponseWithReconnect: sendPlanResponseWithReconnectCh,
 } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/run-reconnect.js').replace(/\\/g, '/')
@@ -384,6 +385,7 @@ const {
 const {
   isBackgroundConnectionError: isBackgroundConnectionErrorFx,
   runDetachedWithReconnect: runDetachedWithReconnectFx,
+  runResponseFromSnapshot: runResponseFromSnapshotFx,
   sendPlanResponseWithReconnect: sendPlanResponseWithReconnectFx,
 } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/run-reconnect.js').replace(/\\/g, '/')
@@ -55930,6 +55932,52 @@ test('sidepanel run errors dedupe streamed, returned, and restored copies by tab
     assert.equal(claimRunError({ ...base, message: 'A different failure.' }).duplicate, false, `${label}: distinct errors in one run should render`);
     assert.equal(claimRunError({ ...base, requestId: 'req-gmail-retry' }).duplicate, false, `${label}: identical errors from separate runs should render`);
     assert.equal(claimRunError({ ...base, tabId: 42 }).duplicate, false, `${label}: identical errors from separate tabs should render`);
+  }
+});
+
+test('failed planner snapshots keep the actionable warning as the only error presentation', () => {
+  for (const [label, runResponseFromSnapshot] of [
+    ['chrome', runResponseFromSnapshotCh],
+    ['firefox', runResponseFromSnapshotFx],
+  ]) {
+    const plannerMessage = 'Planner request failed before a valid response was available. No tools ran.';
+    const plannerResponse = runResponseFromSnapshot({
+      status: 'failed',
+      requestId: `${label}-planner-failure`,
+      finalContent: plannerMessage,
+      events: [{
+        type: 'warning',
+        data: {
+          code: 'planner_request_failed',
+          message: plannerMessage,
+          failureKind: 'request',
+        },
+      }],
+    });
+    assert.deepEqual(
+      plannerResponse.updates.map(update => update.type),
+      ['warning'],
+      `${label}: planner failure card should not be followed by a synthesized generic error`,
+    );
+
+    const ordinaryResponse = runResponseFromSnapshot({
+      status: 'failed',
+      requestId: `${label}-ordinary-failure`,
+      finalContent: 'Error: Ordinary provider failure.',
+      events: [],
+    });
+    assert.equal(ordinaryResponse.updates.length, 1, `${label}: ordinary failed snapshot should synthesize one error`);
+    assert.equal(ordinaryResponse.updates[0]?.type, 'error', `${label}: ordinary failure should remain an error update`);
+    assert.equal(ordinaryResponse.updates[0]?.data?.message, 'Ordinary provider failure.', `${label}: synthesized error copy`);
+
+    const recordedResponse = runResponseFromSnapshot({
+      status: 'failed',
+      requestId: `${label}-recorded-failure`,
+      finalContent: 'Error: Recorded provider failure.',
+      events: [{ type: 'error', data: { message: 'Recorded provider failure.' } }],
+    });
+    assert.equal(recordedResponse.updates.length, 1, `${label}: recorded error should not be duplicated`);
+    assert.equal(recordedResponse.updates[0]?.type, 'error', `${label}: recorded error should be preserved`);
   }
 });
 


### PR DESCRIPTION
## Summary

- keep `planner_request_failed` warnings as the single actionable Retry/Providers presentation
- prevent reconnect snapshot recovery from synthesizing a second generic error for the same planner failure
- preserve generic error synthesis for ordinary failed snapshots and existing error events
- add mirrored Chrome and Firefox regression coverage

## Root cause

Planner request failures are recorded as actionable warning events, while their terminal run snapshot is marked failed. `runResponseFromSnapshot` synthesized a generic error for every failed snapshot without an explicit error event, so the side panel rendered both the planner warning card and a second generic error card.

## User impact

A failed planner request now shows one actionable error card instead of two duplicate presentations. Other failure types retain their existing fallback error behavior.

## Validation

- `node --check src/chrome/src/run-reconnect.js`
- `node --check src/firefox/src/run-reconnect.js`
- new Chrome/Firefox planner snapshot regression passes
- `npm run test:security` — 60/60 checks passed
- main suite — 1,432 passed; one unrelated existing failure remains because `package.json` is `26.0.10` while the changelog latest entry is `26.0.0`
