### PR TITLE
Fix form submission recovery and rich-text targeting

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -65,6 +65,7 @@ import {
   formatPlanScratchpad,
   userMessageToText,
   messageContentToText,
+  plannerClarificationForPage,
 } from './planner.js';
 import { extractFirstJsonObject } from './json-extract.js';
 import { repairAssistantDisplayText, sanitizeText as sanitizePlannerText } from './text-sanitize.js';
@@ -1924,6 +1925,10 @@ export class Agent extends LoopDetector {
       identity,
     });
     const obligation = recorded.obligation;
+    const associatedEditorRef = typeof candidate?.associatedEditorRef === 'string'
+      && /^ref_\d+$/.test(candidate.associatedEditorRef)
+      ? candidate.associatedEditorRef
+      : '';
     Object.assign(result, {
       success: false,
       verified: false,
@@ -1935,13 +1940,16 @@ export class Agent extends LoopDetector {
       richTextToolbar: true,
       targetKind: obligation.targetKind,
       recoveryRequired: 'editor_body',
+      ...(associatedEditorRef ? { associatedEditorRef } : {}),
       retryable: false,
       visualTargetAudit: {
         source: decision.source,
         confidence: audit?.confidence ?? null,
         regionKind: audit?.regionKind || 'uncertain',
       },
-      error: 'This edit was blocked before dispatch because the target is a rich-text formatting toolbar control, not the editor body. Do not retry this ref or another font-family, font-size, style, color, or link control in the same toolbar. Re-read the tree, focus the associated editor body, enter the requested content there, and verify that exact editor edit.',
+      error: associatedEditorRef
+        ? `This edit was blocked before dispatch because the target is a rich-text formatting toolbar control, not the editor body. Do not retry this ref or another font-family, font-size, style, color, or link control in the same toolbar. Use the associated editor body ${associatedEditorRef}, enter the requested content there, and verify that exact editor edit.`
+        : 'This edit was blocked before dispatch because the target is a rich-text formatting toolbar control, not the editor body. Do not retry this ref or another font-family, font-size, style, color, or link control in the same toolbar. Re-read the tree, focus the associated editor body, enter the requested content there, and verify that exact editor edit.',
     });
     const runId = this.currentRunId.get(tabId);
     if (runId) {
@@ -7909,9 +7917,25 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const scratchpadFacts = scratchpadBody.length > 1800
       ? `…${scratchpadBody.slice(scratchpadBody.length - 1800)}`
       : scratchpadBody;
+    let plannerClarification = null;
+    for (let index = messages.length - 1; index >= 1; index -= 1) {
+      const message = messages[index];
+      if (this._isPinnedAgentStateMessage(message) || this._isLocalConversationStatusMessage(message)) continue;
+      if (
+        message?.role === 'assistant'
+        && message.webbrainPlannerClarification?.requiresSubmission === true
+      ) {
+        plannerClarification = {
+          requiresSubmission: true,
+          pageUrl: String(message.webbrainPlannerClarification.pageUrl || '').slice(0, 500),
+        };
+      }
+      break;
+    }
     return {
       priorUserTask: priorUserTask.slice(0, 1200),
       scratchpadFacts: scratchpadFacts === '(empty)' ? '' : scratchpadFacts,
+      plannerClarification,
     };
   }
 
@@ -8186,7 +8210,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         tabId, enriched, onUpdate, costState, runId, historyDigest, tabInfo, mode, runOptions, followUpContext,
       );
       if (!gate.proceed) {
-        messages.push({ role: 'assistant', content: gate.message || 'More information is required.' });
+        messages.push(this._plannerTerminalAssistantMessage(gate, tabInfo));
         this._persist(tabId);
       }
       return gate;
@@ -8203,7 +8227,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         tabId, enriched, onUpdate, costState, runId, historyDigest, tabInfo, mode, runOptions, followUpContext,
       );
     if (!gate.proceed) {
-      messages.push({ role: 'assistant', content: gate.message || 'More information is required.' });
+      messages.push(this._plannerTerminalAssistantMessage(gate, tabInfo));
       this._persist(tabId);
       return {
         proceed: false,
@@ -8211,6 +8235,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         reason: gate.reason,
         requestKind: gate.requestKind,
         requiresStateChange: gate.requiresStateChange,
+        requiresSubmission: gate.requiresSubmission === true,
         // Carried so a caller can tell an auth failure from a transient one
         // without re-parsing the message text.
         ...(gate.failureKind ? { failureKind: gate.failureKind } : {}),
@@ -8289,7 +8314,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     ];
   }
 
-  _plannerIntentConsistencyIssue(plan) {
+  _plannerIntentConsistencyIssue(plan, followUpContext = {}) {
     if (!plan || !Array.isArray(plan.steps)) return null;
     const tools = [...new Set(
       plan.steps.flatMap(step => Array.isArray(step?.tools) ? step.tools : [])
@@ -8303,14 +8328,25 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (plan.request_kind === 'plan_only' && executionTools.length > 0) {
       return { kind: 'plan_only_with_execution_tools', tools: executionTools };
     }
+    if (
+      plan.request_kind === 'execute'
+      && followUpContext?.plannerClarification?.requiresSubmission === true
+      && plan.requires_submission !== true
+    ) {
+      return { kind: 'clarification_submit_intent_dropped', tools };
+    }
     return null;
   }
 
   _plannerIntentConsistencyRepairMessages(plannerMessages, issue) {
     const issueKind = issue?.kind === 'respond_with_tools'
       || issue?.kind === 'plan_only_with_execution_tools'
+      || issue?.kind === 'clarification_submit_intent_dropped'
       ? issue.kind
       : 'unknown';
+    const clarificationGuidance = issueKind === 'clarification_submit_intent_dropped'
+      ? ' The trusted unresolved-clarification block records that the user had authorized an eventual submission for the task being clarified. Decide semantically whether the current User task directly answers or continues that clarification. If it does and does not revoke submission, keep execute and set requires_submission=true. If it changes, cancels, or explicitly limits the task to filling without submission, keep the appropriate non-submit intent.'
+      : '';
     return [
       ...plannerMessages,
       {
@@ -8322,20 +8358,24 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           'Keep plan_only only when the user asked merely for a plan, outline, strategy, or discussion without authorizing execution. ' +
           'Use execute when producing the requested answer needs a fresh page, browser, network, memory, or scheduling tool; read-only execution still has requires_state_change false. ' +
           'Use respond only when existing conversation or working-note context is sufficient and list no tools. ' +
+          clarificationGuidance +
           'Do not infer permission for a mutation that the current user task did not authorize. No prose, markdown, tool calls, or reasoning text.',
       },
     ];
   }
 
-  _plannerIntentUnresolvedConsistencyIssue(plan, recheckedIssueKind = null) {
-    const issue = this._plannerIntentConsistencyIssue(plan);
+  _plannerIntentUnresolvedConsistencyIssue(plan, recheckedIssueKind = null, followUpContext = {}) {
+    const issue = this._plannerIntentConsistencyIssue(plan, followUpContext);
     if (!issue) return null;
     // Repeating plan_only after the focused semantic recheck confirms that the
     // user asked only for a plan. A respond plan that still lists tools can
     // never be routed response-only, and a new issue after either repair has
     // not received the focused consistency check.
     if (
-      issue.kind === 'plan_only_with_execution_tools'
+      (
+        issue.kind === 'plan_only_with_execution_tools'
+        || issue.kind === 'clarification_submit_intent_dropped'
+      )
       && recheckedIssueKind === issue.kind
     ) {
       return null;
@@ -8426,6 +8466,20 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       || 'No plan was produced.';
   }
 
+  _plannerTerminalAssistantMessage(gate = {}, tabInfo = null) {
+    const message = {
+      role: 'assistant',
+      content: gate.message || 'More information is required.',
+    };
+    if (gate.requestKind === 'clarify' && gate.requiresSubmission === true) {
+      message.webbrainPlannerClarification = {
+        requiresSubmission: true,
+        pageUrl: String(tabInfo?.tabUrl || ''),
+      };
+    }
+    return message;
+  }
+
   _plannerProgressLedgerGateFields(plan) {
     const policy = ['enabled', 'disabled', 'auto'].includes(plan?.memory?.progress_ledger_policy)
       ? plan.memory.progress_ledger_policy
@@ -8484,6 +8538,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    */
   async _runPlannerIntentGate(tabId, enriched, onUpdate, costState, runId = null, historyDigest = '', tabInfo = null, conversationMode = 'act', runOptions = {}, followUpContext = {}) {
     const { tabUrl, tabTitle } = tabInfo || await this._getTabUrlTitle(tabId);
+    followUpContext = {
+      ...followUpContext,
+      plannerClarification: plannerClarificationForPage(
+        followUpContext.plannerClarification,
+        tabUrl,
+      ),
+    };
     const locale = runOptions?.locale || 'en';
     const provider = this.providerManager.getActive();
     const plannerMessages = buildPlannerIntentMessages(enriched, tabUrl, tabTitle, historyDigest, {
@@ -8491,6 +8552,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       locale,
       priorUserTask: followUpContext.priorUserTask,
       scratchpadFacts: followUpContext.scratchpadFacts,
+      plannerClarification: followUpContext.plannerClarification,
     });
     const plannerStep = 0;
     onUpdate('thinking', { step: plannerStep, note: 'Understanding request…' });
@@ -8545,7 +8607,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         plan = parsePlanFromContent(result.content, { requireIntent: true, locale });
       }
       const consistencyIssue = !plannerRepairUsed
-        ? this._plannerIntentConsistencyIssue(plan)
+        ? this._plannerIntentConsistencyIssue(plan, followUpContext)
         : null;
       if (consistencyIssue) {
         plannerRepairUsed = true;
@@ -8564,7 +8626,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (!plan) {
         return this._plannerReadOnlyFallback(runOptions, onUpdate);
       }
-      if (this._plannerIntentUnresolvedConsistencyIssue(plan, consistencyRepairKind)) {
+      if (this._plannerIntentUnresolvedConsistencyIssue(plan, consistencyRepairKind, followUpContext)) {
         return this._plannerReadOnlyFallback(runOptions, onUpdate);
       }
       if (plan.request_kind === 'respond') {
@@ -8582,6 +8644,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           reason: plan.request_kind,
           requestKind: plan.request_kind,
           requiresStateChange: false,
+          requiresSubmission: plan.request_kind === 'clarify' && plan.requires_submission === true,
         };
       }
       return {
@@ -8611,6 +8674,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    */
   async _runPlannerGate(tabId, enriched, onUpdate, costState, runId = null, historyDigest = '', tabInfo = null, plannerMode = this._plannerMode(), conversationMode = 'act', runOptions = {}, followUpContext = {}) {
     const { tabUrl, tabTitle } = tabInfo || await this._getTabUrlTitle(tabId);
+    followUpContext = {
+      ...followUpContext,
+      plannerClarification: plannerClarificationForPage(
+        followUpContext.plannerClarification,
+        tabUrl,
+      ),
+    };
     const locale = runOptions?.locale || 'en';
 
     onUpdate('thinking', { step: 0, note: 'Planning…' });
@@ -8625,6 +8695,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       locale,
       priorUserTask: followUpContext.priorUserTask,
       scratchpadFacts: followUpContext.scratchpadFacts,
+      plannerClarification: followUpContext.plannerClarification,
     });
     const plannerStep = 0;
 
@@ -8683,7 +8754,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         plan = parsePlanFromContent(result.content, { requireIntent: true, locale });
       }
       const consistencyIssue = !plannerRepairUsed
-        ? this._plannerIntentConsistencyIssue(plan)
+        ? this._plannerIntentConsistencyIssue(plan, followUpContext)
         : null;
       if (consistencyIssue) {
         plannerRepairUsed = true;
@@ -8709,7 +8780,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           ? this._strictPlannerFailure(onUpdate)
           : this._plannerReadOnlyFallback(runOptions, onUpdate);
       }
-      if (this._plannerIntentUnresolvedConsistencyIssue(plan, consistencyRepairKind)) {
+      if (this._plannerIntentUnresolvedConsistencyIssue(plan, consistencyRepairKind, followUpContext)) {
         return this._normalizePlanBeforeActMode(plannerMode) === 'strict'
           ? this._strictPlannerFailure(onUpdate)
           : this._plannerReadOnlyFallback(runOptions, onUpdate);
@@ -8729,6 +8800,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           reason: plan.request_kind,
           requestKind: plan.request_kind,
           requiresStateChange: false,
+          requiresSubmission: plan.request_kind === 'clarify' && plan.requires_submission === true,
         };
       }
 

--- a/src/chrome/src/agent/planner.js
+++ b/src/chrome/src/agent/planner.js
@@ -57,7 +57,8 @@ Rules:
 - A request to answer, summarize, explain, analyze, or draft a response about currently visible/open page content is execute when producing the answer needs a fresh page or browser read, even if the final deliverable is only text and requires_state_change is false. Example: "How should I respond to this open email?" is execute because the email must be read now; it is not plan_only merely because the deliverable is advice or a draft.
 - respond must not include steps that need page, browser, network, memory, or scheduling tools. If any such tool is needed to produce the requested answer, classify the request as execute instead.
 - requires_state_change is true only when completing an execute request needs a mutation such as interacting with form/account state, modifying page data, downloading/uploading a file, a write-method network request, a Dev patch, or scheduling work. It is false for reads, analysis, summaries, navigation, scrolling, hovering, window/viewport changes, plan_only, and clarify.
-- requires_submission is true only when completing an execute request requires an explicit form/dialog commit action such as Submit, Save, Send, Publish, Post, or Confirm. It is false for filling, editing, checking, or selecting without committing, including explicit do-not-submit tasks and autosave UIs, and false for non-execute requests.
+- requires_submission is true when the user-authorized task ultimately requires an explicit form/dialog commit action such as Submit, Save, Send, Publish, Post, or Confirm. For clarify, preserve true when the missing answer is only a prerequisite to that already-requested commit; clarify itself still performs no action. It is false for filling, editing, checking, or selecting without committing, including explicit do-not-submit tasks and autosave UIs, and false for respond and plan_only.
+- Do not classify a follow-up as clarify merely because it refers to answers, drafts, or values already prepared in the ongoing task or currently present on the page. When the user authorizes using those existing values, classify execute and inspect them with read tools; clarify only after the available trusted context or runtime inspection cannot supply a required value.
 - allows_planner_shaped_result is true only when the user explicitly requests planner-like final data (summary/steps JSON or Plan/Steps/Workflow markdown). Never changes request_kind.
 - allows_app_state_tool_evidence is true only when the requested work itself is reading/updating WebBrain scratchpad or progress ledger (not incidental bookkeeping).
 - Write canonical summary, steps, and risks in English. Also write localized summary, step actions, and risks in the requested wbLocale. Keep stable tool names, skill_ids, IDs, and execution metadata in English.
@@ -122,7 +123,8 @@ Rules:
 - respond must not include steps that need page, browser, network, memory, or scheduling tools. If any such tool is needed to produce the requested answer, classify the request as execute instead.
 - When a required form value is unavailable from trusted or public evidence, leave the field untouched and classify as clarify. Never plan to focus, clear, or write an empty value as a stand-in for missing personal information.
 - requires_state_change is true only when an execute request needs a mutation such as interacting with form/account state, modifying page data, downloading/uploading a file, a write-method network request, a Dev patch, or scheduling work. It is false for reads, analysis, summaries, navigation, scrolling, hovering, window/viewport changes, plan_only, and clarify.
-- requires_submission is true only when an execute request must explicitly commit a form/dialog with an action such as Submit, Save, Send, Publish, Post, or Confirm. It is false for filling, editing, checking, or selecting without committing, including explicit do-not-submit tasks and autosave UIs, and false for non-execute requests.
+- requires_submission is true when the user-authorized task ultimately requires an explicit form/dialog commit action such as Submit, Save, Send, Publish, Post, or Confirm. For clarify, preserve true when the missing answer is only a prerequisite to that already-requested commit; clarify itself still performs no action. It is false for filling, editing, checking, or selecting without committing, including explicit do-not-submit tasks and autosave UIs, and false for respond and plan_only.
+- Do not classify a follow-up as clarify merely because it refers to answers, drafts, or values already prepared in the ongoing task or currently present on the page. When the user authorizes using those existing values, classify execute and inspect them with read tools; clarify only after the available trusted context or runtime inspection cannot supply a required value.
 - allows_planner_shaped_result is true only when the user explicitly requests planner-like final data (summary/steps JSON or Plan/Steps/Workflow markdown). Never changes request_kind.
 - allows_app_state_tool_evidence is true only when the requested work itself is reading/updating WebBrain scratchpad or progress ledger (not incidental bookkeeping).
 - memory.use_progress_ledger is true only for repeated peer-item work that benefits from one row per item. Sequential workflow stages, sites, apps, or destinations are not peer items. Set progress_action to the canonical repeated action, otherwise null.
@@ -201,6 +203,22 @@ export function sanitizePlannerPageField(value, max = 500) {
   return sanitizeText(withoutBoundaryTags, max, { collapseWhitespace: true });
 }
 
+export function plannerClarificationForPage(clarification, pageUrl) {
+  if (!clarification || clarification.requiresSubmission !== true) return null;
+  const recordedPageUrl = String(clarification.pageUrl || '').trim();
+  const currentPageUrl = String(pageUrl || '').trim();
+  if (!recordedPageUrl || !currentPageUrl) return null;
+  try {
+    if (new URL(recordedPageUrl).href !== new URL(currentPageUrl).href) return null;
+  } catch {
+    if (recordedPageUrl !== currentPageUrl) return null;
+  }
+  return {
+    requiresSubmission: true,
+    pageUrl: recordedPageUrl.slice(0, 500),
+  };
+}
+
 export function buildPlannerMessages(enrichedUserMessage, pageUrl, pageTitle, historyDigest = '', opts = {}) {
   const userText = userMessageToText(enrichedUserMessage);
   const history = sanitizeText(historyDigest, 2000);
@@ -210,6 +228,11 @@ export function buildPlannerMessages(enrichedUserMessage, pageUrl, pageTitle, hi
   const priorUserTask = sanitizeText(opts.priorUserTask, 1200);
   const priorUserTaskBlock = priorUserTask
     ? `Prior user request (authentic user-authored context for resolving follow-ups, but it does NOT authorize repeating an earlier mutation; only the current User task authorizes new action):\n${priorUserTask}\n\n`
+    : '';
+  const clarification = plannerClarificationForPage(opts.plannerClarification, pageUrl);
+  const clarificationPageUrl = sanitizePlannerPageField(clarification?.pageUrl, 300);
+  const clarificationBlock = clarification?.requiresSubmission === true
+    ? `Unresolved planner clarification (trusted app state for one direct continuation only):\n- The user-authorized task required an eventual explicit submission.\n- Page URL when clarification was asked: ${clarificationPageUrl || 'unknown'}\nUse this only if the current User task directly answers or continues that clarification on the same task. Preserve requires_submission=true for that continuation unless the current User task revokes submission. Ignore it for a new task, a cancellation, a different page workflow, or a do-not-submit instruction.\n\n`
     : '';
   const scratchpadFacts = sanitizePlannerPageField(opts.scratchpadFacts, 1800);
   const scratchpadBlock = scratchpadFacts
@@ -226,7 +249,7 @@ export function buildPlannerMessages(enrichedUserMessage, pageUrl, pageTitle, hi
     { role: 'system', content: buildPlannerSystemPrompt(opts) },
     {
       role: 'user',
-      content: `${thinkingDirective}${priorUserTaskBlock}${historyBlock}${scratchpadBlock}<untrusted_page_content>\nPage URL: ${safeUrl}\nPage title: ${safeTitle}\n</untrusted_page_content>\n\nUser task:\n${userText}`,
+      content: `${thinkingDirective}${priorUserTaskBlock}${clarificationBlock}${historyBlock}${scratchpadBlock}<untrusted_page_content>\nPage URL: ${safeUrl}\nPage title: ${safeTitle}\n</untrusted_page_content>\n\nUser task:\n${userText}`,
     },
   ];
 }
@@ -306,7 +329,8 @@ export function normalizePlan(obj, opts = {}) {
       ? localizedInput.risks.map((risk) => sanitizeText(risk, 200)).filter(Boolean).slice(0, 6)
       : [],
   };
-  const requiresSubmission = executablePlan
+  const submissionBearingPlan = executablePlan || requestKind === 'clarify';
+  const requiresSubmission = submissionBearingPlan
     ? (hasRequiresSubmission ? obj.requires_submission === true : null)
     : false;
   const requiresStateChange = executablePlan

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -273,6 +273,35 @@
       : null;
   }
 
+  function _isFullyVisibleForInteraction(el) {
+    try {
+      if (!el?.isConnected) return false;
+      const view = el.ownerDocument?.defaultView || window;
+      const rect = el.getBoundingClientRect();
+      if (
+        rect.width < 1
+        || rect.height < 1
+        || rect.left < 0
+        || rect.top < 0
+        || rect.right > view.innerWidth
+        || rect.bottom > view.innerHeight
+      ) return false;
+      for (let node = _composedParent(el); node && node !== el.ownerDocument; node = _composedParent(node)) {
+        if (node.nodeType !== Node.ELEMENT_NODE) continue;
+        const style = view.getComputedStyle(node);
+        const clipsX = /^(?:auto|scroll|hidden|clip)$/.test(style.overflowX);
+        const clipsY = /^(?:auto|scroll|hidden|clip)$/.test(style.overflowY);
+        if (!clipsX && !clipsY) continue;
+        const parentRect = node.getBoundingClientRect();
+        if (clipsX && (rect.left < parentRect.left || rect.right > parentRect.right)) return false;
+        if (clipsY && (rect.top < parentRect.top || rect.bottom > parentRect.bottom)) return false;
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   function _isComposedAncestor(ancestor, node) {
     let cur = node;
     while (cur) {
@@ -4373,7 +4402,9 @@
               },
             );
           }
-          try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
+          if (!_isFullyVisibleForInteraction(el)) {
+            try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
+          }
           try { el.focus({ preventScroll: true }); } catch {}
           const rect = el.getBoundingClientRect();
           if (!el.isConnected || rect.width < 1 || rect.height < 1) {

--- a/src/chrome/src/content/rich-text-toolbar-heuristic.js
+++ b/src/chrome/src/content/rich-text-toolbar-heuristic.js
@@ -342,8 +342,10 @@ var __wbRichTextToolbarHeuristic = (() => {
       ].join(',');
 
       let cluster = null;
+      let guardCluster = null;
       let node = _composedParent(el);
       for (let depth = 1; node && depth <= 6; depth++, node = _composedParent(node)) {
+        if (['FORM', 'BODY', 'HTML'].includes(String(node.tagName || '').toUpperCase())) break;
         if (!_visibleFieldContextNode(node)) continue;
         const region = node.getBoundingClientRect();
         if (region.height > 160 || region.width < rect.width) continue;
@@ -352,7 +354,21 @@ var __wbRichTextToolbarHeuristic = (() => {
         if (!controls.includes(el)) controls.unshift(el);
         if (controls.length < 2 || controls.length > 40) continue;
         const area = region.width * region.height;
-        if (!cluster || area < cluster.area) cluster = { node, controls, region, area };
+        const entry = { node, controls, region, area };
+        if (!cluster || area < cluster.area) cluster = entry;
+        // Component toolbars without role="toolbar" often wrap an input in a
+        // tiny 40px sub-container while the adjacent Body/Heading control is a
+        // generic div. Keep the smallest cluster for scoring, but widen the
+        // recovery region only when the compact row has a definite associated
+        // editor. This keeps ordinary one-row forms out of the blocked scope.
+        if (
+          controls.length >= 3
+          && region.height <= 96
+          && (!guardCluster || region.width > guardCluster.region.width)
+        ) {
+          const associatedEditor = _associatedRichTextEditor(node);
+          if (associatedEditor) guardCluster = { ...entry, associatedEditor };
+        }
       }
 
       const reasons = [];
@@ -366,7 +382,12 @@ var __wbRichTextToolbarHeuristic = (() => {
       if (semanticToolbar) { reasons.push('semantic_toolbar'); score += 4; }
       if (score < 4) return null;
 
-      const regionNode = semanticToolbar || cluster?.node || _composedParent(el) || el;
+      const directParent = _composedParent(el);
+      const safeDirectParent = directParent
+        && !['FORM', 'BODY', 'HTML'].includes(String(directParent.tagName || '').toUpperCase())
+        ? directParent
+        : null;
+      const regionNode = semanticToolbar || guardCluster?.node || cluster?.node || safeDirectParent || el;
       const region = regionNode.getBoundingClientRect();
       const related = _richTextToolbarQueryAcrossOpenShadowRoots(regionNode, interactiveSelector, 30)
         .filter(candidate => !candidate.isContentEditable && _visibleFieldContextNode(candidate))
@@ -398,7 +419,9 @@ var __wbRichTextToolbarHeuristic = (() => {
           } catch {}
         }
       }
-      const associatedEditor = _associatedRichTextEditor(regionNode);
+      const associatedEditor = guardCluster?.node === regionNode
+        ? guardCluster.associatedEditor
+        : _associatedRichTextEditor(regionNode);
       // A formatting affordance the control declares itself, or an ARIA
       // toolbar that demonstrably belongs to an editor. [role=toolbar] alone
       // is not evidence of a rich-text editor: ordinary app toolbars hold

--- a/src/chrome/src/providers/base.js
+++ b/src/chrome/src/providers/base.js
@@ -127,7 +127,17 @@ export class BaseLLMProvider {
   }
 
   _mapMessages(messages) {
-    return mapProviderMessages(messages, this.config);
+    const sanitized = (Array.isArray(messages) ? messages : []).map((message) => {
+      if (!message || typeof message !== 'object' || !Object.hasOwn(message, 'webbrainPlannerClarification')) {
+        return message;
+      }
+      const {
+        webbrainPlannerClarification: _plannerClarification,
+        ...providerMessage
+      } = message;
+      return providerMessage;
+    });
+    return mapProviderMessages(sanitized, this.config);
   }
 
   _supportsReasoningContentReplay(_options = {}) {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -66,6 +66,7 @@ import {
   formatPlanScratchpad,
   userMessageToText,
   messageContentToText,
+  plannerClarificationForPage,
 } from './planner.js';
 import { extractFirstJsonObject } from './json-extract.js';
 import { repairAssistantDisplayText, sanitizeText as sanitizePlannerText } from './text-sanitize.js';
@@ -1998,6 +1999,10 @@ export class Agent extends LoopDetector {
       identity,
     });
     const obligation = recorded.obligation;
+    const associatedEditorRef = typeof candidate?.associatedEditorRef === 'string'
+      && /^ref_\d+$/.test(candidate.associatedEditorRef)
+      ? candidate.associatedEditorRef
+      : '';
     Object.assign(result, {
       success: false,
       verified: false,
@@ -2009,13 +2014,16 @@ export class Agent extends LoopDetector {
       richTextToolbar: true,
       targetKind: obligation.targetKind,
       recoveryRequired: 'editor_body',
+      ...(associatedEditorRef ? { associatedEditorRef } : {}),
       retryable: false,
       visualTargetAudit: {
         source: decision.source,
         confidence: audit?.confidence ?? null,
         regionKind: audit?.regionKind || 'uncertain',
       },
-      error: 'This edit was blocked before dispatch because the target is a rich-text formatting toolbar control, not the editor body. Do not retry this ref or another font-family, font-size, style, color, or link control in the same toolbar. Re-read the tree, focus the associated editor body, enter the requested content there, and verify that exact editor edit.',
+      error: associatedEditorRef
+        ? `This edit was blocked before dispatch because the target is a rich-text formatting toolbar control, not the editor body. Do not retry this ref or another font-family, font-size, style, color, or link control in the same toolbar. Use the associated editor body ${associatedEditorRef}, enter the requested content there, and verify that exact editor edit.`
+        : 'This edit was blocked before dispatch because the target is a rich-text formatting toolbar control, not the editor body. Do not retry this ref or another font-family, font-size, style, color, or link control in the same toolbar. Re-read the tree, focus the associated editor body, enter the requested content there, and verify that exact editor edit.',
     });
     const runId = this.currentRunId.get(tabId);
     if (runId) {
@@ -6863,9 +6871,25 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const scratchpadFacts = scratchpadBody.length > 1800
       ? `…${scratchpadBody.slice(scratchpadBody.length - 1800)}`
       : scratchpadBody;
+    let plannerClarification = null;
+    for (let index = messages.length - 1; index >= 1; index -= 1) {
+      const message = messages[index];
+      if (this._isPinnedAgentStateMessage(message) || this._isLocalConversationStatusMessage(message)) continue;
+      if (
+        message?.role === 'assistant'
+        && message.webbrainPlannerClarification?.requiresSubmission === true
+      ) {
+        plannerClarification = {
+          requiresSubmission: true,
+          pageUrl: String(message.webbrainPlannerClarification.pageUrl || '').slice(0, 500),
+        };
+      }
+      break;
+    }
     return {
       priorUserTask: priorUserTask.slice(0, 1200),
       scratchpadFacts: scratchpadFacts === '(empty)' ? '' : scratchpadFacts,
+      plannerClarification,
     };
   }
 
@@ -7136,7 +7160,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         tabId, enriched, onUpdate, costState, runId, historyDigest, tabInfo, mode, runOptions, followUpContext,
       );
       if (!gate.proceed) {
-        messages.push({ role: 'assistant', content: gate.message || 'More information is required.' });
+        messages.push(this._plannerTerminalAssistantMessage(gate, tabInfo));
         this._persist(tabId);
       }
       return gate;
@@ -7153,7 +7177,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         tabId, enriched, onUpdate, costState, runId, historyDigest, tabInfo, mode, runOptions, followUpContext,
       );
     if (!gate.proceed) {
-      messages.push({ role: 'assistant', content: gate.message || 'More information is required.' });
+      messages.push(this._plannerTerminalAssistantMessage(gate, tabInfo));
       this._persist(tabId);
       return {
         proceed: false,
@@ -7161,6 +7185,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         reason: gate.reason,
         requestKind: gate.requestKind,
         requiresStateChange: gate.requiresStateChange,
+        requiresSubmission: gate.requiresSubmission === true,
         // Carried so a caller can tell an auth failure from a transient one
         // without re-parsing the message text.
         ...(gate.failureKind ? { failureKind: gate.failureKind } : {}),
@@ -7238,7 +7263,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     ];
   }
 
-  _plannerIntentConsistencyIssue(plan) {
+  _plannerIntentConsistencyIssue(plan, followUpContext = {}) {
     if (!plan || !Array.isArray(plan.steps)) return null;
     const tools = [...new Set(
       plan.steps.flatMap(step => Array.isArray(step?.tools) ? step.tools : [])
@@ -7252,14 +7277,25 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (plan.request_kind === 'plan_only' && executionTools.length > 0) {
       return { kind: 'plan_only_with_execution_tools', tools: executionTools };
     }
+    if (
+      plan.request_kind === 'execute'
+      && followUpContext?.plannerClarification?.requiresSubmission === true
+      && plan.requires_submission !== true
+    ) {
+      return { kind: 'clarification_submit_intent_dropped', tools };
+    }
     return null;
   }
 
   _plannerIntentConsistencyRepairMessages(plannerMessages, issue) {
     const issueKind = issue?.kind === 'respond_with_tools'
       || issue?.kind === 'plan_only_with_execution_tools'
+      || issue?.kind === 'clarification_submit_intent_dropped'
       ? issue.kind
       : 'unknown';
+    const clarificationGuidance = issueKind === 'clarification_submit_intent_dropped'
+      ? ' The trusted unresolved-clarification block records that the user had authorized an eventual submission for the task being clarified. Decide semantically whether the current User task directly answers or continues that clarification. If it does and does not revoke submission, keep execute and set requires_submission=true. If it changes, cancels, or explicitly limits the task to filling without submission, keep the appropriate non-submit intent.'
+      : '';
     return [
       ...plannerMessages,
       {
@@ -7271,20 +7307,24 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           'Keep plan_only only when the user asked merely for a plan, outline, strategy, or discussion without authorizing execution. ' +
           'Use execute when producing the requested answer needs a fresh page, browser, network, memory, or scheduling tool; read-only execution still has requires_state_change false. ' +
           'Use respond only when existing conversation or working-note context is sufficient and list no tools. ' +
+          clarificationGuidance +
           'Do not infer permission for a mutation that the current user task did not authorize. No prose, markdown, tool calls, or reasoning text.',
       },
     ];
   }
 
-  _plannerIntentUnresolvedConsistencyIssue(plan, recheckedIssueKind = null) {
-    const issue = this._plannerIntentConsistencyIssue(plan);
+  _plannerIntentUnresolvedConsistencyIssue(plan, recheckedIssueKind = null, followUpContext = {}) {
+    const issue = this._plannerIntentConsistencyIssue(plan, followUpContext);
     if (!issue) return null;
     // Repeating plan_only after the focused semantic recheck confirms that the
     // user asked only for a plan. A respond plan that still lists tools can
     // never be routed response-only, and a new issue after either repair has
     // not received the focused consistency check.
     if (
-      issue.kind === 'plan_only_with_execution_tools'
+      (
+        issue.kind === 'plan_only_with_execution_tools'
+        || issue.kind === 'clarification_submit_intent_dropped'
+      )
       && recheckedIssueKind === issue.kind
     ) {
       return null;
@@ -7375,6 +7415,20 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       || 'No plan was produced.';
   }
 
+  _plannerTerminalAssistantMessage(gate = {}, tabInfo = null) {
+    const message = {
+      role: 'assistant',
+      content: gate.message || 'More information is required.',
+    };
+    if (gate.requestKind === 'clarify' && gate.requiresSubmission === true) {
+      message.webbrainPlannerClarification = {
+        requiresSubmission: true,
+        pageUrl: String(tabInfo?.tabUrl || ''),
+      };
+    }
+    return message;
+  }
+
   _plannerProgressLedgerGateFields(plan) {
     const policy = ['enabled', 'disabled', 'auto'].includes(plan?.memory?.progress_ledger_policy)
       ? plan.memory.progress_ledger_policy
@@ -7433,6 +7487,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    */
   async _runPlannerIntentGate(tabId, enriched, onUpdate, costState, runId = null, historyDigest = '', tabInfo = null, conversationMode = 'act', runOptions = {}, followUpContext = {}) {
     const { tabUrl, tabTitle } = tabInfo || await this._getTabUrlTitle(tabId);
+    followUpContext = {
+      ...followUpContext,
+      plannerClarification: plannerClarificationForPage(
+        followUpContext.plannerClarification,
+        tabUrl,
+      ),
+    };
     const locale = runOptions?.locale || 'en';
     const provider = this.providerManager.getActive();
     const plannerMessages = buildPlannerIntentMessages(enriched, tabUrl, tabTitle, historyDigest, {
@@ -7440,6 +7501,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       locale,
       priorUserTask: followUpContext.priorUserTask,
       scratchpadFacts: followUpContext.scratchpadFacts,
+      plannerClarification: followUpContext.plannerClarification,
     });
     const plannerStep = 0;
     onUpdate('thinking', { step: plannerStep, note: 'Understanding request…' });
@@ -7494,7 +7556,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         plan = parsePlanFromContent(result.content, { requireIntent: true, locale });
       }
       const consistencyIssue = !plannerRepairUsed
-        ? this._plannerIntentConsistencyIssue(plan)
+        ? this._plannerIntentConsistencyIssue(plan, followUpContext)
         : null;
       if (consistencyIssue) {
         plannerRepairUsed = true;
@@ -7513,7 +7575,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (!plan) {
         return this._plannerReadOnlyFallback(runOptions, onUpdate);
       }
-      if (this._plannerIntentUnresolvedConsistencyIssue(plan, consistencyRepairKind)) {
+      if (this._plannerIntentUnresolvedConsistencyIssue(plan, consistencyRepairKind, followUpContext)) {
         return this._plannerReadOnlyFallback(runOptions, onUpdate);
       }
       if (plan.request_kind === 'respond') {
@@ -7531,6 +7593,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           reason: plan.request_kind,
           requestKind: plan.request_kind,
           requiresStateChange: false,
+          requiresSubmission: plan.request_kind === 'clarify' && plan.requires_submission === true,
         };
       }
       return {
@@ -7556,6 +7619,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   async _runPlannerGate(tabId, enriched, onUpdate, costState, runId = null, historyDigest = '', tabInfo = null, plannerMode = this._plannerMode(), conversationMode = 'act', runOptions = {}, followUpContext = {}) {
     const { tabUrl, tabTitle } = tabInfo || await this._getTabUrlTitle(tabId);
+    followUpContext = {
+      ...followUpContext,
+      plannerClarification: plannerClarificationForPage(
+        followUpContext.plannerClarification,
+        tabUrl,
+      ),
+    };
     const locale = runOptions?.locale || 'en';
 
     onUpdate('thinking', { step: 0, note: 'Planning…' });
@@ -7570,6 +7640,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       locale,
       priorUserTask: followUpContext.priorUserTask,
       scratchpadFacts: followUpContext.scratchpadFacts,
+      plannerClarification: followUpContext.plannerClarification,
     });
     const plannerStep = 0;
 
@@ -7628,7 +7699,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         plan = parsePlanFromContent(result.content, { requireIntent: true, locale });
       }
       const consistencyIssue = !plannerRepairUsed
-        ? this._plannerIntentConsistencyIssue(plan)
+        ? this._plannerIntentConsistencyIssue(plan, followUpContext)
         : null;
       if (consistencyIssue) {
         plannerRepairUsed = true;
@@ -7654,7 +7725,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           ? this._strictPlannerFailure(onUpdate)
           : this._plannerReadOnlyFallback(runOptions, onUpdate);
       }
-      if (this._plannerIntentUnresolvedConsistencyIssue(plan, consistencyRepairKind)) {
+      if (this._plannerIntentUnresolvedConsistencyIssue(plan, consistencyRepairKind, followUpContext)) {
         return this._normalizePlanBeforeActMode(plannerMode) === 'strict'
           ? this._strictPlannerFailure(onUpdate)
           : this._plannerReadOnlyFallback(runOptions, onUpdate);
@@ -7674,6 +7745,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           reason: plan.request_kind,
           requestKind: plan.request_kind,
           requiresStateChange: false,
+          requiresSubmission: plan.request_kind === 'clarify' && plan.requires_submission === true,
         };
       }
 

--- a/src/firefox/src/agent/planner.js
+++ b/src/firefox/src/agent/planner.js
@@ -57,7 +57,8 @@ Rules:
 - A request to answer, summarize, explain, analyze, or draft a response about currently visible/open page content is execute when producing the answer needs a fresh page or browser read, even if the final deliverable is only text and requires_state_change is false. Example: "How should I respond to this open email?" is execute because the email must be read now; it is not plan_only merely because the deliverable is advice or a draft.
 - respond must not include steps that need page, browser, network, memory, or scheduling tools. If any such tool is needed to produce the requested answer, classify the request as execute instead.
 - requires_state_change is true only when completing an execute request needs a mutation such as interacting with form/account state, modifying page data, downloading/uploading a file, a write-method network request, a Dev patch, or scheduling work. It is false for reads, analysis, summaries, navigation, scrolling, hovering, window/viewport changes, plan_only, and clarify.
-- requires_submission is true only when completing an execute request requires an explicit form/dialog commit action such as Submit, Save, Send, Publish, Post, or Confirm. It is false for filling, editing, checking, or selecting without committing, including explicit do-not-submit tasks and autosave UIs, and false for non-execute requests.
+- requires_submission is true when the user-authorized task ultimately requires an explicit form/dialog commit action such as Submit, Save, Send, Publish, Post, or Confirm. For clarify, preserve true when the missing answer is only a prerequisite to that already-requested commit; clarify itself still performs no action. It is false for filling, editing, checking, or selecting without committing, including explicit do-not-submit tasks and autosave UIs, and false for respond and plan_only.
+- Do not classify a follow-up as clarify merely because it refers to answers, drafts, or values already prepared in the ongoing task or currently present on the page. When the user authorizes using those existing values, classify execute and inspect them with read tools; clarify only after the available trusted context or runtime inspection cannot supply a required value.
 - allows_planner_shaped_result is true only when the user explicitly requests planner-like final data (summary/steps JSON or Plan/Steps/Workflow markdown). Never changes request_kind.
 - allows_app_state_tool_evidence is true only when the requested work itself is reading/updating WebBrain scratchpad or progress ledger (not incidental bookkeeping).
 - Write canonical summary, steps, and risks in English. Also write localized summary, step actions, and risks in the requested wbLocale. Keep stable tool names, skill_ids, IDs, and execution metadata in English.
@@ -122,7 +123,8 @@ Rules:
 - respond must not include steps that need page, browser, network, memory, or scheduling tools. If any such tool is needed to produce the requested answer, classify the request as execute instead.
 - When a required form value is unavailable from trusted or public evidence, leave the field untouched and classify as clarify. Never plan to focus, clear, or write an empty value as a stand-in for missing personal information.
 - requires_state_change is true only when an execute request needs a mutation such as interacting with form/account state, modifying page data, downloading/uploading a file, a write-method network request, a Dev patch, or scheduling work. It is false for reads, analysis, summaries, navigation, scrolling, hovering, window/viewport changes, plan_only, and clarify.
-- requires_submission is true only when an execute request must explicitly commit a form/dialog with an action such as Submit, Save, Send, Publish, Post, or Confirm. It is false for filling, editing, checking, or selecting without committing, including explicit do-not-submit tasks and autosave UIs, and false for non-execute requests.
+- requires_submission is true when the user-authorized task ultimately requires an explicit form/dialog commit action such as Submit, Save, Send, Publish, Post, or Confirm. For clarify, preserve true when the missing answer is only a prerequisite to that already-requested commit; clarify itself still performs no action. It is false for filling, editing, checking, or selecting without committing, including explicit do-not-submit tasks and autosave UIs, and false for respond and plan_only.
+- Do not classify a follow-up as clarify merely because it refers to answers, drafts, or values already prepared in the ongoing task or currently present on the page. When the user authorizes using those existing values, classify execute and inspect them with read tools; clarify only after the available trusted context or runtime inspection cannot supply a required value.
 - allows_planner_shaped_result is true only when the user explicitly requests planner-like final data (summary/steps JSON or Plan/Steps/Workflow markdown). Never changes request_kind.
 - allows_app_state_tool_evidence is true only when the requested work itself is reading/updating WebBrain scratchpad or progress ledger (not incidental bookkeeping).
 - memory.use_progress_ledger is true only for repeated peer-item work that benefits from one row per item. Sequential workflow stages, sites, apps, or destinations are not peer items. Set progress_action to the canonical repeated action, otherwise null.
@@ -201,6 +203,22 @@ export function sanitizePlannerPageField(value, max = 500) {
   return sanitizeText(withoutBoundaryTags, max, { collapseWhitespace: true });
 }
 
+export function plannerClarificationForPage(clarification, pageUrl) {
+  if (!clarification || clarification.requiresSubmission !== true) return null;
+  const recordedPageUrl = String(clarification.pageUrl || '').trim();
+  const currentPageUrl = String(pageUrl || '').trim();
+  if (!recordedPageUrl || !currentPageUrl) return null;
+  try {
+    if (new URL(recordedPageUrl).href !== new URL(currentPageUrl).href) return null;
+  } catch {
+    if (recordedPageUrl !== currentPageUrl) return null;
+  }
+  return {
+    requiresSubmission: true,
+    pageUrl: recordedPageUrl.slice(0, 500),
+  };
+}
+
 export function buildPlannerMessages(enrichedUserMessage, pageUrl, pageTitle, historyDigest = '', opts = {}) {
   const userText = userMessageToText(enrichedUserMessage);
   const history = sanitizeText(historyDigest, 2000);
@@ -210,6 +228,11 @@ export function buildPlannerMessages(enrichedUserMessage, pageUrl, pageTitle, hi
   const priorUserTask = sanitizeText(opts.priorUserTask, 1200);
   const priorUserTaskBlock = priorUserTask
     ? `Prior user request (authentic user-authored context for resolving follow-ups, but it does NOT authorize repeating an earlier mutation; only the current User task authorizes new action):\n${priorUserTask}\n\n`
+    : '';
+  const clarification = plannerClarificationForPage(opts.plannerClarification, pageUrl);
+  const clarificationPageUrl = sanitizePlannerPageField(clarification?.pageUrl, 300);
+  const clarificationBlock = clarification?.requiresSubmission === true
+    ? `Unresolved planner clarification (trusted app state for one direct continuation only):\n- The user-authorized task required an eventual explicit submission.\n- Page URL when clarification was asked: ${clarificationPageUrl || 'unknown'}\nUse this only if the current User task directly answers or continues that clarification on the same task. Preserve requires_submission=true for that continuation unless the current User task revokes submission. Ignore it for a new task, a cancellation, a different page workflow, or a do-not-submit instruction.\n\n`
     : '';
   const scratchpadFacts = sanitizePlannerPageField(opts.scratchpadFacts, 1800);
   const scratchpadBlock = scratchpadFacts
@@ -226,7 +249,7 @@ export function buildPlannerMessages(enrichedUserMessage, pageUrl, pageTitle, hi
     { role: 'system', content: buildPlannerSystemPrompt(opts) },
     {
       role: 'user',
-      content: `${thinkingDirective}${priorUserTaskBlock}${historyBlock}${scratchpadBlock}<untrusted_page_content>\nPage URL: ${safeUrl}\nPage title: ${safeTitle}\n</untrusted_page_content>\n\nUser task:\n${userText}`,
+      content: `${thinkingDirective}${priorUserTaskBlock}${clarificationBlock}${historyBlock}${scratchpadBlock}<untrusted_page_content>\nPage URL: ${safeUrl}\nPage title: ${safeTitle}\n</untrusted_page_content>\n\nUser task:\n${userText}`,
     },
   ];
 }
@@ -306,7 +329,8 @@ export function normalizePlan(obj, opts = {}) {
       ? localizedInput.risks.map((risk) => sanitizeText(risk, 200)).filter(Boolean).slice(0, 6)
       : [],
   };
-  const requiresSubmission = executablePlan
+  const submissionBearingPlan = executablePlan || requestKind === 'clarify';
+  const requiresSubmission = submissionBearingPlan
     ? (hasRequiresSubmission ? obj.requires_submission === true : null)
     : false;
   const requiresStateChange = executablePlan

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -496,6 +496,35 @@
       : null;
   }
 
+  function _isFullyVisibleForInteraction(el) {
+    try {
+      if (!el?.isConnected) return false;
+      const view = el.ownerDocument?.defaultView || window;
+      const rect = el.getBoundingClientRect();
+      if (
+        rect.width < 1
+        || rect.height < 1
+        || rect.left < 0
+        || rect.top < 0
+        || rect.right > view.innerWidth
+        || rect.bottom > view.innerHeight
+      ) return false;
+      for (let node = _composedParent(el); node && node !== el.ownerDocument; node = _composedParent(node)) {
+        if (node.nodeType !== Node.ELEMENT_NODE) continue;
+        const style = view.getComputedStyle(node);
+        const clipsX = /^(?:auto|scroll|hidden|clip)$/.test(style.overflowX);
+        const clipsY = /^(?:auto|scroll|hidden|clip)$/.test(style.overflowY);
+        if (!clipsX && !clipsY) continue;
+        const parentRect = node.getBoundingClientRect();
+        if (clipsX && (rect.left < parentRect.left || rect.right > parentRect.right)) return false;
+        if (clipsY && (rect.top < parentRect.top || rect.bottom > parentRect.bottom)) return false;
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   function _isComposedAncestor(ancestor, node) {
     let cur = node;
     while (cur) {
@@ -3656,7 +3685,9 @@
           const targetRole = String(el.getAttribute?.('role') || '').toLowerCase();
           const canonicalTargetName = _axCanonicalName(el);
           const targetName = canonicalTargetName || _axAccessibleName(el);
-          try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
+          if (!_isFullyVisibleForInteraction(el)) {
+            try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
+          }
           try { el.focus({ preventScroll: true }); } catch {}
           const rect = el.getBoundingClientRect();
           if (!el.isConnected || rect.width < 1 || rect.height < 1) {

--- a/src/firefox/src/content/rich-text-toolbar-heuristic.js
+++ b/src/firefox/src/content/rich-text-toolbar-heuristic.js
@@ -342,8 +342,10 @@ var __wbRichTextToolbarHeuristic = (() => {
       ].join(',');
 
       let cluster = null;
+      let guardCluster = null;
       let node = _composedParent(el);
       for (let depth = 1; node && depth <= 6; depth++, node = _composedParent(node)) {
+        if (['FORM', 'BODY', 'HTML'].includes(String(node.tagName || '').toUpperCase())) break;
         if (!_visibleFieldContextNode(node)) continue;
         const region = node.getBoundingClientRect();
         if (region.height > 160 || region.width < rect.width) continue;
@@ -352,7 +354,21 @@ var __wbRichTextToolbarHeuristic = (() => {
         if (!controls.includes(el)) controls.unshift(el);
         if (controls.length < 2 || controls.length > 40) continue;
         const area = region.width * region.height;
-        if (!cluster || area < cluster.area) cluster = { node, controls, region, area };
+        const entry = { node, controls, region, area };
+        if (!cluster || area < cluster.area) cluster = entry;
+        // Component toolbars without role="toolbar" often wrap an input in a
+        // tiny 40px sub-container while the adjacent Body/Heading control is a
+        // generic div. Keep the smallest cluster for scoring, but widen the
+        // recovery region only when the compact row has a definite associated
+        // editor. This keeps ordinary one-row forms out of the blocked scope.
+        if (
+          controls.length >= 3
+          && region.height <= 96
+          && (!guardCluster || region.width > guardCluster.region.width)
+        ) {
+          const associatedEditor = _associatedRichTextEditor(node);
+          if (associatedEditor) guardCluster = { ...entry, associatedEditor };
+        }
       }
 
       const reasons = [];
@@ -366,7 +382,12 @@ var __wbRichTextToolbarHeuristic = (() => {
       if (semanticToolbar) { reasons.push('semantic_toolbar'); score += 4; }
       if (score < 4) return null;
 
-      const regionNode = semanticToolbar || cluster?.node || _composedParent(el) || el;
+      const directParent = _composedParent(el);
+      const safeDirectParent = directParent
+        && !['FORM', 'BODY', 'HTML'].includes(String(directParent.tagName || '').toUpperCase())
+        ? directParent
+        : null;
+      const regionNode = semanticToolbar || guardCluster?.node || cluster?.node || safeDirectParent || el;
       const region = regionNode.getBoundingClientRect();
       const related = _richTextToolbarQueryAcrossOpenShadowRoots(regionNode, interactiveSelector, 30)
         .filter(candidate => !candidate.isContentEditable && _visibleFieldContextNode(candidate))
@@ -398,7 +419,9 @@ var __wbRichTextToolbarHeuristic = (() => {
           } catch {}
         }
       }
-      const associatedEditor = _associatedRichTextEditor(regionNode);
+      const associatedEditor = guardCluster?.node === regionNode
+        ? guardCluster.associatedEditor
+        : _associatedRichTextEditor(regionNode);
       // A formatting affordance the control declares itself, or an ARIA
       // toolbar that demonstrably belongs to an editor. [role=toolbar] alone
       // is not evidence of a rich-text editor: ordinary app toolbars hold

--- a/src/firefox/src/providers/base.js
+++ b/src/firefox/src/providers/base.js
@@ -127,7 +127,17 @@ export class BaseLLMProvider {
   }
 
   _mapMessages(messages) {
-    return mapProviderMessages(messages, this.config);
+    const sanitized = (Array.isArray(messages) ? messages : []).map((message) => {
+      if (!message || typeof message !== 'object' || !Object.hasOwn(message, 'webbrainPlannerClarification')) {
+        return message;
+      }
+      const {
+        webbrainPlannerClarification: _plannerClarification,
+        ...providerMessage
+      } = message;
+      return providerMessage;
+    });
+    return mapProviderMessages(sanitized, this.config);
   }
 
   _supportsReasoningContentReplay(_options = {}) {

--- a/test/fixtures/rich-text-toolbar.mjs
+++ b/test/fixtures/rich-text-toolbar.mjs
@@ -51,6 +51,170 @@ export function registerRichTextToolbarFixtures({
       }
     });
 
+    test(`${browserKind}: ordinary compact form controls stay outside a widened toolbar region`, async (page) => {
+      await setupContentHtml(page, `<!doctype html>
+        <style>
+          body { margin: 20px; font: 16px sans-serif; }
+          #ordinary-form { width: 720px; height: 60px; display: flex; align-items: center; gap: 8px; }
+          #quantity { width: 22px; height: 16px; }
+          #title { width: 240px; height: 24px; }
+        </style>
+        <form id="ordinary-form">
+          <input id="quantity" value="11">
+          <input id="title" aria-label="Title">
+          <button id="save" type="button">Save</button>
+        </form>`, browserKind);
+      const refs = await page.evaluate(() => ({
+        form: window.__wb_ax_ref(document.querySelector('#ordinary-form')),
+        quantity: window.__wb_ax_ref(document.querySelector('#quantity')),
+        title: window.__wb_ax_ref(document.querySelector('#title')),
+        save: window.__wb_ax_ref(document.querySelector('#save')),
+      }));
+      const quantityProbe = await call(page, 'probe_rich_text_toolbar_retry_target', {
+        toolName: 'set_field',
+        args: { ref_id: refs.quantity, text: 'Document prose' },
+      });
+      const candidate = quantityProbe?.fieldMeta?.toolbarCandidate;
+      if (
+        !candidate
+        || candidate.regionRef === refs.form
+        || candidate.relatedRefs?.includes(refs.title)
+        || candidate.relatedRefs?.includes(refs.save)
+        || candidate.associatedEditorRef
+      ) {
+        throw new Error(`ordinary form siblings must stay outside the numeric candidate's recovery region: ${JSON.stringify({ refs, quantityProbe })}`);
+      }
+      const saveProbe = await call(page, 'probe_rich_text_toolbar_retry_target', {
+        toolName: 'click_ax',
+        args: { ref_id: refs.save },
+      });
+      if (!saveProbe?.resolved || saveProbe.toolbarContext === true) {
+        throw new Error(`ordinary Save control must not inherit toolbar context: ${JSON.stringify(saveProbe)}`);
+      }
+
+      const AgentClass = browserKind === 'chrome' ? Agent : FirefoxAgent;
+      const agent = new AgentClass({ getVisionProvider: async () => null });
+      const tabId = browserKind === 'chrome' ? 1881 : 1882;
+      agent._applyRichTextToolbarWrongTarget(
+        tabId,
+        'set_field',
+        { ref_id: refs.quantity, text: 'Document prose', clear: true },
+        {},
+        candidate,
+        { source: 'structural', targetKind: 'font_size' },
+        null,
+        quantityProbe,
+      );
+      agent._probeRichTextToolbarRetryTarget = async () => saveProbe;
+      const saveBlock = await agent._richTextToolbarToolBlock(tabId, 'click_ax', { ref_id: refs.save });
+      if (saveBlock) {
+        throw new Error(`ordinary Save control must remain dispatchable after a blocked numeric mis-target: ${JSON.stringify(saveBlock)}`);
+      }
+    });
+
+    test(`${browserKind}: roleless nested toolbar binds Body/Heading siblings to the blocked recovery region`, async (page) => {
+      await setupContentHtml(page, `<!doctype html>
+        <style>
+          body { margin: 20px; font: 16px sans-serif; }
+          #editor-shell { width: 620px; border: 1px solid #aaa; }
+          #roleless-toolbar { height: 42px; display: flex; align-items: center; gap: 8px; padding: 0 8px; border-bottom: 1px solid #ccc; }
+          #style-control, #family-control { height: 24px; display: flex; align-items: center; padding: 0 8px; border: 1px solid #bbb; }
+          #size-wrap { width: 44px; height: 24px; display: flex; align-items: center; overflow: hidden; }
+          #font-size { width: 22px; height: 16px; }
+          #visual-editor { min-height: 150px; position: relative; padding: 12px; }
+          #editor-proxy { position: absolute; right: 12px; top: 12px; width: 23px; height: 23px; }
+        </style>
+        <div id="editor-shell">
+          <div id="roleless-toolbar">
+            <div id="style-control" tabindex="0">Heading3</div>
+            <div id="family-control" tabindex="0">Default</div>
+            <div id="size-wrap"><input id="font-size" value="11"><button type="button">v</button></div>
+            <button type="button">B</button><button type="button">I</button><button type="button">U</button>
+          </div>
+          <div id="visual-editor"><h3>Existing answer</h3><textarea id="editor-proxy" aria-label="Editor input"></textarea></div>
+        </div>`, browserKind);
+      const refs = await page.evaluate(() => ({
+        toolbar: window.__wb_ax_ref(document.querySelector('#roleless-toolbar')),
+        style: window.__wb_ax_ref(document.querySelector('#style-control')),
+        size: window.__wb_ax_ref(document.querySelector('#font-size')),
+        proxy: window.__wb_ax_ref(document.querySelector('#editor-proxy')),
+      }));
+      const sizeProbe = await call(page, 'probe_rich_text_toolbar_retry_target', {
+        toolName: 'set_field',
+        args: { ref_id: refs.size, text: 'Document prose' },
+      });
+      const candidate = sizeProbe?.fieldMeta?.toolbarCandidate;
+      if (
+        !candidate
+        || candidate.regionRef !== refs.toolbar
+        || candidate.associatedEditorRef !== refs.proxy
+      ) {
+        throw new Error(`roleless toolbar must widen past the nested size wrapper and bind its proxy editor: ${JSON.stringify({ refs, sizeProbe })}`);
+      }
+      const styleProbe = await call(page, 'probe_rich_text_toolbar_retry_target', {
+        toolName: 'click_ax',
+        args: { ref_id: refs.style },
+      });
+      if (
+        !styleProbe?.resolved
+        || styleProbe.toolbarContext !== true
+        || styleProbe.toolbarRegionRef !== refs.toolbar
+        || styleProbe.toolbarRegionKey !== candidate.regionKey
+      ) {
+        throw new Error(`Body/Heading sibling must resolve to the same roleless toolbar region: ${JSON.stringify({ candidate, styleProbe })}`);
+      }
+
+      const AgentClass = browserKind === 'chrome' ? Agent : FirefoxAgent;
+      const agent = new AgentClass({ getVisionProvider: async () => null });
+      const tabId = browserKind === 'chrome' ? 1901 : 1902;
+      const wrongTarget = {};
+      agent._applyRichTextToolbarWrongTarget(
+        tabId,
+        'set_field',
+        { ref_id: refs.size, text: 'Document prose', clear: true },
+        wrongTarget,
+        candidate,
+        { source: 'structural', targetKind: 'font_size' },
+        null,
+        sizeProbe,
+      );
+      if (wrongTarget.associatedEditorRef !== refs.proxy || !String(wrongTarget.error || '').includes(refs.proxy)) {
+        throw new Error(`blocked write must surface the exact associated editor ref: ${JSON.stringify(wrongTarget)}`);
+      }
+      agent._probeRichTextToolbarRetryTarget = async () => styleProbe;
+      const styleBlock = await agent._richTextToolbarToolBlock(tabId, 'click_ax', { ref_id: refs.style });
+      if (!styleBlock?.wrongTarget || styleBlock.dispatched !== false) {
+        throw new Error(`Body/Heading toolbar retry must be blocked before it can change formatting: ${JSON.stringify(styleBlock)}`);
+      }
+    });
+
+    test(`${browserKind}: click_ax keeps an already-visible nested textarea at its current scroll position`, async (page) => {
+      await setupContentHtml(page, `<!doctype html>
+        <style>
+          body { margin: 0; }
+          #scroller { width: 500px; height: 180px; overflow: auto; border: 1px solid #aaa; }
+          .spacer { height: 260px; }
+          #editor-proxy { display: block; width: 23px; height: 23px; }
+        </style>
+        <div id="scroller"><div class="spacer"></div><textarea id="editor-proxy"></textarea><div class="spacer"></div></div>`, browserKind);
+      const state = await page.evaluate(() => {
+        const scroller = document.querySelector('#scroller');
+        const target = document.querySelector('#editor-proxy');
+        scroller.scrollTop = 230;
+        return {
+          ref: window.__wb_ax_ref(target),
+          before: scroller.scrollTop,
+          targetRect: target.getBoundingClientRect().toJSON(),
+          scrollerRect: scroller.getBoundingClientRect().toJSON(),
+        };
+      });
+      const response = await call(page, 'click_ax', { ref_id: state.ref });
+      const after = await page.evaluate(() => document.querySelector('#scroller').scrollTop);
+      if (!response?.success || after !== state.before) {
+        throw new Error(`visible proxy textarea click must not recenter its scroll container: ${JSON.stringify({ state, response, after })}`);
+      }
+    });
+
     test(`${browserKind}: rich-text toolbar metadata covers labelled controls and excludes labelled ordinary fields`, async (page) => {
       await setupContentFixture(page, 'rich-text-toolbar-target.html', browserKind);
 

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -104,6 +104,9 @@ async function setupContentHtml(page, html, browserKind) {
   // Simulate manifest injection followed by extension-reload recovery.
   await page.addScriptTag({ content: pageGuardSrc });
   await page.addScriptTag({ content: firefox ? stubFirefoxBrowser : stubChrome });
+  await page.addScriptTag({
+    content: await readFile(firefox ? firefoxAccessibilityTreeJsPath : accessibilityTreeJsPath, 'utf-8'),
+  });
   await page.addScriptTag({ content: await readFile(firefox ? firefoxToolbarHeuristicJsPath : toolbarHeuristicJsPath, 'utf-8') });
   const src = await readFile(firefox ? firefoxContentJsPath : contentJsPath, 'utf-8');
   await page.addScriptTag({ content: src });

--- a/test/run.js
+++ b/test/run.js
@@ -38517,6 +38517,25 @@ test('provider compatibility defaults preserve legacy chat request bodies', () =
       temperature: 0.2,
       max_tokens: 123,
     });
+    const internalMessages = [{
+      role: 'assistant',
+      content: 'What value should I use?',
+      webbrainPlannerClarification: {
+        requiresSubmission: true,
+        pageUrl: 'https://example.test/application',
+      },
+    }];
+    const internalBody = provider._buildChatCompletionsBody(internalMessages, {}, false);
+    assert.deepEqual(
+      internalBody.messages,
+      [{ role: 'assistant', content: 'What value should I use?' }],
+      'app-only planner clarification metadata must not reach Chat Completions providers',
+    );
+    assert.equal(
+      internalMessages[0].webbrainPlannerClarification.requiresSubmission,
+      true,
+      'provider message sanitization must not mutate persisted conversation state',
+    );
   }
   for (const Provider of [LlamaCppProviderCh, LlamaCppProviderFx]) {
     const provider = new Provider({ baseUrl: 'http://localhost:8080' });
@@ -54403,6 +54422,27 @@ test('planner: parse and format structured plan', () => {
   assert.equal(respond?.requires_state_change, false, 'respond must never authorize page mutation');
   assert.equal(respond?.requires_submission, false, 'respond must never require submission');
   assert.equal(respond?.scheduling, null, 'respond must not preserve scheduling metadata');
+
+  for (const parse of [parsePlanFromContent, parsePlanFromContentFx]) {
+    const clarifyBeforeSubmit = parse(JSON.stringify({
+      request_kind: 'clarify',
+      requires_state_change: false,
+      requires_submission: true,
+      summary: 'Ask for the missing answer before submitting the form.',
+      steps: [],
+      memory: {},
+      scheduling: null,
+      risks: [],
+      localized: {
+        locale: 'en',
+        summary: 'What answer should I use before submitting?',
+        steps: [],
+        risks: [],
+      },
+    }), { requireIntent: true, locale: 'en' });
+    assert.equal(clarifyBeforeSubmit?.requires_state_change, false, 'clarify must never authorize an immediate mutation');
+    assert.equal(clarifyBeforeSubmit?.requires_submission, true, 'clarify must retain the eventual user-authorized submit intent');
+  }
 });
 
 test('planner: parse JSON inside markdown fence', () => {
@@ -54447,6 +54487,8 @@ test('planner: prompt treats page context as untrusted data', () => {
   assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /"use_progress_ledger": boolean/);
   assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /"requires_submission": boolean/);
   assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /explicit do-not-submit tasks and autosave UIs/i);
+  assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /For clarify, preserve true.*already-requested commit/i);
+  assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /answers, drafts, or values already prepared.*classify execute and inspect/i);
   assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /sequential workflow stages, sites, apps, or destinations are not peer items/i);
   assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /lacks usable timing or cadence.*clarify/i);
   assert.match(PLANNER_INTENT_SYSTEM_PROMPT, /Calendar\/cron recurrence.*unsupported/i);
@@ -54767,6 +54809,138 @@ test('planner consistency repair keeps model-derived plan fields out of trusted 
       `${AgentClass.name}: model-derived plan data crossed the trust boundary`,
     );
   }
+});
+
+test('planner consistency repair preserves submit intent across one direct clarification continuation', async () => {
+  await withPlannerBrowserGlobals(async () => {
+    for (const [agentIndex, AgentClass] of [AgentCh, AgentFx].entries()) {
+      for (const [routeIndex, route] of ['intent', 'full'].entries()) {
+        const responses = [false, true].map(requiresSubmission => plannerFixtureJson({
+          request_kind: 'execute',
+          requires_state_change: true,
+          requires_submission: requiresSubmission,
+          summary: 'Fill the remaining application answers and submit the form.',
+          confidence: 0.99,
+          steps: [
+            { id: '1', action: 'Fill the remaining answers.', tools: ['set_field'] },
+            { id: '2', action: 'Submit and verify the form.', tools: ['click_ax', 'read_page'] },
+          ],
+          localized: {
+            locale: 'en',
+            summary: 'Fill the remaining application answers and submit the form.',
+            steps: [
+              { id: '1', action: 'Fill the remaining answers.' },
+              { id: '2', action: 'Submit and verify the form.' },
+            ],
+            risks: [],
+          },
+        }));
+        const requests = [];
+        const provider = {
+          promptTier: 'full',
+          model: 'planner-submit-continuation-test',
+          name: 'planner-submit-continuation-test',
+          chat: async messages => {
+            requests.push(messages);
+            return { content: responses.shift(), usage: {} };
+          },
+        };
+        const agent = new AgentClass({ getActive: () => provider, getVisionProvider: async () => null });
+        agent.setPlanReviewSettings({ mode: 'never' });
+        const followUpContext = {
+          priorUserTask: 'Fill and submit this application.',
+          scratchpadFacts: '',
+          plannerClarification: {
+            requiresSubmission: true,
+            pageUrl: 'https://example.test/application',
+          },
+        };
+        const args = [
+          9340 + (agentIndex * 20) + (routeIndex * 10),
+          { role: 'user', content: 'Use the WebBrain details and answer the remaining questions.' },
+          () => {},
+          null,
+          null,
+          '',
+          { tabUrl: 'https://example.test/application', tabTitle: 'Application' },
+        ];
+        const gate = route === 'intent'
+          ? await agent._runPlannerIntentGate(...args, 'act', { locale: 'en' }, followUpContext)
+          : await agent._runPlannerGate(...args, 'try', 'act', { locale: 'en' }, followUpContext);
+
+        assert.equal(gate.proceed, true, `${AgentClass.name}: ${route} continuation did not execute`);
+        assert.equal(gate.requiresSubmission, true, `${AgentClass.name}: ${route} dropped clarified submit intent`);
+        assert.equal(requests.length, 2, `${AgentClass.name}: ${route} should get one semantic submit-intent recheck`);
+        assert.match(requests[0][1].content, /Unresolved planner clarification/);
+        assert.match(requests[1].at(-1)?.content || '', /clarification_submit_intent_dropped/);
+        assert.equal(responses.length, 0);
+      }
+    }
+  });
+});
+
+test('planner submit clarification does not cross page boundaries', async () => {
+  await withPlannerBrowserGlobals(async () => {
+    for (const [agentIndex, AgentClass] of [AgentCh, AgentFx].entries()) {
+      for (const [routeIndex, route] of ['intent', 'full'].entries()) {
+        const response = plannerFixtureJson({
+          request_kind: 'execute',
+          requires_state_change: true,
+          requires_submission: false,
+          summary: 'Fill the different form without submitting it.',
+          confidence: 0.99,
+          steps: [
+            { id: '1', action: 'Fill the requested fields without submitting.', tools: ['set_field'] },
+          ],
+          localized: {
+            locale: 'en',
+            summary: 'Fill the different form without submitting it.',
+            steps: [
+              { id: '1', action: 'Fill the requested fields without submitting.' },
+            ],
+            risks: [],
+          },
+        });
+        const requests = [];
+        const provider = {
+          promptTier: 'full',
+          model: 'planner-submit-page-scope-test',
+          name: 'planner-submit-page-scope-test',
+          chat: async messages => {
+            requests.push(messages);
+            return { content: response, usage: {} };
+          },
+        };
+        const agent = new AgentClass({ getActive: () => provider, getVisionProvider: async () => null });
+        agent.setPlanReviewSettings({ mode: 'never' });
+        const followUpContext = {
+          priorUserTask: 'Fill and submit the first application.',
+          scratchpadFacts: '',
+          plannerClarification: {
+            requiresSubmission: true,
+            pageUrl: 'https://example.test/first-application',
+          },
+        };
+        const args = [
+          9380 + (agentIndex * 20) + (routeIndex * 10),
+          { role: 'user', content: 'Fill this different form without submitting it.' },
+          () => {},
+          null,
+          null,
+          '',
+          { tabUrl: 'https://example.test/second-application', tabTitle: 'Second application' },
+        ];
+        const gate = route === 'intent'
+          ? await agent._runPlannerIntentGate(...args, 'act', { locale: 'en' }, followUpContext)
+          : await agent._runPlannerGate(...args, 'try', 'act', { locale: 'en' }, followUpContext);
+
+        assert.equal(gate.proceed, true, `${AgentClass.name}: ${route} different-page task did not execute`);
+        assert.equal(gate.requiresSubmission, false, `${AgentClass.name}: ${route} carried stale submit intent across pages`);
+        assert.equal(requests.length, 1, `${AgentClass.name}: ${route} should not repair submit intent from another page`);
+        assert.doesNotMatch(requests[0][1].content, /Unresolved planner clarification/);
+      }
+    }
+  });
 });
 
 test('planner falls back safely when repaired respond intent still lists tools', async () => {
@@ -60068,6 +60242,35 @@ test('planner input: active prior task and pending draft survive long tool chatt
     const context = agent._buildPlannerFollowUpContext(messages);
     assert.match(context.priorUserTask, /Draft and send Gary/, `${label}: original task fell out of planner context`);
     assert.match(context.scratchpadFacts, /\[pending draft\]/, `${label}: pending draft fell out of planner context`);
+
+    const clarificationMessages = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'Fill these answers and submit the form.' },
+      agent._plannerTerminalAssistantMessage({
+        requestKind: 'clarify',
+        requiresSubmission: true,
+        message: 'What should I use for the final answer?',
+      }, { tabUrl: 'https://example.test/application' }),
+    ];
+    const clarificationContext = agent._buildPlannerFollowUpContext(clarificationMessages);
+    assert.equal(clarificationContext.plannerClarification?.requiresSubmission, true, `${label}: pending submit clarification was not retained`);
+    const clarificationPlannerMessages = build(
+      { role: 'user', content: 'Use the WebBrain details.' },
+      'https://example.test/application',
+      'Application',
+      agent._buildPlannerHistoryDigest(clarificationMessages),
+      clarificationContext,
+    );
+    assert.match(clarificationPlannerMessages[1].content, /Unresolved planner clarification[\s\S]*eventual explicit submission/);
+    assert.match(clarificationPlannerMessages[1].content, /unless the current User task revokes submission/);
+    const changedPagePlannerMessages = build(
+      { role: 'user', content: 'Fill this different form without submitting it.' },
+      'https://example.test/other-application',
+      'Other application',
+      agent._buildPlannerHistoryDigest(clarificationMessages),
+      clarificationContext,
+    );
+    assert.doesNotMatch(changedPagePlannerMessages[1].content, /Unresolved planner clarification/);
 
     const plannerMessages = build(
       { role: 'user', content: 'Just tell me what you were going to draft.' },


### PR DESCRIPTION
## Summary

- Preserve explicit submit intent across a direct planner clarification continuation, scoped to the same page URL.
- Strip WebBrain-only clarification metadata before provider requests.
- Widen roleless rich-text toolbar recovery only when a definite associated editor exists, while keeping ordinary compact forms outside the blocked region.
- Surface the associated editor ref after toolbar mis-targets and avoid recentering elements that are already fully visible.

## Why

The traced form workflow eventually filled the rich-text answer correctly, but the agent repeatedly targeted formatting controls and then lost the original submit intent after clarification. It returned toward the top of the page instead of completing the authorized submission.

The root causes were a too-narrow nested toolbar cluster, submit intent that was not retained as trusted continuation state, and unconditional scrolling before accessibility clicks.

## Impact

The agent can recover from a formatting-toolbar mis-target by focusing the exact editor body, preserve an authorized eventual submission through one same-page clarification, and leave unrelated form controls dispatchable.

Chrome and Firefox implementations remain aligned.

## Validation

- `node test/run.js`: 1483 passed; 1 existing checkout failure for the missing tracked store archive
- `npm run test:fixtures`: 143 passed; 2 existing selection-shortcut fixture failures
- `npm run test:toolbar-guard`: 33/33 passed
- `npm run test:security`: 60/60 passed
- Syntax checks, Chrome/Firefox parity checks, and `git diff --check` passed