### PR TITLE
feat(mcp): MCP server + LM Studio browser delegation over the existing bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,9 @@ claude mcp add webbrain -- npx -y @webbrain/mcp-server
 ```
 
 Then point **WebBrain → Settings → Cloud bridge** at
-`ws://127.0.0.1:17374/extension` and enable it.
+`ws://127.0.0.1:17374/extension` and enable it. **Chromium only** — the bridge
+runs from the extension's offscreen document, which the Firefox build does not
+have.
 
 ```
 webbrain_run(task: "open the Stripe dashboard and list last week's failed
@@ -283,10 +285,11 @@ lms clone webbrain/web-tools
 ```
 
 `fetch_url` and `research_url` are pure Node HTTP — no browser needed, but also
-no cookies, no session and no JavaScript. With the extension installed,
-`browser_task` adds delegation to your real signed-in browser, reaching the
-authenticated and client-rendered pages plain HTTP cannot. It degrades with an
-actionable message when no extension is attached.
+no cookies, no session and no JavaScript. With the extension installed on a
+Chromium browser, `browser_task` adds delegation to your real signed-in browser,
+reaching the authenticated and client-rendered pages plain HTTP cannot. It
+degrades with an actionable message when no extension is attached, and the HTTP
+tools keep working on Firefox.
 
 Source: [`lmstudio-plugin/`](lmstudio-plugin/).
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ configuration. Bug reports and feature requests belong in
 src/chrome/     Manifest V3 build — service worker, chrome.scripting, sidePanel
 src/firefox/    Manifest V2 build — background page, executeScript, sidebar_action
 docs/           Design and reference docs (en, zh-CN, fr)
-lmstudio-plugin/  fetch_url + research_url as a standalone LM Studio plugin
+mcp-server/     MCP server — delegate browser tasks from Claude Code, Codex, Cursor
+lmstudio-plugin/  Web tools + browser delegation as a standalone LM Studio plugin
 web/            Landing site and docs site
 test/           Node test suite, LLM scenario benchmarks, security corpora
 ```
@@ -243,17 +244,49 @@ register it in `providers/manager.js` — mirroring both changes to
 
 Recent changes are in [CHANGELOG.md](CHANGELOG.md).
 
+## MCP server
+
+Let a coding agent use *your* browser. Claude Code, Codex, Cursor and OpenClaw
+can delegate a task to WebBrain running in the session you are already signed
+into — cookies present, SSO already passed. A headless framework starts logged
+out and stalls at the first login wall; this does not.
+
+```bash
+claude mcp add webbrain -- npx -y @webbrain/mcp-server
+```
+
+Then point **WebBrain → Settings → Cloud bridge** at
+`ws://127.0.0.1:17374/extension` and enable it.
+
+```
+webbrain_run(task: "open the Stripe dashboard and list last week's failed
+             payments with amounts and customer emails", mode: "ask")
+```
+
+`mode='ask'` is read-only. `mode='act'` can click and type, gated by the same
+in-browser approval prompts a human gets. The server exposes task delegation
+rather than the ~50 low-level browser primitives: WebBrain's permission gate
+lives in the agent loop, so per-primitive access over a socket would sit below
+the gate and bypass it. Details in [`mcp-server/`](mcp-server/).
+
+> The extension holds **one** bridge socket at a time — WebBrain Cloud (17373),
+> the MCP server (17374), or the LM Studio plugin (17375). Switch by changing
+> the URL in Settings.
+
 ## LM Studio plugin
 
-`fetch_url` and `research_url` also ship as a standalone
-[LM Studio](https://lmstudio.ai) plugin at
-[`webbrain/web-tools`](https://lmstudio.ai/webbrain/web-tools), for web-fetching
-tool-use inside LM Studio chats without the browser extension. Pure Node, no
-headless browser.
+A standalone [LM Studio](https://lmstudio.ai) plugin at
+[`webbrain/web-tools`](https://lmstudio.ai/webbrain/web-tools):
 
 ```bash
 lms clone webbrain/web-tools
 ```
+
+`fetch_url` and `research_url` are pure Node HTTP — no browser needed, but also
+no cookies, no session and no JavaScript. With the extension installed,
+`browser_task` adds delegation to your real signed-in browser, reaching the
+authenticated and client-rendered pages plain HTTP cannot. It degrades with an
+actionable message when no extension is attached.
 
 Source: [`lmstudio-plugin/`](lmstudio-plugin/).
 

--- a/lmstudio-plugin/README.md
+++ b/lmstudio-plugin/README.md
@@ -1,7 +1,9 @@
 # WebBrain Web Tools — LM Studio plugin
 
-Give any LM Studio model the ability to read the live web. Two tools,
-no browser required:
+Give any LM Studio model the ability to read the live web — and, if you
+have the browser extension, to act inside your own signed-in session.
+
+**Works with no browser, nothing installed:**
 
 - **`fetch_url`** — raw HTTP fetch with content-type smarts. JSON gets
   pretty-printed, HTML is stripped to readable text + `<title>`,
@@ -11,6 +13,21 @@ no browser required:
   article body, not the navigation chrome." Extracts `<main>` /
   `<article>`, drops header/nav/footer/aside before stripping tags.
   Best for news, blog posts, READMEs, Wikipedia, docs.
+
+**Adds real browser access when the [WebBrain extension](https://webbrain.one)
+is installed:**
+
+- **`browser_task`** — hand a goal to WebBrain running in the browser
+  you are already logged into. Reaches the authenticated dashboards,
+  webmail and client-rendered apps that plain HTTP cannot see.
+  `mode='ask'` is read-only; `mode='act'` can click and type, gated by
+  in-browser approval prompts.
+- **`browser_status`** — report whether the extension is attached, and
+  what to do if it isn't.
+
+The browser tools are always offered. Without an extension they return an
+actionable message instead of failing opaquely, so the model can tell you
+how to switch the capability on rather than retrying blindly.
 
 Long text results are context-friendly by default. Instead of dumping
 the first N characters and losing everything after the cutoff, the tools
@@ -46,23 +63,39 @@ Try it:
 The model should call `research_url` and come back with live
 headlines.
 
-## What this plugin can't do
+## Connect your browser (optional)
 
-Listed up front so it doesn't bite you mid-session:
+`browser_task` needs the [WebBrain extension](https://webbrain.one). The
+extension dials out to this plugin — a Manifest V3 extension cannot listen
+on a socket, so the plugin hosts the listener.
+
+1. Install the extension and open your browser.
+2. In **WebBrain → Settings → Cloud bridge**, set the URL to
+   `ws://127.0.0.1:17375/extension` and enable it.
+3. Ask the model to call `browser_status` to confirm.
+
+> **One bridge at a time.** The extension holds exactly one outbound bridge
+> socket. Pointing it here means it is *not* pointed at WebBrain Cloud
+> (`17373`) or the MCP server (`17374`). Override the port with
+> `WEBBRAIN_BRIDGE_PORT`.
+
+Try it:
+
+> Check my GitHub notifications and summarise anything that mentions me.
+
+## What the HTTP tools can't do
+
+Listed up front so it doesn't bite you mid-session. All three limits apply
+to `fetch_url` and `research_url` only — `browser_task` is the answer to
+every one of them:
 
 - **No JavaScript rendering.** Single-page apps that hydrate from
   JSON (Twitter, Notion, modern dashboards) return near-empty text.
   The plugin flags this with `spaSuspected: true` so the model can
   give up gracefully instead of looping.
-- **No clicks, no typing, no screenshots.** Those need a real
-  browser. The WebBrain extension does that; this plugin is the
-  read-only subset.
+- **No clicks, no typing, no screenshots.** Those need a real browser.
 - **No cookies, no login.** Each fetch is anonymous from your IP
   with no shared session — pages behind a login are out of reach.
-
-If you need any of the above, install the [WebBrain browser
-extension](https://webbrain.one) instead (or alongside) — same
-model server, full agent loop with browser interaction.
 
 ## Develop locally
 
@@ -88,15 +121,23 @@ Node project.
 ├── package.json           ← npm deps + build scripts
 ├── tsconfig.json          ← strict-mode TS, ES2022
 └── src/
-    ├── index.ts           ← plugin registration glue
+    ├── index.ts            ← plugin registration glue
     ├── tools/
-    │   ├── fetchUrl.ts    ← fetch_url implementation
-    │   └── researchUrl.ts ← research_url implementation
+    │   ├── fetchUrl.ts     ← fetch_url implementation
+    │   ├── researchUrl.ts  ← research_url implementation
+    │   └── browserTask.ts  ← browser_task + browser_status
     └── util/
-        ├── htmlToText.ts  ← regex HTML stripper
-        ├── safeFetch.ts   ← redirect-revalidating wrapper + streaming cap
-        └── urlGuard.ts    ← private-IP / file:// blocker
+        ├── htmlToText.ts   ← regex HTML stripper
+        ├── safeFetch.ts    ← redirect-revalidating wrapper + streaming cap
+        ├── urlGuard.ts     ← private-IP / file:// blocker
+        └── bridgeClient.ts ← WebSocket listener the extension dials into
 ```
+
+`bridgeClient.ts` is a deliberate standalone copy of the same protocol in
+[`mcp-server/src/bridge.ts`](../mcp-server/src/bridge.ts). The two ship to
+different registries — LM Studio Hub and npm — and sharing a package would
+drag the monorepo into both installs. **Change the protocol in one, change
+it in the other.**
 
 `tools/` and `util/` are pure functions with no SDK dependency — you
 can `import` them from any Node project that wants the same
@@ -108,6 +149,24 @@ The plugin runs in your local Node process, so anything reachable
 from that process is reachable from the LLM. The defenses below are
 layered — each closes a class of bypass the previous one missed —
 but DNS rebinding is a known residual gap (see end of this section).
+
+**The browser bridge is a separate trust surface from the HTTP tools.**
+Everything below concerns `fetch_url` / `research_url`. For `browser_task`:
+
+- The bridge listener binds `127.0.0.1` only. Anything that can reach that
+  port can drive your signed-in browser — never expose it to a network or a
+  container bridge.
+- Connections must send the extension's `hello` frame with
+  `client: "webbrain-extension"`; anything else is closed. This is **not**
+  authentication — the shipping extension sends no shared secret, so a local
+  process could impersonate it. Treat the port as trusted-local.
+- `browser_task` delegates a *goal*, never individual clicks. WebBrain's
+  capability × origin permission gate runs inside its own agent loop, so
+  every approval prompt a human would see still fires. That is why this
+  plugin does not expose the low-level browser primitives.
+- A `timeout` does **not** cancel the run. A task that already submitted a
+  form should not be silently killed; the browser keeps going and the result
+  stays visible in the WebBrain side panel.
 
 - **URL guard, structural (sync).** Requests to RFC1918 (`10.*`,
   `172.16-31.*`, `192.168.*`), loopback (`127.*`, `::1`), link-local

--- a/lmstudio-plugin/README.md
+++ b/lmstudio-plugin/README.md
@@ -29,6 +29,8 @@ is installed on a Chromium browser** (Chrome, Edge, Brave, Opera, Vivaldi —
 - **`browser_respond`** — forward the user's answer when a task pauses with
   `needs_user_input`. Use the `runId` and `clarifyId` returned by the task;
   never guess the answer on the user's behalf.
+- **`browser_abort`** — stop a continuing run by `runId`. Browser actions that
+  already completed are not rolled back.
 
 The browser tools are always offered. Without an extension they return an
 actionable message instead of failing opaquely, so the model can tell you
@@ -139,7 +141,7 @@ Node project.
     ├── tools/
     │   ├── fetchUrl.ts     ← fetch_url implementation
     │   ├── researchUrl.ts  ← research_url implementation
-    │   └── browserTask.ts  ← browser task + status/respond recovery tools
+    │   └── browserTask.ts  ← browser task + status/respond/abort recovery tools
     └── util/
         ├── htmlToText.ts   ← regex HTML stripper
         ├── safeFetch.ts    ← redirect-revalidating wrapper + streaming cap

--- a/lmstudio-plugin/README.md
+++ b/lmstudio-plugin/README.md
@@ -15,7 +15,8 @@ have the browser extension, to act inside your own signed-in session.
   Best for news, blog posts, READMEs, Wikipedia, docs.
 
 **Adds real browser access when the [WebBrain extension](https://webbrain.one)
-is installed:**
+is installed on a Chromium browser** (Chrome, Edge, Brave, Opera, Vivaldi —
+[not Firefox](#why-not-firefox)):
 
 - **`browser_task`** — hand a goal to WebBrain running in the browser
   you are already logged into. Reaches the authenticated dashboards,
@@ -65,9 +66,18 @@ headlines.
 
 ## Connect your browser (optional)
 
-`browser_task` needs the [WebBrain extension](https://webbrain.one). The
-extension dials out to this plugin — a Manifest V3 extension cannot listen
-on a socket, so the plugin hosts the listener.
+`browser_task` needs the [WebBrain extension](https://webbrain.one) on a
+**Chromium browser** — Chrome, Edge, Brave, Opera or Vivaldi. The extension
+dials out to this plugin; a Manifest V3 extension cannot listen on a socket,
+so the plugin hosts the listener.
+
+### Why not Firefox
+
+The bridge runs from the extension's **offscreen document**, and the Firefox
+build has none — see [`src/firefox/ARCHITECTURE.md`](../src/firefox/ARCHITECTURE.md).
+`cloud-bridge.js` and `cloud-runs.js` exist only under `src/chrome/`. On
+Firefox, `browser_task` will always return the not-connected response.
+`fetch_url` and `research_url` are unaffected and work everywhere.
 
 1. Install the extension and open your browser.
 2. In **WebBrain → Settings → Cloud bridge**, set the URL to

--- a/lmstudio-plugin/README.md
+++ b/lmstudio-plugin/README.md
@@ -24,7 +24,11 @@ is installed on a Chromium browser** (Chrome, Edge, Brave, Opera, Vivaldi —
   `mode='ask'` is read-only; `mode='act'` can click and type, gated by
   in-browser approval prompts.
 - **`browser_status`** — report whether the extension is attached, and
-  what to do if it isn't.
+  what to do if it isn't. Pass a `runId` to poll a task that outlived its
+  initial timeout and retrieve the eventual result.
+- **`browser_respond`** — forward the user's answer when a task pauses with
+  `needs_user_input`. Use the `runId` and `clarifyId` returned by the task;
+  never guess the answer on the user's behalf.
 
 The browser tools are always offered. Without an extension they return an
 actionable message instead of failing opaquely, so the model can tell you
@@ -135,7 +139,7 @@ Node project.
     ├── tools/
     │   ├── fetchUrl.ts     ← fetch_url implementation
     │   ├── researchUrl.ts  ← research_url implementation
-    │   └── browserTask.ts  ← browser_task + browser_status
+    │   └── browserTask.ts  ← browser task + status/respond recovery tools
     └── util/
         ├── htmlToText.ts   ← regex HTML stripper
         ├── safeFetch.ts    ← redirect-revalidating wrapper + streaming cap

--- a/lmstudio-plugin/manifest.json
+++ b/lmstudio-plugin/manifest.json
@@ -8,6 +8,7 @@
     "web",
     "fetch",
     "research",
-    "browser-tools"
+    "browser-tools",
+    "browser-agent"
   ]
 }

--- a/lmstudio-plugin/package-lock.json
+++ b/lmstudio-plugin/package-lock.json
@@ -1,19 +1,21 @@
 {
   "name": "@webbrain/lmstudio-web-tools",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@webbrain/lmstudio-web-tools",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@lmstudio/sdk": "^1.0.0",
+        "ws": "^8.18.0",
         "zod": "^3.23.0"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
+        "@types/ws": "^8.5.10",
         "typescript": "^5.5.0"
       },
       "engines": {
@@ -50,6 +52,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/ansi-styles": {

--- a/lmstudio-plugin/package.json
+++ b/lmstudio-plugin/package.json
@@ -3,6 +3,7 @@
   "displayName": "WebBrain Web Tools",
   "description": "Web tools for LM Studio. fetch_url (raw HTTP, content-type aware) and research_url (readable article body) work with pure Node and no dependencies. With the WebBrain extension installed on a Chromium browser (Chrome, Edge, Brave), browser_task additionally delegates goals to your real, already-signed-in browser session — pages behind a login or rendered client-side that plain HTTP cannot reach. Firefox is not supported for browser_task: that build has no offscreen document, so it cannot host the bridge.",
   "version": "0.2.0",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
@@ -15,6 +16,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "test": "npm run build && node --test \"test/*.test.mjs\"",
     "clean": "rm -rf dist"
   },
   "keywords": [

--- a/lmstudio-plugin/package.json
+++ b/lmstudio-plugin/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@webbrain/lmstudio-web-tools",
   "displayName": "WebBrain Web Tools",
-  "description": "Web fetching + research tools for LM Studio. Adds fetch_url (raw HTTP, content-type aware) and research_url (extracts the readable article body) to any chat. Pure Node — no browser dependency. Ports the same network-tools the WebBrain Chrome/Firefox extension uses.",
-  "version": "0.1.0",
+  "description": "Web tools for LM Studio. fetch_url (raw HTTP, content-type aware) and research_url (readable article body) work with pure Node and no dependencies. With the WebBrain Chrome/Firefox extension installed, browser_task additionally delegates goals to your real, already-signed-in browser session — pages behind a login or rendered client-side that plain HTTP cannot reach.",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
@@ -25,15 +25,19 @@
     "fetch",
     "research",
     "browser-tools",
+    "browser-agent",
+    "browser-automation",
     "webbrain"
   ],
   "dependencies": {
     "@lmstudio/sdk": "^1.0.0",
+    "ws": "^8.18.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "@types/node": "^20.11.0"
+    "@types/node": "^20.11.0",
+    "@types/ws": "^8.5.10"
   },
   "files": [
     "dist",

--- a/lmstudio-plugin/package.json
+++ b/lmstudio-plugin/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "npm run build && node --test \"test/*.test.mjs\"",
+    "test": "npm run build && node --test test/browserTask.test.mjs",
     "clean": "rm -rf dist"
   },
   "keywords": [

--- a/lmstudio-plugin/package.json
+++ b/lmstudio-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webbrain/lmstudio-web-tools",
   "displayName": "WebBrain Web Tools",
-  "description": "Web tools for LM Studio. fetch_url (raw HTTP, content-type aware) and research_url (readable article body) work with pure Node and no dependencies. With the WebBrain Chrome/Firefox extension installed, browser_task additionally delegates goals to your real, already-signed-in browser session — pages behind a login or rendered client-side that plain HTTP cannot reach.",
+  "description": "Web tools for LM Studio. fetch_url (raw HTTP, content-type aware) and research_url (readable article body) work with pure Node and no dependencies. With the WebBrain extension installed on a Chromium browser (Chrome, Edge, Brave), browser_task additionally delegates goals to your real, already-signed-in browser session — pages behind a login or rendered client-side that plain HTTP cannot reach. Firefox is not supported for browser_task: that build has no offscreen document, so it cannot host the bridge.",
   "version": "0.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/lmstudio-plugin/src/index.ts
+++ b/lmstudio-plugin/src/index.ts
@@ -30,7 +30,12 @@ import type { PluginContext } from "@lmstudio/sdk";
 import { z } from "zod";
 import { fetchUrl } from "./tools/fetchUrl.js";
 import { researchUrl } from "./tools/researchUrl.js";
-import { browserRespond, browserStatus, browserTask } from "./tools/browserTask.js";
+import {
+  browserAbort,
+  browserRespond,
+  browserStatus,
+  browserTask,
+} from "./tools/browserTask.js";
 import { sharedBridge } from "./util/bridgeClient.js";
 
 const fetchUrlTool = tool({
@@ -162,7 +167,8 @@ const browserTaskTool = tool({
     "prefer it whenever you only need to read. mode='act' allows interaction, " +
     "and the user approves consequential actions in the browser.\n\n" +
     "If a task keeps running, poll browser_status with its runId. If it needs user " +
-    "input, ask the user and forward their answer with browser_respond.\n\n" +
+    "input, ask the user and forward their answer with browser_respond. If the user " +
+    "wants a continuing run stopped, call browser_abort.\n\n" +
     "Requires the WebBrain extension (https://webbrain.one) on a Chromium browser " +
     "(Chrome, Edge, Brave), pointed at this plugin's bridge. Firefox cannot host the " +
     "bridge. If it is not connected the tool returns a hint explaining exactly what to " +
@@ -242,6 +248,19 @@ const browserRespondTool = tool({
     JSON.stringify(await browserRespond({ runId, clarifyId, answer, timeout }), null, 2),
 });
 
+const browserAbortTool = tool({
+  name: "browser_abort",
+  description:
+    "Stop a browser run that is still running, waiting for input, or no longer needed. " +
+    "Use the runId returned by browser_task, browser_status, or browser_respond. Actions " +
+    "already completed in the browser are not undone.",
+  parameters: {
+    runId: z.string().min(1).describe("The continuing browser run to stop."),
+  },
+  implementation: async ({ runId }) =>
+    JSON.stringify(await browserAbort(runId), null, 2),
+});
+
 /**
  * Plugin entry point. LM Studio's plugin runner calls this once at
  * load time with a `PluginContext` builder. We register the tools
@@ -274,6 +293,7 @@ export async function main(ctx: PluginContext): Promise<void> {
     browserTaskTool,
     browserStatusTool,
     browserRespondTool,
+    browserAbortTool,
   ]);
 }
 

--- a/lmstudio-plugin/src/index.ts
+++ b/lmstudio-plugin/src/index.ts
@@ -1,6 +1,14 @@
 /**
- * LM Studio plugin entry — registers two web-fetching tools with the
- * host's tool-provider system.
+ * LM Studio plugin entry — registers web-fetching tools plus, when the
+ * WebBrain browser extension is attached, real browser delegation.
+ *
+ * Two tiers, deliberately:
+ *   - `fetch_url` / `research_url` are pure Node HTTP. They need nothing
+ *     installed and work forever, but they have no cookies, no session and
+ *     no JavaScript — anything behind a login is invisible to them.
+ *   - `browser_task` hands a goal to the WebBrain extension running in the
+ *     user's own signed-in browser. It degrades with a clear, actionable
+ *     message when no extension is connected rather than failing opaquely.
  *
  * Tool implementations live in `./tools/*.ts` as pure functions so
  * they stay portable across SDK API changes. Only the `main(ctx)`
@@ -22,6 +30,7 @@ import type { PluginContext } from "@lmstudio/sdk";
 import { z } from "zod";
 import { fetchUrl } from "./tools/fetchUrl.js";
 import { researchUrl } from "./tools/researchUrl.js";
+import { browserStatus, browserTask } from "./tools/browserTask.js";
 
 const fetchUrlTool = tool({
   name: "fetch_url",
@@ -139,15 +148,86 @@ const researchUrlTool = tool({
   },
 });
 
+const browserTaskTool = tool({
+  name: "browser_task",
+  description:
+    "Run a task in the user's REAL browser — already signed in, with their " +
+    "existing cookies and sessions. Use this whenever a page needs " +
+    "authentication or renders client-side: an email inbox, an admin panel, a " +
+    "SaaS dashboard behind SSO, a single-page app. fetch_url and research_url " +
+    "cannot see any of those; they are plain HTTP with no session.\n\n" +
+    "Describe the goal in plain language, as you would to a colleague sharing " +
+    "their screen. mode='ask' is read-only and cannot click, type or submit — " +
+    "prefer it whenever you only need to read. mode='act' allows interaction, " +
+    "and the user approves consequential actions in the browser.\n\n" +
+    "Requires the WebBrain extension (https://webbrain.one) to be installed and " +
+    "pointed at this plugin's bridge. If it is not, the tool returns a hint " +
+    "explaining exactly what to do — relay that to the user rather than retrying.",
+  parameters: {
+    task: z
+      .string()
+      .describe(
+        "The goal in plain language, e.g. 'open my Gmail and list unread " +
+          "messages from this week with sender and subject'.",
+      ),
+    mode: z
+      .enum(["ask", "act"])
+      .optional()
+      .describe(
+        "'ask' (default) is read-only. 'act' permits clicking, typing and " +
+          "navigation, gated by in-browser approval prompts.",
+      ),
+    timeout: z
+      .number()
+      .optional()
+      .describe(
+        "How long to wait in ms before handing control back. Default 180000. " +
+          "The run continues in the browser past this point; it is not cancelled.",
+      ),
+    allowApiMutations: z
+      .boolean()
+      .optional()
+      .describe(
+        "Lift WebBrain's UI-first rule so it may issue mutating HTTP requests " +
+          "directly instead of clicking through the visible interface. Off by " +
+          "default and rarely correct.",
+      ),
+  },
+  implementation: async ({ task, mode, timeout, allowApiMutations }) => {
+    const result = await browserTask({ task, mode, timeout, allowApiMutations });
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+const browserStatusTool = tool({
+  name: "browser_status",
+  description:
+    "Check whether the WebBrain browser extension is currently connected to " +
+    "this plugin. Call this when browser_task reports it is unavailable, so you " +
+    "can tell the user precisely what to fix instead of retrying blindly.",
+  parameters: {},
+  implementation: async () => JSON.stringify(await browserStatus(), null, 2),
+});
+
 /**
  * Plugin entry point. LM Studio's plugin runner calls this once at
- * load time with a `PluginContext` builder. We register both tools
+ * load time with a `PluginContext` builder. We register the tools
  * via the chained `withToolsProvider(...)` API; the callback is
  * invoked any time the host needs a fresh list of tools (e.g. when
  * settings change).
+ *
+ * The browser tools are always advertised, even with no extension attached.
+ * Hiding them would make the model believe the capability does not exist;
+ * offering them with an actionable failure message lets it tell the user how
+ * to turn the capability on.
  */
 export async function main(ctx: PluginContext): Promise<void> {
-  ctx.withToolsProvider(async () => [fetchUrlTool, researchUrlTool]);
+  ctx.withToolsProvider(async () => [
+    fetchUrlTool,
+    researchUrlTool,
+    browserTaskTool,
+    browserStatusTool,
+  ]);
 }
 
 // Some plugin loaders look at the default export instead of `main`.

--- a/lmstudio-plugin/src/index.ts
+++ b/lmstudio-plugin/src/index.ts
@@ -200,7 +200,7 @@ const browserTaskTool = tool({
       .describe(
         "Lift WebBrain's UI-first rule so it may issue mutating HTTP requests " +
           "directly instead of clicking through the visible interface. Off by " +
-          "default and rarely correct.",
+          "default and rarely correct. Only valid when mode is 'act'.",
       ),
   },
   implementation: async ({ task, mode, timeout, allowApiMutations }) => {

--- a/lmstudio-plugin/src/index.ts
+++ b/lmstudio-plugin/src/index.ts
@@ -189,10 +189,14 @@ const browserTaskTool = tool({
       ),
     timeout: z
       .number()
+      .int()
+      .positive()
+      .max(3_600_000)
       .optional()
       .describe(
         "How long to wait in ms before handing control back. Default 180000. " +
-          "The run continues in the browser past this point; it is not cancelled.",
+          "Minimum 1, maximum 3600000. The run continues in the browser past " +
+          "this point; it is not cancelled.",
       ),
     allowApiMutations: z
       .boolean()

--- a/lmstudio-plugin/src/index.ts
+++ b/lmstudio-plugin/src/index.ts
@@ -160,9 +160,10 @@ const browserTaskTool = tool({
     "their screen. mode='ask' is read-only and cannot click, type or submit — " +
     "prefer it whenever you only need to read. mode='act' allows interaction, " +
     "and the user approves consequential actions in the browser.\n\n" +
-    "Requires the WebBrain extension (https://webbrain.one) to be installed and " +
-    "pointed at this plugin's bridge. If it is not, the tool returns a hint " +
-    "explaining exactly what to do — relay that to the user rather than retrying.",
+    "Requires the WebBrain extension (https://webbrain.one) on a Chromium browser " +
+    "(Chrome, Edge, Brave), pointed at this plugin's bridge. Firefox cannot host the " +
+    "bridge. If it is not connected the tool returns a hint explaining exactly what to " +
+    "do — relay that to the user rather than retrying.",
   parameters: {
     task: z
       .string()

--- a/lmstudio-plugin/src/index.ts
+++ b/lmstudio-plugin/src/index.ts
@@ -31,6 +31,7 @@ import { z } from "zod";
 import { fetchUrl } from "./tools/fetchUrl.js";
 import { researchUrl } from "./tools/researchUrl.js";
 import { browserRespond, browserStatus, browserTask } from "./tools/browserTask.js";
+import { sharedBridge } from "./util/bridgeClient.js";
 
 const fetchUrlTool = tool({
   name: "fetch_url",
@@ -254,6 +255,19 @@ const browserRespondTool = tool({
  * to turn the capability on.
  */
 export async function main(ctx: PluginContext): Promise<void> {
+  // Open the listener while the plugin initializes. The extension reconnects
+  // with exponential backoff, so deferring this until the first browser tool
+  // call can leave a correctly configured user waiting up to 30 seconds.
+  // Listener failure must not take down the pure-HTTP tools.
+  try {
+    await sharedBridge().ensureStarted();
+  } catch (error) {
+    console.error(
+      "[webbrain-lmstudio] browser bridge listener could not start:",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
   ctx.withToolsProvider(async () => [
     fetchUrlTool,
     researchUrlTool,

--- a/lmstudio-plugin/src/index.ts
+++ b/lmstudio-plugin/src/index.ts
@@ -30,7 +30,7 @@ import type { PluginContext } from "@lmstudio/sdk";
 import { z } from "zod";
 import { fetchUrl } from "./tools/fetchUrl.js";
 import { researchUrl } from "./tools/researchUrl.js";
-import { browserStatus, browserTask } from "./tools/browserTask.js";
+import { browserRespond, browserStatus, browserTask } from "./tools/browserTask.js";
 
 const fetchUrlTool = tool({
   name: "fetch_url",
@@ -160,6 +160,8 @@ const browserTaskTool = tool({
     "their screen. mode='ask' is read-only and cannot click, type or submit — " +
     "prefer it whenever you only need to read. mode='act' allows interaction, " +
     "and the user approves consequential actions in the browser.\n\n" +
+    "If a task keeps running, poll browser_status with its runId. If it needs user " +
+    "input, ask the user and forward their answer with browser_respond.\n\n" +
     "Requires the WebBrain extension (https://webbrain.one) on a Chromium browser " +
     "(Chrome, Edge, Brave), pointed at this plugin's bridge. Firefox cannot host the " +
     "bridge. If it is not connected the tool returns a hint explaining exactly what to " +
@@ -203,11 +205,40 @@ const browserTaskTool = tool({
 const browserStatusTool = tool({
   name: "browser_status",
   description:
-    "Check whether the WebBrain browser extension is currently connected to " +
-    "this plugin. Call this when browser_task reports it is unavailable, so you " +
-    "can tell the user precisely what to fix instead of retrying blindly.",
-  parameters: {},
-  implementation: async () => JSON.stringify(await browserStatus(), null, 2),
+    "With no runId, check whether the WebBrain extension is connected to this plugin. " +
+    "With a runId returned by browser_task or browser_respond, retrieve that run's " +
+    "current progress or final result. Poll the existing run instead of starting a " +
+    "duplicate task after a timeout.",
+  parameters: {
+    runId: z
+      .string()
+      .optional()
+      .describe("Existing browser run to inspect. Omit for connection status only."),
+  },
+  implementation: async ({ runId }) =>
+    JSON.stringify(await browserStatus(runId), null, 2),
+});
+
+const browserRespondTool = tool({
+  name: "browser_respond",
+  description:
+    "Answer a question from a browser run whose status is needs_user_input, then wait " +
+    "for the run to continue. The answer must come from the user; never invent it. Use " +
+    "the runId and clarifyId returned by browser_task or browser_status.",
+  parameters: {
+    runId: z.string().min(1).describe("The browser run waiting for an answer."),
+    clarifyId: z.string().min(1).describe("The pending clarification to answer."),
+    answer: z.string().min(1).describe("The user's answer, forwarded verbatim."),
+    timeout: z
+      .number()
+      .optional()
+      .describe(
+        "How long to wait in ms after answering. Default 180000. The run continues " +
+          "after a timeout and can be polled with browser_status.",
+      ),
+  },
+  implementation: async ({ runId, clarifyId, answer, timeout }) =>
+    JSON.stringify(await browserRespond({ runId, clarifyId, answer, timeout }), null, 2),
 });
 
 /**
@@ -228,6 +259,7 @@ export async function main(ctx: PluginContext): Promise<void> {
     researchUrlTool,
     browserTaskTool,
     browserStatusTool,
+    browserRespondTool,
   ]);
 }
 

--- a/lmstudio-plugin/src/tools/browserTask.ts
+++ b/lmstudio-plugin/src/tools/browserTask.ts
@@ -142,7 +142,8 @@ async function waitForRun(
     } catch (error) {
       if (
         Date.now() >= deadline ||
-        (error instanceof BridgeError && error.code === "COMMAND_TIMEOUT")
+        (error instanceof BridgeError &&
+          (error.code === "COMMAND_TIMEOUT" || error.code === "COMMAND_INTERRUPTED"))
       ) {
         return { snapshot, timedOut: true };
       }
@@ -191,7 +192,10 @@ export async function browserTask(args: BrowserTaskArgs): Promise<BrowserTaskRes
         Math.max(1, deadline - Date.now()),
       );
     } catch (error) {
-      if (error instanceof BridgeError && error.code === "COMMAND_TIMEOUT") {
+      if (
+        error instanceof BridgeError &&
+        (error.code === "COMMAND_TIMEOUT" || error.code === "COMMAND_INTERRUPTED")
+      ) {
         return resultOf({ runId, status: "running" }, true);
       }
       throw error;
@@ -270,7 +274,10 @@ export async function browserRespond(args: BrowserRespondArgs): Promise<BrowserT
         Math.max(1, deadline - Date.now()),
       );
     } catch (error) {
-      if (error instanceof BridgeError && error.code === "COMMAND_TIMEOUT") {
+      if (
+        error instanceof BridgeError &&
+        (error.code === "COMMAND_TIMEOUT" || error.code === "COMMAND_INTERRUPTED")
+      ) {
         return resultOf({ runId: args.runId, status: "running" }, true);
       }
       throw error;

--- a/lmstudio-plugin/src/tools/browserTask.ts
+++ b/lmstudio-plugin/src/tools/browserTask.ts
@@ -89,7 +89,8 @@ function resultOf(snapshot: CloudSnapshot, timedOut = false): BrowserTaskResult 
       hint:
         "The task is still running in the browser and was NOT cancelled. Call " +
         "browser_status with this runId to retrieve its progress or eventual result; " +
-        "do not start a duplicate browser_task.",
+        "do not start a duplicate browser_task. Call browser_abort with this runId if " +
+        "the user wants it stopped.",
     };
   }
 
@@ -126,10 +127,20 @@ async function waitForRun(
   const deadline = Date.now() + waitMs;
   while (Date.now() < deadline) {
     await sleep(Math.min(POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())));
-    const polled = await bridge.request<CloudSnapshot | { runs: CloudSnapshot[] }>(
-      "cloud_status",
-      { runId },
-    );
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) break;
+
+    let polled: CloudSnapshot | { runs: CloudSnapshot[] };
+    try {
+      polled = await bridge.request<CloudSnapshot | { runs: CloudSnapshot[] }>(
+        "cloud_status",
+        { runId },
+        remainingMs,
+      );
+    } catch (error) {
+      if (Date.now() >= deadline) return { snapshot, timedOut: true };
+      throw error;
+    }
     if ((polled as { runs?: CloudSnapshot[] }).runs) continue;
     snapshot = polled as CloudSnapshot;
     if (TERMINAL_STATUSES.has(snapshot.status) || snapshot.status === "needs_user_input") {
@@ -230,6 +241,24 @@ export async function browserRespond(args: BrowserRespondArgs): Promise<BrowserT
     return {
       ok: false,
       runId: args.runId,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/** Stop a continuing run. Actions it already completed are not rolled back. */
+export async function browserAbort(runId: string): Promise<BrowserTaskResult> {
+  const bridge = sharedBridge();
+  try {
+    const connectionError = await ensureConnected(2_000);
+    if (connectionError) return { ...connectionError, runId };
+
+    const snapshot = await bridge.request<CloudSnapshot>("cloud_abort", { runId });
+    return resultOf(snapshot);
+  } catch (error) {
+    return {
+      ok: false,
+      runId,
       error: error instanceof Error ? error.message : String(error),
     };
   }

--- a/lmstudio-plugin/src/tools/browserTask.ts
+++ b/lmstudio-plugin/src/tools/browserTask.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  BridgeError,
   TERMINAL_STATUSES,
   sharedBridge,
   type CloudSnapshot,
@@ -138,7 +139,12 @@ async function waitForRun(
         remainingMs,
       );
     } catch (error) {
-      if (Date.now() >= deadline) return { snapshot, timedOut: true };
+      if (
+        Date.now() >= deadline ||
+        (error instanceof BridgeError && error.code === "COMMAND_TIMEOUT")
+      ) {
+        return { snapshot, timedOut: true };
+      }
       throw error;
     }
     if ((polled as { runs?: CloudSnapshot[] }).runs) continue;

--- a/lmstudio-plugin/src/tools/browserTask.ts
+++ b/lmstudio-plugin/src/tools/browserTask.ts
@@ -1,0 +1,170 @@
+/**
+ * browser_task — delegate a web task to the user's real browser session.
+ *
+ * This is the capability `fetch_url` and `research_url` structurally cannot
+ * provide. They are pure HTTP: no cookies, no session, no JavaScript. Anything
+ * behind a login, or any page that hydrates client-side, is invisible to them.
+ * The WebBrain extension runs inside the browser the user is already signed
+ * into, so it sees exactly what they see.
+ *
+ * Scope is task-level on purpose. WebBrain's permission gate lives in its agent
+ * loop, not in its individual tool dispatch — exposing the low-level primitives
+ * over a socket would move the trust boundary out of the browser and defeat the
+ * approval prompts. Delegating a goal keeps every gate intact.
+ */
+
+import {
+  BridgeError,
+  TERMINAL_STATUSES,
+  sharedBridge,
+  type CloudSnapshot,
+} from "../util/bridgeClient.js";
+
+export interface BrowserTaskArgs {
+  task: string;
+  mode?: "ask" | "act";
+  timeout?: number;
+  allowApiMutations?: boolean;
+}
+
+export interface BrowserTaskResult {
+  ok: boolean;
+  runId?: string;
+  status?: string;
+  needsUserInput?: boolean;
+  question?: string;
+  clarifyId?: string;
+  stillRunning?: boolean;
+  finalUrl?: string;
+  text?: string;
+  error?: string;
+  hint?: string;
+}
+
+const POLL_INTERVAL_MS = 1_000;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function bodyOf(snapshot: CloudSnapshot): string {
+  if (snapshot.result !== undefined && snapshot.result !== null) {
+    return typeof snapshot.result === "string"
+      ? snapshot.result
+      : JSON.stringify(snapshot.result, null, 2);
+  }
+  return snapshot.content || snapshot.summary || "";
+}
+
+export async function browserTask(args: BrowserTaskArgs): Promise<BrowserTaskResult> {
+  const bridge = sharedBridge();
+  const mode = args.mode === "act" ? "act" : "ask";
+  const timeoutMs = Math.min(Math.max(args.timeout ?? 180_000, 5_000), 3_600_000);
+
+  try {
+    await bridge.ensureStarted();
+
+    if (!bridge.isConnected()) {
+      // Give a reconnecting extension a beat before declaring failure.
+      await bridge.waitForExtension(2_000);
+    }
+    if (!bridge.isConnected()) {
+      return {
+        ok: false,
+        error: "WebBrain browser extension not connected.",
+        hint: bridge.notConnectedMessage(),
+      };
+    }
+
+    const payload: Record<string, unknown> = { task: args.task, mode };
+    if (args.allowApiMutations) payload.apiMutationsAllowed = true;
+
+    const started = await bridge.request<CloudSnapshot>("cloud_run", payload);
+    const runId = started.runId;
+
+    const deadline = Date.now() + timeoutMs;
+    let snapshot: CloudSnapshot = started;
+
+    while (Date.now() < deadline) {
+      if (TERMINAL_STATUSES.has(snapshot.status) || snapshot.status === "needs_user_input") break;
+      await sleep(POLL_INTERVAL_MS);
+      const polled = await bridge.request<CloudSnapshot | { runs: CloudSnapshot[] }>(
+        "cloud_status",
+        { runId },
+      );
+      if ((polled as { runs?: CloudSnapshot[] }).runs) continue;
+      snapshot = polled as CloudSnapshot;
+    }
+
+    if (snapshot.status === "needs_user_input") {
+      const pending = snapshot.pendingInput ?? {};
+      return {
+        ok: false,
+        runId,
+        status: snapshot.status,
+        needsUserInput: true,
+        question: String(pending.question ?? "(no question text supplied)"),
+        clarifyId: String(pending.clarifyId ?? pending.clarify_id ?? ""),
+        hint:
+          "WebBrain paused because a human decision is required. Ask the user this " +
+          "question and answer it in the WebBrain side panel — do not guess on their behalf.",
+      };
+    }
+
+    if (!TERMINAL_STATUSES.has(snapshot.status)) {
+      return {
+        ok: false,
+        runId,
+        status: snapshot.status,
+        stillRunning: true,
+        hint:
+          `The task is still running in the browser after ${Math.round(timeoutMs / 1000)}s. ` +
+          "It was NOT cancelled — watch the WebBrain side panel, or raise `timeout`.",
+      };
+    }
+
+    if (snapshot.status !== "completed") {
+      return {
+        ok: false,
+        runId,
+        status: snapshot.status,
+        error: snapshot.error || `Run ended with status '${snapshot.status}'.`,
+        finalUrl: snapshot.finalUrl,
+      };
+    }
+
+    return {
+      ok: true,
+      runId,
+      status: snapshot.status,
+      finalUrl: snapshot.finalUrl,
+      text: bodyOf(snapshot),
+    };
+  } catch (error) {
+    if (error instanceof BridgeError) {
+      return { ok: false, error: error.message };
+    }
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/** Lightweight connectivity probe so the model can explain a failure precisely. */
+export async function browserStatus(): Promise<{
+  connected: boolean;
+  listeningOn: string;
+  hint?: string;
+}> {
+  const bridge = sharedBridge();
+  try {
+    await bridge.ensureStarted();
+    if (!bridge.isConnected()) await bridge.waitForExtension(1_500);
+  } catch (error) {
+    return {
+      connected: false,
+      listeningOn: bridge.url,
+      hint: `Could not open the bridge listener: ${
+        error instanceof Error ? error.message : String(error)
+      }. Another process may already hold that port.`,
+    };
+  }
+  return bridge.isConnected()
+    ? { connected: true, listeningOn: bridge.url }
+    : { connected: false, listeningOn: bridge.url, hint: bridge.notConnectedMessage() };
+}

--- a/lmstudio-plugin/src/tools/browserTask.ts
+++ b/lmstudio-plugin/src/tools/browserTask.ts
@@ -1,20 +1,13 @@
 /**
- * browser_task — delegate a web task to the user's real browser session.
- *
- * This is the capability `fetch_url` and `research_url` structurally cannot
- * provide. They are pure HTTP: no cookies, no session, no JavaScript. Anything
- * behind a login, or any page that hydrates client-side, is invisible to them.
- * The WebBrain extension runs inside the browser the user is already signed
- * into, so it sees exactly what they see.
+ * Browser delegation tools for the user's real, already-authenticated session.
  *
  * Scope is task-level on purpose. WebBrain's permission gate lives in its agent
- * loop, not in its individual tool dispatch — exposing the low-level primitives
- * over a socket would move the trust boundary out of the browser and defeat the
- * approval prompts. Delegating a goal keeps every gate intact.
+ * loop, not in individual tool dispatch, so exposing low-level primitives over
+ * a socket would move the trust boundary out of the browser. Delegating a goal
+ * keeps every approval prompt intact.
  */
 
 import {
-  BridgeError,
   TERMINAL_STATUSES,
   sharedBridge,
   type CloudSnapshot,
@@ -41,8 +34,25 @@ export interface BrowserTaskResult {
   hint?: string;
 }
 
+export interface BrowserConnectionResult {
+  connected: boolean;
+  listeningOn: string;
+  hint?: string;
+}
+
+export interface BrowserRespondArgs {
+  runId: string;
+  clarifyId: string;
+  answer: string;
+  timeout?: number;
+}
+
 const POLL_INTERVAL_MS = 1_000;
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function timeoutMs(value: number | undefined): number {
+  return Math.min(Math.max(value ?? 180_000, 5_000), 3_600_000);
+}
 
 function bodyOf(snapshot: CloudSnapshot): string {
   if (snapshot.result !== undefined && snapshot.result !== null) {
@@ -53,118 +63,174 @@ function bodyOf(snapshot: CloudSnapshot): string {
   return snapshot.content || snapshot.summary || "";
 }
 
+function resultOf(snapshot: CloudSnapshot, timedOut = false): BrowserTaskResult {
+  if (snapshot.status === "needs_user_input") {
+    const pending = snapshot.pendingInput ?? {};
+    return {
+      ok: false,
+      runId: snapshot.runId,
+      status: snapshot.status,
+      needsUserInput: true,
+      question: String(pending.question ?? "(no question text supplied)"),
+      clarifyId: String(pending.clarifyId ?? pending.clarify_id ?? ""),
+      hint:
+        "WebBrain paused because a human decision is required. Ask the user this " +
+        "question, then call browser_respond with this runId and clarifyId. Do not " +
+        "guess on their behalf.",
+    };
+  }
+
+  if (timedOut || !TERMINAL_STATUSES.has(snapshot.status)) {
+    return {
+      ok: false,
+      runId: snapshot.runId,
+      status: snapshot.status,
+      stillRunning: true,
+      hint:
+        "The task is still running in the browser and was NOT cancelled. Call " +
+        "browser_status with this runId to retrieve its progress or eventual result; " +
+        "do not start a duplicate browser_task.",
+    };
+  }
+
+  if (snapshot.status !== "completed") {
+    return {
+      ok: false,
+      runId: snapshot.runId,
+      status: snapshot.status,
+      error: snapshot.error || `Run ended with status '${snapshot.status}'.`,
+      finalUrl: snapshot.finalUrl,
+    };
+  }
+
+  return {
+    ok: true,
+    runId: snapshot.runId,
+    status: snapshot.status,
+    finalUrl: snapshot.finalUrl,
+    text: bodyOf(snapshot),
+  };
+}
+
+async function waitForRun(
+  runId: string,
+  initial: CloudSnapshot,
+  waitMs: number,
+): Promise<{ snapshot: CloudSnapshot; timedOut: boolean }> {
+  let snapshot = initial;
+  if (TERMINAL_STATUSES.has(snapshot.status) || snapshot.status === "needs_user_input") {
+    return { snapshot, timedOut: false };
+  }
+
+  const bridge = sharedBridge();
+  const deadline = Date.now() + waitMs;
+  while (Date.now() < deadline) {
+    await sleep(Math.min(POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())));
+    const polled = await bridge.request<CloudSnapshot | { runs: CloudSnapshot[] }>(
+      "cloud_status",
+      { runId },
+    );
+    if ((polled as { runs?: CloudSnapshot[] }).runs) continue;
+    snapshot = polled as CloudSnapshot;
+    if (TERMINAL_STATUSES.has(snapshot.status) || snapshot.status === "needs_user_input") {
+      return { snapshot, timedOut: false };
+    }
+  }
+  return { snapshot, timedOut: true };
+}
+
+async function ensureConnected(waitMs: number): Promise<BrowserTaskResult | null> {
+  const bridge = sharedBridge();
+  await bridge.ensureStarted();
+  if (!bridge.isConnected()) await bridge.waitForExtension(waitMs);
+  if (bridge.isConnected()) return null;
+  return {
+    ok: false,
+    error: "WebBrain browser extension not connected.",
+    hint: bridge.notConnectedMessage(),
+  };
+}
+
 export async function browserTask(args: BrowserTaskArgs): Promise<BrowserTaskResult> {
   const bridge = sharedBridge();
   const mode = args.mode === "act" ? "act" : "ask";
-  const timeoutMs = Math.min(Math.max(args.timeout ?? 180_000, 5_000), 3_600_000);
 
   try {
-    await bridge.ensureStarted();
-
-    if (!bridge.isConnected()) {
-      // Give a reconnecting extension a beat before declaring failure.
-      await bridge.waitForExtension(2_000);
-    }
-    if (!bridge.isConnected()) {
-      return {
-        ok: false,
-        error: "WebBrain browser extension not connected.",
-        hint: bridge.notConnectedMessage(),
-      };
-    }
+    const connectionError = await ensureConnected(2_000);
+    if (connectionError) return connectionError;
 
     const payload: Record<string, unknown> = { task: args.task, mode };
     if (args.allowApiMutations) payload.apiMutationsAllowed = true;
 
     const started = await bridge.request<CloudSnapshot>("cloud_run", payload);
-    const runId = started.runId;
-
-    const deadline = Date.now() + timeoutMs;
-    let snapshot: CloudSnapshot = started;
-
-    while (Date.now() < deadline) {
-      if (TERMINAL_STATUSES.has(snapshot.status) || snapshot.status === "needs_user_input") break;
-      await sleep(POLL_INTERVAL_MS);
-      const polled = await bridge.request<CloudSnapshot | { runs: CloudSnapshot[] }>(
-        "cloud_status",
-        { runId },
-      );
-      if ((polled as { runs?: CloudSnapshot[] }).runs) continue;
-      snapshot = polled as CloudSnapshot;
-    }
-
-    if (snapshot.status === "needs_user_input") {
-      const pending = snapshot.pendingInput ?? {};
-      return {
-        ok: false,
-        runId,
-        status: snapshot.status,
-        needsUserInput: true,
-        question: String(pending.question ?? "(no question text supplied)"),
-        clarifyId: String(pending.clarifyId ?? pending.clarify_id ?? ""),
-        hint:
-          "WebBrain paused because a human decision is required. Ask the user this " +
-          "question and answer it in the WebBrain side panel — do not guess on their behalf.",
-      };
-    }
-
-    if (!TERMINAL_STATUSES.has(snapshot.status)) {
-      return {
-        ok: false,
-        runId,
-        status: snapshot.status,
-        stillRunning: true,
-        hint:
-          `The task is still running in the browser after ${Math.round(timeoutMs / 1000)}s. ` +
-          "It was NOT cancelled — watch the WebBrain side panel, or raise `timeout`.",
-      };
-    }
-
-    if (snapshot.status !== "completed") {
-      return {
-        ok: false,
-        runId,
-        status: snapshot.status,
-        error: snapshot.error || `Run ended with status '${snapshot.status}'.`,
-        finalUrl: snapshot.finalUrl,
-      };
-    }
-
-    return {
-      ok: true,
-      runId,
-      status: snapshot.status,
-      finalUrl: snapshot.finalUrl,
-      text: bodyOf(snapshot),
-    };
+    const settled = await waitForRun(started.runId, started, timeoutMs(args.timeout));
+    return resultOf(settled.snapshot, settled.timedOut);
   } catch (error) {
-    if (error instanceof BridgeError) {
-      return { ok: false, error: error.message };
-    }
     return { ok: false, error: error instanceof Error ? error.message : String(error) };
   }
 }
 
-/** Lightweight connectivity probe so the model can explain a failure precisely. */
-export async function browserStatus(): Promise<{
-  connected: boolean;
-  listeningOn: string;
-  hint?: string;
-}> {
+/** Check connectivity, or retrieve an existing run when a run ID is supplied. */
+export async function browserStatus(
+  runId?: string,
+): Promise<BrowserConnectionResult | BrowserTaskResult> {
   const bridge = sharedBridge();
   try {
     await bridge.ensureStarted();
     if (!bridge.isConnected()) await bridge.waitForExtension(1_500);
   } catch (error) {
-    return {
-      connected: false,
-      listeningOn: bridge.url,
-      hint: `Could not open the bridge listener: ${
+    const message =
+      `Could not open the bridge listener: ${
         error instanceof Error ? error.message : String(error)
-      }. Another process may already hold that port.`,
+      }. Another process may already hold that port.`;
+    return runId
+      ? { ok: false, runId, error: message }
+      : { connected: false, listeningOn: bridge.url, hint: message };
+  }
+
+  if (!bridge.isConnected()) {
+    return runId
+      ? {
+          ok: false,
+          runId,
+          error: "WebBrain browser extension not connected.",
+          hint: bridge.notConnectedMessage(),
+        }
+      : { connected: false, listeningOn: bridge.url, hint: bridge.notConnectedMessage() };
+  }
+  if (!runId) return { connected: true, listeningOn: bridge.url };
+
+  try {
+    const snapshot = await bridge.request<CloudSnapshot>("cloud_status", { runId });
+    return resultOf(snapshot);
+  } catch (error) {
+    return {
+      ok: false,
+      runId,
+      error: error instanceof Error ? error.message : String(error),
     };
   }
-  return bridge.isConnected()
-    ? { connected: true, listeningOn: bridge.url }
-    : { connected: false, listeningOn: bridge.url, hint: bridge.notConnectedMessage() };
+}
+
+/** Forward a user's answer to a paused run, then wait for its next settled state. */
+export async function browserRespond(args: BrowserRespondArgs): Promise<BrowserTaskResult> {
+  const bridge = sharedBridge();
+  try {
+    const connectionError = await ensureConnected(2_000);
+    if (connectionError) return { ...connectionError, runId: args.runId };
+
+    const resumed = await bridge.request<CloudSnapshot>("cloud_respond", {
+      runId: args.runId,
+      clarifyId: args.clarifyId,
+      answer: args.answer,
+    });
+    const settled = await waitForRun(args.runId, resumed, timeoutMs(args.timeout));
+    return resultOf(settled.snapshot, settled.timedOut);
+  } catch (error) {
+    return {
+      ok: false,
+      runId: args.runId,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 }

--- a/lmstudio-plugin/src/tools/browserTask.ts
+++ b/lmstudio-plugin/src/tools/browserTask.ts
@@ -53,7 +53,7 @@ const POLL_INTERVAL_MS = 1_000;
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function timeoutMs(value: number | undefined): number {
-  return Math.min(Math.max(value ?? 180_000, 5_000), 3_600_000);
+  return Math.min(Math.max(value ?? 180_000, 1), 3_600_000);
 }
 
 function bodyOf(snapshot: CloudSnapshot): string {

--- a/lmstudio-plugin/src/tools/browserTask.ts
+++ b/lmstudio-plugin/src/tools/browserTask.ts
@@ -128,7 +128,6 @@ async function waitForRun(
   const bridge = sharedBridge();
   const deadline = Date.now() + waitMs;
   while (Date.now() < deadline) {
-    await sleep(Math.min(POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())));
     const remainingMs = deadline - Date.now();
     if (remainingMs <= 0) break;
 
@@ -154,6 +153,8 @@ async function waitForRun(
     if (TERMINAL_STATUSES.has(snapshot.status) || snapshot.status === "needs_user_input") {
       return { snapshot, timedOut: false };
     }
+
+    await sleep(Math.min(POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())));
   }
   return { snapshot, timedOut: true };
 }

--- a/lmstudio-plugin/src/tools/browserTask.ts
+++ b/lmstudio-plugin/src/tools/browserTask.ts
@@ -13,6 +13,7 @@ import {
   sharedBridge,
   type CloudSnapshot,
 } from "../util/bridgeClient.js";
+import { randomUUID } from "node:crypto";
 
 export interface BrowserTaskArgs {
   task: string;
@@ -171,16 +172,35 @@ async function ensureConnected(waitMs: number): Promise<BrowserTaskResult | null
 export async function browserTask(args: BrowserTaskArgs): Promise<BrowserTaskResult> {
   const bridge = sharedBridge();
   const mode = args.mode === "act" ? "act" : "ask";
+  const waitMs = timeoutMs(args.timeout);
+  const deadline = Date.now() + waitMs;
+  const runId = `lm_${randomUUID()}`;
 
   try {
     const connectionError = await ensureConnected(2_000);
     if (connectionError) return connectionError;
 
-    const payload: Record<string, unknown> = { task: args.task, mode };
+    const payload: Record<string, unknown> = { runId, task: args.task, mode };
     if (args.allowApiMutations) payload.apiMutationsAllowed = true;
 
-    const started = await bridge.request<CloudSnapshot>("cloud_run", payload);
-    const settled = await waitForRun(started.runId, started, timeoutMs(args.timeout));
+    let started: CloudSnapshot;
+    try {
+      started = await bridge.request<CloudSnapshot>(
+        "cloud_run",
+        payload,
+        Math.max(1, deadline - Date.now()),
+      );
+    } catch (error) {
+      if (error instanceof BridgeError && error.code === "COMMAND_TIMEOUT") {
+        return resultOf({ runId, status: "running" }, true);
+      }
+      throw error;
+    }
+    const settled = await waitForRun(
+      started.runId,
+      started,
+      Math.max(0, deadline - Date.now()),
+    );
     return resultOf(settled.snapshot, settled.timedOut);
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : String(error) };
@@ -232,16 +252,34 @@ export async function browserStatus(
 /** Forward a user's answer to a paused run, then wait for its next settled state. */
 export async function browserRespond(args: BrowserRespondArgs): Promise<BrowserTaskResult> {
   const bridge = sharedBridge();
+  const waitMs = timeoutMs(args.timeout);
+  const deadline = Date.now() + waitMs;
   try {
     const connectionError = await ensureConnected(2_000);
     if (connectionError) return { ...connectionError, runId: args.runId };
 
-    const resumed = await bridge.request<CloudSnapshot>("cloud_respond", {
-      runId: args.runId,
-      clarifyId: args.clarifyId,
-      answer: args.answer,
-    });
-    const settled = await waitForRun(args.runId, resumed, timeoutMs(args.timeout));
+    let resumed: CloudSnapshot;
+    try {
+      resumed = await bridge.request<CloudSnapshot>(
+        "cloud_respond",
+        {
+          runId: args.runId,
+          clarifyId: args.clarifyId,
+          answer: args.answer,
+        },
+        Math.max(1, deadline - Date.now()),
+      );
+    } catch (error) {
+      if (error instanceof BridgeError && error.code === "COMMAND_TIMEOUT") {
+        return resultOf({ runId: args.runId, status: "running" }, true);
+      }
+      throw error;
+    }
+    const settled = await waitForRun(
+      args.runId,
+      resumed,
+      Math.max(0, deadline - Date.now()),
+    );
     return resultOf(settled.snapshot, settled.timedOut);
   } catch (error) {
     return {

--- a/lmstudio-plugin/src/tools/browserTask.ts
+++ b/lmstudio-plugin/src/tools/browserTask.ts
@@ -158,10 +158,18 @@ async function waitForRun(
   return { snapshot, timedOut: true };
 }
 
-async function ensureConnected(waitMs: number): Promise<BrowserTaskResult | null> {
+async function ensureConnected(
+  waitMs: number,
+  deadline?: number,
+): Promise<BrowserTaskResult | null> {
   const bridge = sharedBridge();
   await bridge.ensureStarted();
-  if (!bridge.isConnected()) await bridge.waitForExtension(waitMs);
+  const boundedWaitMs = deadline == null
+    ? waitMs
+    : Math.min(waitMs, Math.max(0, deadline - Date.now()));
+  if (!bridge.isConnected() && boundedWaitMs > 0) {
+    await bridge.waitForExtension(boundedWaitMs);
+  }
   if (bridge.isConnected()) return null;
   return {
     ok: false,
@@ -185,8 +193,15 @@ export async function browserTask(args: BrowserTaskArgs): Promise<BrowserTaskRes
   const runId = `lm_${randomUUID()}`;
 
   try {
-    const connectionError = await ensureConnected(2_000);
+    const connectionError = await ensureConnected(2_000, deadline);
     if (connectionError) return connectionError;
+    if (Date.now() >= deadline) {
+      return {
+        ok: false,
+        error: "Browser task timeout expired before cloud_run could be dispatched.",
+        hint: "No browser run was started. Retry with a longer timeout after the extension connects.",
+      };
+    }
 
     const payload: Record<string, unknown> = { runId, task: args.task, mode };
     if (args.allowApiMutations) payload.apiMutationsAllowed = true;
@@ -266,8 +281,16 @@ export async function browserRespond(args: BrowserRespondArgs): Promise<BrowserT
   const waitMs = timeoutMs(args.timeout);
   const deadline = Date.now() + waitMs;
   try {
-    const connectionError = await ensureConnected(2_000);
+    const connectionError = await ensureConnected(2_000, deadline);
     if (connectionError) return { ...connectionError, runId: args.runId };
+    if (Date.now() >= deadline) {
+      return {
+        ok: false,
+        runId: args.runId,
+        error: "Browser response timeout expired before cloud_respond could be dispatched.",
+        hint: "No answer was sent. Retry after the extension reconnects.",
+      };
+    }
 
     let resumed: CloudSnapshot;
     try {

--- a/lmstudio-plugin/src/tools/browserTask.ts
+++ b/lmstudio-plugin/src/tools/browserTask.ts
@@ -173,6 +173,13 @@ async function ensureConnected(waitMs: number): Promise<BrowserTaskResult | null
 export async function browserTask(args: BrowserTaskArgs): Promise<BrowserTaskResult> {
   const bridge = sharedBridge();
   const mode = args.mode === "act" ? "act" : "ask";
+  if (args.allowApiMutations && mode !== "act") {
+    return {
+      ok: false,
+      error: "API mutation permission requires mode 'act'.",
+      hint: "Use mode 'ask' without allowApiMutations for read-only work, or explicitly choose mode 'act'.",
+    };
+  }
   const waitMs = timeoutMs(args.timeout);
   const deadline = Date.now() + waitMs;
   const runId = `lm_${randomUUID()}`;

--- a/lmstudio-plugin/src/util/bridgeClient.ts
+++ b/lmstudio-plugin/src/util/bridgeClient.ts
@@ -228,6 +228,7 @@ export class BridgeClient {
   async request<T = unknown>(
     action: BridgeAction,
     payload: Record<string, unknown> = {},
+    timeoutMs = this.commandTimeoutMs,
   ): Promise<T> {
     await this.ensureStarted();
     const socket = this.socket;
@@ -237,14 +238,15 @@ export class BridgeClient {
 
     const id = this.nextId++;
     const frame = JSON.stringify({ id, action, payload });
+    const responseTimeoutMs = Math.max(1, Math.min(this.commandTimeoutMs, timeoutMs));
 
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
         reject(
-          new BridgeError(`WebBrain did not answer '${action}' within ${this.commandTimeoutMs}ms.`),
+          new BridgeError(`WebBrain did not answer '${action}' within ${responseTimeoutMs}ms.`),
         );
-      }, this.commandTimeoutMs);
+      }, responseTimeoutMs);
 
       this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject, timer });
 

--- a/lmstudio-plugin/src/util/bridgeClient.ts
+++ b/lmstudio-plugin/src/util/bridgeClient.ts
@@ -50,10 +50,12 @@ export const TERMINAL_STATUSES = new Set(["completed", "failed", "aborted"]);
 
 export class BridgeError extends Error {
   readonly status?: number;
-  constructor(message: string, status?: number) {
+  readonly code?: "COMMAND_TIMEOUT";
+  constructor(message: string, status?: number, code?: "COMMAND_TIMEOUT") {
     super(message);
     this.name = "BridgeError";
     this.status = status;
+    this.code = code;
   }
 }
 
@@ -244,7 +246,11 @@ export class BridgeClient {
       const timer = setTimeout(() => {
         this.pending.delete(id);
         reject(
-          new BridgeError(`WebBrain did not answer '${action}' within ${responseTimeoutMs}ms.`),
+          new BridgeError(
+            `WebBrain did not answer '${action}' within ${responseTimeoutMs}ms.`,
+            undefined,
+            "COMMAND_TIMEOUT",
+          ),
         );
       }, responseTimeoutMs);
 

--- a/lmstudio-plugin/src/util/bridgeClient.ts
+++ b/lmstudio-plugin/src/util/bridgeClient.ts
@@ -75,6 +75,17 @@ export interface BridgeOptions {
   commandTimeoutMs?: number;
 }
 
+function isAllowedBridgeOrigin(origin: string | string[] | undefined): boolean {
+  if (origin == null) return true;
+  if (Array.isArray(origin)) return false;
+  try {
+    const protocol = new URL(origin).protocol;
+    return protocol === "chrome-extension:" || protocol === "moz-extension:";
+  } catch {
+    return false;
+  }
+}
+
 export class BridgeClient {
   private wss: WebSocketServer | null = null;
   private socket: WebSocket | null = null;
@@ -114,6 +125,10 @@ export class BridgeClient {
     });
 
     this.wss!.on("connection", (socket, request) => {
+      if (!isAllowedBridgeOrigin(request.headers.origin)) {
+        socket.close(1008, "Untrusted Origin");
+        return;
+      }
       if (!(request.url || "").startsWith(this.path)) {
         socket.close(1008, "Unexpected path");
         return;

--- a/lmstudio-plugin/src/util/bridgeClient.ts
+++ b/lmstudio-plugin/src/util/bridgeClient.ts
@@ -50,8 +50,12 @@ export const TERMINAL_STATUSES = new Set(["completed", "failed", "aborted"]);
 
 export class BridgeError extends Error {
   readonly status?: number;
-  readonly code?: "COMMAND_TIMEOUT";
-  constructor(message: string, status?: number, code?: "COMMAND_TIMEOUT") {
+  readonly code?: "COMMAND_TIMEOUT" | "COMMAND_INTERRUPTED";
+  constructor(
+    message: string,
+    status?: number,
+    code?: "COMMAND_TIMEOUT" | "COMMAND_INTERRUPTED",
+  ) {
     super(message);
     this.name = "BridgeError";
     this.status = status;
@@ -115,7 +119,13 @@ export class BridgeClient {
         return;
       }
       if (this.socket) {
-        this.failAllPending(new BridgeError("WebBrain extension connection was superseded."));
+        this.failAllPending(
+          new BridgeError(
+            "WebBrain extension connection was superseded.",
+            undefined,
+            "COMMAND_INTERRUPTED",
+          ),
+        );
         try {
           this.socket.close(1000, "Superseded");
         } catch {
@@ -130,7 +140,13 @@ export class BridgeClient {
         if (this.socket !== socket) return;
         this.socket = null;
         this.handshakenSocket = null;
-        this.failAllPending(new BridgeError("WebBrain extension disconnected mid-command."));
+        this.failAllPending(
+          new BridgeError(
+            "WebBrain extension disconnected mid-command.",
+            undefined,
+            "COMMAND_INTERRUPTED",
+          ),
+        );
       });
       socket.on("error", () => {
         /* close handler does the cleanup */

--- a/lmstudio-plugin/src/util/bridgeClient.ts
+++ b/lmstudio-plugin/src/util/bridgeClient.ts
@@ -203,10 +203,12 @@ export class BridgeClient {
     return (
       "No WebBrain browser extension is connected, so browser tools are unavailable. " +
       `This plugin is listening on ${this.url}. To connect: install the WebBrain ` +
-      "extension (https://webbrain.one), open your browser, then set WebBrain → " +
-      `Settings → Cloud bridge to ${this.url} and enable it. The extension holds one ` +
-      "bridge at a time, so it cannot also be pointed at WebBrain Cloud (17373) or the " +
-      "MCP server (17374). fetch_url and research_url keep working without the extension."
+      "extension (https://webbrain.one) on a Chromium browser — Chrome, Edge, Brave, " +
+      "Opera or Vivaldi — open it, then set WebBrain → Settings → Cloud bridge to " +
+      `${this.url} and enable it. The extension holds one bridge at a time, so it ` +
+      "cannot also be pointed at WebBrain Cloud (17373) or the MCP server (17374). " +
+      "Firefox cannot host the bridge at all: that build has no offscreen document. " +
+      "fetch_url and research_url keep working everywhere, with or without the extension."
     );
   }
 

--- a/lmstudio-plugin/src/util/bridgeClient.ts
+++ b/lmstudio-plugin/src/util/bridgeClient.ts
@@ -75,7 +75,7 @@ export class BridgeClient {
   private pending = new Map<number, Pending>();
   private nextId = 1;
   private waiters: Array<() => void> = [];
-  private handshakeDone = false;
+  private handshakenSocket: WebSocket | null = null;
 
   readonly port: number;
   readonly path: string;
@@ -100,7 +100,10 @@ export class BridgeClient {
       // Loopback only. Anything that can reach this port can drive the user's
       // logged-in browser, so it must never bind a routable interface.
       const wss = new WebSocketServer({ host: "127.0.0.1", port: this.port }, () => resolve());
-      wss.on("error", reject);
+      wss.on("error", (error) => {
+        if (this.wss === wss && !wss.address()) this.wss = null;
+        reject(error);
+      });
       this.wss = wss;
     });
 
@@ -110,6 +113,7 @@ export class BridgeClient {
         return;
       }
       if (this.socket) {
+        this.failAllPending(new BridgeError("WebBrain extension connection was superseded."));
         try {
           this.socket.close(1000, "Superseded");
         } catch {
@@ -117,13 +121,13 @@ export class BridgeClient {
         }
       }
       this.socket = socket;
-      this.handshakeDone = false;
+      this.handshakenSocket = null;
 
       socket.on("message", (raw) => this.handleMessage(socket, raw.toString()));
       socket.on("close", () => {
         if (this.socket !== socket) return;
         this.socket = null;
-        this.handshakeDone = false;
+        this.handshakenSocket = null;
         this.failAllPending(new BridgeError("WebBrain extension disconnected mid-command."));
       });
       socket.on("error", () => {
@@ -133,6 +137,8 @@ export class BridgeClient {
   }
 
   private handleMessage(socket: WebSocket, data: string): void {
+    if (this.socket !== socket) return;
+
     let msg: Record<string, unknown>;
     try {
       msg = JSON.parse(data);
@@ -143,10 +149,13 @@ export class BridgeClient {
     if (msg.type === "hello") {
       if (msg.client !== "webbrain-extension") {
         socket.close(1008, "Unknown client");
-        if (this.socket === socket) this.socket = null;
+        if (this.socket === socket) {
+          this.socket = null;
+          this.handshakenSocket = null;
+        }
         return;
       }
-      this.handshakeDone = true;
+      this.handshakenSocket = socket;
       const waiters = this.waiters;
       this.waiters = [];
       for (const wake of waiters) wake();
@@ -181,7 +190,11 @@ export class BridgeClient {
   }
 
   isConnected(): boolean {
-    return this.socket !== null && this.socket.readyState === 1 && this.handshakeDone;
+    return (
+      this.socket !== null &&
+      this.socket.readyState === 1 &&
+      this.handshakenSocket === this.socket
+    );
   }
 
   waitForExtension(timeoutMs: number): Promise<boolean> {
@@ -218,7 +231,7 @@ export class BridgeClient {
   ): Promise<T> {
     await this.ensureStarted();
     const socket = this.socket;
-    if (!socket || socket.readyState !== 1) {
+    if (!socket || !this.isConnected()) {
       throw new BridgeError(this.notConnectedMessage());
     }
 
@@ -260,6 +273,7 @@ export class BridgeClient {
         /* ignore */
       }
       this.socket = null;
+      this.handshakenSocket = null;
     }
     if (this.wss) {
       await new Promise<void>((resolve) => this.wss!.close(() => resolve()));

--- a/lmstudio-plugin/src/util/bridgeClient.ts
+++ b/lmstudio-plugin/src/util/bridgeClient.ts
@@ -1,0 +1,274 @@
+/**
+ * Bridge client — talks to the WebBrain browser extension.
+ *
+ * The extension cannot listen on a socket (Manifest V3 has no such API), so
+ * `src/chrome/src/offscreen/cloud-bridge.js` dials OUT from an offscreen
+ * document and we host the listener. Every command is initiated here and
+ * answered by the browser.
+ *
+ * Wire protocol (unchanged from the shipping extension):
+ *   extension -> us   {type:'hello', client, protocolVersion, capabilities, status}
+ *   us -> extension   {id, action, payload}
+ *   extension -> us   {id, ok:true, result} | {id, ok:false, error, status?}
+ *
+ * This is deliberately a standalone copy of the same ~150 lines that live in
+ * `mcp-server/src/bridge.ts`. The two are separately published artifacts — this
+ * one goes to LM Studio's registry, that one to npm — and coupling them through
+ * a shared package would drag the whole monorepo into both installs. If you
+ * change the protocol, change both.
+ *
+ * Default port is 17375: WebBrain Cloud owns 17373 and the MCP server owns
+ * 17374. The extension holds exactly ONE bridge socket, so only one of the
+ * three can be attached at a time.
+ */
+
+import { WebSocketServer, type WebSocket } from "ws";
+
+export type BridgeAction = "cloud_run" | "cloud_status" | "cloud_respond" | "cloud_abort";
+
+export interface CloudSnapshot {
+  runId: string;
+  status:
+    | "running"
+    | "needs_user_input"
+    | "aborting"
+    | "completed"
+    | "failed"
+    | "aborted";
+  mode?: "ask" | "act";
+  task?: string;
+  pendingInput?: Record<string, unknown> | null;
+  result?: unknown;
+  summary?: string;
+  content?: string;
+  finalUrl?: string;
+  error?: string;
+  [key: string]: unknown;
+}
+
+export const TERMINAL_STATUSES = new Set(["completed", "failed", "aborted"]);
+
+export class BridgeError extends Error {
+  readonly status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "BridgeError";
+    this.status = status;
+  }
+}
+
+interface Pending {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export interface BridgeOptions {
+  port?: number;
+  path?: string;
+  commandTimeoutMs?: number;
+}
+
+export class BridgeClient {
+  private wss: WebSocketServer | null = null;
+  private socket: WebSocket | null = null;
+  private pending = new Map<number, Pending>();
+  private nextId = 1;
+  private waiters: Array<() => void> = [];
+  private handshakeDone = false;
+
+  readonly port: number;
+  readonly path: string;
+  readonly commandTimeoutMs: number;
+
+  constructor(options: BridgeOptions = {}) {
+    this.port = options.port ?? Number(process.env.WEBBRAIN_BRIDGE_PORT ?? 17375);
+    this.path = options.path ?? (process.env.WEBBRAIN_BRIDGE_PATH || "/extension");
+    this.commandTimeoutMs =
+      options.commandTimeoutMs ?? Number(process.env.WEBBRAIN_COMMAND_TIMEOUT_MS ?? 30_000);
+  }
+
+  get url(): string {
+    return `ws://127.0.0.1:${this.port}${this.path}`;
+  }
+
+  /** Idempotent — safe to call before every tool invocation. */
+  async ensureStarted(): Promise<void> {
+    if (this.wss) return;
+
+    await new Promise<void>((resolve, reject) => {
+      // Loopback only. Anything that can reach this port can drive the user's
+      // logged-in browser, so it must never bind a routable interface.
+      const wss = new WebSocketServer({ host: "127.0.0.1", port: this.port }, () => resolve());
+      wss.on("error", reject);
+      this.wss = wss;
+    });
+
+    this.wss!.on("connection", (socket, request) => {
+      if (!(request.url || "").startsWith(this.path)) {
+        socket.close(1008, "Unexpected path");
+        return;
+      }
+      if (this.socket) {
+        try {
+          this.socket.close(1000, "Superseded");
+        } catch {
+          /* already gone */
+        }
+      }
+      this.socket = socket;
+      this.handshakeDone = false;
+
+      socket.on("message", (raw) => this.handleMessage(socket, raw.toString()));
+      socket.on("close", () => {
+        if (this.socket !== socket) return;
+        this.socket = null;
+        this.handshakeDone = false;
+        this.failAllPending(new BridgeError("WebBrain extension disconnected mid-command."));
+      });
+      socket.on("error", () => {
+        /* close handler does the cleanup */
+      });
+    });
+  }
+
+  private handleMessage(socket: WebSocket, data: string): void {
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(data);
+    } catch {
+      return;
+    }
+
+    if (msg.type === "hello") {
+      if (msg.client !== "webbrain-extension") {
+        socket.close(1008, "Unknown client");
+        if (this.socket === socket) this.socket = null;
+        return;
+      }
+      this.handshakeDone = true;
+      const waiters = this.waiters;
+      this.waiters = [];
+      for (const wake of waiters) wake();
+      return;
+    }
+
+    const id = typeof msg.id === "number" ? msg.id : null;
+    if (id == null) return;
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    this.pending.delete(id);
+    clearTimeout(entry.timer);
+
+    if (msg.ok === false) {
+      entry.reject(
+        new BridgeError(
+          String(msg.error || "Unknown bridge error"),
+          typeof msg.status === "number" ? msg.status : undefined,
+        ),
+      );
+      return;
+    }
+    entry.resolve(msg.result);
+  }
+
+  private failAllPending(error: Error): void {
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  isConnected(): boolean {
+    return this.socket !== null && this.socket.readyState === 1 && this.handshakeDone;
+  }
+
+  waitForExtension(timeoutMs: number): Promise<boolean> {
+    if (this.isConnected()) return Promise.resolve(true);
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        this.waiters = this.waiters.filter((w) => w !== wake);
+        resolve(false);
+      }, timeoutMs);
+      const wake = () => {
+        clearTimeout(timer);
+        resolve(true);
+      };
+      this.waiters.push(wake);
+    });
+  }
+
+  notConnectedMessage(): string {
+    return (
+      "No WebBrain browser extension is connected, so browser tools are unavailable. " +
+      `This plugin is listening on ${this.url}. To connect: install the WebBrain ` +
+      "extension (https://webbrain.one), open your browser, then set WebBrain → " +
+      `Settings → Cloud bridge to ${this.url} and enable it. The extension holds one ` +
+      "bridge at a time, so it cannot also be pointed at WebBrain Cloud (17373) or the " +
+      "MCP server (17374). fetch_url and research_url keep working without the extension."
+    );
+  }
+
+  async request<T = unknown>(
+    action: BridgeAction,
+    payload: Record<string, unknown> = {},
+  ): Promise<T> {
+    await this.ensureStarted();
+    const socket = this.socket;
+    if (!socket || socket.readyState !== 1) {
+      throw new BridgeError(this.notConnectedMessage());
+    }
+
+    const id = this.nextId++;
+    const frame = JSON.stringify({ id, action, payload });
+
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new BridgeError(`WebBrain did not answer '${action}' within ${this.commandTimeoutMs}ms.`),
+        );
+      }, this.commandTimeoutMs);
+
+      this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject, timer });
+
+      try {
+        socket.send(frame);
+      } catch (error) {
+        this.pending.delete(id);
+        clearTimeout(timer);
+        reject(
+          new BridgeError(
+            `Failed to send '${action}': ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          ),
+        );
+      }
+    });
+  }
+
+  async stop(): Promise<void> {
+    this.failAllPending(new BridgeError("Bridge shutting down."));
+    if (this.socket) {
+      try {
+        this.socket.close(1001, "Shutting down");
+      } catch {
+        /* ignore */
+      }
+      this.socket = null;
+    }
+    if (this.wss) {
+      await new Promise<void>((resolve) => this.wss!.close(() => resolve()));
+      this.wss = null;
+    }
+  }
+}
+
+/** Process-wide singleton: one listener per plugin process, not per tool call. */
+let shared: BridgeClient | null = null;
+export function sharedBridge(): BridgeClient {
+  if (!shared) shared = new BridgeClient();
+  return shared;
+}

--- a/lmstudio-plugin/test/browserTask.test.mjs
+++ b/lmstudio-plugin/test/browserTask.test.mjs
@@ -193,6 +193,23 @@ test("browser_abort forwards the continuing run ID", async () => {
   assert.deepEqual(abort.payload, { runId: "stalled-run" });
 });
 
+test("a web-page origin cannot replace the connected extension", async () => {
+  const page = new WebSocket(sharedBridge().url, {
+    headers: { Origin: "https://attacker.example" },
+  });
+  let receivedCommands = 0;
+  page.on("message", () => {
+    receivedCommands += 1;
+  });
+  await once(page, "close");
+
+  assert.equal(sharedBridge().isConnected(), true);
+  const result = await browserStatus("origin-safe-run");
+  assert.equal(result.ok, true);
+  assert.equal(result.runId, "origin-safe-run");
+  assert.equal(receivedCommands, 0);
+});
+
 test("browser_task preserves its generated run ID when the start socket disconnects", async () => {
   const result = await browserTask({ task: "disconnect initial response", timeout: 5_000 });
 

--- a/lmstudio-plugin/test/browserTask.test.mjs
+++ b/lmstudio-plugin/test/browserTask.test.mjs
@@ -169,6 +169,16 @@ test("browser_task bounds a stalled status request by its run timeout", async ()
   assert.ok(elapsedMs < 1_500, `command timeout lost the run for ${elapsedMs}ms`);
 });
 
+test("browser_task honors a timeout below five seconds", async () => {
+  const startedAt = Date.now();
+  const result = await browserTask({ task: "stall status response", timeout: 100 });
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.equal(result.stillRunning, true);
+  assert.equal(result.runId, "stalled-run");
+  assert.ok(elapsedMs < 500, `100ms timeout was stretched to ${elapsedMs}ms`);
+});
+
 test("browser_task preserves its generated run ID when the initial response stalls", async () => {
   const startedAt = Date.now();
   const result = await browserTask({ task: "stall initial response", timeout: 5_000 });

--- a/lmstudio-plugin/test/browserTask.test.mjs
+++ b/lmstudio-plugin/test/browserTask.test.mjs
@@ -170,12 +170,19 @@ test("browser_task bounds a stalled status request by its run timeout", async ()
 });
 
 test("browser_task honors a timeout below five seconds", async () => {
+  const statusRequestsBefore = received.filter(
+    (message) => message.action === "cloud_status" && message.payload.runId === "stalled-run",
+  ).length;
   const startedAt = Date.now();
   const result = await browserTask({ task: "stall status response", timeout: 100 });
   const elapsedMs = Date.now() - startedAt;
 
   assert.equal(result.stillRunning, true);
   assert.equal(result.runId, "stalled-run");
+  const statusRequestsAfter = received.filter(
+    (message) => message.action === "cloud_status" && message.payload.runId === "stalled-run",
+  ).length;
+  assert.equal(statusRequestsAfter, statusRequestsBefore + 1);
   assert.ok(elapsedMs < 500, `100ms timeout was stretched to ${elapsedMs}ms`);
 });
 

--- a/lmstudio-plugin/test/browserTask.test.mjs
+++ b/lmstudio-plugin/test/browserTask.test.mjs
@@ -127,6 +127,20 @@ test("browser_task tells the model how to answer a paused run", async () => {
   assert.match(result.hint, /browser_respond/);
 });
 
+test("browser_task rejects API mutation permission in ask mode before dispatch", async () => {
+  const before = received.filter((message) => message.action === "cloud_run").length;
+  const result = await browserTask({
+    task: "read the page",
+    mode: "ask",
+    allowApiMutations: true,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /requires mode 'act'/);
+  const after = received.filter((message) => message.action === "cloud_run").length;
+  assert.equal(after, before);
+});
+
 test("browser_respond forwards IDs and the user's answer, then returns completion", async () => {
   const result = await browserRespond({
     runId: "clarify-run",

--- a/lmstudio-plugin/test/browserTask.test.mjs
+++ b/lmstudio-plugin/test/browserTask.test.mjs
@@ -51,6 +51,10 @@ before(async () => {
     received.push(message);
 
     if (message.action === "cloud_run") {
+      if (message.payload.task === "disconnect initial response") {
+        socket.terminate();
+        return;
+      }
       if (message.payload.task === "stall initial response") return;
       if (message.payload.task === "stall status response") {
         reply(message, { runId: "stalled-run", status: "running" });
@@ -173,6 +177,18 @@ test("browser_abort forwards the continuing run ID", async () => {
 
   const abort = received.find((message) => message.action === "cloud_abort");
   assert.deepEqual(abort.payload, { runId: "stalled-run" });
+});
+
+test("browser_task preserves its generated run ID when the start socket disconnects", async () => {
+  const result = await browserTask({ task: "disconnect initial response", timeout: 5_000 });
+
+  assert.equal(result.stillRunning, true);
+  assert.match(result.runId, /^lm_/);
+  const request = received.find(
+    (message) =>
+      message.action === "cloud_run" && message.payload.task === "disconnect initial response",
+  );
+  assert.equal(request.payload.runId, result.runId);
 });
 
 test("a replacement socket receives nothing until it sends a valid hello", async () => {

--- a/lmstudio-plugin/test/browserTask.test.mjs
+++ b/lmstudio-plugin/test/browserTask.test.mjs
@@ -242,6 +242,26 @@ test("a replacement socket receives nothing until it sends a valid hello", async
   await new Promise((resolve) => setTimeout(resolve, 20));
 
   assert.equal(sharedBridge().isConnected(), false);
+  const taskStartedAt = Date.now();
+  const task = await browserTask({ task: "wait for extension", timeout: 100 });
+  const taskElapsedMs = Date.now() - taskStartedAt;
+  assert.equal(task.ok, false);
+  assert.match(task.error, /not connected/i);
+  assert.ok(taskElapsedMs < 500, `100ms task connection wait took ${taskElapsedMs}ms`);
+
+  const respondStartedAt = Date.now();
+  const response = await browserRespond({
+    runId: "paused-run",
+    clarifyId: "clarify-1",
+    answer: "yes",
+    timeout: 100,
+  });
+  const respondElapsedMs = Date.now() - respondStartedAt;
+  assert.equal(response.ok, false);
+  assert.equal(response.runId, "paused-run");
+  assert.match(response.error, /not connected/i);
+  assert.ok(respondElapsedMs < 500, `100ms response connection wait took ${respondElapsedMs}ms`);
+
   await assert.rejects(
     () => sharedBridge().request("cloud_run", { task: "private task", mode: "ask" }),
     /No WebBrain browser extension is connected/,

--- a/lmstudio-plugin/test/browserTask.test.mjs
+++ b/lmstudio-plugin/test/browserTask.test.mjs
@@ -9,9 +9,11 @@ import {
   browserStatus,
   browserTask,
 } from "../dist/tools/browserTask.js";
+import { main } from "../dist/index.js";
 import { sharedBridge } from "../dist/util/bridgeClient.js";
 
 let socket;
+let toolsProvider;
 const received = [];
 
 async function freePort() {
@@ -31,8 +33,15 @@ function reply(message, result) {
 
 before(async () => {
   process.env.WEBBRAIN_BRIDGE_PORT = String(await freePort());
+  const context = {
+    withToolsProvider(provider) {
+      toolsProvider = provider;
+      return context;
+    },
+  };
+  await main(context);
+
   const bridge = sharedBridge();
-  await bridge.ensureStarted();
 
   socket = new WebSocket(bridge.url);
   socket.on("message", (raw) => {
@@ -72,6 +81,15 @@ after(async () => {
   await sharedBridge().stop();
 });
 
+test("plugin initialization starts the bridge and registers browser recovery tools", async () => {
+  assert.equal(typeof toolsProvider, "function");
+  const tools = await toolsProvider();
+  const names = tools.map((registeredTool) => registeredTool.name);
+  assert.ok(names.includes("browser_status"));
+  assert.ok(names.includes("browser_respond"));
+  assert.equal(sharedBridge().isConnected(), true);
+});
+
 test("browser_status polls an existing run and returns its result", async () => {
   const result = await browserStatus("finished-run");
   assert.equal(result.ok, true);
@@ -104,4 +122,24 @@ test("browser_respond forwards IDs and the user's answer, then returns completio
     clarifyId: "clarify-1",
     answer: "The work account",
   });
+});
+
+test("a replacement socket receives nothing until it sends a valid hello", async () => {
+  const rogue = new WebSocket(sharedBridge().url);
+  let receivedCommands = 0;
+  rogue.on("message", () => {
+    receivedCommands += 1;
+  });
+  await once(rogue, "open");
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(sharedBridge().isConnected(), false);
+  await assert.rejects(
+    () => sharedBridge().request("cloud_run", { task: "private task", mode: "ask" }),
+    /No WebBrain browser extension is connected/,
+  );
+  assert.equal(receivedCommands, 0);
+
+  rogue.close();
+  await once(rogue, "close");
 });

--- a/lmstudio-plugin/test/browserTask.test.mjs
+++ b/lmstudio-plugin/test/browserTask.test.mjs
@@ -5,6 +5,7 @@ import { after, before, test } from "node:test";
 import WebSocket from "ws";
 
 import {
+  browserAbort,
   browserRespond,
   browserStatus,
   browserTask,
@@ -49,6 +50,10 @@ before(async () => {
     received.push(message);
 
     if (message.action === "cloud_run") {
+      if (message.payload.task === "stall status response") {
+        reply(message, { runId: "stalled-run", status: "running" });
+        return;
+      }
       reply(message, {
         runId: "clarify-run",
         status: "needs_user_input",
@@ -60,7 +65,16 @@ before(async () => {
       reply(message, { runId: message.payload.runId, status: "running" });
       return;
     }
+    if (message.action === "cloud_abort") {
+      reply(message, {
+        runId: message.payload.runId,
+        status: "aborted",
+        error: "Abort requested.",
+      });
+      return;
+    }
     if (message.action === "cloud_status") {
+      if (message.payload.runId === "stalled-run") return;
       reply(message, {
         runId: message.payload.runId,
         status: "completed",
@@ -87,6 +101,7 @@ test("plugin initialization starts the bridge and registers browser recovery too
   const names = tools.map((registeredTool) => registeredTool.name);
   assert.ok(names.includes("browser_status"));
   assert.ok(names.includes("browser_respond"));
+  assert.ok(names.includes("browser_abort"));
   assert.equal(sharedBridge().isConnected(), true);
 });
 
@@ -122,6 +137,25 @@ test("browser_respond forwards IDs and the user's answer, then returns completio
     clarifyId: "clarify-1",
     answer: "The work account",
   });
+});
+
+test("browser_task bounds a stalled status request by its run timeout", async () => {
+  const startedAt = Date.now();
+  const result = await browserTask({ task: "stall status response", timeout: 5_000 });
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.equal(result.stillRunning, true);
+  assert.equal(result.runId, "stalled-run");
+  assert.ok(elapsedMs < 6_000, `5000ms timeout took ${elapsedMs}ms`);
+});
+
+test("browser_abort forwards the continuing run ID", async () => {
+  const result = await browserAbort("stalled-run");
+  assert.equal(result.runId, "stalled-run");
+  assert.equal(result.status, "aborted");
+
+  const abort = received.find((message) => message.action === "cloud_abort");
+  assert.deepEqual(abort.payload, { runId: "stalled-run" });
 });
 
 test("a replacement socket receives nothing until it sends a valid hello", async () => {

--- a/lmstudio-plugin/test/browserTask.test.mjs
+++ b/lmstudio-plugin/test/browserTask.test.mjs
@@ -34,6 +34,7 @@ function reply(message, result) {
 
 before(async () => {
   process.env.WEBBRAIN_BRIDGE_PORT = String(await freePort());
+  process.env.WEBBRAIN_COMMAND_TIMEOUT_MS = "50";
   const context = {
     withToolsProvider(provider) {
       toolsProvider = provider;
@@ -146,7 +147,7 @@ test("browser_task bounds a stalled status request by its run timeout", async ()
 
   assert.equal(result.stillRunning, true);
   assert.equal(result.runId, "stalled-run");
-  assert.ok(elapsedMs < 6_000, `5000ms timeout took ${elapsedMs}ms`);
+  assert.ok(elapsedMs < 1_500, `command timeout lost the run for ${elapsedMs}ms`);
 });
 
 test("browser_abort forwards the continuing run ID", async () => {

--- a/lmstudio-plugin/test/browserTask.test.mjs
+++ b/lmstudio-plugin/test/browserTask.test.mjs
@@ -51,6 +51,7 @@ before(async () => {
     received.push(message);
 
     if (message.action === "cloud_run") {
+      if (message.payload.task === "stall initial response") return;
       if (message.payload.task === "stall status response") {
         reply(message, { runId: "stalled-run", status: "running" });
         return;
@@ -148,6 +149,21 @@ test("browser_task bounds a stalled status request by its run timeout", async ()
   assert.equal(result.stillRunning, true);
   assert.equal(result.runId, "stalled-run");
   assert.ok(elapsedMs < 1_500, `command timeout lost the run for ${elapsedMs}ms`);
+});
+
+test("browser_task preserves its generated run ID when the initial response stalls", async () => {
+  const startedAt = Date.now();
+  const result = await browserTask({ task: "stall initial response", timeout: 5_000 });
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.equal(result.stillRunning, true);
+  assert.match(result.runId, /^lm_/);
+  const request = received.find(
+    (message) =>
+      message.action === "cloud_run" && message.payload.task === "stall initial response",
+  );
+  assert.equal(request.payload.runId, result.runId);
+  assert.ok(elapsedMs < 500, `initial command timeout took ${elapsedMs}ms`);
 });
 
 test("browser_abort forwards the continuing run ID", async () => {

--- a/lmstudio-plugin/test/browserTask.test.mjs
+++ b/lmstudio-plugin/test/browserTask.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { createServer } from "node:net";
+import { after, before, test } from "node:test";
+import WebSocket from "ws";
+
+import {
+  browserRespond,
+  browserStatus,
+  browserTask,
+} from "../dist/tools/browserTask.js";
+import { sharedBridge } from "../dist/util/bridgeClient.js";
+
+let socket;
+const received = [];
+
+async function freePort() {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  server.close();
+  await once(server, "close");
+  return port;
+}
+
+function reply(message, result) {
+  socket.send(JSON.stringify({ id: message.id, ok: true, result }));
+}
+
+before(async () => {
+  process.env.WEBBRAIN_BRIDGE_PORT = String(await freePort());
+  const bridge = sharedBridge();
+  await bridge.ensureStarted();
+
+  socket = new WebSocket(bridge.url);
+  socket.on("message", (raw) => {
+    const message = JSON.parse(raw.toString());
+    received.push(message);
+
+    if (message.action === "cloud_run") {
+      reply(message, {
+        runId: "clarify-run",
+        status: "needs_user_input",
+        pendingInput: { question: "Which account?", clarifyId: "clarify-1" },
+      });
+      return;
+    }
+    if (message.action === "cloud_respond") {
+      reply(message, { runId: message.payload.runId, status: "running" });
+      return;
+    }
+    if (message.action === "cloud_status") {
+      reply(message, {
+        runId: message.payload.runId,
+        status: "completed",
+        result: `result for ${message.payload.runId}`,
+      });
+    }
+  });
+  await once(socket, "open");
+  socket.send(JSON.stringify({ type: "hello", client: "webbrain-extension" }));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+});
+
+after(async () => {
+  if (socket?.readyState === WebSocket.OPEN) {
+    socket.close();
+    await once(socket, "close");
+  }
+  await sharedBridge().stop();
+});
+
+test("browser_status polls an existing run and returns its result", async () => {
+  const result = await browserStatus("finished-run");
+  assert.equal(result.ok, true);
+  assert.equal(result.runId, "finished-run");
+  assert.equal(result.status, "completed");
+  assert.equal(result.text, "result for finished-run");
+});
+
+test("browser_task tells the model how to answer a paused run", async () => {
+  const result = await browserTask({ task: "Open the requested account", timeout: 5_000 });
+  assert.equal(result.needsUserInput, true);
+  assert.equal(result.runId, "clarify-run");
+  assert.equal(result.clarifyId, "clarify-1");
+  assert.match(result.hint, /browser_respond/);
+});
+
+test("browser_respond forwards IDs and the user's answer, then returns completion", async () => {
+  const result = await browserRespond({
+    runId: "clarify-run",
+    clarifyId: "clarify-1",
+    answer: "The work account",
+    timeout: 5_000,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.text, "result for clarify-run");
+  const response = received.find((message) => message.action === "cloud_respond");
+  assert.deepEqual(response.payload, {
+    runId: "clarify-run",
+    clarifyId: "clarify-1",
+    answer: "The work account",
+  });
+});

--- a/mcp-server/.gitignore
+++ b/mcp-server/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.DS_Store

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,110 @@
+# WebBrain MCP Server
+
+Give any MCP client — Claude Code, Codex, Cursor, OpenClaw — the ability to run tasks in **your real browser session**: already signed in, cookies present, MFA already passed.
+
+That session is the whole point. A headless automation framework starts logged out of everything and hits a login wall on the first useful page. WebBrain is already inside the browser you use.
+
+```
+Claude Code ──stdio──▶ webbrain-mcp ──ws://127.0.0.1:17374──▶ WebBrain extension ──▶ your tabs
+```
+
+## Install
+
+```bash
+npm install -g @webbrain/mcp-server
+```
+
+Or run from a checkout:
+
+```bash
+cd mcp-server && npm install && npm run build
+```
+
+## Connect the browser
+
+The MCP server hosts the listener; the extension dials out to it. A Manifest V3 extension cannot listen on a socket, so the direction is fixed.
+
+1. Install the [WebBrain extension](https://webbrain.one) and open your browser.
+2. In **WebBrain → Settings → Cloud bridge**, set the URL to `ws://127.0.0.1:17374/extension` and enable it.
+3. Ask your MCP client to call `webbrain_connection` to confirm.
+
+> **One bridge at a time.** The extension holds exactly one outbound bridge socket. Pointing it here means it is *not* pointed at WebBrain Cloud (`17373`) or the LM Studio plugin (`17375`). Switch by changing the URL in Settings.
+
+## Register with a client
+
+**Claude Code**
+
+```bash
+claude mcp add webbrain -- npx -y @webbrain/mcp-server
+```
+
+**Codex / Cursor / anything reading `mcp.json`**
+
+```json
+{
+  "mcpServers": {
+    "webbrain": {
+      "command": "npx",
+      "args": ["-y", "@webbrain/mcp-server"]
+    }
+  }
+}
+```
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `webbrain_run` | Delegate a task. `mode='ask'` is read-only; `mode='act'` can click and type, gated by in-browser approval. |
+| `webbrain_status` | Poll a run, or list every run. |
+| `webbrain_respond` | Answer a run sitting at `needs_user_input`. |
+| `webbrain_abort` | Stop a run. Actions already taken are not undone. |
+| `webbrain_connection` | Report whether the extension is attached, and how to fix it if not. |
+
+### Example
+
+> "Open my Stripe dashboard and list last week's failed payments."
+
+```
+webbrain_run(task: "open the Stripe dashboard and list last week's failed
+             payments with amounts and customer emails", mode: "ask")
+```
+
+Read-only, in the tab you are already authenticated in. No API key, no headless login dance.
+
+## Why task-level and not 50 browser tools
+
+WebBrain exposes roughly fifty primitives internally — `click_ax`, `type_ax`, `extract_data`, `iframe_read` and so on. This server deliberately does **not** surface them.
+
+**Safety.** WebBrain's capability × origin permission gate runs in the agent loop (`_executeToolBatch`), not inside `executeTool()`. An MCP layer calling primitives directly would sit *below* the gate and bypass every approval prompt the product is built on. Delegating a goal keeps the trust boundary in the browser, where the human is.
+
+**Cost.** Driving a UI one primitive at a time over a socket costs a round trip and a slab of tokens per click. Handing over a goal costs one call.
+
+## Configuration
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `WEBBRAIN_BRIDGE_PORT` | `17374` | Port the extension connects to. |
+| `WEBBRAIN_BRIDGE_PATH` | `/extension` | Path segment; must match the URL in Settings. |
+| `WEBBRAIN_COMMAND_TIMEOUT_MS` | `30000` | Per-command reply timeout. |
+| `WEBBRAIN_RUN_TIMEOUT_MS` | `300000` | Default ceiling for `webbrain_run` polling. |
+| `WEBBRAIN_POLL_INTERVAL_MS` | `1000` | Status poll interval. |
+
+## Security notes
+
+- The listener binds `127.0.0.1` only. Anything that can reach this port can drive your signed-in browser — never expose it to a network or a container bridge.
+- Connections must present the extension's `hello` frame with `client: "webbrain-extension"`; anything else is closed. This is **not** authentication. The shipping extension sends no shared secret, so a local process could impersonate it. Treat the port as trusted-local, and see [`docs/security-model.md`](../docs/security-model.md).
+- A `webbrain_run` timeout does **not** abort the run. A task that already submitted a form should not be silently killed — the browser keeps going and `webbrain_status` picks it back up.
+- `allow_api_mutations` lifts WebBrain's UI-first rule and is off by default. The UI path is visible and stoppable; direct API mutations are neither.
+
+## Tests
+
+```bash
+npm run build && node --test test/bridge.test.mjs
+```
+
+The suite stands up the real listener and connects a fake extension speaking the exact frames `src/chrome/src/offscreen/cloud-bridge.js` emits — handshake, id correlation under concurrency, error propagation, disconnect mid-command, and the poll/timeout/clarify paths. If the extension's wire format changes, these fail. That is intentional.
+
+## License
+
+MIT

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -95,7 +95,7 @@ WebBrain exposes roughly fifty primitives internally — `click_ax`, `type_ax`, 
 ## Security notes
 
 - The listener binds `127.0.0.1` only. Anything that can reach this port can drive your signed-in browser — never expose it to a network or a container bridge.
-- Connections must present the extension's `hello` frame with `client: "webbrain-extension"`; anything else is closed. This is **not** authentication. The shipping extension sends no shared secret, so a local process could impersonate it. Treat the port as trusted-local, and see [`docs/security-model.md`](../docs/security-model.md).
+- Connections from HTTP(S) pages and other non-extension browser origins are rejected before they can replace the extension socket. Accepted connections must also present the extension's `hello` frame with `client: "webbrain-extension"`; anything else is closed. This is **not** authentication. The shipping extension sends no shared secret, so a local process could impersonate it. Treat the port as trusted-local, and see [`docs/security-model.md`](../docs/security-model.md).
 - A `webbrain_run` timeout does **not** abort the run. A task that already submitted a form should not be silently killed — the browser keeps going and `webbrain_status` picks it back up.
 - `allow_api_mutations` lifts WebBrain's UI-first rule and is off by default. It is accepted only with `mode: "act"`; Ask runs remain read-only. The UI path is visible and stoppable; direct API mutations are neither.
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -22,6 +22,8 @@ cd mcp-server && npm install && npm run build
 
 ## Connect the browser
 
+> **Chromium only.** Chrome, Edge, Brave, Opera, Vivaldi. The bridge runs from the extension's **offscreen document**, and the Firefox build has none — `cloud-bridge.js` and `cloud-runs.js` live only under `src/chrome/`. See [`src/firefox/ARCHITECTURE.md`](../src/firefox/ARCHITECTURE.md).
+
 The MCP server hosts the listener; the extension dials out to it. A Manifest V3 extension cannot listen on a socket, so the direction is fixed.
 
 1. Install the [WebBrain extension](https://webbrain.one) and open your browser.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -97,7 +97,7 @@ WebBrain exposes roughly fifty primitives internally — `click_ax`, `type_ax`, 
 - The listener binds `127.0.0.1` only. Anything that can reach this port can drive your signed-in browser — never expose it to a network or a container bridge.
 - Connections must present the extension's `hello` frame with `client: "webbrain-extension"`; anything else is closed. This is **not** authentication. The shipping extension sends no shared secret, so a local process could impersonate it. Treat the port as trusted-local, and see [`docs/security-model.md`](../docs/security-model.md).
 - A `webbrain_run` timeout does **not** abort the run. A task that already submitted a form should not be silently killed — the browser keeps going and `webbrain_status` picks it back up.
-- `allow_api_mutations` lifts WebBrain's UI-first rule and is off by default. The UI path is visible and stoppable; direct API mutations are neither.
+- `allow_api_mutations` lifts WebBrain's UI-first rule and is off by default. It is accepted only with `mode: "act"`; Ask runs remain read-only. The UI path is visible and stoppable; direct API mutations are neither.
 
 ## Tests
 

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,0 +1,1254 @@
+{
+  "name": "@webbrain/mcp-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@webbrain/mcp-server",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "ws": "^8.18.0",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "webbrain-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "@types/ws": "^8.5.10",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@webbrain/mcp-server",
+  "displayName": "WebBrain MCP Server",
+  "description": "Model Context Protocol server that lets any MCP client (Claude Code, Codex, Cursor, OpenClaw) delegate browser tasks to a running WebBrain extension — in the user's real, already-authenticated browser session.",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "webbrain-mcp": "dist/index.js"
+  },
+  "license": "MIT",
+  "homepage": "https://webbrain.one",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webbrain-one/webbrain.git",
+    "directory": "mcp-server"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "webbrain",
+    "browser-agent",
+    "browser-automation",
+    "claude-code",
+    "codex",
+    "cursor"
+  ],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "ws": "^8.18.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/ws": "^8.5.10",
+    "typescript": "^5.5.0"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -20,7 +20,10 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "clean": "rm -rf dist"
+    "test": "npm run build && node --test \"test/*.test.mjs\"",
+    "clean": "rm -rf dist",
+    "prepack": "npm run build",
+    "prepare": "npm run build"
   },
   "keywords": [
     "mcp",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -20,7 +20,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "test": "npm run build && node --test \"test/*.test.mjs\"",
+    "test": "npm run build && node --test test/bridge.test.mjs test/config.test.mjs test/runs-request-timeout.test.mjs test/runs-timeout.test.mjs test/stdio-shutdown.test.mjs",
     "clean": "rm -rf dist",
     "prepack": "npm run build",
     "prepare": "npm run build"

--- a/mcp-server/src/bridge.ts
+++ b/mcp-server/src/bridge.ts
@@ -81,6 +81,7 @@ export class WebBrainBridge {
   private nextId = 1;
   private extensionCapabilities: string[] = [];
   private extensionProtocol: number | null = null;
+  private handshakenSocket: WebSocket | null = null;
   private waiters: Array<() => void> = [];
 
   async start(): Promise<void> {
@@ -109,6 +110,9 @@ export class WebBrainBridge {
       // browser restart or an offscreen-document teardown, and the stale socket
       // is never reused.
       if (this.socket) {
+        this.failAllPending(
+          new BridgeError("WebBrain extension connection was superseded mid-command."),
+        );
         try {
           this.socket.close(1000, "Superseded by a newer extension connection");
         } catch {
@@ -117,6 +121,9 @@ export class WebBrainBridge {
       }
 
       this.socket = socket;
+      this.handshakenSocket = null;
+      this.extensionCapabilities = [];
+      this.extensionProtocol = null;
       log(`extension connected on ${config.bridgePath}`);
 
       socket.on("message", (raw) => this.handleMessage(socket, raw.toString()));
@@ -124,6 +131,7 @@ export class WebBrainBridge {
       socket.on("close", () => {
         if (this.socket !== socket) return;
         this.socket = null;
+        this.handshakenSocket = null;
         this.extensionCapabilities = [];
         this.extensionProtocol = null;
         log("extension disconnected");
@@ -139,6 +147,8 @@ export class WebBrainBridge {
   }
 
   private handleMessage(socket: WebSocket, data: string): void {
+    if (this.socket !== socket) return;
+
     let msg: Record<string, unknown>;
     try {
       msg = JSON.parse(data);
@@ -152,9 +162,13 @@ export class WebBrainBridge {
       if (msg.client !== "webbrain-extension") {
         log(`rejecting unknown bridge client: ${String(msg.client)}`);
         socket.close(1008, "Unknown client");
-        if (this.socket === socket) this.socket = null;
+        if (this.socket === socket) {
+          this.socket = null;
+          this.handshakenSocket = null;
+        }
         return;
       }
+      this.handshakenSocket = socket;
       this.extensionProtocol = typeof msg.protocolVersion === "number" ? msg.protocolVersion : null;
       this.extensionCapabilities = Array.isArray(msg.capabilities)
         ? (msg.capabilities as string[])
@@ -194,7 +208,11 @@ export class WebBrainBridge {
   }
 
   isConnected(): boolean {
-    return this.socket !== null && this.socket.readyState === 1; // OPEN
+    return (
+      this.socket !== null &&
+      this.socket.readyState === 1 &&
+      this.handshakenSocket === this.socket
+    );
   }
 
   capabilities(): string[] {
@@ -203,7 +221,7 @@ export class WebBrainBridge {
 
   /** Resolve once the extension has connected and completed its handshake. */
   waitForExtension(timeoutMs: number): Promise<boolean> {
-    if (this.isConnected() && this.extensionProtocol !== null) return Promise.resolve(true);
+    if (this.isConnected()) return Promise.resolve(true);
     return new Promise((resolve) => {
       const timer = setTimeout(() => {
         this.waiters = this.waiters.filter((w) => w !== wake);
@@ -223,7 +241,7 @@ export class WebBrainBridge {
     payload: Record<string, unknown> = {},
   ): Promise<T> {
     const socket = this.socket;
-    if (!socket || socket.readyState !== 1) {
+    if (!socket || !this.isConnected()) {
       throw new BridgeError(
         "No WebBrain extension is connected. Open the browser, then set " +
           "WebBrain → Settings → Cloud bridge to " +
@@ -269,6 +287,7 @@ export class WebBrainBridge {
         /* ignore */
       }
       this.socket = null;
+      this.handshakenSocket = null;
     }
     if (this.wss) {
       await new Promise<void>((resolve) => this.wss!.close(() => resolve()));

--- a/mcp-server/src/bridge.ts
+++ b/mcp-server/src/bridge.ts
@@ -62,8 +62,12 @@ interface Pending {
 
 export class BridgeError extends Error {
   readonly status?: number;
-  readonly code?: "COMMAND_TIMEOUT";
-  constructor(message: string, status?: number, code?: "COMMAND_TIMEOUT") {
+  readonly code?: "COMMAND_TIMEOUT" | "COMMAND_INTERRUPTED";
+  constructor(
+    message: string,
+    status?: number,
+    code?: "COMMAND_TIMEOUT" | "COMMAND_INTERRUPTED",
+  ) {
     super(message);
     this.name = "BridgeError";
     this.status = status;
@@ -113,7 +117,11 @@ export class WebBrainBridge {
       // is never reused.
       if (this.socket) {
         this.failAllPending(
-          new BridgeError("WebBrain extension connection was superseded mid-command."),
+          new BridgeError(
+            "WebBrain extension connection was superseded mid-command.",
+            undefined,
+            "COMMAND_INTERRUPTED",
+          ),
         );
         try {
           this.socket.close(1000, "Superseded by a newer extension connection");
@@ -137,7 +145,13 @@ export class WebBrainBridge {
         this.extensionCapabilities = [];
         this.extensionProtocol = null;
         log("extension disconnected");
-        this.failAllPending(new BridgeError("WebBrain extension disconnected mid-command."));
+        this.failAllPending(
+          new BridgeError(
+            "WebBrain extension disconnected mid-command.",
+            undefined,
+            "COMMAND_INTERRUPTED",
+          ),
+        );
       });
 
       socket.on("error", (error) => {

--- a/mcp-server/src/bridge.ts
+++ b/mcp-server/src/bridge.ts
@@ -62,10 +62,12 @@ interface Pending {
 
 export class BridgeError extends Error {
   readonly status?: number;
-  constructor(message: string, status?: number) {
+  readonly code?: "COMMAND_TIMEOUT";
+  constructor(message: string, status?: number, code?: "COMMAND_TIMEOUT") {
     super(message);
     this.name = "BridgeError";
     this.status = status;
+    this.code = code;
   }
 }
 
@@ -260,6 +262,8 @@ export class WebBrainBridge {
         reject(
           new BridgeError(
             `WebBrain did not answer '${action}' within ${responseTimeoutMs}ms.`,
+            undefined,
+            "COMMAND_TIMEOUT",
           ),
         );
       }, responseTimeoutMs);

--- a/mcp-server/src/bridge.ts
+++ b/mcp-server/src/bridge.ts
@@ -80,6 +80,17 @@ function log(...args: unknown[]): void {
   console.error("[webbrain-mcp]", ...args);
 }
 
+function isAllowedBridgeOrigin(origin: string | string[] | undefined): boolean {
+  if (origin == null) return true;
+  if (Array.isArray(origin)) return false;
+  try {
+    const protocol = new URL(origin).protocol;
+    return protocol === "chrome-extension:" || protocol === "moz-extension:";
+  } catch {
+    return false;
+  }
+}
+
 export class WebBrainBridge {
   private wss: WebSocketServer | null = null;
   private socket: WebSocket | null = null;
@@ -106,6 +117,14 @@ export class WebBrainBridge {
 
     this.wss!.on("connection", (socket, request) => {
       const url = request.url || "";
+      const origin = request.headers.origin;
+      // Browser WebSocket clients always send Origin. Only extension pages may
+      // reach this trusted-local command channel; native clients send none.
+      if (!isAllowedBridgeOrigin(origin)) {
+        log(`rejected WebSocket origin: ${String(origin)}`);
+        socket.close(1008, "Untrusted Origin");
+        return;
+      }
       if (!url.startsWith(config.bridgePath)) {
         log(`rejected connection on unexpected path: ${url}`);
         socket.close(1008, "Unexpected path");

--- a/mcp-server/src/bridge.ts
+++ b/mcp-server/src/bridge.ts
@@ -239,6 +239,7 @@ export class WebBrainBridge {
   async request<T = unknown>(
     action: BridgeAction,
     payload: Record<string, unknown> = {},
+    timeoutMs = config.commandTimeoutMs,
   ): Promise<T> {
     const socket = this.socket;
     if (!socket || !this.isConnected()) {
@@ -251,16 +252,17 @@ export class WebBrainBridge {
 
     const id = this.nextId++;
     const frame = JSON.stringify({ id, action, payload });
+    const responseTimeoutMs = Math.max(1, Math.min(config.commandTimeoutMs, timeoutMs));
 
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
         reject(
           new BridgeError(
-            `WebBrain did not answer '${action}' within ${config.commandTimeoutMs}ms.`,
+            `WebBrain did not answer '${action}' within ${responseTimeoutMs}ms.`,
           ),
         );
-      }, config.commandTimeoutMs);
+      }, responseTimeoutMs);
 
       this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject, timer });
 

--- a/mcp-server/src/bridge.ts
+++ b/mcp-server/src/bridge.ts
@@ -1,0 +1,278 @@
+/**
+ * Bridge server — the local endpoint the WebBrain extension connects OUT to.
+ *
+ * Direction matters: a Manifest V3 extension cannot listen on a socket, so
+ * `src/chrome/src/offscreen/cloud-bridge.js` dials out from an offscreen
+ * document and we host the listener. That also means every command below is
+ * initiated by us and answered by the extension.
+ *
+ * Wire protocol (already shipping in the extension, unchanged here):
+ *   extension -> us   {type:'hello', client, protocolVersion, capabilities, status}
+ *   us -> extension   {id, action, payload}
+ *   extension -> us   {id, ok:true,  result}
+ *                     {id, ok:false, error, status?}
+ *
+ * The extension spreads `payload` over the message it forwards to its own
+ * background worker, so payload keys become top-level fields there. Send the
+ * exact field names `cloud-runs.js` reads.
+ */
+
+import { WebSocketServer, type WebSocket } from "ws";
+import { config } from "./config.js";
+
+/** Actions already present in the extension's ALLOWED_BRIDGE_ACTIONS set. */
+export type BridgeAction =
+  | "cloud_run"
+  | "cloud_status"
+  | "cloud_respond"
+  | "cloud_abort";
+
+export interface CloudSnapshot {
+  runId: string;
+  status: "running" | "needs_user_input" | "aborting" | "completed" | "failed" | "aborted";
+  mode?: "ask" | "act";
+  tabId?: number;
+  task?: string;
+  structured?: boolean;
+  pendingInput?: {
+    clarifyId?: string;
+    clarify_id?: string;
+    question?: string;
+    [key: string]: unknown;
+  } | null;
+  result?: unknown;
+  summary?: string;
+  content?: string;
+  finalUrl?: string;
+  error?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  completedAt?: string | null;
+  updates?: unknown[];
+  [key: string]: unknown;
+}
+
+export const TERMINAL_STATUSES = new Set(["completed", "failed", "aborted"]);
+
+interface Pending {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+export class BridgeError extends Error {
+  readonly status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "BridgeError";
+    this.status = status;
+  }
+}
+
+/** Log to stderr only — stdout is the MCP stdio transport and must stay clean. */
+function log(...args: unknown[]): void {
+  console.error("[webbrain-mcp]", ...args);
+}
+
+export class WebBrainBridge {
+  private wss: WebSocketServer | null = null;
+  private socket: WebSocket | null = null;
+  private pending = new Map<number, Pending>();
+  private nextId = 1;
+  private extensionCapabilities: string[] = [];
+  private extensionProtocol: number | null = null;
+  private waiters: Array<() => void> = [];
+
+  async start(): Promise<void> {
+    if (this.wss) return;
+
+    await new Promise<void>((resolve, reject) => {
+      // Bind to loopback explicitly. Never expose this listener to the network:
+      // anything that can reach it can drive the user's logged-in browser.
+      const wss = new WebSocketServer(
+        { host: "127.0.0.1", port: config.bridgePort },
+        () => resolve(),
+      );
+      wss.on("error", reject);
+      this.wss = wss;
+    });
+
+    this.wss!.on("connection", (socket, request) => {
+      const url = request.url || "";
+      if (!url.startsWith(config.bridgePath)) {
+        log(`rejected connection on unexpected path: ${url}`);
+        socket.close(1008, "Unexpected path");
+        return;
+      }
+
+      // Latest connection wins. The extension reconnects with backoff after a
+      // browser restart or an offscreen-document teardown, and the stale socket
+      // is never reused.
+      if (this.socket) {
+        try {
+          this.socket.close(1000, "Superseded by a newer extension connection");
+        } catch {
+          /* already gone */
+        }
+      }
+
+      this.socket = socket;
+      log(`extension connected on ${config.bridgePath}`);
+
+      socket.on("message", (raw) => this.handleMessage(socket, raw.toString()));
+
+      socket.on("close", () => {
+        if (this.socket !== socket) return;
+        this.socket = null;
+        this.extensionCapabilities = [];
+        this.extensionProtocol = null;
+        log("extension disconnected");
+        this.failAllPending(new BridgeError("WebBrain extension disconnected mid-command."));
+      });
+
+      socket.on("error", (error) => {
+        log("socket error:", error instanceof Error ? error.message : String(error));
+      });
+    });
+
+    log(`listening on ws://127.0.0.1:${config.bridgePort}${config.bridgePath}`);
+  }
+
+  private handleMessage(socket: WebSocket, data: string): void {
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(data);
+    } catch {
+      log("dropped non-JSON frame from extension");
+      return;
+    }
+
+    // Handshake frame — no id, nothing to correlate.
+    if (msg.type === "hello") {
+      if (msg.client !== "webbrain-extension") {
+        log(`rejecting unknown bridge client: ${String(msg.client)}`);
+        socket.close(1008, "Unknown client");
+        if (this.socket === socket) this.socket = null;
+        return;
+      }
+      this.extensionProtocol = typeof msg.protocolVersion === "number" ? msg.protocolVersion : null;
+      this.extensionCapabilities = Array.isArray(msg.capabilities)
+        ? (msg.capabilities as string[])
+        : [];
+      log(
+        `handshake ok — protocol v${this.extensionProtocol}, capabilities: ` +
+          (this.extensionCapabilities.join(", ") || "none"),
+      );
+      const waiters = this.waiters;
+      this.waiters = [];
+      for (const wake of waiters) wake();
+      return;
+    }
+
+    const id = typeof msg.id === "number" ? msg.id : null;
+    if (id == null) return;
+
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    this.pending.delete(id);
+    clearTimeout(entry.timer);
+
+    if (msg.ok === false) {
+      const status = typeof msg.status === "number" ? msg.status : undefined;
+      entry.reject(new BridgeError(String(msg.error || "Unknown bridge error"), status));
+      return;
+    }
+    entry.resolve(msg.result);
+  }
+
+  private failAllPending(error: Error): void {
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  isConnected(): boolean {
+    return this.socket !== null && this.socket.readyState === 1; // OPEN
+  }
+
+  capabilities(): string[] {
+    return [...this.extensionCapabilities];
+  }
+
+  /** Resolve once the extension has connected and completed its handshake. */
+  waitForExtension(timeoutMs: number): Promise<boolean> {
+    if (this.isConnected() && this.extensionProtocol !== null) return Promise.resolve(true);
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        this.waiters = this.waiters.filter((w) => w !== wake);
+        resolve(false);
+      }, timeoutMs);
+      const wake = () => {
+        clearTimeout(timer);
+        resolve(true);
+      };
+      this.waiters.push(wake);
+    });
+  }
+
+  /** Send one command and await the extension's reply. */
+  async request<T = unknown>(
+    action: BridgeAction,
+    payload: Record<string, unknown> = {},
+  ): Promise<T> {
+    const socket = this.socket;
+    if (!socket || socket.readyState !== 1) {
+      throw new BridgeError(
+        "No WebBrain extension is connected. Open the browser, then set " +
+          "WebBrain → Settings → Cloud bridge to " +
+          `ws://127.0.0.1:${config.bridgePort}${config.bridgePath} and enable it.`,
+      );
+    }
+
+    const id = this.nextId++;
+    const frame = JSON.stringify({ id, action, payload });
+
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new BridgeError(
+            `WebBrain did not answer '${action}' within ${config.commandTimeoutMs}ms.`,
+          ),
+        );
+      }, config.commandTimeoutMs);
+
+      this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject, timer });
+
+      try {
+        socket.send(frame);
+      } catch (error) {
+        this.pending.delete(id);
+        clearTimeout(timer);
+        reject(
+          new BridgeError(
+            `Failed to send '${action}': ${error instanceof Error ? error.message : String(error)}`,
+          ),
+        );
+      }
+    });
+  }
+
+  async stop(): Promise<void> {
+    this.failAllPending(new BridgeError("Bridge shutting down."));
+    if (this.socket) {
+      try {
+        this.socket.close(1001, "Server shutting down");
+      } catch {
+        /* ignore */
+      }
+      this.socket = null;
+    }
+    if (this.wss) {
+      await new Promise<void>((resolve) => this.wss!.close(() => resolve()));
+      this.wss = null;
+    }
+  }
+}

--- a/mcp-server/src/config.ts
+++ b/mcp-server/src/config.ts
@@ -1,0 +1,44 @@
+/**
+ * Runtime configuration, all environment-driven.
+ *
+ * The bridge port intentionally defaults to 17374, NOT 17373. WebBrain Cloud's
+ * sidecar owns 17373, and `cloud-bridge.js` holds exactly one outbound socket —
+ * so the extension can be pointed at Cloud or at this server, never both. Using
+ * a distinct port keeps the failure mode obvious ("nothing connected") instead
+ * of two processes fighting over one listener.
+ */
+
+function intFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`${name} must be a valid TCP port, got: ${raw}`);
+  }
+  return parsed;
+}
+
+export const config = {
+  /** Port this process listens on for the extension's outbound bridge socket. */
+  bridgePort: intFromEnv("WEBBRAIN_BRIDGE_PORT", 17374),
+
+  /** Path segment the extension connects to. Must match the URL set in WebBrain settings. */
+  bridgePath: process.env.WEBBRAIN_BRIDGE_PATH || "/extension",
+
+  /**
+   * How long to wait for the extension to answer a single bridge command.
+   * Starting a run returns immediately; this is not the task timeout.
+   */
+  commandTimeoutMs: intFromEnv("WEBBRAIN_COMMAND_TIMEOUT_MS", 30_000),
+
+  /** Default ceiling for how long `webbrain_run` will poll before giving up. */
+  defaultRunTimeoutMs: intFromEnv("WEBBRAIN_RUN_TIMEOUT_MS", 300_000),
+
+  /** Interval between `cloud_status` polls while a run is in flight. */
+  pollIntervalMs: intFromEnv("WEBBRAIN_POLL_INTERVAL_MS", 1_000),
+} as const;
+
+/** The URL the user must paste into WebBrain → Settings → Cloud bridge. */
+export function bridgeUrl(): string {
+  return `ws://127.0.0.1:${config.bridgePort}${config.bridgePath}`;
+}

--- a/mcp-server/src/config.ts
+++ b/mcp-server/src/config.ts
@@ -8,19 +8,43 @@
  * of two processes fighting over one listener.
  */
 
-function intFromEnv(name: string, fallback: number): number {
+function parseIntFromEnv(name: string, raw: string): number {
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || String(parsed) !== raw.trim()) {
+    throw new Error(`${name} must be an integer, got: ${raw}`);
+  }
+  return parsed;
+}
+
+/** Ports carry a 16-bit ceiling. Durations must NOT — see durationFromEnv. */
+function portFromEnv(name: string, fallback: number): number {
   const raw = process.env[name];
   if (!raw) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65535) {
-    throw new Error(`${name} must be a valid TCP port, got: ${raw}`);
+  const parsed = parseIntFromEnv(name, raw);
+  if (parsed <= 0 || parsed > 65535) {
+    throw new Error(`${name} must be a valid TCP port (1-65535), got: ${raw}`);
+  }
+  return parsed;
+}
+
+/**
+ * Millisecond durations. Deliberately separate from portFromEnv: reusing the
+ * port validator here rejected every timeout above 65535ms, including the
+ * five-minute default this file itself documents.
+ */
+function durationFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = parseIntFromEnv(name, raw);
+  if (parsed <= 0) {
+    throw new Error(`${name} must be a positive duration in milliseconds, got: ${raw}`);
   }
   return parsed;
 }
 
 export const config = {
   /** Port this process listens on for the extension's outbound bridge socket. */
-  bridgePort: intFromEnv("WEBBRAIN_BRIDGE_PORT", 17374),
+  bridgePort: portFromEnv("WEBBRAIN_BRIDGE_PORT", 17374),
 
   /** Path segment the extension connects to. Must match the URL set in WebBrain settings. */
   bridgePath: process.env.WEBBRAIN_BRIDGE_PATH || "/extension",
@@ -29,13 +53,13 @@ export const config = {
    * How long to wait for the extension to answer a single bridge command.
    * Starting a run returns immediately; this is not the task timeout.
    */
-  commandTimeoutMs: intFromEnv("WEBBRAIN_COMMAND_TIMEOUT_MS", 30_000),
+  commandTimeoutMs: durationFromEnv("WEBBRAIN_COMMAND_TIMEOUT_MS", 30_000),
 
   /** Default ceiling for how long `webbrain_run` will poll before giving up. */
-  defaultRunTimeoutMs: intFromEnv("WEBBRAIN_RUN_TIMEOUT_MS", 300_000),
+  defaultRunTimeoutMs: durationFromEnv("WEBBRAIN_RUN_TIMEOUT_MS", 300_000),
 
   /** Interval between `cloud_status` polls while a run is in flight. */
-  pollIntervalMs: intFromEnv("WEBBRAIN_POLL_INTERVAL_MS", 1_000),
+  pollIntervalMs: durationFromEnv("WEBBRAIN_POLL_INTERVAL_MS", 1_000),
 } as const;
 
 /** The URL the user must paste into WebBrain → Settings → Cloud bridge. */

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -132,7 +132,10 @@ server.registerTool(
           Math.max(1, deadline - Date.now()),
         );
       } catch (error) {
-        if (error instanceof BridgeError && error.code === "COMMAND_TIMEOUT") {
+        if (
+          error instanceof BridgeError &&
+          (error.code === "COMMAND_TIMEOUT" || error.code === "COMMAND_INTERRUPTED")
+        ) {
           return ok(describeSnapshot({ runId, status: "running" }, true));
         }
         throw error;
@@ -222,7 +225,10 @@ server.registerTool(
           Math.max(1, deadline - Date.now()),
         );
       } catch (error) {
-        if (error instanceof BridgeError && error.code === "COMMAND_TIMEOUT") {
+        if (
+          error instanceof BridgeError &&
+          (error.code === "COMMAND_TIMEOUT" || error.code === "COMMAND_INTERRUPTED")
+        ) {
           return ok(describeSnapshot({ runId: run_id, status: "running" }, true));
         }
         throw error;

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -92,7 +92,7 @@ server.registerTool(
         .describe(
           "Lift WebBrain's UI-first rule so the agent may issue mutating HTTP requests " +
             "directly instead of clicking through the interface. Off by default and rarely " +
-            "correct — the UI path is visible and stoppable.",
+            "correct — the UI path is visible and stoppable. Only valid when mode is 'act'.",
         ),
       timeout_seconds: z
         .number()

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -257,10 +257,10 @@ server.registerTool(
 async function main(): Promise<void> {
   await bridge.start();
 
-  // Best-effort: gives the extension a moment to reconnect if the browser is
-  // already open, so the first tool call usually succeeds rather than teaching
-  // the model that browser tools are flaky.
-  void bridge.waitForExtension(3_000);
+  // Give an already-open extension a bounded chance to reconnect before the
+  // stdio server advertises browser tools. If this promise is discarded, the
+  // grace period is illusory and the first tool call can race the reconnect.
+  await bridge.waitForExtension(3_000);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -267,13 +267,23 @@ async function main(): Promise<void> {
   console.error("[webbrain-mcp] ready on stdio");
 }
 
+let shuttingDown = false;
 async function shutdown(): Promise<void> {
-  await bridge.stop();
+  if (shuttingDown) return;
+  shuttingDown = true;
+  await bridge.stop().catch((error) => {
+    console.error("[webbrain-mcp] shutdown error:", error);
+  });
   process.exit(0);
 }
 
 process.on("SIGINT", () => void shutdown());
 process.on("SIGTERM", () => void shutdown());
+// MCP hosts commonly stop stdio servers by closing the child's stdin rather
+// than sending a signal. Without these handlers the WebSocket listener keeps
+// the event loop alive and leaves port 17374 occupied by an orphan process.
+process.stdin.once("end", () => void shutdown());
+process.stdin.once("close", () => void shutdown());
 
 main().catch((error) => {
   console.error("[webbrain-mcp] fatal:", error);

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -243,10 +243,13 @@ server.registerTool(
     }
     return ok(
       `Not connected. Listening on ${bridgeUrl()}, but no extension has dialled in.\n\n` +
-        "To connect: open the browser, then in WebBrain → Settings set the bridge URL to\n" +
+        "To connect: open a Chromium browser (Chrome, Edge, Brave), then in " +
+        "WebBrain → Settings set the bridge URL to\n" +
         `  ${bridgeUrl()}\n` +
-        "and enable it. Note the extension holds one bridge socket at a time, so this " +
-        "cannot run at the same time as WebBrain Cloud on port 17373.",
+        "and enable it. The extension holds one bridge socket at a time, so this cannot " +
+        "run at the same time as WebBrain Cloud on port 17373.\n\n" +
+        "Firefox cannot host the bridge — that build has no offscreen document. If the " +
+        "user is on Firefox, say so rather than suggesting settings changes.",
     );
   },
 );

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -21,6 +21,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { randomUUID } from "node:crypto";
 import { z } from "zod";
 
 import { BridgeError, WebBrainBridge, type CloudSnapshot } from "./bridge.js";
@@ -113,13 +114,29 @@ server.registerTool(
     },
   },
   async ({ task, mode, tab_id, allow_api_mutations, timeout_seconds, wait }): Promise<TextResult> => {
+    const timeoutMs = timeout_seconds ? timeout_seconds * 1000 : config.defaultRunTimeoutMs;
+    const deadline = Date.now() + timeoutMs;
+    const runId = `mcp_${randomUUID()}`;
     try {
-      const started = await startRun(bridge, {
-        task,
-        mode,
-        tabId: tab_id,
-        apiMutationsAllowed: allow_api_mutations,
-      });
+      let started: CloudSnapshot;
+      try {
+        started = await startRun(
+          bridge,
+          {
+            runId,
+            task,
+            mode,
+            tabId: tab_id,
+            apiMutationsAllowed: allow_api_mutations,
+          },
+          Math.max(1, deadline - Date.now()),
+        );
+      } catch (error) {
+        if (error instanceof BridgeError && error.code === "COMMAND_TIMEOUT") {
+          return ok(describeSnapshot({ runId, status: "running" }, true));
+        }
+        throw error;
+      }
 
       if (!wait) {
         return ok(
@@ -128,8 +145,9 @@ server.registerTool(
         );
       }
 
-      const timeoutMs = timeout_seconds ? timeout_seconds * 1000 : config.defaultRunTimeoutMs;
-      const { snapshot, timedOut } = await awaitSettled(bridge, started.runId, { timeoutMs });
+      const { snapshot, timedOut } = await awaitSettled(bridge, started.runId, {
+        timeoutMs: Math.max(0, deadline - Date.now()),
+      });
       return ok(describeSnapshot(snapshot, timedOut));
     } catch (error) {
       return toolError(error);
@@ -192,10 +210,26 @@ server.registerTool(
     },
   },
   async ({ run_id, clarify_id, answer, timeout_seconds }): Promise<TextResult> => {
+    const timeoutMs = timeout_seconds ? timeout_seconds * 1000 : config.defaultRunTimeoutMs;
+    const deadline = Date.now() + timeoutMs;
     try {
-      await respond(bridge, run_id, clarify_id, answer);
-      const timeoutMs = timeout_seconds ? timeout_seconds * 1000 : config.defaultRunTimeoutMs;
-      const { snapshot, timedOut } = await awaitSettled(bridge, run_id, { timeoutMs });
+      try {
+        await respond(
+          bridge,
+          run_id,
+          clarify_id,
+          answer,
+          Math.max(1, deadline - Date.now()),
+        );
+      } catch (error) {
+        if (error instanceof BridgeError && error.code === "COMMAND_TIMEOUT") {
+          return ok(describeSnapshot({ runId: run_id, status: "running" }, true));
+        }
+        throw error;
+      }
+      const { snapshot, timedOut } = await awaitSettled(bridge, run_id, {
+        timeoutMs: Math.max(0, deadline - Date.now()),
+      });
       return ok(describeSnapshot(snapshot, timedOut));
     } catch (error) {
       return toolError(error);

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+/**
+ * WebBrain MCP server.
+ *
+ * Gives any MCP client — Claude Code, Codex, Cursor, OpenClaw — the ability to
+ * delegate a browser task to the user's REAL browser session: already logged
+ * in, cookies present, MFA already passed. That session is the thing a headless
+ * automation framework cannot reproduce, and it is the only reason this server
+ * is interesting.
+ *
+ * Scope is deliberately coarse. We expose task delegation, not the ~50
+ * low-level browser primitives, because:
+ *   1. the permission gate lives in the extension's agent loop, not in
+ *      `executeTool()`, so per-primitive access would bypass every safety
+ *      property WebBrain advertises; and
+ *   2. driving 50 primitives over a socket costs a round trip and a pile of
+ *      tokens per click. Delegation is both safer and cheaper.
+ *
+ * stdout belongs to the MCP stdio transport. All logging goes to stderr.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+import { BridgeError, WebBrainBridge, type CloudSnapshot } from "./bridge.js";
+import { bridgeUrl, config } from "./config.js";
+import { abort, awaitSettled, describeSnapshot, getStatus, respond, startRun } from "./runs.js";
+
+const bridge = new WebBrainBridge();
+
+const server = new McpServer({
+  name: "webbrain",
+  version: "0.1.0",
+});
+
+type TextResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+const ok = (text: string): TextResult => ({ content: [{ type: "text", text }] });
+const fail = (text: string): TextResult => ({ content: [{ type: "text", text }], isError: true });
+
+function toolError(error: unknown): TextResult {
+  if (error instanceof BridgeError) return fail(error.message);
+  return fail(error instanceof Error ? error.message : String(error));
+}
+
+server.registerTool(
+  "webbrain_run",
+  {
+    title: "Run a browser task in the user's real session",
+    description:
+      "Delegate a web task to WebBrain running in the user's actual browser — already " +
+      "signed in, with existing cookies and sessions. Use this when a task needs a page " +
+      "the caller cannot reach: an authenticated dashboard, a webmail account, an admin " +
+      "panel, a SaaS report behind SSO. Describe the goal in plain language, the way you " +
+      "would to a colleague sharing the screen.\n\n" +
+      "mode='ask' is read-only: it reads, extracts and summarises, and cannot click, type " +
+      "or submit. mode='act' allows interaction, and the user is prompted in-browser to " +
+      "approve consequential actions. Prefer 'ask' whenever you only need to read.\n\n" +
+      "If the run stops with status 'needs_user_input', relay the question to the user and " +
+      "answer with webbrain_respond — never guess on their behalf.",
+    inputSchema: {
+      task: z
+        .string()
+        .min(1)
+        .describe(
+          "The goal, in plain language. e.g. 'open the Stripe dashboard and list last " +
+            "week's failed payments with amounts and customer emails'.",
+        ),
+      mode: z
+        .enum(["ask", "act"])
+        .default("ask")
+        .describe(
+          "'ask' is read-only and cannot modify the page. 'act' permits clicking, typing " +
+            "and navigation, gated by in-browser approval. Default 'ask'.",
+        ),
+      tab_id: z
+        .number()
+        .int()
+        .optional()
+        .describe(
+          "Target a specific browser tab. Omit to use the active tab, which is almost " +
+            "always what you want.",
+        ),
+      allow_api_mutations: z
+        .boolean()
+        .default(false)
+        .describe(
+          "Lift WebBrain's UI-first rule so the agent may issue mutating HTTP requests " +
+            "directly instead of clicking through the interface. Off by default and rarely " +
+            "correct — the UI path is visible and stoppable.",
+        ),
+      timeout_seconds: z
+        .number()
+        .int()
+        .positive()
+        .max(3600)
+        .optional()
+        .describe(
+          "How long to wait before returning control. The run keeps going in the browser " +
+            "past this point; poll webbrain_status to pick it back up.",
+        ),
+      wait: z
+        .boolean()
+        .default(true)
+        .describe(
+          "Wait for the run to settle. Set false to start it and return the run_id " +
+            "immediately.",
+        ),
+    },
+  },
+  async ({ task, mode, tab_id, allow_api_mutations, timeout_seconds, wait }): Promise<TextResult> => {
+    try {
+      const started = await startRun(bridge, {
+        task,
+        mode,
+        tabId: tab_id,
+        apiMutationsAllowed: allow_api_mutations,
+      });
+
+      if (!wait) {
+        return ok(
+          `Started in the background.\n${describeSnapshot(started)}\n\n` +
+            "Poll webbrain_status with this run_id for progress.",
+        );
+      }
+
+      const timeoutMs = timeout_seconds ? timeout_seconds * 1000 : config.defaultRunTimeoutMs;
+      const { snapshot, timedOut } = await awaitSettled(bridge, started.runId, { timeoutMs });
+      return ok(describeSnapshot(snapshot, timedOut));
+    } catch (error) {
+      return toolError(error);
+    }
+  },
+);
+
+server.registerTool(
+  "webbrain_status",
+  {
+    title: "Check a browser run",
+    description:
+      "Fetch the current state of a WebBrain run, including its result once finished. " +
+      "Omit run_id to list every run this browser knows about.",
+    inputSchema: {
+      run_id: z
+        .string()
+        .optional()
+        .describe("The run to inspect. Omit to list all runs."),
+    },
+  },
+  async ({ run_id }): Promise<TextResult> => {
+    try {
+      const result = await getStatus(bridge, run_id);
+      const runs = (result as { runs?: CloudSnapshot[] }).runs;
+      if (runs) {
+        if (!runs.length) return ok("No WebBrain runs on record.");
+        return ok(
+          runs
+            .map((run) => `${run.runId}  ${run.status.padEnd(16)}  ${run.task ?? ""}`)
+            .join("\n"),
+        );
+      }
+      return ok(describeSnapshot(result as CloudSnapshot));
+    } catch (error) {
+      return toolError(error);
+    }
+  },
+);
+
+server.registerTool(
+  "webbrain_respond",
+  {
+    title: "Answer a question from a browser run",
+    description:
+      "Supply the user's answer to a run sitting at status 'needs_user_input', then keep " +
+      "waiting for it to settle. The answer must come from the user — WebBrain pauses " +
+      "precisely because a human decision is required.",
+    inputSchema: {
+      run_id: z.string().describe("The run that is waiting."),
+      clarify_id: z.string().describe("The clarify_id reported alongside the question."),
+      answer: z.string().min(1).describe("The user's answer, passed through verbatim."),
+      timeout_seconds: z
+        .number()
+        .int()
+        .positive()
+        .max(3600)
+        .optional()
+        .describe("How long to wait after answering before returning control."),
+    },
+  },
+  async ({ run_id, clarify_id, answer, timeout_seconds }): Promise<TextResult> => {
+    try {
+      await respond(bridge, run_id, clarify_id, answer);
+      const timeoutMs = timeout_seconds ? timeout_seconds * 1000 : config.defaultRunTimeoutMs;
+      const { snapshot, timedOut } = await awaitSettled(bridge, run_id, { timeoutMs });
+      return ok(describeSnapshot(snapshot, timedOut));
+    } catch (error) {
+      return toolError(error);
+    }
+  },
+);
+
+server.registerTool(
+  "webbrain_abort",
+  {
+    title: "Stop a browser run",
+    description:
+      "Halt a run that is going wrong or is no longer needed. Note that actions already " +
+      "taken in the browser are not undone.",
+    inputSchema: {
+      run_id: z.string().describe("The run to stop."),
+    },
+  },
+  async ({ run_id }): Promise<TextResult> => {
+    try {
+      const snapshot = await abort(bridge, run_id);
+      return ok(describeSnapshot(snapshot));
+    } catch (error) {
+      return toolError(error);
+    }
+  },
+);
+
+server.registerTool(
+  "webbrain_connection",
+  {
+    title: "Check the WebBrain browser connection",
+    description:
+      "Report whether a WebBrain extension is currently attached. Call this first when a " +
+      "browser tool fails, so you can tell the user what to fix instead of retrying blindly.",
+    inputSchema: {},
+  },
+  async (): Promise<TextResult> => {
+    if (bridge.isConnected()) {
+      const caps = bridge.capabilities();
+      return ok(
+        `Connected. Listening on ${bridgeUrl()}.` +
+          (caps.length ? `\nExtension capabilities: ${caps.join(", ")}` : ""),
+      );
+    }
+    return ok(
+      `Not connected. Listening on ${bridgeUrl()}, but no extension has dialled in.\n\n` +
+        "To connect: open the browser, then in WebBrain → Settings set the bridge URL to\n" +
+        `  ${bridgeUrl()}\n` +
+        "and enable it. Note the extension holds one bridge socket at a time, so this " +
+        "cannot run at the same time as WebBrain Cloud on port 17373.",
+    );
+  },
+);
+
+async function main(): Promise<void> {
+  await bridge.start();
+
+  // Best-effort: gives the extension a moment to reconnect if the browser is
+  // already open, so the first tool call usually succeeds rather than teaching
+  // the model that browser tools are flaky.
+  void bridge.waitForExtension(3_000);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("[webbrain-mcp] ready on stdio");
+}
+
+async function shutdown(): Promise<void> {
+  await bridge.stop();
+  process.exit(0);
+}
+
+process.on("SIGINT", () => void shutdown());
+process.on("SIGTERM", () => void shutdown());
+
+main().catch((error) => {
+  console.error("[webbrain-mcp] fatal:", error);
+  process.exit(1);
+});

--- a/mcp-server/src/runs.ts
+++ b/mcp-server/src/runs.ts
@@ -18,6 +18,7 @@ import { BridgeError, TERMINAL_STATUSES, WebBrainBridge, type CloudSnapshot } fr
 import { config } from "./config.js";
 
 export interface StartRunOptions {
+  runId?: string;
   task: string;
   mode: "ask" | "act";
   tabId?: number;
@@ -34,16 +35,18 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 export async function startRun(
   bridge: WebBrainBridge,
   options: StartRunOptions,
+  timeoutMs?: number,
 ): Promise<CloudSnapshot> {
   const payload: Record<string, unknown> = {
     task: options.task,
     mode: options.mode,
   };
+  if (options.runId) payload.runId = options.runId;
   if (options.tabId != null) payload.tabId = options.tabId;
   if (options.apiMutationsAllowed) payload.apiMutationsAllowed = true;
   if (options.outputSchema != null) payload.outputSchema = options.outputSchema;
 
-  return await bridge.request<CloudSnapshot>("cloud_run", payload);
+  return await bridge.request<CloudSnapshot>("cloud_run", payload, timeoutMs);
 }
 
 export async function getStatus(
@@ -64,8 +67,13 @@ export async function respond(
   runId: string,
   clarifyId: string,
   answer: string,
+  timeoutMs?: number,
 ): Promise<CloudSnapshot> {
-  return await bridge.request<CloudSnapshot>("cloud_respond", { runId, clarifyId, answer });
+  return await bridge.request<CloudSnapshot>(
+    "cloud_respond",
+    { runId, clarifyId, answer },
+    timeoutMs,
+  );
 }
 
 export async function abort(bridge: WebBrainBridge, runId: string): Promise<CloudSnapshot> {

--- a/mcp-server/src/runs.ts
+++ b/mcp-server/src/runs.ts
@@ -37,6 +37,10 @@ export async function startRun(
   options: StartRunOptions,
   timeoutMs?: number,
 ): Promise<CloudSnapshot> {
+  if (options.apiMutationsAllowed && options.mode !== "act") {
+    throw new BridgeError("API mutation permission requires mode 'act'.", 400);
+  }
+
   const payload: Record<string, unknown> = {
     task: options.task,
     mode: options.mode,

--- a/mcp-server/src/runs.ts
+++ b/mcp-server/src/runs.ts
@@ -84,7 +84,7 @@ export async function awaitSettled(
   let last: CloudSnapshot | null = null;
 
   while (Date.now() < deadline) {
-    await sleep(config.pollIntervalMs);
+    await sleep(Math.min(config.pollIntervalMs, Math.max(0, deadline - Date.now())));
 
     const result = await getStatus(bridge, runId);
     const snapshot = (result as { runs?: CloudSnapshot[] }).runs

--- a/mcp-server/src/runs.ts
+++ b/mcp-server/src/runs.ts
@@ -49,9 +49,14 @@ export async function startRun(
 export async function getStatus(
   bridge: WebBrainBridge,
   runId?: string,
+  timeoutMs?: number,
 ): Promise<CloudSnapshot | { runs: CloudSnapshot[] }> {
   const payload = runId ? { runId } : {};
-  return await bridge.request<CloudSnapshot | { runs: CloudSnapshot[] }>("cloud_status", payload);
+  return await bridge.request<CloudSnapshot | { runs: CloudSnapshot[] }>(
+    "cloud_status",
+    payload,
+    timeoutMs,
+  );
 }
 
 export async function respond(
@@ -81,12 +86,20 @@ export async function awaitSettled(
   { timeoutMs }: AwaitOptions,
 ): Promise<{ snapshot: CloudSnapshot; timedOut: boolean }> {
   const deadline = Date.now() + timeoutMs;
-  let last: CloudSnapshot | null = null;
+  let last: CloudSnapshot = { runId, status: "running" };
 
   while (Date.now() < deadline) {
     await sleep(Math.min(config.pollIntervalMs, Math.max(0, deadline - Date.now())));
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) break;
 
-    const result = await getStatus(bridge, runId);
+    let result: CloudSnapshot | { runs: CloudSnapshot[] };
+    try {
+      result = await getStatus(bridge, runId, remainingMs);
+    } catch (error) {
+      if (Date.now() >= deadline) return { snapshot: last, timedOut: true };
+      throw error;
+    }
     const snapshot = (result as { runs?: CloudSnapshot[] }).runs
       ? null
       : (result as CloudSnapshot);
@@ -99,9 +112,6 @@ export async function awaitSettled(
     }
   }
 
-  if (!last) {
-    last = (await getStatus(bridge, runId)) as CloudSnapshot;
-  }
   return { snapshot: last, timedOut: true };
 }
 

--- a/mcp-server/src/runs.ts
+++ b/mcp-server/src/runs.ts
@@ -1,0 +1,148 @@
+/**
+ * Run orchestration.
+ *
+ * `cloud_run` returns as soon as the run is registered — the actual work happens
+ * in a detached async IIFE inside the extension (`cloud-runs.js`). So starting a
+ * task gives us a snapshot with status 'running', and we poll `cloud_status`
+ * until it reaches a terminal state or stops to ask the user something.
+ *
+ * Important: every tool call still travels the full agent loop inside the
+ * extension (`agent.processMessage` -> `_executeToolBatch`), which means the
+ * capability x origin permission gate is enforced exactly as it is for a human
+ * driving the side panel. This server deliberately does NOT expose the
+ * individual browser primitives — `executeTool()` has no gate of its own, and
+ * calling it directly would move the trust boundary out of the browser.
+ */
+
+import { TERMINAL_STATUSES, WebBrainBridge, type CloudSnapshot } from "./bridge.js";
+import { config } from "./config.js";
+
+export interface StartRunOptions {
+  task: string;
+  mode: "ask" | "act";
+  tabId?: number;
+  apiMutationsAllowed?: boolean;
+  outputSchema?: unknown;
+}
+
+export interface AwaitOptions {
+  timeoutMs: number;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function startRun(
+  bridge: WebBrainBridge,
+  options: StartRunOptions,
+): Promise<CloudSnapshot> {
+  const payload: Record<string, unknown> = {
+    task: options.task,
+    mode: options.mode,
+  };
+  if (options.tabId != null) payload.tabId = options.tabId;
+  if (options.apiMutationsAllowed) payload.apiMutationsAllowed = true;
+  if (options.outputSchema != null) payload.outputSchema = options.outputSchema;
+
+  return await bridge.request<CloudSnapshot>("cloud_run", payload);
+}
+
+export async function getStatus(
+  bridge: WebBrainBridge,
+  runId?: string,
+): Promise<CloudSnapshot | { runs: CloudSnapshot[] }> {
+  const payload = runId ? { runId } : {};
+  return await bridge.request<CloudSnapshot | { runs: CloudSnapshot[] }>("cloud_status", payload);
+}
+
+export async function respond(
+  bridge: WebBrainBridge,
+  runId: string,
+  clarifyId: string,
+  answer: string,
+): Promise<CloudSnapshot> {
+  return await bridge.request<CloudSnapshot>("cloud_respond", { runId, clarifyId, answer });
+}
+
+export async function abort(bridge: WebBrainBridge, runId: string): Promise<CloudSnapshot> {
+  return await bridge.request<CloudSnapshot>("cloud_abort", { runId });
+}
+
+/**
+ * Poll until the run finishes, needs the user, or we run out of patience.
+ *
+ * A timeout here does NOT abort the run — the browser keeps working and the
+ * caller can resume with `webbrain_status`. Silently killing a half-finished
+ * task that may have already submitted a form would be worse than reporting
+ * that it is still going.
+ */
+export async function awaitSettled(
+  bridge: WebBrainBridge,
+  runId: string,
+  { timeoutMs }: AwaitOptions,
+): Promise<{ snapshot: CloudSnapshot; timedOut: boolean }> {
+  const deadline = Date.now() + timeoutMs;
+  let last: CloudSnapshot | null = null;
+
+  while (Date.now() < deadline) {
+    await sleep(config.pollIntervalMs);
+
+    const result = await getStatus(bridge, runId);
+    const snapshot = (result as { runs?: CloudSnapshot[] }).runs
+      ? null
+      : (result as CloudSnapshot);
+
+    if (!snapshot) continue;
+    last = snapshot;
+
+    if (TERMINAL_STATUSES.has(snapshot.status) || snapshot.status === "needs_user_input") {
+      return { snapshot, timedOut: false };
+    }
+  }
+
+  if (!last) {
+    last = (await getStatus(bridge, runId)) as CloudSnapshot;
+  }
+  return { snapshot: last, timedOut: true };
+}
+
+/** Render a snapshot as the text an calling agent actually needs to read. */
+export function describeSnapshot(snapshot: CloudSnapshot, timedOut = false): string {
+  const lines: string[] = [];
+  lines.push(`run_id: ${snapshot.runId}`);
+  lines.push(`status: ${snapshot.status}${timedOut ? " (still running — poll webbrain_status)" : ""}`);
+  if (snapshot.mode) lines.push(`mode: ${snapshot.mode}`);
+  if (snapshot.finalUrl) lines.push(`final_url: ${snapshot.finalUrl}`);
+
+  if (snapshot.status === "needs_user_input" && snapshot.pendingInput) {
+    const clarifyId = snapshot.pendingInput.clarifyId || snapshot.pendingInput.clarify_id || "";
+    const question = snapshot.pendingInput.question || "(no question text supplied)";
+    lines.push("");
+    lines.push("WebBrain is waiting on a human decision before it continues.");
+    lines.push(`question: ${question}`);
+    lines.push(`clarify_id: ${clarifyId}`);
+    lines.push(
+      "Relay this to the user and send their answer with webbrain_respond. " +
+        "Do not invent an answer on their behalf.",
+    );
+  }
+
+  if (snapshot.error) {
+    lines.push("");
+    lines.push(`error: ${snapshot.error}`);
+  }
+
+  const body =
+    snapshot.result !== undefined && snapshot.result !== null
+      ? typeof snapshot.result === "string"
+        ? snapshot.result
+        : JSON.stringify(snapshot.result, null, 2)
+      : snapshot.content || snapshot.summary || "";
+
+  if (body) {
+    lines.push("");
+    lines.push("--- result ---");
+    lines.push(body);
+  }
+
+  return lines.join("\n");
+}

--- a/mcp-server/src/runs.ts
+++ b/mcp-server/src/runs.ts
@@ -14,7 +14,7 @@
  * calling it directly would move the trust boundary out of the browser.
  */
 
-import { TERMINAL_STATUSES, WebBrainBridge, type CloudSnapshot } from "./bridge.js";
+import { BridgeError, TERMINAL_STATUSES, WebBrainBridge, type CloudSnapshot } from "./bridge.js";
 import { config } from "./config.js";
 
 export interface StartRunOptions {
@@ -97,7 +97,12 @@ export async function awaitSettled(
     try {
       result = await getStatus(bridge, runId, remainingMs);
     } catch (error) {
-      if (Date.now() >= deadline) return { snapshot: last, timedOut: true };
+      if (
+        Date.now() >= deadline ||
+        (error instanceof BridgeError && error.code === "COMMAND_TIMEOUT")
+      ) {
+        return { snapshot: last, timedOut: true };
+      }
       throw error;
     }
     const snapshot = (result as { runs?: CloudSnapshot[] }).runs

--- a/mcp-server/src/runs.ts
+++ b/mcp-server/src/runs.ts
@@ -101,7 +101,6 @@ export async function awaitSettled(
   let last: CloudSnapshot = { runId, status: "running" };
 
   while (Date.now() < deadline) {
-    await sleep(Math.min(config.pollIntervalMs, Math.max(0, deadline - Date.now())));
     const remainingMs = deadline - Date.now();
     if (remainingMs <= 0) break;
 
@@ -128,6 +127,8 @@ export async function awaitSettled(
     if (TERMINAL_STATUSES.has(snapshot.status) || snapshot.status === "needs_user_input") {
       return { snapshot, timedOut: false };
     }
+
+    await sleep(Math.min(config.pollIntervalMs, Math.max(0, deadline - Date.now())));
   }
 
   return { snapshot: last, timedOut: true };

--- a/mcp-server/src/runs.ts
+++ b/mcp-server/src/runs.ts
@@ -107,7 +107,8 @@ export async function awaitSettled(
     } catch (error) {
       if (
         Date.now() >= deadline ||
-        (error instanceof BridgeError && error.code === "COMMAND_TIMEOUT")
+        (error instanceof BridgeError &&
+          (error.code === "COMMAND_TIMEOUT" || error.code === "COMMAND_INTERRUPTED"))
       ) {
         return { snapshot: last, timedOut: true };
       }

--- a/mcp-server/test/bridge.test.mjs
+++ b/mcp-server/test/bridge.test.mjs
@@ -155,6 +155,38 @@ test("a client that is not the extension is rejected", async () => {
   await bridge.stop();
 });
 
+test("a web-page origin cannot replace the connected extension", async () => {
+  const bridge = new WebBrainBridge();
+  await bridge.start();
+
+  const extension = fakeExtension(bridgeUrl(), (msg) => ({
+    ok: true,
+    result: { runId: msg.payload.runId || "safe-run", status: "running" },
+  }));
+  await bridge.waitForExtension(3000);
+
+  const page = new WebSocket(bridgeUrl(), {
+    headers: { Origin: "https://attacker.example" },
+  });
+  let receivedCommands = 0;
+  page.on("message", () => {
+    receivedCommands += 1;
+  });
+  await new Promise((resolve) => page.on("close", resolve));
+
+  assert.equal(bridge.isConnected(), true, "page origin replaced the extension socket");
+  const result = await bridge.request("cloud_run", {
+    runId: "origin-safe-run",
+    task: "private task",
+    mode: "ask",
+  });
+  assert.equal(result.runId, "origin-safe-run");
+  assert.equal(receivedCommands, 0, "page origin received a task frame");
+
+  extension.close();
+  await bridge.stop();
+});
+
 test("a new socket cannot inherit an earlier extension handshake", async () => {
   const bridge = new WebBrainBridge();
   await bridge.start();

--- a/mcp-server/test/bridge.test.mjs
+++ b/mcp-server/test/bridge.test.mjs
@@ -196,7 +196,14 @@ test("disconnect mid-command rejects rather than hanging", async () => {
   const pending = bridge.request("cloud_run", { task: "x", mode: "ask" });
   setTimeout(() => ext.terminate(), 60);
 
-  await assert.rejects(pending, /disconnected mid-command/);
+  await assert.rejects(
+    pending,
+    (error) => {
+      assert.match(error.message, /disconnected mid-command/);
+      assert.equal(error.code, "COMMAND_INTERRUPTED");
+      return true;
+    },
+  );
   await bridge.stop();
 });
 

--- a/mcp-server/test/bridge.test.mjs
+++ b/mcp-server/test/bridge.test.mjs
@@ -1,0 +1,254 @@
+/**
+ * Bridge round-trip tests.
+ *
+ * These stand up the real listener and connect a fake extension that speaks the
+ * exact frame shapes `src/chrome/src/offscreen/cloud-bridge.js` emits. If the
+ * extension's wire format changes, these fail — which is the point.
+ *
+ * Run: node test/bridge.test.mjs   (after `npm run build`)
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import WebSocket from "ws";
+
+process.env.WEBBRAIN_BRIDGE_PORT = process.env.WEBBRAIN_BRIDGE_PORT || "17399";
+process.env.WEBBRAIN_COMMAND_TIMEOUT_MS = "2000";
+process.env.WEBBRAIN_POLL_INTERVAL_MS = "20";
+
+const { WebBrainBridge, BridgeError, TERMINAL_STATUSES } = await import("../dist/bridge.js");
+const { bridgeUrl } = await import("../dist/config.js");
+const { awaitSettled, describeSnapshot } = await import("../dist/runs.js");
+
+/** Minimal stand-in for the extension's offscreen bridge client. */
+function fakeExtension(url, handler, { client = "webbrain-extension" } = {}) {
+  const socket = new WebSocket(url);
+  socket.on("open", () => {
+    socket.send(
+      JSON.stringify({
+        type: "hello",
+        client,
+        protocolVersion: 2,
+        capabilities: ["saved_workflows_v1", "run_modes_v1", "scheduled_jobs_v1"],
+        status: { enabled: true },
+      }),
+    );
+  });
+  socket.on("message", async (raw) => {
+    const msg = JSON.parse(raw.toString());
+    if (!msg.action) return;
+    const reply = await handler(msg);
+    socket.send(JSON.stringify({ id: msg.id, ...reply }));
+  });
+  return socket;
+}
+
+test("handshake, command correlation, and payload shape", async () => {
+  const bridge = new WebBrainBridge();
+  await bridge.start();
+
+  const seen = [];
+  const ext = fakeExtension(bridgeUrl(), (msg) => {
+    seen.push(msg);
+    return {
+      ok: true,
+      result: { runId: "run_1", status: "running", mode: msg.payload.mode, task: msg.payload.task },
+    };
+  });
+
+  assert.equal(await bridge.waitForExtension(3000), true, "extension should complete handshake");
+  assert.deepEqual(bridge.capabilities(), [
+    "saved_workflows_v1",
+    "run_modes_v1",
+    "scheduled_jobs_v1",
+  ]);
+
+  const result = await bridge.request("cloud_run", { task: "read this page", mode: "ask" });
+  assert.equal(result.runId, "run_1");
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].action, "cloud_run");
+  // cloud-runs.js reads `task` and `mode` off the spread payload.
+  assert.equal(seen[0].payload.task, "read this page");
+  assert.equal(seen[0].payload.mode, "ask");
+  assert.equal(typeof seen[0].id, "number");
+
+  ext.close();
+  await bridge.stop();
+});
+
+test("concurrent commands resolve to their own replies", async () => {
+  const bridge = new WebBrainBridge();
+  await bridge.start();
+
+  const ext = fakeExtension(bridgeUrl(), async (msg) => {
+    // Answer out of order on purpose: correlation must be by id, not arrival.
+    const delay = msg.payload.task === "slow" ? 120 : 10;
+    await new Promise((r) => setTimeout(r, delay));
+    return { ok: true, result: { runId: msg.payload.task, status: "running" } };
+  });
+  await bridge.waitForExtension(3000);
+
+  const [slow, quick] = await Promise.all([
+    bridge.request("cloud_run", { task: "slow", mode: "ask" }),
+    bridge.request("cloud_run", { task: "quick", mode: "ask" }),
+  ]);
+  assert.equal(slow.runId, "slow");
+  assert.equal(quick.runId, "quick");
+
+  ext.close();
+  await bridge.stop();
+});
+
+test("extension errors surface as BridgeError with status", async () => {
+  const bridge = new WebBrainBridge();
+  await bridge.start();
+
+  const ext = fakeExtension(bridgeUrl(), () => ({
+    ok: false,
+    error: "Cloud run `mode` must be `ask` or `act`.",
+    status: 400,
+  }));
+  await bridge.waitForExtension(3000);
+
+  await assert.rejects(
+    () => bridge.request("cloud_run", { task: "x", mode: "sideways" }),
+    (error) => {
+      assert.ok(error instanceof BridgeError);
+      assert.equal(error.status, 400);
+      assert.match(error.message, /must be `ask` or `act`/);
+      return true;
+    },
+  );
+
+  ext.close();
+  await bridge.stop();
+});
+
+test("no extension attached produces an actionable message", async () => {
+  const bridge = new WebBrainBridge();
+  await bridge.start();
+
+  await assert.rejects(
+    () => bridge.request("cloud_status", {}),
+    (error) => {
+      assert.ok(error instanceof BridgeError);
+      assert.match(error.message, /No WebBrain extension is connected/);
+      assert.match(error.message, /Cloud bridge/);
+      return true;
+    },
+  );
+
+  await bridge.stop();
+});
+
+test("a client that is not the extension is rejected", async () => {
+  const bridge = new WebBrainBridge();
+  await bridge.start();
+
+  const rogue = fakeExtension(bridgeUrl(), () => ({ ok: true, result: {} }), {
+    client: "definitely-not-webbrain",
+  });
+  const closed = new Promise((resolve) => rogue.on("close", resolve));
+  await closed;
+  assert.equal(bridge.isConnected(), false, "rogue client must not be treated as the extension");
+
+  await bridge.stop();
+});
+
+test("disconnect mid-command rejects rather than hanging", async () => {
+  const bridge = new WebBrainBridge();
+  await bridge.start();
+
+  const ext = fakeExtension(bridgeUrl(), async () => {
+    // Never replies; the socket dies underneath the pending request.
+    await new Promise(() => {});
+  });
+  await bridge.waitForExtension(3000);
+
+  const pending = bridge.request("cloud_run", { task: "x", mode: "ask" });
+  setTimeout(() => ext.terminate(), 60);
+
+  await assert.rejects(pending, /disconnected mid-command/);
+  await bridge.stop();
+});
+
+test("awaitSettled polls to a terminal status", async () => {
+  const bridge = new WebBrainBridge();
+  await bridge.start();
+
+  let polls = 0;
+  const ext = fakeExtension(bridgeUrl(), (msg) => {
+    if (msg.action !== "cloud_status") return { ok: true, result: {} };
+    polls += 1;
+    return {
+      ok: true,
+      result:
+        polls < 3
+          ? { runId: "r", status: "running" }
+          : { runId: "r", status: "completed", content: "42 open invoices", finalUrl: "https://x/y" },
+    };
+  });
+  await bridge.waitForExtension(3000);
+
+  const { snapshot, timedOut } = await awaitSettled(bridge, "r", { timeoutMs: 4000 });
+  assert.equal(timedOut, false);
+  assert.equal(snapshot.status, "completed");
+  assert.ok(TERMINAL_STATUSES.has(snapshot.status));
+
+  const text = describeSnapshot(snapshot);
+  assert.match(text, /42 open invoices/);
+  assert.match(text, /final_url: https:\/\/x\/y/);
+
+  ext.close();
+  await bridge.stop();
+});
+
+test("awaitSettled stops on needs_user_input and surfaces clarify_id", async () => {
+  const bridge = new WebBrainBridge();
+  await bridge.start();
+
+  const ext = fakeExtension(bridgeUrl(), (msg) => {
+    if (msg.action !== "cloud_status") return { ok: true, result: {} };
+    return {
+      ok: true,
+      result: {
+        runId: "r",
+        status: "needs_user_input",
+        pendingInput: { clarifyId: "c_42", question: "Which account should I use?" },
+      },
+    };
+  });
+  await bridge.waitForExtension(3000);
+
+  const { snapshot } = await awaitSettled(bridge, "r", { timeoutMs: 4000 });
+  assert.equal(snapshot.status, "needs_user_input");
+
+  const text = describeSnapshot(snapshot);
+  assert.match(text, /clarify_id: c_42/);
+  assert.match(text, /Which account should I use\?/);
+  assert.match(text, /Do not invent an answer/);
+
+  ext.close();
+  await bridge.stop();
+});
+
+test("awaitSettled reports a timeout without aborting the run", async () => {
+  const bridge = new WebBrainBridge();
+  await bridge.start();
+
+  const actions = [];
+  const ext = fakeExtension(bridgeUrl(), (msg) => {
+    actions.push(msg.action);
+    return { ok: true, result: { runId: "r", status: "running" } };
+  });
+  await bridge.waitForExtension(3000);
+
+  const { snapshot, timedOut } = await awaitSettled(bridge, "r", { timeoutMs: 150 });
+  assert.equal(timedOut, true);
+  assert.equal(snapshot.status, "running");
+  assert.ok(!actions.includes("cloud_abort"), "a timeout must never abort the user's run");
+  assert.match(describeSnapshot(snapshot, true), /still running/);
+
+  ext.close();
+  await bridge.stop();
+});

--- a/mcp-server/test/bridge.test.mjs
+++ b/mcp-server/test/bridge.test.mjs
@@ -155,6 +155,34 @@ test("a client that is not the extension is rejected", async () => {
   await bridge.stop();
 });
 
+test("a new socket cannot inherit an earlier extension handshake", async () => {
+  const bridge = new WebBrainBridge();
+  await bridge.start();
+
+  const extension = fakeExtension(bridgeUrl(), () => ({ ok: true, result: {} }));
+  await bridge.waitForExtension(3000);
+  assert.equal(bridge.isConnected(), true);
+
+  const rogue = new WebSocket(bridgeUrl());
+  let receivedCommands = 0;
+  rogue.on("message", () => {
+    receivedCommands += 1;
+  });
+  await new Promise((resolve) => rogue.on("open", resolve));
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(bridge.isConnected(), false, "the replacement socket has not sent hello");
+  await assert.rejects(
+    () => bridge.request("cloud_run", { task: "private task", mode: "ask" }),
+    /No WebBrain extension is connected/,
+  );
+  assert.equal(receivedCommands, 0, "an unverified socket must not receive task frames");
+
+  rogue.close();
+  extension.close();
+  await bridge.stop();
+});
+
 test("disconnect mid-command rejects rather than hanging", async () => {
   const bridge = new WebBrainBridge();
   await bridge.start();

--- a/mcp-server/test/config.test.mjs
+++ b/mcp-server/test/config.test.mjs
@@ -1,0 +1,110 @@
+/**
+ * Config parsing tests.
+ *
+ * Regression guard for a real bug: a single `intFromEnv` helper applied a
+ * port-shaped 1-65535 ceiling to every numeric setting, so exporting the
+ * five-minute run timeout that the README documents as the DEFAULT
+ * (`WEBBRAIN_RUN_TIMEOUT_MS=300000`) crashed the server at startup with
+ * "must be a valid TCP port".
+ *
+ * Ports and durations are different types with different bounds. These tests
+ * exist to keep them that way.
+ *
+ * Run: node --test test/config.test.mjs   (after `npm run build`)
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+/** ESM caches by URL, so a unique query string forces a fresh module + re-read of env. */
+let seq = 0;
+async function loadConfig(env) {
+  const saved = {};
+  for (const [key, value] of Object.entries(env)) {
+    saved[key] = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return await import(`../dist/config.js?case=${seq++}`);
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+const CLEAN = {
+  WEBBRAIN_BRIDGE_PORT: undefined,
+  WEBBRAIN_BRIDGE_PATH: undefined,
+  WEBBRAIN_COMMAND_TIMEOUT_MS: undefined,
+  WEBBRAIN_RUN_TIMEOUT_MS: undefined,
+  WEBBRAIN_POLL_INTERVAL_MS: undefined,
+};
+
+test("defaults are sane and the bridge URL is loopback", async () => {
+  const { config, bridgeUrl } = await loadConfig(CLEAN);
+  assert.equal(config.bridgePort, 17374, "must not collide with Cloud on 17373");
+  assert.equal(config.bridgePath, "/extension");
+  assert.equal(config.commandTimeoutMs, 30_000);
+  assert.equal(config.defaultRunTimeoutMs, 300_000);
+  assert.equal(config.pollIntervalMs, 1_000);
+  assert.equal(bridgeUrl(), "ws://127.0.0.1:17374/extension");
+});
+
+test("durations above the 16-bit port ceiling are accepted", async () => {
+  // The exact value the README documents. This threw before the fix.
+  const { config } = await loadConfig({ ...CLEAN, WEBBRAIN_RUN_TIMEOUT_MS: "300000" });
+  assert.equal(config.defaultRunTimeoutMs, 300_000);
+});
+
+test("every duration setting accepts a large value", async () => {
+  const { config } = await loadConfig({
+    ...CLEAN,
+    WEBBRAIN_COMMAND_TIMEOUT_MS: "120000",
+    WEBBRAIN_RUN_TIMEOUT_MS: "3600000",
+    WEBBRAIN_POLL_INTERVAL_MS: "250000",
+  });
+  assert.equal(config.commandTimeoutMs, 120_000);
+  assert.equal(config.defaultRunTimeoutMs, 3_600_000);
+  assert.equal(config.pollIntervalMs, 250_000);
+});
+
+test("ports keep their 1-65535 bound", async () => {
+  await assert.rejects(
+    () => loadConfig({ ...CLEAN, WEBBRAIN_BRIDGE_PORT: "70000" }),
+    /must be a valid TCP port/,
+  );
+  await assert.rejects(
+    () => loadConfig({ ...CLEAN, WEBBRAIN_BRIDGE_PORT: "0" }),
+    /must be a valid TCP port/,
+  );
+});
+
+test("non-numeric and partially-numeric values are rejected outright", async () => {
+  await assert.rejects(
+    () => loadConfig({ ...CLEAN, WEBBRAIN_BRIDGE_PORT: "abc" }),
+    /must be an integer/,
+  );
+  // parseInt("8080abc") silently yields 8080; that is a typo, not a config.
+  await assert.rejects(
+    () => loadConfig({ ...CLEAN, WEBBRAIN_BRIDGE_PORT: "8080abc" }),
+    /must be an integer/,
+  );
+  await assert.rejects(
+    () => loadConfig({ ...CLEAN, WEBBRAIN_RUN_TIMEOUT_MS: "5s" }),
+    /must be an integer/,
+  );
+});
+
+test("non-positive durations are rejected", async () => {
+  await assert.rejects(
+    () => loadConfig({ ...CLEAN, WEBBRAIN_POLL_INTERVAL_MS: "0" }),
+    /positive duration in milliseconds/,
+  );
+  await assert.rejects(
+    () => loadConfig({ ...CLEAN, WEBBRAIN_COMMAND_TIMEOUT_MS: "-1" }),
+    /positive duration in milliseconds/,
+  );
+});

--- a/mcp-server/test/runs-request-timeout.test.mjs
+++ b/mcp-server/test/runs-request-timeout.test.mjs
@@ -63,3 +63,20 @@ test("a command timeout returns the run ID instead of losing recovery access", a
   assert.equal(result.snapshot.runId, "recoverable-run");
   assert.equal(result.snapshot.status, "running");
 });
+
+test("a disconnected status request preserves recovery access to the run", async () => {
+  const bridge = {
+    async request() {
+      throw new BridgeError(
+        "extension disconnected mid-command",
+        undefined,
+        "COMMAND_INTERRUPTED",
+      );
+    },
+  };
+
+  const result = await awaitSettled(bridge, "interrupted-run", { timeoutMs: 5_000 });
+  assert.equal(result.timedOut, true);
+  assert.equal(result.snapshot.runId, "interrupted-run");
+  assert.equal(result.snapshot.status, "running");
+});

--- a/mcp-server/test/runs-request-timeout.test.mjs
+++ b/mcp-server/test/runs-request-timeout.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.WEBBRAIN_POLL_INTERVAL_MS = "5";
+
+const { awaitSettled } = await import("../dist/runs.js");
+
+test("awaitSettled bounds each status request by the remaining run budget", async () => {
+  let observedRequestTimeout;
+  const bridge = {
+    async request(_action, _payload, requestTimeoutMs) {
+      observedRequestTimeout = requestTimeoutMs;
+      const delayMs = (requestTimeoutMs ?? 500) + 5;
+      return await new Promise((_resolve, reject) => {
+        setTimeout(() => reject(new Error("status response stalled")), delayMs);
+      });
+    },
+  };
+
+  const startedAt = Date.now();
+  const result = await awaitSettled(bridge, "stalled-run", { timeoutMs: 40 });
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.equal(result.timedOut, true);
+  assert.equal(result.snapshot.status, "running");
+  assert.ok(observedRequestTimeout > 0 && observedRequestTimeout < 40);
+  assert.ok(elapsedMs < 250, `40ms timeout took ${elapsedMs}ms`);
+});

--- a/mcp-server/test/runs-request-timeout.test.mjs
+++ b/mcp-server/test/runs-request-timeout.test.mjs
@@ -29,6 +29,26 @@ test("startRun forwards its caller-supplied run ID and command budget", async ()
   });
 });
 
+test("startRun rejects API mutation permission in ask mode before dispatch", async () => {
+  let dispatched = false;
+  const bridge = {
+    async request() {
+      dispatched = true;
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      startRun(bridge, {
+        task: "read the page",
+        mode: "ask",
+        apiMutationsAllowed: true,
+      }),
+    /requires mode 'act'/,
+  );
+  assert.equal(dispatched, false);
+});
+
 test("awaitSettled bounds each status request by the remaining run budget", async () => {
   let observedRequestTimeout;
   const bridge = {

--- a/mcp-server/test/runs-request-timeout.test.mjs
+++ b/mcp-server/test/runs-request-timeout.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 process.env.WEBBRAIN_POLL_INTERVAL_MS = "5";
 
 const { awaitSettled } = await import("../dist/runs.js");
+const { BridgeError } = await import("../dist/bridge.js");
 
 test("awaitSettled bounds each status request by the remaining run budget", async () => {
   let observedRequestTimeout;
@@ -25,4 +26,17 @@ test("awaitSettled bounds each status request by the remaining run budget", asyn
   assert.equal(result.snapshot.status, "running");
   assert.ok(observedRequestTimeout > 0 && observedRequestTimeout < 40);
   assert.ok(elapsedMs < 250, `40ms timeout took ${elapsedMs}ms`);
+});
+
+test("a command timeout returns the run ID instead of losing recovery access", async () => {
+  const bridge = {
+    async request() {
+      throw new BridgeError("status command timed out", undefined, "COMMAND_TIMEOUT");
+    },
+  };
+
+  const result = await awaitSettled(bridge, "recoverable-run", { timeoutMs: 5_000 });
+  assert.equal(result.timedOut, true);
+  assert.equal(result.snapshot.runId, "recoverable-run");
+  assert.equal(result.snapshot.status, "running");
 });

--- a/mcp-server/test/runs-request-timeout.test.mjs
+++ b/mcp-server/test/runs-request-timeout.test.mjs
@@ -67,7 +67,7 @@ test("awaitSettled bounds each status request by the remaining run budget", asyn
 
   assert.equal(result.timedOut, true);
   assert.equal(result.snapshot.status, "running");
-  assert.ok(observedRequestTimeout > 0 && observedRequestTimeout < 40);
+  assert.ok(observedRequestTimeout > 0 && observedRequestTimeout <= 40);
   assert.ok(elapsedMs < 250, `40ms timeout took ${elapsedMs}ms`);
 });
 

--- a/mcp-server/test/runs-request-timeout.test.mjs
+++ b/mcp-server/test/runs-request-timeout.test.mjs
@@ -3,8 +3,31 @@ import test from "node:test";
 
 process.env.WEBBRAIN_POLL_INTERVAL_MS = "5";
 
-const { awaitSettled } = await import("../dist/runs.js");
+const { awaitSettled, startRun } = await import("../dist/runs.js");
 const { BridgeError } = await import("../dist/bridge.js");
+
+test("startRun forwards its caller-supplied run ID and command budget", async () => {
+  let observed;
+  const bridge = {
+    async request(action, payload, requestTimeoutMs) {
+      observed = { action, payload, requestTimeoutMs };
+      return { runId: payload.runId, status: "running" };
+    },
+  };
+
+  const result = await startRun(
+    bridge,
+    { runId: "recoverable-start", task: "do work", mode: "ask" },
+    25,
+  );
+
+  assert.equal(result.runId, "recoverable-start");
+  assert.deepEqual(observed, {
+    action: "cloud_run",
+    payload: { runId: "recoverable-start", task: "do work", mode: "ask" },
+    requestTimeoutMs: 25,
+  });
+});
 
 test("awaitSettled bounds each status request by the remaining run budget", async () => {
   let observedRequestTimeout;

--- a/mcp-server/test/runs-timeout.test.mjs
+++ b/mcp-server/test/runs-timeout.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// Load runs.ts with a poll interval much longer than the requested run timeout.
+// Before the deadline cap, this 20ms timeout blocked for the full 500ms poll.
+process.env.WEBBRAIN_POLL_INTERVAL_MS = "500";
+
+const { awaitSettled } = await import("../dist/runs.js");
+
+test("awaitSettled never sleeps past the requested deadline", async () => {
+  const bridge = {
+    async request() {
+      return { runId: "deadline-run", status: "running" };
+    },
+  };
+
+  const startedAt = Date.now();
+  const result = await awaitSettled(bridge, "deadline-run", { timeoutMs: 20 });
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.equal(result.timedOut, true);
+  assert.equal(result.snapshot.status, "running");
+  assert.ok(elapsedMs < 250, `20ms timeout took ${elapsedMs}ms`);
+});

--- a/mcp-server/test/runs-timeout.test.mjs
+++ b/mcp-server/test/runs-timeout.test.mjs
@@ -8,8 +8,10 @@ process.env.WEBBRAIN_POLL_INTERVAL_MS = "500";
 const { awaitSettled } = await import("../dist/runs.js");
 
 test("awaitSettled never sleeps past the requested deadline", async () => {
+  let requestCount = 0;
   const bridge = {
     async request() {
+      requestCount += 1;
       return { runId: "deadline-run", status: "running" };
     },
   };
@@ -20,5 +22,22 @@ test("awaitSettled never sleeps past the requested deadline", async () => {
 
   assert.equal(result.timedOut, true);
   assert.equal(result.snapshot.status, "running");
+  assert.ok(requestCount >= 1, "the run must be polled before the first sleep");
   assert.ok(elapsedMs < 250, `20ms timeout took ${elapsedMs}ms`);
+});
+
+test("awaitSettled polls immediately when the timeout is shorter than the interval", async () => {
+  let requestCount = 0;
+  const bridge = {
+    async request() {
+      requestCount += 1;
+      return { runId: "fast-run", status: "completed", result: "done" };
+    },
+  };
+
+  const result = await awaitSettled(bridge, "fast-run", { timeoutMs: 20 });
+
+  assert.equal(result.timedOut, false);
+  assert.equal(result.snapshot.status, "completed");
+  assert.equal(requestCount, 1);
 });

--- a/mcp-server/test/stdio-shutdown.test.mjs
+++ b/mcp-server/test/stdio-shutdown.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createServer } from "node:net";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const packageDir = fileURLToPath(new URL("..", import.meta.url));
+
+async function freePort() {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  server.close();
+  await once(server, "close");
+  return port;
+}
+
+function waitForText(stream, pattern, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let output = "";
+    const timer = setTimeout(() => {
+      stream.off("data", onData);
+      reject(new Error(`Timed out waiting for ${pattern}; stderr was: ${output}`));
+    }, timeoutMs);
+    const onData = (chunk) => {
+      output += chunk.toString();
+      if (!pattern.test(output)) return;
+      clearTimeout(timer);
+      stream.off("data", onData);
+      resolve(output);
+    };
+    stream.on("data", onData);
+  });
+}
+
+test("closing MCP stdin stops the bridge process", async () => {
+  const port = await freePort();
+  const child = spawn(process.execPath, ["dist/index.js"], {
+    cwd: packageDir,
+    env: { ...process.env, WEBBRAIN_BRIDGE_PORT: String(port) },
+    stdio: ["pipe", "ignore", "pipe"],
+  });
+
+  try {
+    await waitForText(child.stderr, /ready on stdio/, 7_000);
+    const exited = once(child, "exit");
+    child.stdin.end();
+
+    const [code, signal] = await Promise.race([
+      exited,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("MCP process stayed alive after stdin EOF")), 2_000),
+      ),
+    ]);
+    assert.equal(signal, null);
+    assert.equal(code, 0);
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) child.kill();
+  }
+});

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -4457,6 +4457,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   async _executeToolBatch(tabId, toolCalls, messages, onUpdate, provider, partialAssistantText = null, allowedToolNames = AGENT_TOOL_NAMES, step = null, runOptions = {}, toolSchemas = null) {
     let didStateChange = false;
+    const apiMutationsDeniedForRun = runOptions.apiMutationsDenied === true;
+    const apiMutationsAllowedForRun = () =>
+      !apiMutationsDeniedForRun && this.isApiMutationsAllowed(tabId);
     const promptTier = this._resolvePromptTier();
     const completionBatchStartState = this.completionInvariants.get(tabId) || null;
     // Set of tools whose side effect can navigate the page. We snapshot the
@@ -4727,18 +4730,25 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         onUpdate('warning', { message });
         continue;
       }
-      if (isNetworkMutation(fnName, fnArgs) && !this.isApiMutationsAllowed(tabId)) {
+      if (isNetworkMutation(fnName, fnArgs) && !apiMutationsAllowedForRun()) {
+        const askModeError = apiMutationsDeniedForRun
+          ? `API mutations via ${fnName} are not allowed in Ask mode. Do not retry this mutating API call in this run; continue with read-only tools or return what you can observe.`
+          : `API mutations via ${fnName} require the user to enable /allow-api for this conversation. Do not retry this mutating API call unless the user enables /allow-api; continue through the visible UI or ask the user to type /allow-api.`;
         messages.push({
           role: 'tool',
           tool_call_id: tc.id,
           content: JSON.stringify({
             success: false,
             denied: true,
-            requiresApiAllow: true,
-            error: `API mutations via ${fnName} require the user to enable /allow-api for this conversation. Do not retry this mutating API call unless the user enables /allow-api; continue through the visible UI or ask the user to type /allow-api.`,
+            requiresApiAllow: !apiMutationsDeniedForRun,
+            error: askModeError,
           }),
         });
-        onUpdate('warning', { message: 'API mutation blocked until /allow-api is enabled.' });
+        onUpdate('warning', {
+          message: apiMutationsDeniedForRun
+            ? 'API mutation blocked because Ask mode is read-only.'
+            : 'API mutation blocked until /allow-api is enabled.',
+        });
         continue;
       }
       const formValidationCandidate = !protectedPageFailure
@@ -4882,7 +4892,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         for (const capability of capabilities) {
           if (!requiresMandatoryWebMCPGates && this._skipPermissionGate) { gateDisabled = true; break; }
           // /allow-api waives ONLY write-method network egress.
-          if (capability === Capability.NETWORK && isNetworkMutation(fnName, fnArgs) && this.isApiMutationsAllowed(tabId)) continue;
+          if (capability === Capability.NETWORK && isNetworkMutation(fnName, fnArgs) && apiMutationsAllowedForRun()) continue;
           // Every distinct host the call touches must be granted. Usually one,
           // but download_files takes a urls[] array that can span many hosts.
           const gateArgs = this._skillPermissionArgsForCapability(skillCallTool, capability, fnArgs);

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -465,6 +465,9 @@ export class Agent extends LoopDetector {
     // clearConversation. Persisted with the conversation so a service
     // worker restart preserves it.
     this.apiAllowedTabs = new Set();
+    // Cloud callers can grant API mutations for one managed run without
+    // mutating the conversation's persistent /allow-api choice.
+    this.temporaryApiAllowedTabs = new Set();
     // Global Advanced-setting opt-in. This is deliberately separate from
     // apiAllowedTabs so resetting a conversation clears only its slash-command
     // override, while disabling the stored setting revokes global permission
@@ -1668,6 +1671,30 @@ export class Agent extends LoopDetector {
       this.apiAllowedTabs.add(tabId);
     } else {
       this.apiAllowedTabs.delete(tabId);
+      if (!this.isApiMutationsAllowed(tabId)) this.apiAllowedInjected.delete(tabId);
+    }
+  }
+
+  setTemporaryApiMutationsAllowed(tabId, allowed) {
+    if (allowed) {
+      this.temporaryApiAllowedTabs.add(tabId);
+      return;
+    }
+
+    this.temporaryApiAllowedTabs.delete(tabId);
+    // A user may have enabled /allow-api or the global setting while the run
+    // was active. In that case the injected authorization is still current.
+    if (this.isApiMutationsAllowed(tabId)) return;
+
+    if (this.apiAllowedInjected.has(tabId)) {
+      const messages = this.conversations.get(tabId);
+      if (Array.isArray(messages)) {
+        messages.push({
+          role: 'user',
+          content: '[CURRENT API MUTATION AUTHORIZATION — NOT ALLOWED: The temporary API mutation authorization for the completed browser run has ended. This current state supersedes any earlier [USER OVERRIDE — API MUTATIONS ALLOWED] note. Do not plan or call POST/PUT/PATCH/DELETE requests through fetch_url or research_url unless the user explicitly enables /allow-api for this conversation. Continue through the visible UI or ask for /allow-api.]',
+        });
+        this._persist(tabId);
+      }
       this.apiAllowedInjected.delete(tabId);
     }
   }
@@ -1682,7 +1709,7 @@ export class Agent extends LoopDetector {
     // system prompt cannot retract it. Append the live state only for chats
     // that actually saw that note and lost their effective authorization.
     for (const tabId of [...this.apiAllowedInjected]) {
-      if (this.apiAllowedTabs.has(tabId)) continue;
+      if (this.isApiMutationsAllowed(tabId)) continue;
       const messages = this.conversations.get(tabId);
       if (Array.isArray(messages)) {
         messages.push({
@@ -1696,7 +1723,9 @@ export class Agent extends LoopDetector {
   }
 
   isApiMutationsAllowed(tabId) {
-    return this.alwaysAllowApiMutations || this.apiAllowedTabs.has(tabId);
+    return this.alwaysAllowApiMutations
+      || this.apiAllowedTabs.has(tabId)
+      || this.temporaryApiAllowedTabs.has(tabId);
   }
 
   // Browser-free loop detection is inherited from LoopDetector. These
@@ -11337,6 +11366,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this._compactCooldown.delete(tabId);
     this.hydratedTabs.delete(tabId);
     this.apiAllowedTabs.delete(tabId);
+    this.temporaryApiAllowedTabs.delete(tabId);
     this.apiAllowedInjected.delete(tabId);
     this._cleanupTab(tabId, { preserveRunGuard: true });
     const t = this.persistTimers.get(tabId);

--- a/src/chrome/src/cloud-runs.js
+++ b/src/chrome/src/cloud-runs.js
@@ -1033,6 +1033,9 @@ export function createCloudRunController({
     if (agent.isRunning(tabId)) throw new Error(`Tab ${tabId} already has an active WebBrain run.`);
 
     const apiMutationsAllowed = msg.apiMutationsAllowed === true || msg.api_mutations_allowed === true;
+    if (apiMutationsAllowed && mode !== 'act') {
+      throw cloudRunError('API mutation permission requires cloud_run mode `act`.', 400);
+    }
     const grantApiMutationsForRun = apiMutationsAllowed
       && agent.isApiMutationsAllowed?.(tabId) !== true;
     const outputSchema = workflow

--- a/src/chrome/src/cloud-runs.js
+++ b/src/chrome/src/cloud-runs.js
@@ -1102,7 +1102,7 @@ export function createCloudRunController({
             filename: `webbrain-ci-${run.runId}.webm`,
           });
         }
-        if (grantApiMutationsForRun) agent.setApiMutationsAllowed(tabId, true);
+        if (grantApiMutationsForRun) agent.setTemporaryApiMutationsAllowed(tabId, true);
         sendIndicator(tabId, 'WB_SHOW_AGENT_INDICATORS');
         const publishUpdate = (type, data) => pushUpdate(
           run,
@@ -1190,7 +1190,7 @@ export function createCloudRunController({
         // The bridge flag is a run-scoped grant, not the sidebar's persistent
         // /allow-api setting. Revoke only permission this run added; preserve a
         // pre-existing per-conversation or global user grant.
-        if (grantApiMutationsForRun) agent.setApiMutationsAllowed(tabId, false);
+        if (grantApiMutationsForRun) agent.setTemporaryApiMutationsAllowed(tabId, false);
 
         // Do not expose a terminal status until the requested recording has
         // finished flushing to Downloads; pollers use terminality as the cue

--- a/src/chrome/src/cloud-runs.js
+++ b/src/chrome/src/cloud-runs.js
@@ -1033,6 +1033,8 @@ export function createCloudRunController({
     if (agent.isRunning(tabId)) throw new Error(`Tab ${tabId} already has an active WebBrain run.`);
 
     const apiMutationsAllowed = msg.apiMutationsAllowed === true || msg.api_mutations_allowed === true;
+    const grantApiMutationsForRun = apiMutationsAllowed
+      && agent.isApiMutationsAllowed?.(tabId) !== true;
     const outputSchema = workflow
       ? null
       : msg.outputSchema ?? msg.output_schema ?? msg.responseFormat?.schema ?? msg.response_format?.schema ?? null;
@@ -1100,7 +1102,7 @@ export function createCloudRunController({
             filename: `webbrain-ci-${run.runId}.webm`,
           });
         }
-        if (apiMutationsAllowed) agent.setApiMutationsAllowed(tabId, true);
+        if (grantApiMutationsForRun) agent.setApiMutationsAllowed(tabId, true);
         sendIndicator(tabId, 'WB_SHOW_AGENT_INDICATORS');
         const publishUpdate = (type, data) => pushUpdate(
           run,
@@ -1185,6 +1187,11 @@ export function createCloudRunController({
         );
         run.finalUrl = cloudTerminalUrl(redactWorkflowValue(await getTabUrl(tabId)), { strictSecretMode });
       } finally {
+        // The bridge flag is a run-scoped grant, not the sidebar's persistent
+        // /allow-api setting. Revoke only permission this run added; preserve a
+        // pre-existing per-conversation or global user grant.
+        if (grantApiMutationsForRun) agent.setApiMutationsAllowed(tabId, false);
+
         // Do not expose a terminal status until the requested recording has
         // finished flushing to Downloads; pollers use terminality as the cue
         // that traces and artifacts are complete.

--- a/src/chrome/src/cloud-runs.js
+++ b/src/chrome/src/cloud-runs.js
@@ -1149,6 +1149,7 @@ export function createCloudRunController({
           content = await agent.processMessage(tabId, task, publishUpdate, mode, [], {
             cloudRun: true,
             independentRun: true,
+            apiMutationsDenied: mode === 'ask',
             outputSchema,
             onTraceStarted(traceRunId) {
               run.traceRunId = traceRunId;

--- a/test/run.js
+++ b/test/run.js
@@ -11504,6 +11504,13 @@ test('cloud run controller uses the visible tab and persists terminal status', a
     makeRunId: () => 'run_test',
     now: (() => { let tick = 0; return () => new Date(1700000000000 + tick++ * 1000); })(),
   });
+  await assert.rejects(
+    () => controller.startRun({ task: 'Read Google', mode: 'ask', apiMutationsAllowed: true }),
+    /requires cloud_run mode `act`/,
+  );
+  assert.deepEqual(temporaryApiMutationsAllowedCalls, [],
+    'Ask mode dispatched an API mutation permission grant');
+  assert.equal(processArgs, null, 'Ask mode started an agent run with API mutation permission');
   const started = await controller.startRun({ task: 'Open Google', apiMutationsAllowed: true });
   assert.equal(started.status, 'running');
   assert.equal(started.tabId, 17);

--- a/test/run.js
+++ b/test/run.js
@@ -11907,6 +11907,7 @@ test('cloud run controller forwards Ask mode and inherits it for continuations',
   const session = {};
   const tab = { id: 81, url: 'https://en.wikipedia.org/wiki/Alan_Turing', active: true, windowId: 8 };
   const modes = [];
+  const apiMutationDenials = [];
   let nextRun = 0;
   const controller = createCloudRunController({
     chromeApi: {
@@ -11928,8 +11929,9 @@ test('cloud run controller forwards Ask mode and inherits it for continuations',
     agent: {
       isRunning: () => false,
       abort: () => {},
-      processMessage: async (_tabId, task, _onUpdate, mode) => {
+      processMessage: async (_tabId, task, _onUpdate, mode, _attachments, runOptions) => {
         modes.push(mode);
+        apiMutationDenials.push(runOptions.apiMutationsDenied);
         return `Finished: ${task}`;
       },
     },
@@ -11945,6 +11947,8 @@ test('cloud run controller forwards Ask mode and inherits it for continuations',
   assert.equal(parent.mode, 'ask');
   assert.equal(child.mode, 'ask');
   assert.deepEqual(modes, ['ask', 'ask']);
+  assert.deepEqual(apiMutationDenials, [true, true],
+    'Ask cloud runs did not override existing API mutation grants at dispatch');
   await assert.rejects(
     () => controller.startRun({ task: 'Invalid mode', mode: 'dev' }),
     /must be `ask` or `act`/,
@@ -44169,6 +44173,48 @@ test('agent allows mutating fetch_url after conversation or persistent API appro
       assert.doesNotMatch(messages[0].content, /requiresApiAllow/, `${AgentClass.name}: ${approval} mutation was still blocked`);
     }
   }
+});
+
+test('cloud Ask dispatch blocks API mutations even with an existing conversation grant', async () => {
+  const agent = new AgentCh({ getVisionProvider: async () => null });
+  const tabId = 4906;
+  let executed = false;
+  agent.executeTool = async () => {
+    executed = true;
+    return { success: true };
+  };
+  agent._ensureGateSetting = async () => {};
+  agent._skipPermissionGate = true;
+  agent.setApiMutationsAllowed(tabId, true);
+  const messages = [];
+  const updates = [];
+
+  await agent._executeToolBatch(
+    tabId,
+    [{
+      id: 'ask_mutation',
+      function: {
+        name: 'fetch_url',
+        arguments: '{"url":"https://example.test/account","method":"POST"}',
+      },
+    }],
+    messages,
+    (type, data) => updates.push({ type, data }),
+    { supportsVision: false },
+    '',
+    new Set(['fetch_url']),
+    1,
+    { apiMutationsDenied: true },
+  );
+
+  assert.equal(executed, false, 'Ask run dispatched a mutating API call');
+  assert.equal(agent.isApiMutationsAllowed(tabId), true,
+    'Ask run erased the conversation grant instead of overriding it temporarily');
+  const denied = JSON.parse(messages[0].content);
+  assert.equal(denied.denied, true);
+  assert.equal(denied.requiresApiAllow, false);
+  assert.match(denied.error, /not allowed in Ask mode/);
+  assert.ok(updates.some(update => /Ask mode is read-only/.test(update.data?.message || '')));
 });
 
 test('agent counts failed API mutation batch as one loop strategy', async () => {

--- a/test/run.js
+++ b/test/run.js
@@ -11469,6 +11469,7 @@ test('cloud run controller uses the visible tab and persists terminal status', a
   const apiMutationsAllowedCalls = [];
   const agent = {
     isRunning: () => false,
+    isApiMutationsAllowed: () => false,
     abort: () => {},
     setApiMutationsAllowed: (...args) => apiMutationsAllowedCalls.push(args),
     processMessage: (...args) => {
@@ -11588,6 +11589,8 @@ test('cloud run controller uses the visible tab and persists terminal status', a
   assert.equal(completed.status, 'completed');
   assert.equal(completed.result, 'Google');
   assert.equal(session.webbrainCloudRunSnapshots[0].status, 'completed');
+  assert.deepEqual(apiMutationsAllowedCalls, [[17, true], [17, false]],
+    'run-scoped API mutation permission was not revoked');
 });
 
 test('cloud run controller preserves a boolean false root output schema', async () => {

--- a/test/run.js
+++ b/test/run.js
@@ -11466,12 +11466,12 @@ test('cloud run controller uses the visible tab and persists terminal status', a
   let createdTabs = 0;
   let finishRun;
   let processArgs = null;
-  const apiMutationsAllowedCalls = [];
+  const temporaryApiMutationsAllowedCalls = [];
   const agent = {
     isRunning: () => false,
     isApiMutationsAllowed: () => false,
     abort: () => {},
-    setApiMutationsAllowed: (...args) => apiMutationsAllowedCalls.push(args),
+    setTemporaryApiMutationsAllowed: (...args) => temporaryApiMutationsAllowedCalls.push(args),
     processMessage: (...args) => {
       processArgs = args;
       return new Promise(resolve => { finishRun = resolve; });
@@ -11508,7 +11508,7 @@ test('cloud run controller uses the visible tab and persists terminal status', a
   assert.equal(started.status, 'running');
   assert.equal(started.tabId, 17);
   assert.equal(createdTabs, 0, 'a loaded pendingUrl tab should be reused instead of opening about:blank');
-  assert.deepEqual(apiMutationsAllowedCalls, [[17, true]]);
+  assert.deepEqual(temporaryApiMutationsAllowedCalls, [[17, true]]);
   assert.equal(processArgs[1], 'Open Google', 'hidden API allowance must not modify the task text');
   assert.equal(processArgs[3], 'act');
   assert.equal(started.mode, 'act');
@@ -11589,7 +11589,7 @@ test('cloud run controller uses the visible tab and persists terminal status', a
   assert.equal(completed.status, 'completed');
   assert.equal(completed.result, 'Google');
   assert.equal(session.webbrainCloudRunSnapshots[0].status, 'completed');
-  assert.deepEqual(apiMutationsAllowedCalls, [[17, true], [17, false]],
+  assert.deepEqual(temporaryApiMutationsAllowedCalls, [[17, true], [17, false]],
     'run-scoped API mutation permission was not revoked');
 });
 
@@ -40971,6 +40971,38 @@ test('persistent API mutation permission is global and independent of /allow-api
     agent.clearConversation(tabId);
     assert.equal(agent.isApiMutationsAllowed(tabId), true, `${AgentClass.name}: reset cleared the persistent permission`);
   }
+});
+
+test('temporary API mutation permission retracts its prompt without overriding user grants', () => {
+  const agent = new AgentCh({});
+  const revokedTabId = 4894;
+  const stillAllowedTabId = 4895;
+  const revokedMessages = [{ role: 'system', content: 'sys' }];
+  const stillAllowedMessages = [{ role: 'system', content: 'sys' }];
+  const persisted = [];
+  agent._persist = tabId => persisted.push(tabId);
+  agent.conversations.set(revokedTabId, revokedMessages);
+  agent.conversations.set(stillAllowedTabId, stillAllowedMessages);
+
+  agent.setTemporaryApiMutationsAllowed(revokedTabId, true);
+  agent.apiAllowedInjected.add(revokedTabId);
+  agent.setTemporaryApiMutationsAllowed(revokedTabId, false);
+
+  assert.equal(agent.isApiMutationsAllowed(revokedTabId), false);
+  assert.equal(revokedMessages.at(-1)?.role, 'user');
+  assert.match(revokedMessages.at(-1)?.content || '', /CURRENT API MUTATION AUTHORIZATION — NOT ALLOWED/);
+  assert.match(revokedMessages.at(-1)?.content || '', /temporary API mutation authorization/);
+  assert.equal(agent.apiAllowedInjected.has(revokedTabId), false);
+  assert.deepEqual(persisted, [revokedTabId]);
+
+  agent.setTemporaryApiMutationsAllowed(stillAllowedTabId, true);
+  agent.apiAllowedInjected.add(stillAllowedTabId);
+  agent.setApiMutationsAllowed(stillAllowedTabId, true);
+  agent.setTemporaryApiMutationsAllowed(stillAllowedTabId, false);
+
+  assert.equal(agent.isApiMutationsAllowed(stillAllowedTabId), true);
+  assert.equal(stillAllowedMessages.length, 1);
+  assert.equal(agent.apiAllowedInjected.has(stillAllowedTabId), true);
 });
 
 test('disabling persistent API permission retracts stale prompt authorization in both builds', () => {


### PR DESCRIPTION
## Summary

Adds `mcp-server/`, a Model Context Protocol server that lets any MCP client — Claude Code, Codex, Cursor, OpenClaw — delegate a browser task to WebBrain running in the user's **real, already-authenticated session**. Extends the LM Studio plugin with the same capability via `browser_task` / `browser_status`.

That session is the whole point. A headless automation framework starts logged out of everything and stalls at the first login wall. WebBrain is already inside the browser the user is signed into.

```
Claude Code ──stdio──▶ webbrain-mcp ──ws://127.0.0.1:17374──▶ WebBrain extension ──▶ your tabs
```

**No extension changes.** Both clients speak the `cloud_*` actions already present in `ALLOWED_BRIDGE_ACTIONS`, so this works against the shipping extension (v26.2.1) with nothing to release.

## Why task-level, and not the ~50 browser primitives

This was the main design decision, and it went the opposite way from where I started.

**Safety.** WebBrain's capability × origin permission gate runs in the agent loop (`_executeToolBatch`, `agent.js:4572`), *not* inside `executeTool()` (`agent.js:15587`). An MCP layer calling primitives directly would sit below the gate and bypass every approval prompt the product is built on. Delegating a goal routes through `agent.processMessage()` and keeps the trust boundary in the browser, where the human is.

**Cost.** Driving a UI one primitive at a time over a socket costs a round trip and a slab of tokens per click. Handing over a goal costs one call.

If fine-grained control is ever genuinely demanded, that's a separate change that relocates the gate — and it should be scoped as such, not smuggled in here.

## Tools

**MCP server**

| Tool | Purpose |
|---|---|
| `webbrain_run` | Delegate a task. `mode='ask'` is read-only; `mode='act'` can click and type, gated by in-browser approval. |
| `webbrain_status` | Poll a run, or list every run. |
| `webbrain_respond` | Answer a run sitting at `needs_user_input`. |
| `webbrain_abort` | Stop a run. Actions already taken are not undone. |
| `webbrain_connection` | Report whether the extension is attached, and how to fix it if not. |

**LM Studio plugin** — `browser_task`, `browser_status` added alongside the existing `fetch_url` / `research_url`, which keep working with no extension installed.

## Ports

Cloud owns `17373`, the MCP server `17374`, the LM Studio plugin `17375`. The extension holds exactly **one** outbound bridge socket, so precisely one is attachable at a time; switch via **Settings → Cloud bridge**. Distinct ports keep the failure mode legible ("nothing connected") instead of two processes fighting over one listener.

## Verification

- **9/9 bridge tests** (`node --test mcp-server/test/bridge.test.mjs`) drive a fake extension emitting the exact frames `src/chrome/src/offscreen/cloud-bridge.js` sends: handshake, id correlation under deliberately out-of-order replies, error propagation with status codes, disconnect mid-command, poll-to-terminal, `needs_user_input` with `clarify_id` surfacing, and timeout-without-abort. If the extension's wire format changes, these fail — that's intentional.
- **MCP stdio probe**: registers as `webbrain 0.1.0`, all five tools list with correct required fields, `webbrain_connection` returns actionable remediation text.
- **LM Studio e2e**: 7/7 — degrades cleanly with no extension, connects, completes a task, and the outgoing `cloud_run` payload is exactly `{task, mode}`, matching what `cloud-runs.js` reads.
- Both packages typecheck clean under strict TS.

## Reviewer notes

Things I'd want a second opinion on:

- **The `hello` client check is NOT authentication.** Connections must present `client: "webbrain-extension"` and anything else is closed, but the shipping extension sends no shared secret — so a local process could impersonate it and drive the user's signed-in browser. The listener binds `127.0.0.1` only and this is documented as a known limitation in both READMEs. A real bridge token needs an extension-side change and is the obvious next hardening step.
- **A run timeout never aborts the run.** If `webbrain_run` gives up waiting, the browser keeps working and the caller resumes via `webbrain_status`. Silently killing a task that may have already submitted a form seemed worse than reporting it's still going. Worth confirming that's the call you'd make.
- **`allow_api_mutations` is omitted from the payload unless explicitly set**, rather than sent as `false`, so the extension's own default governs instead of ours.
- **`lmstudio-plugin/src/util/bridgeClient.ts` deliberately duplicates `mcp-server/src/bridge.ts`.** The two ship to different registries (LM Studio Hub and npm) and sharing a package would drag the monorepo into both installs. Noted in the LM Studio README as "change one, change the other" — but it is real duplication, and a published `@webbrain/bridge` may be the better long-term answer.
- **The browser tools are always advertised**, even with no extension attached. Hiding them would teach the model the capability doesn't exist; offering them with an actionable failure message lets it tell the user how to switch it on.

## Try it

```bash
npm install -g @webbrain/mcp-server
claude mcp add webbrain -- npx -y @webbrain/mcp-server
```

Then point **WebBrain → Settings → Cloud bridge** at `ws://127.0.0.1:17374/extension` and enable it.

```
webbrain_run(task: "open the Stripe dashboard and list last week's failed
             payments with amounts and customer emails", mode: "ask")
```

Read-only, in the tab you're already authenticated in. No API key, no headless login dance.
