### PR TITLE
Exclude WebBrain Cloud from cost limits

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -103,7 +103,9 @@ const DEFAULT_CLOUD_COST_ALLOWANCE_USD = 10;
 const PLAN_REVIEW_CONFIDENCE_DEFAULT = 0.75;
 const COST_ALLOWANCE_SESSION_KEY = 'costAllowanceSessionUsd';
 const COST_ALLOWANCE_TOTAL_KEY = 'costAllowanceTotalUsd';
-const CLOUD_COST_SPENT_KEY = 'cloudCostSpentUsd';
+// Do not inherit the legacy cloudCostSpentUsd bucket: it also contains
+// historical WebBrain Cloud estimates, which are exempt from user spend caps.
+const CLOUD_COST_SPENT_KEY = 'meteredProviderCostSpentUsd';
 const COST_EPSILON = 1e-9;
 const TOKENS_PER_MILLION = 1_000_000;
 const DEFAULT_INPUT_COST_PER_MILLION_USD = 3;
@@ -392,7 +394,7 @@ export class Agent extends LoopDetector {
     this.screenshotClickScale = new Map();
     this.costAllowanceSessionUsd = DEFAULT_CLOUD_COST_ALLOWANCE_USD;
     this.costAllowanceTotalUsd = DEFAULT_CLOUD_COST_ALLOWANCE_USD;
-    this.cloudCostSpentUsd = 0;
+    this.meteredProviderCostSpentUsd = 0;
     this._costUpdateQueue = Promise.resolve();
 
     // Strict secret-handling mode. When true, the system prompt and `done`
@@ -543,7 +545,7 @@ export class Agent extends LoopDetector {
           this.costAllowanceTotalUsd = this._normalizeCostLimit(changes[COST_ALLOWANCE_TOTAL_KEY].newValue);
         }
         if (changes[CLOUD_COST_SPENT_KEY]) {
-          this.cloudCostSpentUsd = this._normalizeCostSpent(changes[CLOUD_COST_SPENT_KEY].newValue);
+          this.meteredProviderCostSpentUsd = this._normalizeCostSpent(changes[CLOUD_COST_SPENT_KEY].newValue);
         }
       });
     } catch { /* storage API unavailable in this context */ }
@@ -1192,13 +1194,13 @@ export class Agent extends LoopDetector {
 
   _isCostMeteredProvider(provider) {
     const config = provider?.config || {};
-    if (config.category === 'local') return false;
+    // WebBrain Cloud is billed and allowance-controlled by the managed
+    // service, not by the user's per-provider API account. Its upstream token
+    // cost must not consume the extension's user-configured spend allowance.
+    if (config.providerName === 'webbrain-cloud') return false;
     if (this._isLocalBaseUrl(config.baseUrl)) return false;
     if (config.type === 'anthropic_oauth') return false;
-    const isMeteredCategory = config.category === 'cloud' || config.category === 'router';
-    if (isMeteredCategory) return true;
-    if (config.providerName === 'openrouter') return true;
-    return !!(config.apiKey && /^https?:\/\//i.test(config.baseUrl || ''));
+    return config.category === 'cloud' || config.category === 'router';
   }
 
   _usageTokenCounts(usage) {
@@ -1342,12 +1344,12 @@ export class Agent extends LoopDetector {
       ]);
       this.costAllowanceSessionUsd = this._normalizeCostLimit(stored[COST_ALLOWANCE_SESSION_KEY]);
       this.costAllowanceTotalUsd = this._normalizeCostLimit(stored[COST_ALLOWANCE_TOTAL_KEY]);
-      this.cloudCostSpentUsd = this._normalizeCostSpent(stored[CLOUD_COST_SPENT_KEY]);
+      this.meteredProviderCostSpentUsd = this._normalizeCostSpent(stored[CLOUD_COST_SPENT_KEY]);
     } catch { /* keep in-memory defaults */ }
     return {
       sessionLimitUsd: this.costAllowanceSessionUsd,
       totalLimitUsd: this.costAllowanceTotalUsd,
-      totalSpentUsd: this.cloudCostSpentUsd,
+      totalSpentUsd: this.meteredProviderCostSpentUsd,
     };
   }
 
@@ -1381,7 +1383,7 @@ export class Agent extends LoopDetector {
       const state = await this._getCostAllowanceState();
       const nextTotal = state.totalSpentUsd + costUsd;
       if (costState) costState.spentUsd = this._normalizeCostSpent(costState.spentUsd) + costUsd;
-      this.cloudCostSpentUsd = nextTotal;
+      this.meteredProviderCostSpentUsd = nextTotal;
       try { await chrome.storage.local.set({ [CLOUD_COST_SPENT_KEY]: nextTotal }); } catch {}
       return this._checkCostAllowanceState({ ...state, totalSpentUsd: nextTotal }, costState);
     });

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -715,6 +715,7 @@ export class ProviderManager {
       if (!visionModel || !visionModel.baseUrl || !visionModel.model) return null;
       return new OpenAICompatibleProvider({
         type: 'openai',
+        category: 'cloud',
         label: 'Vision Model',
         providerName: 'vision',
         baseUrl: visionModel.baseUrl,

--- a/src/chrome/src/ui/locales/ar.js
+++ b/src/chrome/src/ui/locales/ar.js
@@ -955,4 +955,5 @@ export default {
   "sp.workflows.healing.keep": "الاحتفاظ بالهدف المحفوظ",
   "sp.workflows.healing.saved": "تم تحديث {count} محددات في «{name}».",
   "sp.workflows.healing.not_saved": "لم يُحفظ المحدد الموافق عليه لـ «{name}» لأن سير العمل تغيّر أو لأن التحقق لم يكن حاسماً.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/bn.js
+++ b/src/chrome/src/ui/locales/bn.js
@@ -953,4 +953,5 @@ export default {
   "sp.workflows.healing.keep": "সংরক্ষিত লক্ষ্যটি রাখুন",
   "sp.workflows.healing.saved": "“{name}”-এ {count}টি লোকেটর আপডেট করা হয়েছে।",
   "sp.workflows.healing.not_saved": "ওয়ার্কফ্লো পরিবর্তিত হওয়ায় বা যাচাই অনিশ্চিত থাকায় “{name}”-এর অনুমোদিত লোকেটর সংরক্ষিত হয়নি।",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/de.js
+++ b/src/chrome/src/ui/locales/de.js
@@ -926,4 +926,5 @@ export default {
   "sp.workflows.healing.keep": "Gespeichertes Ziel beibehalten",
   "sp.workflows.healing.saved": "{count} Locator in „{name}“ aktualisiert.",
   "sp.workflows.healing.not_saved": "Der bestätigte Locator für „{name}“ wurde nicht gespeichert, weil sich der Workflow geändert hat oder die Prüfung nicht eindeutig war.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -554,9 +554,9 @@ export default {
   'st.display.tracing.label': 'Record traces (for model comparison)',
   'st.display.tracing.desc_html': 'Persist every run (LLM requests, responses, tool calls, screenshots) into local IndexedDB so you can inspect and compare models side-by-side. Opens in a separate Traces tab. Off by default because it adds disk writes per step. <a href="traces.html" target="_blank" style="color:var(--accent);">Open Traces page →</a>',
   'st.display.cost_session_limit.label': 'Cloud cost session allowance',
-  'st.display.cost_session_limit.desc': 'Stops cloud and OpenRouter runs before another paid model call once this session reaches the reported or estimated cost allowance. Default $10.',
+  'st.display.cost_session_limit.desc': 'Stops eligible cloud and router runs before another paid model call once this session reaches the reported or estimated cost allowance. Default $10.',
   'st.display.cost_total_limit.label': 'Cloud cost total allowance',
-  'st.display.cost_total_limit.desc': 'Tracks reported or estimated cloud/OpenRouter model spend across the extension and stops further paid calls at the allowance. Local providers are not counted.',
+  'st.display.cost_total_limit.desc': 'Tracks reported or estimated spend for eligible cloud and router model calls across the extension and stops further paid calls at the allowance.',
   'st.display.cost_reset': 'Reset spend',
   'st.display.strict_secret.label': 'Strict secret handling',
   'st.display.strict_secret.desc': 'Refuse to quote credentials (passwords, API keys, tokens, OTPs) in summaries or assistant text — even when you explicitly ask for them. Useful if you regularly share trace files or screen-share. Off by default: webbrain runs in your own browser, so by default the agent shows you values you ask for and just keeps `done` summaries tidy.',
@@ -957,4 +957,5 @@ export default {
   "sp.workflows.healing.keep": "Keep the saved target",
   "sp.workflows.healing.saved": "Updated {count} locator(s) in “{name}”.",
   "sp.workflows.healing.not_saved": "The approved locator for “{name}” was not saved because the workflow changed or verification was inconclusive.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/es.js
+++ b/src/chrome/src/ui/locales/es.js
@@ -955,4 +955,5 @@ export default {
   "sp.workflows.healing.keep": "Conservar el objetivo guardado",
   "sp.workflows.healing.saved": "Se actualizaron {count} localizadores en «{name}».",
   "sp.workflows.healing.not_saved": "El localizador aprobado para «{name}» no se guardó porque el flujo cambió o la verificación no fue concluyente.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/fa.js
+++ b/src/chrome/src/ui/locales/fa.js
@@ -953,4 +953,5 @@ export default {
   "sp.workflows.healing.keep": "حفظ هدف ذخیره‌شده",
   "sp.workflows.healing.saved": "{count} مکان‌یاب در «{name}» به‌روزرسانی شد.",
   "sp.workflows.healing.not_saved": "مکان‌یاب تأییدشدهٔ «{name}» ذخیره نشد، زیرا گردش‌کار تغییر کرده بود یا نتیجهٔ تأیید قطعی نبود.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/fr.js
+++ b/src/chrome/src/ui/locales/fr.js
@@ -955,4 +955,5 @@ export default {
   "sp.workflows.healing.keep": "Conserver la cible enregistrée",
   "sp.workflows.healing.saved": "{count} localisateur(s) mis à jour dans « {name} ».",
   "sp.workflows.healing.not_saved": "Le localisateur approuvé pour « {name} » n’a pas été enregistré, car le workflow a changé ou la vérification était incertaine.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/he.js
+++ b/src/chrome/src/ui/locales/he.js
@@ -908,4 +908,5 @@ export default {
   "sp.workflows.healing.keep": "להשאיר את היעד השמור",
   "sp.workflows.healing.saved": "עודכנו {count} מאתרים ב־„{name}”.",
   "sp.workflows.healing.not_saved": "המאתר שאושר עבור „{name}” לא נשמר משום שתהליך העבודה השתנה או שהאימות לא היה חד־משמעי.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/hi.js
+++ b/src/chrome/src/ui/locales/hi.js
@@ -953,4 +953,5 @@ export default {
   "sp.workflows.healing.keep": "सहेजा गया लक्ष्य रखें",
   "sp.workflows.healing.saved": "“{name}” में {count} लोकेटर अपडेट किए गए।",
   "sp.workflows.healing.not_saved": "“{name}” के लिए स्वीकृत लोकेटर सहेजा नहीं गया क्योंकि वर्कफ़्लो बदल गया था या सत्यापन निर्णायक नहीं था।",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/id.js
+++ b/src/chrome/src/ui/locales/id.js
@@ -955,4 +955,5 @@ export default {
   "sp.workflows.healing.keep": "Pertahankan target tersimpan",
   "sp.workflows.healing.saved": "Memperbarui {count} locator di “{name}”.",
   "sp.workflows.healing.not_saved": "Locator yang disetujui untuk “{name}” tidak disimpan karena alur kerja berubah atau verifikasi tidak meyakinkan.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/ja.js
+++ b/src/chrome/src/ui/locales/ja.js
@@ -955,4 +955,5 @@ export default {
   "sp.workflows.healing.keep": "保存済みの対象を維持",
   "sp.workflows.healing.saved": "「{name}」のロケーターを {count} 件更新しました。",
   "sp.workflows.healing.not_saved": "ワークフローが変更されたか検証結果が不確実だったため、「{name}」で承認されたロケーターは保存されませんでした。",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/ko.js
+++ b/src/chrome/src/ui/locales/ko.js
@@ -955,4 +955,5 @@ export default {
   "sp.workflows.healing.keep": "저장된 대상 유지",
   "sp.workflows.healing.saved": "“{name}”에서 로케이터 {count}개를 업데이트했습니다.",
   "sp.workflows.healing.not_saved": "워크플로가 변경되었거나 검증 결과가 불확실하여 “{name}”에서 승인한 로케이터를 저장하지 않았습니다.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/ms.js
+++ b/src/chrome/src/ui/locales/ms.js
@@ -955,4 +955,5 @@ export default {
   "sp.workflows.healing.keep": "Kekalkan sasaran tersimpan",
   "sp.workflows.healing.saved": "Mengemas kini {count} pencari dalam “{name}”.",
   "sp.workflows.healing.not_saved": "Pencari yang diluluskan untuk “{name}” tidak disimpan kerana aliran kerja berubah atau pengesahan tidak muktamad.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/nl.js
+++ b/src/chrome/src/ui/locales/nl.js
@@ -906,4 +906,5 @@ export default {
   "sp.workflows.healing.keep": "Opgeslagen doel behouden",
   "sp.workflows.healing.saved": "{count} locator(s) in ‘{name}’ bijgewerkt.",
   "sp.workflows.healing.not_saved": "De goedgekeurde locator voor ‘{name}’ is niet opgeslagen omdat de workflow was gewijzigd of de verificatie niet overtuigend was.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/pl.js
+++ b/src/chrome/src/ui/locales/pl.js
@@ -915,4 +915,5 @@ export default {
   "sp.workflows.healing.keep": "Zachowaj zapisany cel",
   "sp.workflows.healing.saved": "Zaktualizowano {count} lokalizatorów w „{name}”.",
   "sp.workflows.healing.not_saved": "Zatwierdzony lokalizator dla „{name}” nie został zapisany, ponieważ przepływ się zmienił lub weryfikacja nie była jednoznaczna.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/pt.js
+++ b/src/chrome/src/ui/locales/pt.js
@@ -953,4 +953,5 @@ export default {
   "sp.workflows.healing.keep": "Manter o alvo salvo",
   "sp.workflows.healing.saved": "Foram atualizados {count} localizadores em “{name}”.",
   "sp.workflows.healing.not_saved": "O localizador aprovado para “{name}” não foi salvo porque o fluxo mudou ou a verificação foi inconclusiva.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/ru.js
+++ b/src/chrome/src/ui/locales/ru.js
@@ -955,4 +955,5 @@ export default {
   "sp.workflows.healing.keep": "Оставить сохранённую цель",
   "sp.workflows.healing.saved": "Обновлено локаторов в «{name}»: {count}.",
   "sp.workflows.healing.not_saved": "Одобренный локатор для «{name}» не сохранён: сценарий изменился или результат проверки оказался неоднозначным.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/th.js
+++ b/src/chrome/src/ui/locales/th.js
@@ -955,4 +955,5 @@ export default {
   "sp.workflows.healing.keep": "ใช้เป้าหมายที่บันทึกไว้ต่อไป",
   "sp.workflows.healing.saved": "อัปเดตตัวระบุตำแหน่ง {count} รายการใน “{name}” แล้ว",
   "sp.workflows.healing.not_saved": "ไม่ได้บันทึกตัวระบุตำแหน่งที่อนุมัติสำหรับ “{name}” เพราะเวิร์กโฟลว์เปลี่ยนแปลงหรือผลการยืนยันไม่ชัดเจน",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/tl.js
+++ b/src/chrome/src/ui/locales/tl.js
@@ -955,4 +955,5 @@ export default {
   "sp.workflows.healing.keep": "Panatilihin ang naka-save na target",
   "sp.workflows.healing.saved": "Na-update ang {count} locator sa “{name}”.",
   "sp.workflows.healing.not_saved": "Hindi na-save ang inaprubahang locator para sa “{name}” dahil nagbago ang workflow o hindi tiyak ang beripikasyon.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/tr.js
+++ b/src/chrome/src/ui/locales/tr.js
@@ -954,4 +954,5 @@ export default {
   "sp.workflows.healing.keep": "Kayıtlı hedefi koru",
   "sp.workflows.healing.saved": "“{name}” içinde {count} bulucu güncellendi.",
   "sp.workflows.healing.not_saved": "İş akışı değiştiği veya doğrulama kesin olmadığı için “{name}” için onaylanan bulucu kaydedilmedi.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/uk.js
+++ b/src/chrome/src/ui/locales/uk.js
@@ -955,4 +955,5 @@ export default {
   "sp.workflows.healing.keep": "Залишити збережену ціль",
   "sp.workflows.healing.saved": "Оновлено локаторів у «{name}»: {count}.",
   "sp.workflows.healing.not_saved": "Схвалений локатор для «{name}» не збережено: робочий процес змінився або результат перевірки був неоднозначним.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/vi.js
+++ b/src/chrome/src/ui/locales/vi.js
@@ -953,4 +953,5 @@ export default {
   "sp.workflows.healing.keep": "Giữ mục tiêu đã lưu",
   "sp.workflows.healing.saved": "Đã cập nhật {count} bộ định vị trong “{name}”.",
   "sp.workflows.healing.not_saved": "Bộ định vị đã phê duyệt cho “{name}” không được lưu vì quy trình đã thay đổi hoặc kết quả xác minh chưa rõ ràng.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/locales/zh.js
+++ b/src/chrome/src/ui/locales/zh.js
@@ -955,4 +955,5 @@ export default {
   "sp.workflows.healing.keep": "保留原目标",
   "sp.workflows.healing.saved": "已更新“{name}”中的 {count} 个定位器。",
   "sp.workflows.healing.not_saved": "“{name}”中已批准的定位器未保存，因为工作流已发生变化或验证结果不确定。",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/chrome/src/ui/settings.html
+++ b/src/chrome/src/ui/settings.html
@@ -1399,6 +1399,7 @@
             <div class="setting-info">
               <div class="setting-label" data-i18n="st.display.cost_session_limit.label"></div>
               <div class="setting-desc" data-i18n="st.display.cost_session_limit.desc"></div>
+              <div class="setting-desc" style="margin-top:4px;color:var(--accent);" data-i18n="st.display.cost_allowance_scope"></div>
             </div>
             <label style="display:flex;align-items:center;gap:4px;background:var(--bg3);border:1px solid var(--border);border-radius:6px;padding:6px 8px;color:var(--text2);font-size:12px;">
               <span>$</span>
@@ -1410,6 +1411,7 @@
             <div class="setting-info">
               <div class="setting-label"><span data-i18n="st.display.cost_total_limit.label"></span> <span id="cost-spent-value" style="color:var(--accent);font-weight:700;margin-left:4px;">$0.00 / $10.00</span></div>
               <div class="setting-desc" data-i18n="st.display.cost_total_limit.desc"></div>
+              <div class="setting-desc" style="margin-top:4px;color:var(--accent);" data-i18n="st.display.cost_allowance_scope"></div>
             </div>
             <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end;">
               <label style="display:flex;align-items:center;gap:4px;background:var(--bg3);border:1px solid var(--border);border-radius:6px;padding:6px 8px;color:var(--text2);font-size:12px;">

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -406,7 +406,7 @@ async function init() {
   chrome.storage.local.remove(['authToken', 'authEmail', 'authDefaultModel']).catch(() => {});
 
   // Load display settings
-  const stored = await chrome.storage.local.get(['verboseMode', 'selectionShortcutEnabled', 'helpImproveWebBrain', 'screenshotFallback', 'maxAgentSteps', 'autoScreenshot', 'useSiteAdapters', 'voiceInputEnabled', 'alwaysAllowApiMutations', 'apiMutationObserverEnabled', 'webMcpEnabled', 'openaiAskStreamingEnabled', 'planBeforeActMode', 'planBeforeAct', 'planReviewMode', 'planReviewConfidenceThreshold', DOWNLOAD_DIRECTORY_STORAGE_KEY, 'notifySound', 'completionConfetti', 'tracingEnabled', 'strictSecretMode', 'agentAllowLocalNetwork', 'scheduledTasksEnabled', 'scheduledRequireConsequentialConfirmation', 'providerFilter', 'requestTimeoutMs', 'clarifyTimeoutSec', 'clarifyTimeoutSemanticsV2', 'costAllowanceSessionUsd', 'costAllowanceTotalUsd', 'cloudCostSpentUsd', 'screenshotRedaction', 'imageDetail', 'maxScreenshotsPerTurn', 'maxImageDimension']);
+  const stored = await chrome.storage.local.get(['verboseMode', 'selectionShortcutEnabled', 'helpImproveWebBrain', 'screenshotFallback', 'maxAgentSteps', 'autoScreenshot', 'useSiteAdapters', 'voiceInputEnabled', 'alwaysAllowApiMutations', 'apiMutationObserverEnabled', 'webMcpEnabled', 'openaiAskStreamingEnabled', 'planBeforeActMode', 'planBeforeAct', 'planReviewMode', 'planReviewConfidenceThreshold', DOWNLOAD_DIRECTORY_STORAGE_KEY, 'notifySound', 'completionConfetti', 'tracingEnabled', 'strictSecretMode', 'agentAllowLocalNetwork', 'scheduledTasksEnabled', 'scheduledRequireConsequentialConfirmation', 'providerFilter', 'requestTimeoutMs', 'clarifyTimeoutSec', 'clarifyTimeoutSemanticsV2', 'costAllowanceSessionUsd', 'costAllowanceTotalUsd', 'meteredProviderCostSpentUsd', 'screenshotRedaction', 'imageDetail', 'maxScreenshotsPerTurn', 'maxImageDimension']);
   if (typeof stored.providerFilter === 'string' && ['all','local','cloud','router'].includes(stored.providerFilter)) {
     providerFilter = stored.providerFilter;
   }
@@ -478,7 +478,7 @@ async function init() {
   tracingToggle.checked = stored.tracingEnabled === true;
   const sessionLimit = normalizeCostAmount(stored.costAllowanceSessionUsd);
   const totalLimit = normalizeCostAmount(stored.costAllowanceTotalUsd);
-  const totalSpent = normalizeCostAmount(stored.cloudCostSpentUsd, 0);
+  const totalSpent = normalizeCostAmount(stored.meteredProviderCostSpentUsd, 0);
   if (costSessionLimitInput) costSessionLimitInput.value = sessionLimit.toFixed(2);
   if (costTotalLimitInput) costTotalLimitInput.value = totalLimit.toFixed(2);
   renderCostAllowanceSpent(totalSpent, totalLimit);
@@ -1165,13 +1165,13 @@ costSessionLimitInput?.addEventListener('change', async () => {
 costTotalLimitInput?.addEventListener('change', async () => {
   const value = normalizeCostAmount(costTotalLimitInput.value);
   costTotalLimitInput.value = value.toFixed(2);
-  const stored = await chrome.storage.local.get(['cloudCostSpentUsd']);
-  renderCostAllowanceSpent(normalizeCostAmount(stored.cloudCostSpentUsd, 0), value);
+  const stored = await chrome.storage.local.get(['meteredProviderCostSpentUsd']);
+  renderCostAllowanceSpent(normalizeCostAmount(stored.meteredProviderCostSpentUsd, 0), value);
   await chrome.storage.local.set({ costAllowanceTotalUsd: value }).catch(() => {});
 });
 
 btnResetCostSpend?.addEventListener('click', async () => {
-  await chrome.storage.local.set({ cloudCostSpentUsd: 0 });
+  await chrome.storage.local.set({ meteredProviderCostSpentUsd: 0 });
   renderCostAllowanceSpent(0, normalizeCostAmount(costTotalLimitInput?.value));
 });
 

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -104,7 +104,9 @@ const DEFAULT_CLOUD_COST_ALLOWANCE_USD = 10;
 const PLAN_REVIEW_CONFIDENCE_DEFAULT = 0.75;
 const COST_ALLOWANCE_SESSION_KEY = 'costAllowanceSessionUsd';
 const COST_ALLOWANCE_TOTAL_KEY = 'costAllowanceTotalUsd';
-const CLOUD_COST_SPENT_KEY = 'cloudCostSpentUsd';
+// Do not inherit the legacy cloudCostSpentUsd bucket: it also contains
+// historical WebBrain Cloud estimates, which are exempt from user spend caps.
+const CLOUD_COST_SPENT_KEY = 'meteredProviderCostSpentUsd';
 const COST_EPSILON = 1e-9;
 const TOKENS_PER_MILLION = 1_000_000;
 const DEFAULT_INPUT_COST_PER_MILLION_USD = 3;
@@ -367,7 +369,7 @@ export class Agent extends LoopDetector {
     this.screenshotClickScale = new Map();
     this.costAllowanceSessionUsd = DEFAULT_CLOUD_COST_ALLOWANCE_USD;
     this.costAllowanceTotalUsd = DEFAULT_CLOUD_COST_ALLOWANCE_USD;
-    this.cloudCostSpentUsd = 0;
+    this.meteredProviderCostSpentUsd = 0;
     this._costUpdateQueue = Promise.resolve();
     // Profile auto-fill (plaintext bio + throwaway password used on
     // signup forms). Loaded in background.js and refreshed live on change.
@@ -490,7 +492,7 @@ export class Agent extends LoopDetector {
           this.costAllowanceTotalUsd = this._normalizeCostLimit(changes[COST_ALLOWANCE_TOTAL_KEY].newValue);
         }
         if (changes[CLOUD_COST_SPENT_KEY]) {
-          this.cloudCostSpentUsd = this._normalizeCostSpent(changes[CLOUD_COST_SPENT_KEY].newValue);
+          this.meteredProviderCostSpentUsd = this._normalizeCostSpent(changes[CLOUD_COST_SPENT_KEY].newValue);
         }
       });
     } catch { /* storage API unavailable in this context */ }
@@ -1266,13 +1268,13 @@ export class Agent extends LoopDetector {
 
   _isCostMeteredProvider(provider) {
     const config = provider?.config || {};
-    if (config.category === 'local') return false;
+    // WebBrain Cloud is billed and allowance-controlled by the managed
+    // service, not by the user's per-provider API account. Its upstream token
+    // cost must not consume the extension's user-configured spend allowance.
+    if (config.providerName === 'webbrain-cloud') return false;
     if (this._isLocalBaseUrl(config.baseUrl)) return false;
     if (config.type === 'anthropic_oauth') return false;
-    const isMeteredCategory = config.category === 'cloud' || config.category === 'router';
-    if (isMeteredCategory) return true;
-    if (config.providerName === 'openrouter') return true;
-    return !!(config.apiKey && /^https?:\/\//i.test(config.baseUrl || ''));
+    return config.category === 'cloud' || config.category === 'router';
   }
 
   _usageTokenCounts(usage) {
@@ -1416,12 +1418,12 @@ export class Agent extends LoopDetector {
       ]);
       this.costAllowanceSessionUsd = this._normalizeCostLimit(stored[COST_ALLOWANCE_SESSION_KEY]);
       this.costAllowanceTotalUsd = this._normalizeCostLimit(stored[COST_ALLOWANCE_TOTAL_KEY]);
-      this.cloudCostSpentUsd = this._normalizeCostSpent(stored[CLOUD_COST_SPENT_KEY]);
+      this.meteredProviderCostSpentUsd = this._normalizeCostSpent(stored[CLOUD_COST_SPENT_KEY]);
     } catch { /* keep in-memory defaults */ }
     return {
       sessionLimitUsd: this.costAllowanceSessionUsd,
       totalLimitUsd: this.costAllowanceTotalUsd,
-      totalSpentUsd: this.cloudCostSpentUsd,
+      totalSpentUsd: this.meteredProviderCostSpentUsd,
     };
   }
 
@@ -1455,7 +1457,7 @@ export class Agent extends LoopDetector {
       const state = await this._getCostAllowanceState();
       const nextTotal = state.totalSpentUsd + costUsd;
       if (costState) costState.spentUsd = this._normalizeCostSpent(costState.spentUsd) + costUsd;
-      this.cloudCostSpentUsd = nextTotal;
+      this.meteredProviderCostSpentUsd = nextTotal;
       try { await browser.storage.local.set({ [CLOUD_COST_SPENT_KEY]: nextTotal }); } catch {}
       return this._checkCostAllowanceState({ ...state, totalSpentUsd: nextTotal }, costState);
     });

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -691,6 +691,7 @@ export class ProviderManager {
       if (!visionModel || !visionModel.baseUrl || !visionModel.model) return null;
       return new OpenAICompatibleProvider({
         type: 'openai',
+        category: 'cloud',
         label: 'Vision Model',
         providerName: 'vision',
         baseUrl: visionModel.baseUrl,

--- a/src/firefox/src/ui/locales/ar.js
+++ b/src/firefox/src/ui/locales/ar.js
@@ -928,4 +928,5 @@ export default {
   "sp.workflows.healing.keep": "الاحتفاظ بالهدف المحفوظ",
   "sp.workflows.healing.saved": "تم تحديث {count} محددات في «{name}».",
   "sp.workflows.healing.not_saved": "لم يُحفظ المحدد الموافق عليه لـ «{name}» لأن سير العمل تغيّر أو لأن التحقق لم يكن حاسماً.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/bn.js
+++ b/src/firefox/src/ui/locales/bn.js
@@ -948,4 +948,5 @@ export default {
   "sp.workflows.healing.keep": "সংরক্ষিত লক্ষ্যটি রাখুন",
   "sp.workflows.healing.saved": "“{name}”-এ {count}টি লোকেটর আপডেট করা হয়েছে।",
   "sp.workflows.healing.not_saved": "ওয়ার্কফ্লো পরিবর্তিত হওয়ায় বা যাচাই অনিশ্চিত থাকায় “{name}”-এর অনুমোদিত লোকেটর সংরক্ষিত হয়নি।",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/de.js
+++ b/src/firefox/src/ui/locales/de.js
@@ -921,4 +921,5 @@ export default {
   "sp.workflows.healing.keep": "Gespeichertes Ziel beibehalten",
   "sp.workflows.healing.saved": "{count} Locator in „{name}“ aktualisiert.",
   "sp.workflows.healing.not_saved": "Der bestätigte Locator für „{name}“ wurde nicht gespeichert, weil sich der Workflow geändert hat oder die Prüfung nicht eindeutig war.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -549,9 +549,9 @@ export default {
   'st.display.tracing.label': 'Record traces (for model comparison)',
   'st.display.tracing.desc_html': 'Persist every run (LLM requests, responses, tool calls, screenshots) into local IndexedDB so you can inspect and compare models side-by-side. Opens in a separate Traces tab. Off by default because it adds disk writes per step. <a href="traces.html" target="_blank" style="color:var(--accent);">Open Traces page →</a>',
   'st.display.cost_session_limit.label': 'Cloud cost session allowance',
-  'st.display.cost_session_limit.desc': 'Stops cloud and OpenRouter runs before another paid model call once this session reaches the reported or estimated cost allowance. Default $10.',
+  'st.display.cost_session_limit.desc': 'Stops eligible cloud and router runs before another paid model call once this session reaches the reported or estimated cost allowance. Default $10.',
   'st.display.cost_total_limit.label': 'Cloud cost total allowance',
-  'st.display.cost_total_limit.desc': 'Tracks reported or estimated cloud/OpenRouter model spend across the extension and stops further paid calls at the allowance. Local providers are not counted.',
+  'st.display.cost_total_limit.desc': 'Tracks reported or estimated spend for eligible cloud and router model calls across the extension and stops further paid calls at the allowance.',
   'st.display.cost_reset': 'Reset spend',
   'st.display.strict_secret.label': 'Strict secret handling',
   'st.display.strict_secret.desc': 'Refuse to quote credentials (passwords, API keys, tokens, OTPs) in summaries or assistant text — even when you explicitly ask for them. Useful if you regularly share trace files or screen-share. Off by default: webbrain runs in your own browser, so by default the agent shows you values you ask for and just keeps `done` summaries tidy.',
@@ -950,4 +950,5 @@ export default {
   "sp.workflows.healing.keep": "Keep the saved target",
   "sp.workflows.healing.saved": "Updated {count} locator(s) in “{name}”.",
   "sp.workflows.healing.not_saved": "The approved locator for “{name}” was not saved because the workflow changed or verification was inconclusive.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/es.js
+++ b/src/firefox/src/ui/locales/es.js
@@ -928,4 +928,5 @@ export default {
   "sp.workflows.healing.keep": "Conservar el objetivo guardado",
   "sp.workflows.healing.saved": "Se actualizaron {count} localizadores en «{name}».",
   "sp.workflows.healing.not_saved": "El localizador aprobado para «{name}» no se guardó porque el flujo cambió o la verificación no fue concluyente.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/fa.js
+++ b/src/firefox/src/ui/locales/fa.js
@@ -948,4 +948,5 @@ export default {
   "sp.workflows.healing.keep": "حفظ هدف ذخیره‌شده",
   "sp.workflows.healing.saved": "{count} مکان‌یاب در «{name}» به‌روزرسانی شد.",
   "sp.workflows.healing.not_saved": "مکان‌یاب تأییدشدهٔ «{name}» ذخیره نشد، زیرا گردش‌کار تغییر کرده بود یا نتیجهٔ تأیید قطعی نبود.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/fr.js
+++ b/src/firefox/src/ui/locales/fr.js
@@ -928,4 +928,5 @@ export default {
   "sp.workflows.healing.keep": "Conserver la cible enregistrée",
   "sp.workflows.healing.saved": "{count} localisateur(s) mis à jour dans « {name} ».",
   "sp.workflows.healing.not_saved": "Le localisateur approuvé pour « {name} » n’a pas été enregistré, car le workflow a changé ou la vérification était incertaine.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/he.js
+++ b/src/firefox/src/ui/locales/he.js
@@ -881,4 +881,5 @@ export default {
   "sp.workflows.healing.keep": "להשאיר את היעד השמור",
   "sp.workflows.healing.saved": "עודכנו {count} מאתרים ב־„{name}”.",
   "sp.workflows.healing.not_saved": "המאתר שאושר עבור „{name}” לא נשמר משום שתהליך העבודה השתנה או שהאימות לא היה חד־משמעי.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/hi.js
+++ b/src/firefox/src/ui/locales/hi.js
@@ -948,4 +948,5 @@ export default {
   "sp.workflows.healing.keep": "सहेजा गया लक्ष्य रखें",
   "sp.workflows.healing.saved": "“{name}” में {count} लोकेटर अपडेट किए गए।",
   "sp.workflows.healing.not_saved": "“{name}” के लिए स्वीकृत लोकेटर सहेजा नहीं गया क्योंकि वर्कफ़्लो बदल गया था या सत्यापन निर्णायक नहीं था।",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/id.js
+++ b/src/firefox/src/ui/locales/id.js
@@ -928,4 +928,5 @@ export default {
   "sp.workflows.healing.keep": "Pertahankan target tersimpan",
   "sp.workflows.healing.saved": "Memperbarui {count} locator di “{name}”.",
   "sp.workflows.healing.not_saved": "Locator yang disetujui untuk “{name}” tidak disimpan karena alur kerja berubah atau verifikasi tidak meyakinkan.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/ja.js
+++ b/src/firefox/src/ui/locales/ja.js
@@ -928,4 +928,5 @@ export default {
   "sp.workflows.healing.keep": "保存済みの対象を維持",
   "sp.workflows.healing.saved": "「{name}」のロケーターを {count} 件更新しました。",
   "sp.workflows.healing.not_saved": "ワークフローが変更されたか検証結果が不確実だったため、「{name}」で承認されたロケーターは保存されませんでした。",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/ko.js
+++ b/src/firefox/src/ui/locales/ko.js
@@ -928,4 +928,5 @@ export default {
   "sp.workflows.healing.keep": "저장된 대상 유지",
   "sp.workflows.healing.saved": "“{name}”에서 로케이터 {count}개를 업데이트했습니다.",
   "sp.workflows.healing.not_saved": "워크플로가 변경되었거나 검증 결과가 불확실하여 “{name}”에서 승인한 로케이터를 저장하지 않았습니다.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/ms.js
+++ b/src/firefox/src/ui/locales/ms.js
@@ -928,4 +928,5 @@ export default {
   "sp.workflows.healing.keep": "Kekalkan sasaran tersimpan",
   "sp.workflows.healing.saved": "Mengemas kini {count} pencari dalam “{name}”.",
   "sp.workflows.healing.not_saved": "Pencari yang diluluskan untuk “{name}” tidak disimpan kerana aliran kerja berubah atau pengesahan tidak muktamad.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/nl.js
+++ b/src/firefox/src/ui/locales/nl.js
@@ -901,4 +901,5 @@ export default {
   "sp.workflows.healing.keep": "Opgeslagen doel behouden",
   "sp.workflows.healing.saved": "{count} locator(s) in ‘{name}’ bijgewerkt.",
   "sp.workflows.healing.not_saved": "De goedgekeurde locator voor ‘{name}’ is niet opgeslagen omdat de workflow was gewijzigd of de verificatie niet overtuigend was.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/pl.js
+++ b/src/firefox/src/ui/locales/pl.js
@@ -888,4 +888,5 @@ export default {
   "sp.workflows.healing.keep": "Zachowaj zapisany cel",
   "sp.workflows.healing.saved": "Zaktualizowano {count} lokalizatorów w „{name}”.",
   "sp.workflows.healing.not_saved": "Zatwierdzony lokalizator dla „{name}” nie został zapisany, ponieważ przepływ się zmienił lub weryfikacja nie była jednoznaczna.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/pt.js
+++ b/src/firefox/src/ui/locales/pt.js
@@ -948,4 +948,5 @@ export default {
   "sp.workflows.healing.keep": "Manter o alvo salvo",
   "sp.workflows.healing.saved": "Foram atualizados {count} localizadores em “{name}”.",
   "sp.workflows.healing.not_saved": "O localizador aprovado para “{name}” não foi salvo porque o fluxo mudou ou a verificação foi inconclusiva.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/ru.js
+++ b/src/firefox/src/ui/locales/ru.js
@@ -928,4 +928,5 @@ export default {
   "sp.workflows.healing.keep": "Оставить сохранённую цель",
   "sp.workflows.healing.saved": "Обновлено локаторов в «{name}»: {count}.",
   "sp.workflows.healing.not_saved": "Одобренный локатор для «{name}» не сохранён: сценарий изменился или результат проверки оказался неоднозначным.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/th.js
+++ b/src/firefox/src/ui/locales/th.js
@@ -928,4 +928,5 @@ export default {
   "sp.workflows.healing.keep": "ใช้เป้าหมายที่บันทึกไว้ต่อไป",
   "sp.workflows.healing.saved": "อัปเดตตัวระบุตำแหน่ง {count} รายการใน “{name}” แล้ว",
   "sp.workflows.healing.not_saved": "ไม่ได้บันทึกตัวระบุตำแหน่งที่อนุมัติสำหรับ “{name}” เพราะเวิร์กโฟลว์เปลี่ยนแปลงหรือผลการยืนยันไม่ชัดเจน",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/tl.js
+++ b/src/firefox/src/ui/locales/tl.js
@@ -928,4 +928,5 @@ export default {
   "sp.workflows.healing.keep": "Panatilihin ang naka-save na target",
   "sp.workflows.healing.saved": "Na-update ang {count} locator sa “{name}”.",
   "sp.workflows.healing.not_saved": "Hindi na-save ang inaprubahang locator para sa “{name}” dahil nagbago ang workflow o hindi tiyak ang beripikasyon.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/tr.js
+++ b/src/firefox/src/ui/locales/tr.js
@@ -927,4 +927,5 @@ export default {
   "sp.workflows.healing.keep": "Kayıtlı hedefi koru",
   "sp.workflows.healing.saved": "“{name}” içinde {count} bulucu güncellendi.",
   "sp.workflows.healing.not_saved": "İş akışı değiştiği veya doğrulama kesin olmadığı için “{name}” için onaylanan bulucu kaydedilmedi.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/uk.js
+++ b/src/firefox/src/ui/locales/uk.js
@@ -928,4 +928,5 @@ export default {
   "sp.workflows.healing.keep": "Залишити збережену ціль",
   "sp.workflows.healing.saved": "Оновлено локаторів у «{name}»: {count}.",
   "sp.workflows.healing.not_saved": "Схвалений локатор для «{name}» не збережено: робочий процес змінився або результат перевірки був неоднозначним.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/vi.js
+++ b/src/firefox/src/ui/locales/vi.js
@@ -948,4 +948,5 @@ export default {
   "sp.workflows.healing.keep": "Giữ mục tiêu đã lưu",
   "sp.workflows.healing.saved": "Đã cập nhật {count} bộ định vị trong “{name}”.",
   "sp.workflows.healing.not_saved": "Bộ định vị đã phê duyệt cho “{name}” không được lưu vì quy trình đã thay đổi hoặc kết quả xác minh chưa rõ ràng.",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/locales/zh.js
+++ b/src/firefox/src/ui/locales/zh.js
@@ -928,4 +928,5 @@ export default {
   "sp.workflows.healing.keep": "保留原目标",
   "sp.workflows.healing.saved": "已更新“{name}”中的 {count} 个定位器。",
   "sp.workflows.healing.not_saved": "“{name}”中已批准的定位器未保存，因为工作流已发生变化或验证结果不确定。",
+  'st.display.cost_allowance_scope': 'Applies only to usage-billed cloud and router providers. WebBrain Cloud and local providers are excluded.',
 };

--- a/src/firefox/src/ui/settings.html
+++ b/src/firefox/src/ui/settings.html
@@ -1380,6 +1380,7 @@
             <div class="setting-info">
               <div class="setting-label" data-i18n="st.display.cost_session_limit.label"></div>
               <div class="setting-desc" data-i18n="st.display.cost_session_limit.desc"></div>
+              <div class="setting-desc" style="margin-top:4px;color:var(--accent);" data-i18n="st.display.cost_allowance_scope"></div>
             </div>
             <label style="display:flex;align-items:center;gap:4px;background:var(--bg3);border:1px solid var(--border);border-radius:6px;padding:6px 8px;color:var(--text2);font-size:12px;">
               <span>$</span>
@@ -1391,6 +1392,7 @@
             <div class="setting-info">
               <div class="setting-label"><span data-i18n="st.display.cost_total_limit.label"></span> <span id="cost-spent-value" style="color:var(--accent);font-weight:700;margin-left:4px;">$0.00 / $10.00</span></div>
               <div class="setting-desc" data-i18n="st.display.cost_total_limit.desc"></div>
+              <div class="setting-desc" style="margin-top:4px;color:var(--accent);" data-i18n="st.display.cost_allowance_scope"></div>
             </div>
             <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end;">
               <label style="display:flex;align-items:center;gap:4px;background:var(--bg3);border:1px solid var(--border);border-radius:6px;padding:6px 8px;color:var(--text2);font-size:12px;">

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -403,7 +403,7 @@ async function init() {
   browser.storage.local.remove(['authToken', 'authEmail', 'authDefaultModel']).catch(() => {});
 
   // Load display settings
-  const stored = await browser.storage.local.get(['verboseMode', 'selectionShortcutEnabled', 'helpImproveWebBrain', 'screenshotFallback', 'maxAgentSteps', 'autoScreenshot', 'useSiteAdapters', 'voiceInputEnabled', 'alwaysAllowApiMutations', 'apiMutationObserverEnabled', 'openaiAskStreamingEnabled', 'planBeforeActMode', 'planBeforeAct', 'planReviewMode', 'planReviewConfidenceThreshold', DOWNLOAD_DIRECTORY_STORAGE_KEY, 'notifySound', 'completionConfetti', 'tracingEnabled', 'strictSecretMode', 'agentAllowLocalNetwork', 'scheduledTasksEnabled', 'scheduledRequireConsequentialConfirmation', 'providerFilter', 'requestTimeoutMs', 'clarifyTimeoutSec', 'clarifyTimeoutSemanticsV2', 'costAllowanceSessionUsd', 'costAllowanceTotalUsd', 'cloudCostSpentUsd', 'screenshotRedaction', 'imageDetail', 'maxScreenshotsPerTurn', 'maxImageDimension']);
+  const stored = await browser.storage.local.get(['verboseMode', 'selectionShortcutEnabled', 'helpImproveWebBrain', 'screenshotFallback', 'maxAgentSteps', 'autoScreenshot', 'useSiteAdapters', 'voiceInputEnabled', 'alwaysAllowApiMutations', 'apiMutationObserverEnabled', 'openaiAskStreamingEnabled', 'planBeforeActMode', 'planBeforeAct', 'planReviewMode', 'planReviewConfidenceThreshold', DOWNLOAD_DIRECTORY_STORAGE_KEY, 'notifySound', 'completionConfetti', 'tracingEnabled', 'strictSecretMode', 'agentAllowLocalNetwork', 'scheduledTasksEnabled', 'scheduledRequireConsequentialConfirmation', 'providerFilter', 'requestTimeoutMs', 'clarifyTimeoutSec', 'clarifyTimeoutSemanticsV2', 'costAllowanceSessionUsd', 'costAllowanceTotalUsd', 'meteredProviderCostSpentUsd', 'screenshotRedaction', 'imageDetail', 'maxScreenshotsPerTurn', 'maxImageDimension']);
   if (typeof stored.providerFilter === 'string' && ['all','local','cloud','router'].includes(stored.providerFilter)) {
     providerFilter = stored.providerFilter;
   }
@@ -469,7 +469,7 @@ async function init() {
   if (tracingToggle) tracingToggle.checked = stored.tracingEnabled === true;
   const sessionLimit = normalizeCostAmount(stored.costAllowanceSessionUsd);
   const totalLimit = normalizeCostAmount(stored.costAllowanceTotalUsd);
-  const totalSpent = normalizeCostAmount(stored.cloudCostSpentUsd, 0);
+  const totalSpent = normalizeCostAmount(stored.meteredProviderCostSpentUsd, 0);
   if (costSessionLimitInput) costSessionLimitInput.value = sessionLimit.toFixed(2);
   if (costTotalLimitInput) costTotalLimitInput.value = totalLimit.toFixed(2);
   renderCostAllowanceSpent(totalSpent, totalLimit);
@@ -1137,13 +1137,13 @@ costSessionLimitInput?.addEventListener('change', async () => {
 costTotalLimitInput?.addEventListener('change', async () => {
   const value = normalizeCostAmount(costTotalLimitInput.value);
   costTotalLimitInput.value = value.toFixed(2);
-  const stored = await browser.storage.local.get(['cloudCostSpentUsd']);
-  renderCostAllowanceSpent(normalizeCostAmount(stored.cloudCostSpentUsd, 0), value);
+  const stored = await browser.storage.local.get(['meteredProviderCostSpentUsd']);
+  renderCostAllowanceSpent(normalizeCostAmount(stored.meteredProviderCostSpentUsd, 0), value);
   await browser.storage.local.set({ costAllowanceTotalUsd: value }).catch(() => {});
 });
 
 btnResetCostSpend?.addEventListener('click', async () => {
-  await browser.storage.local.set({ cloudCostSpentUsd: 0 });
+  await browser.storage.local.set({ meteredProviderCostSpentUsd: 0 });
   renderCostAllowanceSpent(0, normalizeCostAmount(costTotalLimitInput?.value));
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -40367,6 +40367,44 @@ test('Agent cost metering is limited to cloud and router categories and excludes
   }
 });
 
+test('dedicated vision providers are cost-metered when remote and exempt when local', async () => {
+  const originalChrome = globalThis.chrome;
+  const originalBrowser = globalThis.browser;
+  try {
+    for (const [label, apiName, ManagerClass, AgentClass] of [
+      ['chrome', 'chrome', ProviderManagerCh, AgentCh],
+      ['firefox', 'browser', ProviderManagerFx, AgentFx],
+    ]) {
+      let baseUrl = 'https://api.openai.com/v1';
+      globalThis[apiName] = {
+        storage: {
+          local: {
+            get: async () => ({
+              visionModel: { baseUrl, apiKey: 'paid-key', model: 'gpt-5.6-terra' },
+            }),
+          },
+        },
+      };
+
+      const manager = new ManagerClass();
+      const agent = new AgentClass(manager);
+      const remoteVision = await manager.getVisionProvider();
+      assert.equal(remoteVision.config.category, 'cloud', `${label}: dedicated vision should be classified as cloud`);
+      assert.equal(agent._isCostMeteredProvider(remoteVision), true, `${label}: remote dedicated vision should be metered`);
+
+      baseUrl = 'http://localhost:1234/v1';
+      const localVision = await manager.getVisionProvider();
+      assert.equal(localVision.config.category, 'cloud', `${label}: dedicated vision should retain its provider category`);
+      assert.equal(agent._isCostMeteredProvider(localVision), false, `${label}: local dedicated vision should remain exempt`);
+    }
+  } finally {
+    if (originalChrome === undefined) delete globalThis.chrome;
+    else globalThis.chrome = originalChrome;
+    if (originalBrowser === undefined) delete globalThis.browser;
+    else globalThis.browser = originalBrowser;
+  }
+});
+
 test('cost accounting starts a fresh aggregate after the WebBrain Cloud exemption', () => {
   for (const [label, prefix] of [
     ['chrome', 'src/chrome'],

--- a/test/run.js
+++ b/test/run.js
@@ -5230,6 +5230,7 @@ test('config transfer exports and restores Settings values including provider ke
     wb_permissions: [{ capability: 'click', host: 'example.com' }],
     wb_user_memory_v1: { version: 1, records: [{ id: 'mem_1', text: 'Prefer concise answers', kind: 'preference' }] },
     cloudCostSpentUsd: 8.5,
+    meteredProviderCostSpentUsd: 2.5,
     profileSyncToken: 'device-session-secret',
     webbrainDeviceGuid: 'device-guid',
   };
@@ -5249,6 +5250,7 @@ test('config transfer exports and restores Settings values including provider ke
   assert.equal(chromeExport.settings.wb_user_memory_v1.records.length, 1);
   assert.equal(chromeExport.settings.providers.webbrain_cloud.deviceGuid, undefined, 'device identity must not be portable');
   assert.equal(chromeExport.settings.cloudCostSpentUsd, undefined, 'spend counters are runtime state, not config');
+  assert.equal(chromeExport.settings.meteredProviderCostSpentUsd, undefined, 'metered spend counters are runtime state, not config');
   assert.equal(chromeExport.settings.profileSyncToken, undefined, 'Cloud Sync sessions must not be exported');
   assert.equal(chromeExport.settings.webbrainDeviceGuid, undefined, 'device GUID must not be exported');
   assert.match(chromeExport.warning, /plaintext provider API keys/i);
@@ -40325,6 +40327,76 @@ test('Agent cost metering treats bracketed local IPv6 URLs as local', () => {
   }
 });
 
+test('Agent cost metering is limited to cloud and router categories and excludes WebBrain Cloud', () => {
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({});
+    const cases = [
+      {
+        config: { category: 'cloud', providerName: 'webbrain-cloud', baseUrl: 'https://api.webbrain.one/v1' },
+        expected: false,
+        label: 'WebBrain Cloud',
+      },
+      {
+        config: { category: 'cloud', providerName: 'openai', baseUrl: 'https://api.openai.com/v1' },
+        expected: true,
+        label: 'cloud provider',
+      },
+      {
+        config: { category: 'router', providerName: 'openrouter', baseUrl: 'https://openrouter.ai/api/v1' },
+        expected: true,
+        label: 'router provider',
+      },
+      {
+        config: { category: 'local', providerName: 'llamacpp', baseUrl: 'https://remote-local-model.example/v1' },
+        expected: false,
+        label: 'local category',
+      },
+      {
+        config: { providerName: 'custom', baseUrl: 'https://custom.example/v1', apiKey: 'key' },
+        expected: false,
+        label: 'uncategorized remote endpoint',
+      },
+    ];
+    for (const { config, expected, label } of cases) {
+      assert.equal(
+        agent._isCostMeteredProvider({ config }),
+        expected,
+        `${AgentClass.name} should ${expected ? '' : 'not '}meter ${label}`
+      );
+    }
+  }
+});
+
+test('cost accounting starts a fresh aggregate after the WebBrain Cloud exemption', () => {
+  for (const [label, prefix] of [
+    ['chrome', 'src/chrome'],
+    ['firefox', 'src/firefox'],
+  ]) {
+    const agentSource = fs.readFileSync(path.join(ROOT, prefix, 'src/agent/agent.js'), 'utf8');
+    const settingsSource = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/settings.js'), 'utf8');
+    assert.match(
+      agentSource,
+      /const CLOUD_COST_SPENT_KEY = 'meteredProviderCostSpentUsd';/,
+      `${label}: cost accounting should use the metered-only aggregate`,
+    );
+    assert.doesNotMatch(
+      agentSource,
+      /const CLOUD_COST_SPENT_KEY = 'cloudCostSpentUsd';/,
+      `${label}: legacy spend that included WebBrain Cloud must not be inherited`,
+    );
+    assert.match(
+      settingsSource,
+      /meteredProviderCostSpentUsd/,
+      `${label}: Settings should display and reset the metered-only aggregate`,
+    );
+    assert.doesNotMatch(
+      settingsSource,
+      /cloudCostSpentUsd/,
+      `${label}: Settings should not display the legacy mixed aggregate`,
+    );
+  }
+});
+
 test('Agent cost metering treats only real IPv4 literals as local', () => {
   for (const AgentClass of [AgentCh, AgentFx]) {
     const agent = new AgentClass({});
@@ -40345,7 +40417,7 @@ test('Agent cost metering treats only real IPv4 literals as local', () => {
     ]) {
       assert.equal(agent._isLocalBaseUrl(url), false, `${AgentClass.name} should treat ${url} as remote`);
       assert.equal(
-        agent._isCostMeteredProvider({ config: { type: 'openai', baseUrl: url, apiKey: 'paid-key' } }),
+        agent._isCostMeteredProvider({ config: { type: 'openai', category: 'cloud', baseUrl: url, apiKey: 'paid-key' } }),
         true,
         `${AgentClass.name} should meter ${url}`
       );
@@ -40376,7 +40448,7 @@ test('Agent cost metering still treats public IPv6 URLs as remote', () => {
     const agent = new AgentClass({});
     assert.equal(agent._isLocalBaseUrl('https://[2606:4700:4700::1111]/v1'), false);
     assert.equal(
-      agent._isCostMeteredProvider({ config: { type: 'openai', baseUrl: 'https://[2606:4700:4700::1111]/v1', apiKey: 'paid-key' } }),
+      agent._isCostMeteredProvider({ config: { type: 'openai', category: 'router', baseUrl: 'https://[2606:4700:4700::1111]/v1', apiKey: 'paid-key' } }),
       true
     );
   }


### PR DESCRIPTION
## Summary

- restrict local cost allowances to usage-billed cloud and router providers
- exempt managed WebBrain Cloud usage from client-side spend accounting
- start a fresh metered-provider aggregate so historical WebBrain Cloud estimates cannot block BYOK providers
- clarify the allowance scope in both Chrome and Firefox Settings, with locale coverage
- add regression coverage for provider classification and the storage-key migration

## Why

WebBrain Cloud manages its own subscription and fair-use allowances. Treating its estimated upstream token cost as user-paid spend caused the extension to stop subscribed users at the local dollar cap and presented WebBrain's cost as if it were the user's API bill.

## Validation

- `npm test`: 1,531 passed; one pre-existing packaging check failed because the local `dist/webbrain-chrome-27.0.0.zip` artifact is absent
- `npm run test:security`: 60/60 checks passed
- syntax checks passed for the changed Chrome and Firefox agent and Settings modules
- `git diff --check` passed
