### PR TITLE
Report every API-mutation grant in the transcript

### DIFF
--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -5739,7 +5739,7 @@ function bindErrorRetryButton(btn) {
     }
     setMode(payload.mode);
     if (payload.apiMutationsAllowed) {
-      setApiMutationsAllowedForTab(currentTabId, true);
+      grantApiMutationsForTab(currentTabId);
     }
     inputEl.value = payload.text;
     autoResizeInput();
@@ -6738,14 +6738,27 @@ function handleInput() {
 // --- Message Sending ---
 
 // Per-conversation flag for API mutation override (set via /allow-api).
-// Reset on clearConversation. Visible to the user in the chat as a system
-// message and as a sticky badge near the input area.
+// Reset on clearConversation. A grant is reported only by the system message in
+// the transcript, so every grant goes through grantApiMutationsForTab().
 let alwaysAllowApiMutations = false;
 let apiMutationsAllowed = false;
 const apiMutationsAllowedByTab = new Map();
 
 function isApiMutationsAllowedForTab(tabId) {
   return tabId != null && apiMutationsAllowedByTab.get(tabId) === true;
+}
+
+// Grants API mutations for a tab and announces the grant. Setting the per-tab
+// flag directly re-enables POST/PUT/PATCH/DELETE for the whole conversation
+// with nothing on screen. Note the bubble goes to the transcript currently
+// rendered, which is not tabId when a slash command runs for a background tab.
+function grantApiMutationsForTab(tabId) {
+  const wasAlreadyAllowed = isApiMutationsAllowedForTab(tabId);
+  setApiMutationsAllowedForTab(tabId, true);
+  if (!wasAlreadyAllowed) {
+    addPersistentSlashMessage(systemHtml(t('sp.api.enabled_html')));
+  }
+  return !wasAlreadyAllowed;
 }
 
 function setApiMutationsAllowedForTab(tabId, allowed) {
@@ -7157,11 +7170,7 @@ async function parseSlashCommands(text, tabId = currentTabId, options = {}) {
   }
 
   if (command.value === '/allow-api') {
-    const wasAlreadyAllowed = isApiMutationsAllowedForTab(tabId);
-    setApiMutationsAllowedForTab(tabId, true);
-    if (!wasAlreadyAllowed) {
-      addPersistentSlashMessage(systemHtml(t('sp.api.enabled_html')));
-    }
+    grantApiMutationsForTab(tabId);
     return payload;
   }
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -5581,7 +5581,7 @@ function bindErrorRetryButton(btn) {
     }
     setMode(payload.mode);
     if (payload.apiMutationsAllowed) {
-      setApiMutationsAllowedForTab(currentTabId, true);
+      grantApiMutationsForTab(currentTabId);
     }
     inputEl.value = payload.text;
     autoResizeInput();
@@ -6579,13 +6579,28 @@ function handleInput() {
 
 // --- Message Sending ---
 
-// Per-conversation API mutation override (set via /allow-api).
+// Per-conversation API mutation override (set via /allow-api). A grant is
+// reported only by the system message in the transcript, so every grant goes
+// through grantApiMutationsForTab().
 let alwaysAllowApiMutations = false;
 let apiMutationsAllowed = false;
 const apiMutationsAllowedByTab = new Map();
 
 function isApiMutationsAllowedForTab(tabId) {
   return tabId != null && apiMutationsAllowedByTab.get(tabId) === true;
+}
+
+// Grants API mutations for a tab and announces the grant. Setting the per-tab
+// flag directly re-enables POST/PUT/PATCH/DELETE for the whole conversation
+// with nothing on screen. Note the bubble goes to the transcript currently
+// rendered, which is not tabId when a slash command runs for a background tab.
+function grantApiMutationsForTab(tabId) {
+  const wasAlreadyAllowed = isApiMutationsAllowedForTab(tabId);
+  setApiMutationsAllowedForTab(tabId, true);
+  if (!wasAlreadyAllowed) {
+    addPersistentSlashMessage(systemHtml(t('sp.api.enabled_html')));
+  }
+  return !wasAlreadyAllowed;
 }
 
 function setApiMutationsAllowedForTab(tabId, allowed) {
@@ -6992,11 +7007,7 @@ async function parseSlashCommands(text, tabId = currentTabId, options = {}) {
   }
 
   if (command.value === '/allow-api') {
-    const wasAlreadyAllowed = isApiMutationsAllowedForTab(tabId);
-    setApiMutationsAllowedForTab(tabId, true);
-    if (!wasAlreadyAllowed) {
-      addPersistentSlashMessage(systemHtml(t('sp.api.enabled_html')));
-    }
+    grantApiMutationsForTab(tabId);
     return payload;
   }
 

--- a/test/run.js
+++ b/test/run.js
@@ -19561,7 +19561,10 @@ test('chrome /record --full-screen shows the recording banner unless explicitly 
   assert.ok(fullScreenIdx >= 0 && recordIdx >= 0 && fullScreenIdx < recordIdx, 'chrome: full-screen route must run before tab recording');
   const fullScreenBody = panel.slice(fullScreenIdx, recordIdx);
   const helperStart = panel.indexOf('async function startFullScreenRecording');
-  const helperBody = panel.slice(helperStart, panel.indexOf('async function sendMessage', helperStart));
+  assert.notEqual(helperStart, -1, 'chrome: startFullScreenRecording helper should exist');
+  const helperEnd = panel.indexOf('async function sendMessage', helperStart);
+  assert.notEqual(helperEnd, -1, 'chrome: sendMessage should follow the full-screen recording helper');
+  const helperBody = panel.slice(helperStart, helperEnd);
   assert.match(fullScreenBody, /startFullScreenRecording\(tabId/, 'chrome: parser should route /record --full-screen through helper');
   assert.match(helperBody, /prepare_recording_host/, 'chrome: full-screen route should prepare offscreen before recording');
   assert.match(fullScreenBody, /showBanner:\s*!optionValues\.has\('--hide-recording-indicator'\)/, 'chrome: full-screen route should hide the banner only when explicitly requested');
@@ -23969,9 +23972,25 @@ test('sidepanel scopes allow-api override to the tab conversation and confirms i
     const allowIdx = panel.indexOf("if (command.value === '/allow-api')");
     assert.notEqual(allowIdx, -1, `${label}: /allow-api parser missing`);
     const allowBody = panel.slice(allowIdx, panel.indexOf("if (command.value === '/dangerously-skip-permissions')", allowIdx));
-    assert.match(allowBody, /const wasAlreadyAllowed = isApiMutationsAllowedForTab\(tabId\);[\s\S]*?setApiMutationsAllowedForTab\(tabId, true\);/, `${label}: /allow-api should enable only the initiating tab conversation`);
-    assert.match(allowBody, /if \(!wasAlreadyAllowed\) \{[\s\S]*?addPersistentSlashMessage\(systemHtml\(t\('sp\.api\.enabled_html'\)\)\);[\s\S]*?\}/, `${label}: /allow-api should add one transcript confirmation bubble`);
+    assert.match(allowBody, /grantApiMutationsForTab\(tabId\);/, `${label}: /allow-api should enable only the initiating tab conversation`);
     assert.doesNotMatch(allowBody, /apiMutationsAllowed = true;/, `${label}: /allow-api should not enable a global mutation override`);
+
+    const grantIdx = panel.indexOf('function grantApiMutationsForTab(tabId) {');
+    assert.notEqual(grantIdx, -1, `${label}: grantApiMutationsForTab missing`);
+    const grantEnd = panel.indexOf('\n}', grantIdx);
+    assert.notEqual(grantEnd, -1, `${label}: grantApiMutationsForTab is unterminated`);
+    const grantBody = panel.slice(grantIdx, grantEnd);
+    assert.match(grantBody, /const wasAlreadyAllowed = isApiMutationsAllowedForTab\(tabId\);[\s\S]*?setApiMutationsAllowedForTab\(tabId, true\);/, `${label}: a grant should enable only the initiating tab conversation`);
+    assert.match(grantBody, /if \(!wasAlreadyAllowed\) \{[\s\S]*?addPersistentSlashMessage\(systemHtml\(t\('sp\.api\.enabled_html'\)\)\);[\s\S]*?\}/, `${label}: a grant should add one transcript confirmation bubble`);
+
+    // The transcript bubble is the only place a grant is reported, so no other
+    // call site may enable mutations without going through the helper.
+    const directGrants = [...panel.matchAll(/setApiMutationsAllowedForTab\([^)]*,\s*true\)/g)];
+    assert.equal(directGrants.length, 1, `${label}: only grantApiMutationsForTab may enable API mutations`);
+    assert.ok(
+      directGrants[0].index > grantIdx && directGrants[0].index < grantEnd,
+      `${label}: the sole direct grant should live inside grantApiMutationsForTab`,
+    );
   }
 });
 
@@ -24368,8 +24387,8 @@ test('sidepanel keeps retry metadata long enough for returned error updates', ()
     );
     assert.match(
       source,
-      /if \(payload\.apiMutationsAllowed\) \{[\s\S]*?setApiMutationsAllowedForTab\(currentTabId, true\);[\s\S]*?\}[\s\S]*?await sendMessage\(\{/,
-      `${label}: restored retries that replay API mutation permission should resync the visible per-tab API state`,
+      /if \(payload\.apiMutationsAllowed\) \{[\s\S]*?grantApiMutationsForTab\(currentTabId\);[\s\S]*?\}[\s\S]*?await sendMessage\(\{/,
+      `${label}: restored retries that replay API mutation permission should resync the visible per-tab API state and report the grant`,
     );
     assert.match(
       source,


### PR DESCRIPTION
Removing the composer badge left the `/allow-api` parser as the only path that told the user POST/PUT/PATCH/DELETE were allowed for a tab. The retry button granted silently.

That gap opens up after a panel reopen. The in-memory `apiMutationsAllowedByTab` map is wiped, but the cached transcript comes back with its retry buttons intact, so clicking Retry re-enabled mutations for the whole tab conversation with nothing on screen.

Both call sites now go through `grantApiMutationsForTab()`, which sets the flag and emits the confirmation bubble together. A test pins the invariant: exactly one direct `setApiMutationsAllowedForTab(..., true)` call per build, and it has to sit inside the helper.

## What this deliberately does not fix

The bubble still lands in whichever transcript is currently rendered, so a slash command aimed at a background tab reports into the wrong conversation. That behavior predates this change. The comment on the helper now describes it instead of claiming an invariant that does not hold.

The persistent `alwaysAllowApiMutations` setting also has no in-panel indicator. I tried adding one and backed it out. The setting is only writable from the settings page, which opens in a new tab, and activating that tab runs `switchToTab` and repoints `messagesEl` at the settings tab's empty transcript before the toggle fires. The notice landed in an invisible conversation and was discarded on return. It was durable with no counterpart on disable, so a transcript could keep asserting "always enabled" after the setting was turned off. Closing that gap properly means either restoring a badge, which this PR's predecessor deliberately removed, or picking a surface that does not go stale. That is a product call.

## Testing

1560 passed, 1 failed. The failure is `repository changelog retains complete, non-empty release history`: `package.json` is at 27.1.1 while the newest `CHANGELOG.md` section is 27.1.0. It fails the same way on a clean tree at `main` and is unrelated to this branch.

Also guards two `indexOf` anchors in `test/run.js` that were used as slice bounds without a `-1` check. One of them was added in this PR and passed vacuously in exactly the case it existed to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)