### PR TITLE
Detect vision support for local model providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog was generated from the repository Git history and release tags. V
 
 ### Changed
 - Updated the LM Studio plugin for the current browser-delegation protocol.
+- Added model-bound vision capability detection for llama.cpp, LM Studio, and LocalAI, with Auto / Force on / Off settings and fail-closed Chrome/Firefox request routing.
 
 ### Fixed
 - Hid empty assistant placeholders until response content is ready to render.

--- a/README.md
+++ b/README.md
@@ -90,10 +90,11 @@ LM Studio (`:1234/v1`), Jan (`:1337/v1`), and LocalAI (`:8080/v1`) work the same
 way. Load a model with **at least a 16k-token context window** — 8k works only
 with the Compact tier, and 4k is too small for the system prompt plus tool
 schemas. WebBrain auto-detects the real window for llama.cpp, Ollama, and LM
-Studio, and auto-compacts the conversation as it fills up. For Ollama, the
-Vision setting defaults to Auto and reads the selected model's native
-`/api/show` capabilities; Force on and Off remain available as explicit
-overrides. There is also a
+Studio, and auto-compacts the conversation as it fills up. For Ollama,
+llama.cpp, LM Studio, and LocalAI, it also reads native server metadata before
+adding screenshots; Settings provides Auto, Force on, and Off overrides. When
+the optional Model field is blank, the loaded-model capability is rechecked on
+every user turn so a server-side hot swap takes effect. There is also a
 preview `ollama launch webbrain --model <model>` handoff. Details:
 [providers and models](docs/providers-and-models.md#local-providers).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,10 +160,6 @@ background.js handleMessage('chat_start')
 
 ### Step 3: Enrich First User Message
 ```
-providerManager.prepareActiveProviderCapabilities()
-  → for Ollama Auto, resolve the model/base-URL-scoped `/api/show` check
-  → coalesce concurrent checks and fail closed to text-only on metadata errors
-
 _enrichUserMessageWithCurrentPage(tabId, messages, userMessage)
 
   1. Collect URL + title via chrome.tabs.get(tabId)
@@ -709,11 +705,13 @@ testConnection()              → { ok, error, model }
 
 `promptTier` drives both the action prompt and the normal tool subset. Local providers default to Mid, cloud providers are forced Full, and the legacy `useCompactPrompt` flag maps to Compact for existing configs. Dev mode is a separate conversation mode: Mid/Full Dev uses the selected Act tier plus `SYSTEM_PROMPT_DEV_APPENDIX`; Compact Dev is blocked before an LLM request is sent.
 
-Ollama is the exception to OpenAI-compatible model-name vision inference. Its
-`visionMode` is `auto`, `on`, or `off`; Auto performs one coalesced,
-three-second `/api/show` metadata check per model/base URL and service-worker
-lifetime before turn enrichment. Only successful metadata is persisted, and a
-late result is applied only if the same Ollama identity is still configured.
+Ollama, llama.cpp, LM Studio, and LocalAI resolve `supportsVision` from native
+server metadata before page enrichment. Explicit model/base-URL identities are
+cached and protected by stale-result guards; an empty Model field is treated as
+the server's mutable loaded-model slot, so concurrent checks are coalesced only
+within that turn and the next user turn rechecks it. Detection is bounded to
+three seconds and fails closed without failing the text request. User overrides
+bypass detection. Chrome and Firefox share the same parsers and behavior.
 
 See `docs/providers-and-models.md`.
 

--- a/docs/fr/providers-and-models.md
+++ b/docs/fr/providers-and-models.md
@@ -38,7 +38,7 @@ class BaseLLMProvider {
 |---|---|---|---|---|
 | `webbrain_cloud` | `openai` | cloud | `webbrain-cloud 1.0` | Oui |
 | `llamacpp` | `llamacpp` | local | (modèle chargé) | Métadonnées auto / surcharge |
-| `ollama` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |
+| `ollama` | `openai` | local | (modèle chargé) | Auto via `/api/show` / surcharge |
 | `lmstudio` | `openai` | local | (modèle chargé) | Métadonnées auto / surcharge |
 | `jan` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |
 | `vllm` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |

--- a/docs/fr/providers-and-models.md
+++ b/docs/fr/providers-and-models.md
@@ -37,13 +37,13 @@ class BaseLLMProvider {
 | ID Fournisseur | Type | Catégorie | Modèle par défaut | Vision |
 |---|---|---|---|---|
 | `webbrain_cloud` | `openai` | cloud | `webbrain-cloud 1.0` | Oui |
-| `llamacpp` | `llamacpp` | local | (modèle chargé) | Oui (activé par défaut) |
-| `ollama` | `openai` | local | (modèle chargé) | Auto via `/api/show` |
-| `lmstudio` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |
+| `llamacpp` | `llamacpp` | local | (modèle chargé) | Métadonnées auto / surcharge |
+| `ollama` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |
+| `lmstudio` | `openai` | local | (modèle chargé) | Métadonnées auto / surcharge |
 | `jan` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |
 | `vllm` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |
 | `sglang` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |
-| `localai` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |
+| `localai` | `openai` | local | (modèle chargé) | Métadonnées auto / surcharge |
 | `gpt4all` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |
 | `azure_openai` | `azure_openai` | cloud | (déploiement) | Bascule manuelle |
 | `aws_bedrock` | `aws_bedrock` | cloud | (ID de modèle) | Non |
@@ -125,10 +125,15 @@ serveur local a été démarré avec authentification :
 - **SGLang** : `http://localhost:30000/v1` — le serveur compatible OpenAI de SGLang
 - **LocalAI** : `http://localhost:8080/v1` — le serveur compatible OpenAI de LocalAI
 
-Ollama utilise par défaut `visionMode: "auto"` et vérifie le modèle sélectionné
-avec les métadonnées natives de `/api/show` avant de joindre des images. Les
-autres fournisseurs locaux conservent leur comportement explicite
-`supportsVision` existant.
+Ollama, llama.cpp, LM Studio et LocalAI utilisent `visionMode: auto` par défaut.
+WebBrain lit les métadonnées natives du modèle sélectionné avant l'enrichissement et
+n'envoie des captures que si le serveur déclare explicitement l'entrée image.
+Une détection indisponible ou malformée reste en texte seul pour ce tour et
+sera retentée plus tard. Si le champ Modèle est vide, la capacité du modèle
+chargé est revérifiée à chaque tour afin de suivre les changements côté serveur.
+Les réglages proposent Automatique, Forcer
+l'activation et Désactivé ; les autres fournisseurs locaux conservent leur
+interrupteur explicite actuel.
 
 #### Relais de lancement Ollama (préversion)
 
@@ -180,9 +185,16 @@ Le mode Ask ignore le niveau du fournisseur et reste en lecture seule. Le mode A
 |---|---|
 | Compatible OpenAI | Regex sur le nom du modèle (`gpt-4o`, `gpt-5`, `claude-3`, `claude-sonnet-4`, `gemini-2.0-flash`, etc.) |
 | Anthropic | Patterns `claude-(3\|sonnet-4\|opus-4)` |
-| llama.cpp | Interrupteur explicite `supportsVision` dans la configuration |
-| Ollama | Champ `capabilities` de `POST /api/show`, avec repli historique sur `projector_info` / les métadonnées `.vision.` ; réglage Auto / Forcer l'activation / Désactivé |
-| LM Studio / Jan / vLLM / SGLang / LocalAI | Interrupteur explicite `supportsVision` dans la configuration (via le fournisseur OpenAI) |
+| Ollama | `POST /api/show` `capabilities`, avec replis historiques `projector_info` / `.vision.` |
+| llama.cpp | `GET /props` → `modalities.vision`, avec Automatique / Forcer / Désactivé |
+| LM Studio | `GET /api/v1/models` → `capabilities.vision`, puis ancien `/api/v0/models` `type` |
+| LocalAI | `GET /v1/models/capabilities` → `input_modalities` / `capabilities` |
+| Jan / vLLM / SGLang | Interrupteur explicite `supportsVision` dans la configuration (via le fournisseur OpenAI) |
+
+La détection est liée au fournisseur, au modèle exact et à l'URL de base. Les
+requêtes simultanées sont regroupées et une réponse tardive d'une ancienne
+configuration ne peut pas modifier la configuration actuelle. Un fournisseur
+de vision dédié conserve le routage séparé existant.
 
 ### Conversion Anthropic
 
@@ -286,11 +298,4 @@ myprovider: {
 },
 ```
 
-La vision est normalement auto-détectée via une regex sur le nom du modèle.
-Ollama fait exception : son mode Auto utilise les métadonnées natives de
-`/api/show` et échoue de manière fermée vers le mode texte seul si elles ne
-peuvent pas être vérifiées. Si un autre fournisseur a un ensemble connu de
-modèles de vision, ajoutez-les à la regex dans `openai.js`. Définissez
-`supportsStreamUsageOptions: true` uniquement pour les fournisseurs qui
-acceptent `stream_options.include_usage` de style OpenAI ; laissez-le à false
-lorsqu'un fournisseur retourne l'utilisation sans accepter ce champ de requête.
+La vision est auto-détectée via une regex sur le nom du modèle. Si le fournisseur a un ensemble connu de modèles de vision, ajoutez-les à la regex dans `openai.js`. Définissez `supportsStreamUsageOptions: true` uniquement pour les fournisseurs qui acceptent `stream_options.include_usage` de style OpenAI ; laissez-le à false lorsqu'un fournisseur retourne l'utilisation sans accepter ce champ de requête.

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -37,13 +37,13 @@ class BaseLLMProvider {
 | Provider ID | Type | Category | Default Model | Vision |
 |---|---|---|---|---|
 | `webbrain_cloud` | `openai` | cloud | `webbrain-cloud 1.0` | Yes |
-| `llamacpp` | `llamacpp` | local | (loaded model) | Yes (default on) |
-| `ollama` | `openai` | local | (loaded model) | Auto via `/api/show` |
-| `lmstudio` | `openai` | local | (loaded model) | Yes (default on) |
+| `llamacpp` | `llamacpp` | local | (loaded model) | Auto metadata / override |
+| `ollama` | `openai` | local | (loaded model) | Yes (default on) |
+| `lmstudio` | `openai` | local | (loaded model) | Auto metadata / override |
 | `jan` | `openai` | local | (loaded model) | Yes (default on) |
 | `vllm` | `openai` | local | (loaded model) | Yes (default on) |
 | `sglang` | `openai` | local | (loaded model) | Yes (default on) |
-| `localai` | `openai` | local | (loaded model) | Yes (default on) |
+| `localai` | `openai` | local | (loaded model) | Auto metadata / override |
 | `gpt4all` | `openai` | local | (loaded model) | Yes (default on) |
 | `azure_openai` | `azure_openai` | cloud | (deployment) | Manual toggle |
 | `aws_bedrock` | `aws_bedrock` | cloud | (model id) | No |
@@ -155,9 +155,15 @@ local server was started with auth:
 - **SGLang**: `http://localhost:30000/v1` — SGLang's OpenAI-compatible server
 - **LocalAI**: `http://localhost:8080/v1` — LocalAI's OpenAI-compatible server
 
-Ollama defaults to `visionMode: "auto"` and verifies the selected model through
-its native `/api/show` metadata before attaching images. The other local
-providers retain their existing explicit `supportsVision` behavior.
+Ollama, llama.cpp, LM Studio, and LocalAI default to `visionMode: auto`. WebBrain asks
+the selected server for model capability metadata before enrichment and sends
+screenshots only when the response explicitly reports image input. A failed or
+malformed metadata request is text-only for that turn and is retried later;
+Settings can override Auto with Force on or Off. For providers whose Model
+field may be blank, WebBrain coalesces concurrent checks but rechecks once per
+user turn, so changing the model loaded by the server cannot reuse a stale
+answer. Other local providers retain
+their existing explicit `supportsVision` setting.
 
 #### Ollama launch handoff (preview)
 
@@ -218,9 +224,16 @@ Ask mode ignores provider tier and stays read-only. Act mode uses the selected t
 |---|---|
 | OpenAI-compatible | Regex against model name (`gpt-4o`, `gpt-5`, `claude-3`, `claude-sonnet-4`, `gemini-2.0-flash`, etc.) |
 | Anthropic | `claude-(3\|sonnet-4\|opus-4)` patterns |
-| llama.cpp | Explicit `supportsVision` config toggle |
-| Ollama | `POST /api/show` `capabilities`, with legacy projector / `.vision.` metadata fallbacks; Auto / Force on / Off setting |
-| LM Studio / Jan / vLLM / SGLang / LocalAI | Explicit `supportsVision` config toggle (via OpenAI provider) |
+| Ollama | `POST /api/show` `capabilities`, with legacy projector / `.vision.` metadata fallbacks; Auto / Force on / Off |
+| llama.cpp | `GET /props` → `modalities.vision`, with Auto / Force on / Off |
+| LM Studio | `GET /api/v1/models` → `capabilities.vision`; legacy `/api/v0/models` `type`, with overrides |
+| LocalAI | `GET /v1/models/capabilities` → `input_modalities` / `capabilities`, with overrides |
+| Jan / vLLM / SGLang | Explicit `supportsVision` config toggle (via OpenAI provider) |
+
+Auto results are keyed by provider, exact selected model, and canonical base
+URL. Concurrent checks share one request, and a late response from an older
+configuration cannot change the current provider. A separately configured
+dedicated vision provider continues to use the existing split-provider path.
 
 ### Anthropic Conversion
 
@@ -331,10 +344,4 @@ myprovider: {
 },
 ```
 
-Vision is normally auto-detected via model-name regex. Ollama is the exception:
-its Auto mode uses native `/api/show` metadata and fails closed to text-only
-when metadata cannot be verified. If another provider has a known set of vision
-models, add them to the regex in `openai.js`. Set
-`supportsStreamUsageOptions: true` only for providers that accept OpenAI-style
-`stream_options.include_usage`; leave it false when a provider returns usage
-without accepting that request field.
+Vision is auto-detected via model-name regex. If the provider has a known set of vision models, add them to the regex in `openai.js`. Set `supportsStreamUsageOptions: true` only for providers that accept OpenAI-style `stream_options.include_usage`; leave it false when a provider returns usage without accepting that request field.

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -38,7 +38,7 @@ class BaseLLMProvider {
 |---|---|---|---|---|
 | `webbrain_cloud` | `openai` | cloud | `webbrain-cloud 1.0` | Yes |
 | `llamacpp` | `llamacpp` | local | (loaded model) | Auto metadata / override |
-| `ollama` | `openai` | local | (loaded model) | Yes (default on) |
+| `ollama` | `openai` | local | (loaded model) | Auto via `/api/show` / override |
 | `lmstudio` | `openai` | local | (loaded model) | Auto metadata / override |
 | `jan` | `openai` | local | (loaded model) | Yes (default on) |
 | `vllm` | `openai` | local | (loaded model) | Yes (default on) |

--- a/docs/zh-CN/providers-and-models.md
+++ b/docs/zh-CN/providers-and-models.md
@@ -38,7 +38,7 @@ class BaseLLMProvider {
 |---|---|---|---|---|
 | `webbrain_cloud` | `openai` | 云端 | `webbrain-cloud 1.0` | 是 |
 | `llamacpp` | `llamacpp` | 本地 | （已加载模型） | 自动元数据 / 覆盖 |
-| `ollama` | `openai` | 本地 | （已加载模型） | 是（默认开启） |
+| `ollama` | `openai` | 本地 | （已加载模型） | 通过 `/api/show` 自动检测 / 覆盖 |
 | `lmstudio` | `openai` | 本地 | （已加载模型） | 自动元数据 / 覆盖 |
 | `jan` | `openai` | 本地 | （已加载模型） | 是（默认开启） |
 | `vllm` | `openai` | 本地 | （已加载模型） | 是（默认开启） |

--- a/docs/zh-CN/providers-and-models.md
+++ b/docs/zh-CN/providers-and-models.md
@@ -37,13 +37,13 @@ class BaseLLMProvider {
 | 提供商 ID | 类型 | 类别 | 默认模型 | 视觉能力 |
 |---|---|---|---|---|
 | `webbrain_cloud` | `openai` | 云端 | `webbrain-cloud 1.0` | 是 |
-| `llamacpp` | `llamacpp` | 本地 | （已加载模型） | 是（默认开启） |
-| `ollama` | `openai` | 本地 | （已加载模型） | 通过 `/api/show` 自动检测 |
-| `lmstudio` | `openai` | 本地 | （已加载模型） | 是（默认开启） |
+| `llamacpp` | `llamacpp` | 本地 | （已加载模型） | 自动元数据 / 覆盖 |
+| `ollama` | `openai` | 本地 | （已加载模型） | 是（默认开启） |
+| `lmstudio` | `openai` | 本地 | （已加载模型） | 自动元数据 / 覆盖 |
 | `jan` | `openai` | 本地 | （已加载模型） | 是（默认开启） |
 | `vllm` | `openai` | 本地 | （已加载模型） | 是（默认开启） |
 | `sglang` | `openai` | 本地 | （已加载模型） | 是（默认开启） |
-| `localai` | `openai` | 本地 | （已加载模型） | 是（默认开启） |
+| `localai` | `openai` | 本地 | （已加载模型） | 自动元数据 / 覆盖 |
 | `gpt4all` | `openai` | 本地 | （已加载模型） | 是（默认开启） |
 | `azure_openai` | `azure_openai` | 云端 | （部署） | 手动开关 |
 | `aws_bedrock` | `aws_bedrock` | 云端 | （模型 ID） | 否 |
@@ -118,9 +118,11 @@ WebBrain 会直接记录；若服务省略用量，则记录基于字符数的�
 - **SGLang**：`http://localhost:30000/v1` — SGLang 的 OpenAI 兼容服务器
 - **LocalAI**：`http://localhost:8080/v1` — LocalAI 的 OpenAI 兼容服务器
 
-Ollama 默认使用 `visionMode: "auto"`，并在附加图片前通过原生
-`/api/show` 元数据验证所选模型。其他本地提供商保持现有的显式
-`supportsVision` 行为。
+Ollama、llama.cpp、LM Studio 和 LocalAI 默认使用 `visionMode: auto`。WebBrain 在
+页面上下文增强前读取所选模型的原生服务器元数据，只有服务器明确报告支持图像输入时才
+发送截图。元数据请求失败或格式错误时，本回合按纯文本处理，之后会重试。设置中
+可选择自动、强制开启或关闭。模型字段为空时，每个用户回合都会重新检测当前加载
+模型的能力，以便服务端热切换立即生效；其他本地提供商保持现有的显式开关行为。
 
 #### Ollama 启动交接（预览）
 
@@ -170,9 +172,14 @@ Ask 模式忽略提供商层级，保持只读。Act 模式使用所选层级的
 |---|---|
 | OpenAI 兼容 | 根据模型名称进行正则匹配（`gpt-4o`、`gpt-5`、`claude-3`、`claude-sonnet-4`、`gemini-2.0-flash` 等） |
 | Anthropic | `claude-(3\|sonnet-4\|opus-4)` 模式 |
-| llama.cpp | 显式 `supportsVision` 配置开关 |
-| Ollama | `POST /api/show` 的 `capabilities` 字段，并兼容旧版 `projector_info` / `.vision.` 元数据；提供自动 / 强制开启 / 关闭设置 |
-| LM Studio / Jan / vLLM / SGLang / LocalAI | 显式 `supportsVision` 配置开关（通过 OpenAI 提供商） |
+| Ollama | `POST /api/show` 的 `capabilities`，并兼容旧版 `projector_info` / `.vision.` 元数据 |
+| llama.cpp | `GET /props` → `modalities.vision`，支持自动 / 强制开启 / 关闭 |
+| LM Studio | `GET /api/v1/models` → `capabilities.vision`；旧版本回退到 `/api/v0/models` 的 `type` |
+| LocalAI | `GET /v1/models/capabilities` → `input_modalities` / `capabilities` |
+| Jan / vLLM / SGLang | 显式 `supportsVision` 配置开关（通过 OpenAI 提供商） |
+
+检测结果按提供商、精确模型和规范化基础 URL 绑定。并发检测会合并为一次请求，旧
+配置的延迟响应不能修改当前设置。单独配置的视觉提供商继续使用现有的分流路径。
 
 ### Anthropic 转换
 
@@ -269,9 +276,4 @@ myprovider: {
 },
 ```
 
-视觉能力通常通过模型名称正则自动检测。Ollama 是例外：其自动模式使用
-原生 `/api/show` 元数据；无法验证元数据时会安全地回退为纯文本。如果其他
-提供商有已知的视觉模型集，请将它们添加到 `openai.js` 的正则表达式中。仅对
-接受 OpenAI 风格 `stream_options.include_usage` 的提供商设置
-`supportsStreamUsageOptions: true`；当提供商在不接受该请求字段的情况下返回
-使用量时，请将其保持为 false。
+视觉能力通过模型名称正则自动检测。如果提供商有已知的视觉模型集，请将它们添加到 `openai.js` 的正则表达式中。仅对接受 OpenAI 风格 `stream_options.include_usage` 的提供商设置 `supportsStreamUsageOptions: true`；当提供商在不接受该请求字段的情况下返回使用量时，请将其保持为 false。

--- a/src/chrome/README.md
+++ b/src/chrome/README.md
@@ -77,6 +77,11 @@ ollama serve
 # LocalAI: http://localhost:8080/v1
 ```
 
+For llama.cpp, LM Studio, and LocalAI, Vision defaults to **Auto**. WebBrain
+reads the selected model's server metadata before a turn and sends screenshots
+only when image input is reported. Settings also offers **Force on** and
+**Off** overrides; metadata failures remain text-only for that turn.
+
 ### Use it
 
 Click the WebBrain icon → the side panel opens. Type a message like:

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -22554,12 +22554,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     for (const att of attachments) {
       if (att.kind === 'image') {
         if (!provider?.supportsVision) {
-          const ollamaHint = String(provider?.config?.providerName || '').toLowerCase() === 'ollama'
-            ? ' If Ollama metadata is unavailable or incorrect, set its Vision capability to Force on in Settings.'
+          const overrideHint = provider?.config?.visionMode != null
+            ? ' If automatic detection is unavailable or incorrect, set Vision capability to Force on in Settings.'
             : '';
           return {
             ok: false,
-            error: `The active provider (${provider?.name || 'unknown'}) does not support image attachments. Switch to a vision-capable model (e.g. Claude 3+, GPT-4o) or remove the attached image and try again.${ollamaHint}`,
+            error: `The active provider (${provider?.name || 'unknown'}) does not support image attachments. Switch to a vision-capable model (e.g. Claude 3+, GPT-4o) or remove the attached image and try again.${overrideHint}`,
           };
         }
         let modelSourceDataUrl = att.dataUrl;
@@ -22681,10 +22681,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // New user turn: drop transient "allow once" / "deny once" permission grants.
     this.permissions.beginTurn(tabId);
 
-    // Resolve Ollama's model-bound vision capability before enrichment can
-    // capture pixels or attachment validation can inspect supportsVision.
-    // Metadata failures are deliberately non-fatal and leave auto mode
-    // text-only for this turn.
+    // Resolve model-bound local vision metadata before enrichment captures a
+    // screenshot or attachment validation consults provider.supportsVision.
+    // A metadata failure is non-fatal and leaves auto mode text-only this turn.
     try { await this.providerManager.prepareActiveProviderCapabilities?.(); } catch {}
 
     const selectionOnly = runOptions?.sourceGrounding === SELECTION_ONLY_SOURCE_GROUNDING;

--- a/src/chrome/src/providers/fetch-with-fallback.js
+++ b/src/chrome/src/providers/fetch-with-fallback.js
@@ -95,9 +95,12 @@ export async function fetchWithFallback(url, options = {}) {
   try {
     const res = await fetch(url, { ...fetchOptions, signal: controller.signal });
     clearTimeout(timeoutId);
+    // Keep the caller signal linked after headers arrive: aborting the fetch
+    // must also cancel a response body that stalls while the caller reads it.
     return res;
   } catch (directError) {
     clearTimeout(timeoutId);
+    callerSignal?.removeEventListener('abort', abortDirectFromCaller);
 
     if (callerSignal?.aborted) {
       throw callerSignal.reason instanceof Error
@@ -114,15 +117,12 @@ export async function fetchWithFallback(url, options = {}) {
         `Check the URL/credentials and that the server is responding.`
       );
     }
-    // Preserve the previous no-fallback behavior for fetches aborted by the
-    // browser or another lower layer for reasons unrelated to our timer.
     if (directError.name === 'AbortError') throw directError;
 
     // Network error (Failed to fetch) — try offscreen proxy
     console.warn(
       `[WebBrain] Direct fetch to ${url} failed (${directError.message}), trying offscreen proxy...`
     );
-    callerSignal?.removeEventListener('abort', abortDirectFromCaller);
 
     try {
       await ensureOffscreen();
@@ -239,6 +239,7 @@ async function _fetchViaOffscreenProxy(url, fetchOptions, timeoutMs, callerSigna
         // used to leave the caller hanging forever with no active timeout.
         if (msg.hasBody === false || [204, 205, 304].includes(msg.status)) {
           streamController = null;
+          cleanupCallerSignal();
           try {
             resolve(new Response(null, responseInit));
           } catch (e) {
@@ -288,6 +289,7 @@ async function _fetchViaOffscreenProxy(url, fetchOptions, timeoutMs, callerSigna
       } else if (msg?.type === 'done') {
         const sc = streamController;
         streamController = null;
+        cleanupCallerSignal();
         try { sc.close(); } catch {}
         try { port.disconnect(); } catch {}
       }

--- a/src/chrome/src/providers/llamacpp.js
+++ b/src/chrome/src/providers/llamacpp.js
@@ -1,5 +1,6 @@
 import { BaseLLMProvider } from './base.js';
 import { fetchWithFallback } from './fetch-with-fallback.js';
+import { configuredVisionSupport } from './vision-capabilities.js';
 
 /**
  * Provider for local llama.cpp server (OpenAI-compatible API on localhost).
@@ -29,9 +30,7 @@ export class LlamaCppProvider extends BaseLLMProvider {
   }
 
   get supportsVision() {
-    // Local models vary — some llama.cpp / Qwen2-VL / Gemma 3 / LLaVA builds
-    // are multimodal, others are text-only. The user opts in via settings.
-    return !!this.config.supportsVision;
+    return configuredVisionSupport('llamacpp', this.config);
   }
 
   get useCompactPrompt() {

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -22,6 +22,7 @@ import {
   visionCapabilityIdentity,
   visionDetectionMatches,
   visionDetectionSource,
+  visionProviderKind,
 } from './vision-capabilities.js';
 import {
   canonicalizeOllamaBaseUrl,
@@ -87,9 +88,8 @@ export class ProviderManager {
       !OLLAMA_VISION_MODES.has(rawStoredOllama.visionMode)
       || Object.hasOwn(rawStoredOllama, 'supportsVision')
     );
-    const genericVisionConfigMigrated = [...AUTO_VISION_PROVIDER_IDS].some((id) => {
-      const config = data.providers?.[id];
-      return !!config && (
+    const genericVisionConfigMigrated = Object.entries(data.providers || {}).some(([id, config]) => {
+      return !!visionProviderKind(id, config) && (
         !VISION_MODES.has(config.visionMode)
         || Object.hasOwn(config, 'supportsVision')
         || (!String(config.model || '').trim() && config.visionDetection != null)
@@ -623,18 +623,21 @@ export class ProviderManager {
       };
       delete migrated.ollama.supportsVision;
     }
-    for (const id of AUTO_VISION_PROVIDER_IDS) {
-      if (!migrated[id]) continue;
-      const legacySupportsVision = migrated[id].supportsVision;
-      const hasConfiguredModel = !!String(migrated[id].model || '').trim();
+    for (const [id, config] of Object.entries(migrated)) {
+      if (!visionProviderKind(id, config)) continue;
+      const legacySupportsVision = config.supportsVision;
+      const hasConfiguredModel = !!String(config.model || '').trim();
+      const isBuiltInAutoProvider = AUTO_VISION_PROVIDER_IDS.has(id);
       migrated[id] = {
-        ...migrated[id],
-        visionMode: VISION_MODES.has(migrated[id].visionMode)
-          ? migrated[id].visionMode
-          : (legacySupportsVision === false ? 'off' : 'auto'),
+        ...config,
+        visionMode: VISION_MODES.has(config.visionMode)
+          ? config.visionMode
+          : (legacySupportsVision === false
+            ? 'off'
+            : (legacySupportsVision === true && !isBuiltInAutoProvider ? 'on' : 'auto')),
         // With an empty Model field the server's loaded model can change
         // without a settings update, so never restore a persisted detection.
-        visionDetection: hasConfiguredModel ? (migrated[id].visionDetection || null) : null,
+        visionDetection: hasConfiguredModel ? (config.visionDetection || null) : null,
       };
       delete migrated[id].supportsVision;
     }
@@ -731,10 +734,13 @@ export class ProviderManager {
         : 'auto';
       delete normalizedConfig.supportsVision;
     }
-    if (AUTO_VISION_PROVIDER_IDS.has(id)) {
+    if (visionProviderKind(id, normalizedConfig)) {
+      const legacySupportsVision = normalizedConfig.supportsVision;
       normalizedConfig.visionMode = VISION_MODES.has(normalizedConfig.visionMode)
         ? normalizedConfig.visionMode
-        : 'auto';
+        : (typeof legacySupportsVision === 'boolean'
+          ? (legacySupportsVision ? 'on' : 'off')
+          : 'auto');
       delete normalizedConfig.supportsVision;
     }
     switch (normalizedConfig.type) {
@@ -833,31 +839,35 @@ export class ProviderManager {
 
   async ensureVisionCapability(id) {
     const provider = this.providers.get(id);
-    if (!provider || !AUTO_VISION_PROVIDER_IDS.has(id)) return { ok: false, skipped: true };
+    const providerKind = visionProviderKind(id, provider?.config);
+    if (!provider || !providerKind) return { ok: false, skipped: true };
     const mode = VISION_MODES.has(provider.config.visionMode) ? provider.config.visionMode : 'auto';
     if (mode !== 'auto') return { ok: true, skipped: true, supportsVision: mode === 'on' };
-    const identity = visionCapabilityIdentity(id, provider.config);
+    const identity = visionCapabilityIdentity(providerKind, provider.config);
     if (!identity) return { ok: false, skipped: true };
     const hasConfiguredModel = !!identity.model;
-    if (hasConfiguredModel && visionDetectionMatches(id, provider.config)) {
+    if (hasConfiguredModel && visionDetectionMatches(providerKind, provider.config)) {
       return { ok: true, cached: true, supportsVision: provider.config.visionDetection.supportsVision };
     }
 
     const epoch = this._visionCapabilityEpochs.get(id) || 0;
-    let pending = this._visionCapabilityChecks.get(identity.key);
+    const checkKey = `${id}\n${identity.key}`;
+    let pending = this._visionCapabilityChecks.get(checkKey);
     if (!pending) {
-      pending = this._fetchVisionCapability(id, provider, identity);
-      this._visionCapabilityChecks.set(identity.key, pending);
+      pending = this._fetchVisionCapability(providerKind, provider, identity);
+      this._visionCapabilityChecks.set(checkKey, pending);
     }
     const result = await pending;
-    if ((!hasConfiguredModel || !result.ok) && this._visionCapabilityChecks.get(identity.key) === pending) {
+    if ((!hasConfiguredModel || !result.ok) && this._visionCapabilityChecks.get(checkKey) === pending) {
       // Empty-model identities describe whatever is currently loaded, not a
       // stable model. Coalesce only concurrent callers, then recheck next turn.
-      this._visionCapabilityChecks.delete(identity.key);
+      this._visionCapabilityChecks.delete(checkKey);
     }
     const current = this.providers.get(id);
-    const currentIdentity = visionCapabilityIdentity(id, current?.config);
+    const currentKind = visionProviderKind(id, current?.config);
+    const currentIdentity = visionCapabilityIdentity(currentKind, current?.config);
     if (!current || current.config.visionMode !== 'auto'
+      || currentKind !== providerKind
       || currentIdentity?.key !== identity.key
       || (this._visionCapabilityEpochs.get(id) || 0) !== epoch) {
       return { ...result, stale: true };
@@ -871,11 +881,11 @@ export class ProviderManager {
     }
 
     const detection = {
-      providerId: id,
+      providerId: providerKind,
       model: identity.model,
       baseUrl: identity.baseUrl,
       supportsVision: result.supportsVision,
-      source: visionDetectionSource(id),
+      source: visionDetectionSource(providerKind),
       ...(!hasConfiguredModel ? { transient: true } : {}),
     };
     this.providers.set(id, this._createProvider(id, { ...current.config, visionDetection: detection }));
@@ -976,7 +986,8 @@ export class ProviderManager {
 
   async prepareActiveProviderCapabilities() {
     if (this.activeProviderId === 'ollama') return this.ensureOllamaVisionCapability('ollama');
-    if (AUTO_VISION_PROVIDER_IDS.has(this.activeProviderId)) {
+    const activeProvider = this.providers.get(this.activeProviderId);
+    if (visionProviderKind(this.activeProviderId, activeProvider?.config)) {
       return this.ensureVisionCapability(this.activeProviderId);
     }
     return { ok: true, skipped: true };
@@ -1044,12 +1055,19 @@ export class ProviderManager {
         merged.visionDetection = null;
       }
     }
-    if (AUTO_VISION_PROVIDER_IDS.has(id)) {
-      merged.visionMode = VISION_MODES.has(merged.visionMode) ? merged.visionMode : 'auto';
+    const genericVisionKind = visionProviderKind(id, merged);
+    if (genericVisionKind) {
+      const explicitLegacyVision = Object.hasOwn(config, 'supportsVision') && !Object.hasOwn(config, 'visionMode')
+        ? config.supportsVision
+        : null;
+      merged.visionMode = typeof explicitLegacyVision === 'boolean'
+        ? (explicitLegacyVision ? 'on' : 'off')
+        : (VISION_MODES.has(merged.visionMode) ? merged.visionMode : 'auto');
       delete merged.supportsVision;
-      const currentIdentity = visionCapabilityIdentity(id, current);
-      const nextIdentity = visionCapabilityIdentity(id, merged);
-      if (currentIdentity?.key !== nextIdentity?.key || current.visionMode !== merged.visionMode) {
+      const currentKind = visionProviderKind(id, current);
+      const currentIdentity = visionCapabilityIdentity(currentKind, current);
+      const nextIdentity = visionCapabilityIdentity(genericVisionKind, merged);
+      if (currentKind !== genericVisionKind || currentIdentity?.key !== nextIdentity?.key || current.visionMode !== merged.visionMode) {
         merged.visionDetection = null;
         this._visionCapabilityEpochs.set(id, (this._visionCapabilityEpochs.get(id) || 0) + 1);
         for (const key of this._visionCapabilityChecks.keys()) {

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -14,6 +14,16 @@ import { ADDITIONAL_PROVIDER_DEFAULTS } from './provider-catalog.js';
 // fetch ever ran, so onboarding reported "no models" for a reachable server.)
 import { fetchWithFallback } from './fetch-with-fallback.js';
 import {
+  AUTO_VISION_PROVIDER_IDS,
+  VISION_MODES,
+  parseLlamaCppVisionSupport,
+  parseLmStudioVisionSupport,
+  parseLocalAiVisionSupport,
+  visionCapabilityIdentity,
+  visionDetectionMatches,
+  visionDetectionSource,
+} from './vision-capabilities.js';
+import {
   canonicalizeOllamaBaseUrl,
   lmStudioContextWindowIsLive,
   parseLlamaCppPropsContextWindow,
@@ -42,6 +52,7 @@ const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'hugg
 const PROVIDER_CREDENTIAL_KEYS = ['apiKey', 'accessKeyId', 'secretAccessKey', 'sessionToken'];
 const OLLAMA_VISION_MODES = new Set(['auto', 'on', 'off']);
 const OLLAMA_VISION_METADATA_TIMEOUT_MS = 3000;
+const VISION_METADATA_TIMEOUT_MS = 3000;
 
 /**
  * Manages LLM provider instances and persists configuration.
@@ -51,6 +62,8 @@ export class ProviderManager {
     this.providers = new Map();
     this.activeProviderId = null;
     this._ollamaVisionChecks = new Map();
+    this._visionCapabilityChecks = new Map();
+    this._visionCapabilityEpochs = new Map();
   }
 
   /**
@@ -74,6 +87,14 @@ export class ProviderManager {
       !OLLAMA_VISION_MODES.has(rawStoredOllama.visionMode)
       || Object.hasOwn(rawStoredOllama, 'supportsVision')
     );
+    const genericVisionConfigMigrated = [...AUTO_VISION_PROVIDER_IDS].some((id) => {
+      const config = data.providers?.[id];
+      return !!config && (
+        !VISION_MODES.has(config.visionMode)
+        || Object.hasOwn(config, 'supportsVision')
+        || (!String(config.model || '').trim() && config.visionDetection != null)
+      );
+    });
     const hadLegacyClaudeSubscription = Object.hasOwn(data.providers || {}, 'claude_subscription');
     const stored = this._migrateStoredProviderConfigs(data.providers || {});
     const legacyActiveProviderId = ['webbrain', 'openai_subscription'].includes(data.activeProvider)
@@ -84,7 +105,7 @@ export class ProviderManager {
     // without dropping keys that don't exist in stored.
     const defaults = this._defaultConfigs();
     const configs = {};
-    let providerStateMigrated = ollamaVisionConfigMigrated;
+    let providerStateMigrated = ollamaVisionConfigMigrated || genericVisionConfigMigrated;
     for (const [id, config] of Object.entries(defaults)) {
       const storedConfig = stored[id];
       const hasConfiguredMarker = !!storedConfig && Object.hasOwn(storedConfig, 'configured');
@@ -185,14 +206,8 @@ export class ProviderManager {
         model: '',
         contextWindow: 16384,
         supportsAskStreaming: true,
-        // Default ON for local providers: in practice users who reach for
-        // local OpenAI-compatible backends in 2026 are running multimodal
-        // models (Qwen-VL, Llama 3.2-Vision, etc.). False-positives where a
-        // text-only model is loaded with vision=true still work — the agent
-        // just sends image_url blocks the model ignores. False-negatives
-        // (vision-capable model loaded with vision=false) silently lose the
-        // multimodal channel, which is the worse failure mode.
-        supportsVision: true,
+        visionMode: 'auto',
+        visionDetection: null,
         enabled: true,
       },
       ollama: {
@@ -219,7 +234,8 @@ export class ProviderManager {
         contextWindow: 16384,
         apiKey: 'lm-studio',
         supportsAskStreaming: true,
-        supportsVision: true,
+        visionMode: 'auto',
+        visionDetection: null,
         enabled: true,
       },
       jan: {
@@ -271,7 +287,8 @@ export class ProviderManager {
         contextWindow: 16384,
         apiKey: '',
         supportsAskStreaming: true,
-        supportsVision: true,
+        visionMode: 'auto',
+        visionDetection: null,
         enabled: true,
       },
       gpt4all: {
@@ -606,6 +623,21 @@ export class ProviderManager {
       };
       delete migrated.ollama.supportsVision;
     }
+    for (const id of AUTO_VISION_PROVIDER_IDS) {
+      if (!migrated[id]) continue;
+      const legacySupportsVision = migrated[id].supportsVision;
+      const hasConfiguredModel = !!String(migrated[id].model || '').trim();
+      migrated[id] = {
+        ...migrated[id],
+        visionMode: VISION_MODES.has(migrated[id].visionMode)
+          ? migrated[id].visionMode
+          : (legacySupportsVision === false ? 'off' : 'auto'),
+        // With an empty Model field the server's loaded model can change
+        // without a settings update, so never restore a persisted detection.
+        visionDetection: hasConfiguredModel ? (migrated[id].visionDetection || null) : null,
+      };
+      delete migrated[id].supportsVision;
+    }
     // Existing installs stored omitToolsWhenImagesPresent:true for WebBrain
     // Cloud, which suppressed native tools on every screenshot turn and broke
     // tool calling. Force it off so the saved config picks up the new default.
@@ -699,6 +731,12 @@ export class ProviderManager {
         : 'auto';
       delete normalizedConfig.supportsVision;
     }
+    if (AUTO_VISION_PROVIDER_IDS.has(id)) {
+      normalizedConfig.visionMode = VISION_MODES.has(normalizedConfig.visionMode)
+        ? normalizedConfig.visionMode
+        : 'auto';
+      delete normalizedConfig.supportsVision;
+    }
     switch (normalizedConfig.type) {
       case 'llamacpp':
         return new LlamaCppProvider(normalizedConfig);
@@ -728,6 +766,121 @@ export class ProviderManager {
       throw new Error(`No active provider: ${this.activeProviderId}`);
     }
     return provider;
+  }
+
+  async _fetchVisionCapability(providerId, provider, identity) {
+    const root = identity.baseUrl.replace(/\/v1$/i, '');
+    const headers = this._modelListHeaders(provider);
+    const controller = new AbortController();
+    const fetchJson = async (url) => {
+      const response = await fetchWithFallback(url, {
+        method: 'GET',
+        headers,
+        timeoutMs: VISION_METADATA_TIMEOUT_MS,
+        signal: controller.signal,
+      });
+      if (!response.ok) return { ok: false, status: response.status };
+      try {
+        return { ok: true, data: await response.json() };
+      } catch {
+        return { ok: false, malformed: true };
+      }
+    };
+    const request = (async () => {
+      try {
+        if (providerId === 'llamacpp') {
+          const query = identity.model ? `?model=${encodeURIComponent(identity.model)}` : '';
+          const result = await fetchJson(`${root}/props${query}`);
+          if (!result.ok) return result;
+          const supportsVision = parseLlamaCppVisionSupport(result.data);
+          return supportsVision == null ? { ok: false, malformed: true } : { ok: true, supportsVision };
+        }
+        if (providerId === 'lmstudio') {
+          const current = await fetchJson(`${root}/api/v1/models`);
+          if (current.ok) {
+            const supportsVision = parseLmStudioVisionSupport(current.data, identity.model, 'v1');
+            if (supportsVision != null) return { ok: true, supportsVision };
+          }
+          const legacy = await fetchJson(`${root}/api/v0/models`);
+          if (!legacy.ok) return legacy;
+          const supportsVision = parseLmStudioVisionSupport(legacy.data, identity.model, 'v0');
+          return supportsVision == null ? { ok: false, malformed: true } : { ok: true, supportsVision };
+        }
+        if (providerId === 'localai') {
+          const result = await fetchJson(`${root}/v1/models/capabilities`);
+          if (!result.ok) return result;
+          const supportsVision = parseLocalAiVisionSupport(result.data, identity.model);
+          return supportsVision == null ? { ok: false, malformed: true } : { ok: true, supportsVision };
+        }
+        return { ok: false, skipped: true };
+      } catch (error) {
+        return { ok: false, error: error?.message || String(error) };
+      }
+    })();
+    let timeoutId;
+    const timeout = new Promise((resolve) => {
+      timeoutId = setTimeout(() => {
+        controller.abort(new DOMException('Vision capability metadata timed out', 'TimeoutError'));
+        resolve({ ok: false, timeout: true });
+      }, VISION_METADATA_TIMEOUT_MS);
+    });
+    try {
+      return await Promise.race([request, timeout]);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  async ensureVisionCapability(id) {
+    const provider = this.providers.get(id);
+    if (!provider || !AUTO_VISION_PROVIDER_IDS.has(id)) return { ok: false, skipped: true };
+    const mode = VISION_MODES.has(provider.config.visionMode) ? provider.config.visionMode : 'auto';
+    if (mode !== 'auto') return { ok: true, skipped: true, supportsVision: mode === 'on' };
+    const identity = visionCapabilityIdentity(id, provider.config);
+    if (!identity) return { ok: false, skipped: true };
+    const hasConfiguredModel = !!identity.model;
+    if (hasConfiguredModel && visionDetectionMatches(id, provider.config)) {
+      return { ok: true, cached: true, supportsVision: provider.config.visionDetection.supportsVision };
+    }
+
+    const epoch = this._visionCapabilityEpochs.get(id) || 0;
+    let pending = this._visionCapabilityChecks.get(identity.key);
+    if (!pending) {
+      pending = this._fetchVisionCapability(id, provider, identity);
+      this._visionCapabilityChecks.set(identity.key, pending);
+    }
+    const result = await pending;
+    if ((!hasConfiguredModel || !result.ok) && this._visionCapabilityChecks.get(identity.key) === pending) {
+      // Empty-model identities describe whatever is currently loaded, not a
+      // stable model. Coalesce only concurrent callers, then recheck next turn.
+      this._visionCapabilityChecks.delete(identity.key);
+    }
+    const current = this.providers.get(id);
+    const currentIdentity = visionCapabilityIdentity(id, current?.config);
+    if (!current || current.config.visionMode !== 'auto'
+      || currentIdentity?.key !== identity.key
+      || (this._visionCapabilityEpochs.get(id) || 0) !== epoch) {
+      return { ...result, stale: true };
+    }
+    if (!result.ok) {
+      if (!hasConfiguredModel && current.config.visionDetection?.transient === true) {
+        const { visionDetection: _ignored, ...withoutDetection } = current.config;
+        this.providers.set(id, this._createProvider(id, withoutDetection));
+      }
+      return result;
+    }
+
+    const detection = {
+      providerId: id,
+      model: identity.model,
+      baseUrl: identity.baseUrl,
+      supportsVision: result.supportsVision,
+      source: visionDetectionSource(id),
+      ...(!hasConfiguredModel ? { transient: true } : {}),
+    };
+    this.providers.set(id, this._createProvider(id, { ...current.config, visionDetection: detection }));
+    if (hasConfiguredModel) await this.save();
+    return { ok: true, supportsVision: result.supportsVision, detection };
   }
 
   _ollamaVisionIdentity(config) {
@@ -822,8 +975,11 @@ export class ProviderManager {
   }
 
   async prepareActiveProviderCapabilities() {
-    if (this.activeProviderId !== 'ollama') return { ok: true, skipped: true };
-    return this.ensureOllamaVisionCapability('ollama');
+    if (this.activeProviderId === 'ollama') return this.ensureOllamaVisionCapability('ollama');
+    if (AUTO_VISION_PROVIDER_IDS.has(this.activeProviderId)) {
+      return this.ensureVisionCapability(this.activeProviderId);
+    }
+    return { ok: true, skipped: true };
   }
 
   /**
@@ -886,6 +1042,19 @@ export class ProviderManager {
       const nextIdentity = this._ollamaVisionIdentity(merged);
       if (currentIdentity?.key !== nextIdentity?.key || current.visionMode !== merged.visionMode) {
         merged.visionDetection = null;
+      }
+    }
+    if (AUTO_VISION_PROVIDER_IDS.has(id)) {
+      merged.visionMode = VISION_MODES.has(merged.visionMode) ? merged.visionMode : 'auto';
+      delete merged.supportsVision;
+      const currentIdentity = visionCapabilityIdentity(id, current);
+      const nextIdentity = visionCapabilityIdentity(id, merged);
+      if (currentIdentity?.key !== nextIdentity?.key || current.visionMode !== merged.visionMode) {
+        merged.visionDetection = null;
+        this._visionCapabilityEpochs.set(id, (this._visionCapabilityEpochs.get(id) || 0) + 1);
+        for (const key of this._visionCapabilityChecks.keys()) {
+          if (key.startsWith(`${id}\n`)) this._visionCapabilityChecks.delete(key);
+        }
       }
     }
     this.providers.set(id, this._createProvider(id, merged));

--- a/src/chrome/src/providers/openai.js
+++ b/src/chrome/src/providers/openai.js
@@ -7,6 +7,7 @@ import {
 } from './provider-compatibility.js';
 import { normalizeRuntimeTraceConfig } from '../trace/runtime-config.js';
 import { canonicalizeOllamaBaseUrl } from './context-windows.js';
+import { AUTO_VISION_PROVIDER_IDS, configuredVisionSupport } from './vision-capabilities.js';
 
 const OPENAI_RESPONSES_MIN_MAX_OUTPUT_TOKENS = 16;
 const KIMI_CURRENT_TOOL_REASONING_MODELS = new Set([
@@ -105,6 +106,9 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
         && model === detectedModel
         && baseUrl === detectedBaseUrl
         && detection?.supportsVision === true;
+    }
+    if (AUTO_VISION_PROVIDER_IDS.has(providerName)) {
+      return configuredVisionSupport(providerName, this.config);
     }
     // Explicit user opt-in always wins (used by LM Studio and any custom
     // OpenAI-compatible endpoint where the loaded model varies).

--- a/src/chrome/src/providers/vision-capabilities.js
+++ b/src/chrome/src/providers/vision-capabilities.js
@@ -7,6 +7,14 @@ const DETECTION_SOURCES = {
   localai: 'localai_capabilities',
 };
 
+export function visionProviderKind(providerId, config = {}) {
+  if (config?.type === 'llamacpp') return 'llamacpp';
+  const id = String(providerId || '').trim().toLowerCase();
+  if (AUTO_VISION_PROVIDER_IDS.has(id)) return id;
+  const providerName = String(config?.providerName || '').trim().toLowerCase();
+  return AUTO_VISION_PROVIDER_IDS.has(providerName) ? providerName : null;
+}
+
 export function canonicalizeVisionBaseUrl(value) {
   const raw = String(value || '').trim().replace(/\/+$/, '');
   if (!raw) return '';

--- a/src/chrome/src/providers/vision-capabilities.js
+++ b/src/chrome/src/providers/vision-capabilities.js
@@ -1,0 +1,113 @@
+export const AUTO_VISION_PROVIDER_IDS = new Set(['llamacpp', 'lmstudio', 'localai']);
+export const VISION_MODES = new Set(['auto', 'on', 'off']);
+
+const DETECTION_SOURCES = {
+  llamacpp: 'llamacpp_props',
+  lmstudio: 'lmstudio_models',
+  localai: 'localai_capabilities',
+};
+
+export function canonicalizeVisionBaseUrl(value) {
+  const raw = String(value || '').trim().replace(/\/+$/, '');
+  if (!raw) return '';
+  try {
+    const url = new URL(raw);
+    url.hash = '';
+    url.search = '';
+    return url.toString().replace(/\/+$/, '');
+  } catch {
+    return '';
+  }
+}
+
+export function visionCapabilityIdentity(providerId, config) {
+  if (!AUTO_VISION_PROVIDER_IDS.has(providerId)) return null;
+  const baseUrl = canonicalizeVisionBaseUrl(config?.baseUrl);
+  if (!baseUrl) return null;
+  const model = String(config?.model || '').trim();
+  return {
+    providerId,
+    baseUrl,
+    model,
+    key: `${providerId}\n${baseUrl}\n${model.toLowerCase()}`,
+  };
+}
+
+export function visionDetectionMatches(providerId, config, detection = config?.visionDetection, options = {}) {
+  const identity = visionCapabilityIdentity(providerId, config);
+  const transientEmptyModel = options.allowTransient === true
+    && !identity?.model
+    && detection?.transient === true
+    && !String(detection?.model || '').trim();
+  return !!identity
+    && (!!identity.model || transientEmptyModel)
+    && detection?.providerId === providerId
+    && detection?.source === DETECTION_SOURCES[providerId]
+    && canonicalizeVisionBaseUrl(detection?.baseUrl) === identity.baseUrl
+    && String(detection?.model || '').trim().toLowerCase() === identity.model.toLowerCase()
+    && typeof detection?.supportsVision === 'boolean';
+}
+
+export function configuredVisionSupport(providerId, config) {
+  const mode = VISION_MODES.has(config?.visionMode) ? config.visionMode : 'auto';
+  if (mode === 'on') return true;
+  if (mode === 'off') return false;
+  return visionDetectionMatches(providerId, config, config?.visionDetection, { allowTransient: true })
+    && config.visionDetection.supportsVision === true;
+}
+
+function modelId(entry) {
+  return String(entry?.key || entry?.id || entry?.model || entry?.name || '').trim();
+}
+
+function selectModel(entries, requestedModel, { preferLoaded = false } = {}) {
+  if (!Array.isArray(entries) || !entries.length) return null;
+  const requested = String(requestedModel || '').trim().toLowerCase();
+  if (requested) return entries.find(entry => modelId(entry).toLowerCase() === requested) || null;
+  if (preferLoaded) {
+    const loaded = entries.filter(entry =>
+      String(entry?.state || '').toLowerCase() === 'loaded'
+      || (Array.isArray(entry?.loaded_instances) && entry.loaded_instances.length > 0)
+    );
+    if (loaded.length === 1) return loaded[0];
+  }
+  return entries.length === 1 ? entries[0] : null;
+}
+
+export function parseLmStudioVisionSupport(payload, model, apiVersion = 'v1') {
+  const entries = apiVersion === 'v1' ? payload?.models : payload?.data;
+  const entry = selectModel(entries, model, { preferLoaded: true });
+  if (!entry) return null;
+  if (apiVersion === 'v1') {
+    return typeof entry?.capabilities?.vision === 'boolean'
+      ? entry.capabilities.vision
+      : null;
+  }
+  const type = String(entry?.type || '').trim().toLowerCase();
+  if (type === 'vlm') return true;
+  if (type === 'llm') return false;
+  return null;
+}
+
+export function parseLlamaCppVisionSupport(payload) {
+  return typeof payload?.modalities?.vision === 'boolean'
+    ? payload.modalities.vision
+    : null;
+}
+
+export function parseLocalAiVisionSupport(payload, model) {
+  const entry = selectModel(payload?.data, model);
+  if (!entry) return null;
+  if (Array.isArray(entry.input_modalities)) {
+    return entry.input_modalities.some(value => String(value).toLowerCase() === 'image');
+  }
+  if (Array.isArray(entry.capabilities)) {
+    return entry.capabilities.some(value => String(value).toLowerCase() === 'vision');
+  }
+  if (typeof entry?.capabilities?.vision === 'boolean') return entry.capabilities.vision;
+  return null;
+}
+
+export function visionDetectionSource(providerId) {
+  return DETECTION_SOURCES[providerId] || '';
+}

--- a/src/chrome/src/providers/vision-capabilities.js
+++ b/src/chrome/src/providers/vision-capabilities.js
@@ -29,7 +29,7 @@ export function visionCapabilityIdentity(providerId, config) {
     providerId,
     baseUrl,
     model,
-    key: `${providerId}\n${baseUrl}\n${model.toLowerCase()}`,
+    key: `${providerId}\n${baseUrl}\n${model}`,
   };
 }
 
@@ -44,7 +44,7 @@ export function visionDetectionMatches(providerId, config, detection = config?.v
     && detection?.providerId === providerId
     && detection?.source === DETECTION_SOURCES[providerId]
     && canonicalizeVisionBaseUrl(detection?.baseUrl) === identity.baseUrl
-    && String(detection?.model || '').trim().toLowerCase() === identity.model.toLowerCase()
+    && String(detection?.model || '').trim() === identity.model
     && typeof detection?.supportsVision === 'boolean';
 }
 
@@ -62,8 +62,8 @@ function modelId(entry) {
 
 function selectModel(entries, requestedModel, { preferLoaded = false } = {}) {
   if (!Array.isArray(entries) || !entries.length) return null;
-  const requested = String(requestedModel || '').trim().toLowerCase();
-  if (requested) return entries.find(entry => modelId(entry).toLowerCase() === requested) || null;
+  const requested = String(requestedModel || '').trim();
+  if (requested) return entries.find(entry => modelId(entry) === requested) || null;
   if (preferLoaded) {
     const loaded = entries.filter(entry =>
       String(entry?.state || '').toLowerCase() === 'loaded'

--- a/src/chrome/src/ui/locales/ar.js
+++ b/src/chrome/src/ui/locales/ar.js
@@ -277,7 +277,7 @@ export default {
   'st.provider.field.model': 'النموذج',
   'st.provider.field.model_optional': 'النموذج (اختياري)',
   'st.provider.field.supports_vision': 'النموذج يدعم الرؤية (متعدّد الوسائط)',
-  'st.provider.field.vision_auto': 'تلقائي (من Ollama)',
+  'st.provider.field.vision_auto': 'تلقائي',
   'st.provider.field.vision_force_on': 'فرض التشغيل',
   'st.provider.field.vision_detected_vision': 'تم الاكتشاف تلقائيًا: يدعم الرؤية',
   'st.provider.field.vision_detected_text': 'تم الاكتشاف تلقائيًا: نص فقط',

--- a/src/chrome/src/ui/locales/bn.js
+++ b/src/chrome/src/ui/locales/bn.js
@@ -730,7 +730,7 @@ export default {
   'st.provider.field.model_optional': "মডেল (ঐচ্ছিক)",
   'st.provider.field.context_window': "প্রসঙ্গ উইন্ডো (টোকেন)",
   'st.provider.field.supports_vision': "মডেল দৃষ্টি সমর্থন করে (মাল্টিমোডাল)",
-  'st.provider.field.vision_auto': 'স্বয়ংক্রিয় (Ollama থেকে)',
+  'st.provider.field.vision_auto': 'স্বয়ংক্রিয়',
   'st.provider.field.vision_force_on': 'জোর করে চালু',
   'st.provider.field.vision_detected_vision': 'স্বয়ংক্রিয়ভাবে শনাক্ত: ভিশন',
   'st.provider.field.vision_detected_text': 'স্বয়ংক্রিয়ভাবে শনাক্ত: শুধু টেক্সট',

--- a/src/chrome/src/ui/locales/de.js
+++ b/src/chrome/src/ui/locales/de.js
@@ -667,7 +667,7 @@ export default {
   'st.provider.field.model_optional': 'Modell (optional)',
   'st.provider.field.context_window': 'Kontextfenster (Tokens)',
   'st.provider.field.supports_vision': 'Modell unterstützt Vision (multimodal)',
-  'st.provider.field.vision_auto': 'Automatisch (von Ollama)',
+  'st.provider.field.vision_auto': 'Automatisch',
   'st.provider.field.vision_force_on': 'Erzwingen',
   'st.provider.field.vision_detected_vision': 'Automatisch erkannt: Bildverarbeitung',
   'st.provider.field.vision_detected_text': 'Automatisch erkannt: Nur Text',

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -731,7 +731,7 @@ export default {
   'st.provider.field.model_optional': 'Model (optional)',
   'st.provider.field.context_window': 'Context window (tokens)',
   'st.provider.field.supports_vision': 'Model supports vision (multimodal)',
-  'st.provider.field.vision_auto': 'Auto (from Ollama)',
+  'st.provider.field.vision_auto': 'Auto',
   'st.provider.field.vision_force_on': 'Force on',
   'st.provider.field.vision_detected_vision': 'Auto-detected: Vision',
   'st.provider.field.vision_detected_text': 'Auto-detected: Text only',

--- a/src/chrome/src/ui/locales/es.js
+++ b/src/chrome/src/ui/locales/es.js
@@ -277,7 +277,7 @@ export default {
   'st.provider.field.model': 'Modelo',
   'st.provider.field.model_optional': 'Modelo (opcional)',
   'st.provider.field.supports_vision': 'El modelo admite visión (multimodal)',
-  'st.provider.field.vision_auto': 'Automático (desde Ollama)',
+  'st.provider.field.vision_auto': 'Automático',
   'st.provider.field.vision_force_on': 'Forzar activación',
   'st.provider.field.vision_detected_vision': 'Detectado automáticamente: Visión',
   'st.provider.field.vision_detected_text': 'Detectado automáticamente: Solo texto',

--- a/src/chrome/src/ui/locales/fa.js
+++ b/src/chrome/src/ui/locales/fa.js
@@ -730,7 +730,7 @@ export default {
   'st.provider.field.model_optional': "مدل (اختیاری)",
   'st.provider.field.context_window': "پنجره زمینه (توکن ها)",
   'st.provider.field.supports_vision': "مدل از بینایی پشتیبانی می کند (چند وجهی)",
-  'st.provider.field.vision_auto': 'خودکار (از Ollama)',
+  'st.provider.field.vision_auto': 'خودکار',
   'st.provider.field.vision_force_on': 'اجباری روشن',
   'st.provider.field.vision_detected_vision': 'شناسایی خودکار: بینایی',
   'st.provider.field.vision_detected_text': 'شناسایی خودکار: فقط متن',

--- a/src/chrome/src/ui/locales/fr.js
+++ b/src/chrome/src/ui/locales/fr.js
@@ -277,7 +277,7 @@ export default {
   'st.provider.field.model': 'Modèle',
   'st.provider.field.model_optional': 'Modèle (facultatif)',
   'st.provider.field.supports_vision': 'Le modèle gère la vision (multimodal)',
-  'st.provider.field.vision_auto': 'Automatique (depuis Ollama)',
+  'st.provider.field.vision_auto': 'Automatique',
   'st.provider.field.vision_force_on': 'Forcer l’activation',
   'st.provider.field.vision_detected_vision': 'Détection automatique : vision',
   'st.provider.field.vision_detected_text': 'Détection automatique : texte uniquement',

--- a/src/chrome/src/ui/locales/he.js
+++ b/src/chrome/src/ui/locales/he.js
@@ -642,7 +642,7 @@ export default {
   "st.provider.field.model_optional": "מודל (אופציונלי)",
   "st.provider.field.context_window": "חלון הקשר (אסימונים)",
   "st.provider.field.supports_vision": "הדגם תומך בראייה (מולטימודאלי)",
-  'st.provider.field.vision_auto': 'אוטומטי (מ־Ollama)',
+  'st.provider.field.vision_auto': 'אוטומטי',
   'st.provider.field.vision_force_on': 'הפעלה מאולצת',
   'st.provider.field.vision_detected_vision': 'זוהה אוטומטית: ראייה',
   'st.provider.field.vision_detected_text': 'זוהה אוטומטית: טקסט בלבד',

--- a/src/chrome/src/ui/locales/hi.js
+++ b/src/chrome/src/ui/locales/hi.js
@@ -730,7 +730,7 @@ export default {
   'st.provider.field.model_optional': "मॉडल (वैकल्पिक)",
   'st.provider.field.context_window': "संदर्भ विंडो (टोकन)",
   'st.provider.field.supports_vision': "मॉडल दृष्टि का समर्थन करता है (मल्टीमॉडल)",
-  'st.provider.field.vision_auto': 'स्वचालित (Ollama से)',
+  'st.provider.field.vision_auto': 'स्वचालित',
   'st.provider.field.vision_force_on': 'बलपूर्वक चालू',
   'st.provider.field.vision_detected_vision': 'स्वतः पहचाना गया: विज़न',
   'st.provider.field.vision_detected_text': 'स्वतः पहचाना गया: केवल टेक्स्ट',

--- a/src/chrome/src/ui/locales/id.js
+++ b/src/chrome/src/ui/locales/id.js
@@ -277,7 +277,7 @@ export default {
   'st.provider.field.model': 'Model',
   'st.provider.field.model_optional': 'Model (opsional)',
   'st.provider.field.supports_vision': 'Model mendukung visi (multimodal)',
-  'st.provider.field.vision_auto': 'Otomatis (dari Ollama)',
+  'st.provider.field.vision_auto': 'Otomatis',
   'st.provider.field.vision_force_on': 'Paksa aktif',
   'st.provider.field.vision_detected_vision': 'Terdeteksi otomatis: Vision',
   'st.provider.field.vision_detected_text': 'Terdeteksi otomatis: Teks saja',

--- a/src/chrome/src/ui/locales/ja.js
+++ b/src/chrome/src/ui/locales/ja.js
@@ -277,7 +277,7 @@ export default {
   'st.provider.field.model': 'モデル',
   'st.provider.field.model_optional': 'モデル（任意）',
   'st.provider.field.supports_vision': 'モデルは画像認識（マルチモーダル）対応',
-  'st.provider.field.vision_auto': '自動（Ollama から）',
+  'st.provider.field.vision_auto': '自動',
   'st.provider.field.vision_force_on': '強制的にオン',
   'st.provider.field.vision_detected_vision': '自動検出：画像対応',
   'st.provider.field.vision_detected_text': '自動検出：テキストのみ',

--- a/src/chrome/src/ui/locales/ko.js
+++ b/src/chrome/src/ui/locales/ko.js
@@ -277,7 +277,7 @@ export default {
   'st.provider.field.model': '모델',
   'st.provider.field.model_optional': '모델 (선택)',
   'st.provider.field.supports_vision': '모델이 비전(멀티모달)을 지원합니다',
-  'st.provider.field.vision_auto': '자동(Ollama에서)',
+  'st.provider.field.vision_auto': '자동',
   'st.provider.field.vision_force_on': '강제로 켜기',
   'st.provider.field.vision_detected_vision': '자동 감지: 비전',
   'st.provider.field.vision_detected_text': '자동 감지: 텍스트 전용',

--- a/src/chrome/src/ui/locales/ms.js
+++ b/src/chrome/src/ui/locales/ms.js
@@ -277,7 +277,7 @@ export default {
   'st.provider.field.model': 'Model',
   'st.provider.field.model_optional': 'Model (pilihan)',
   'st.provider.field.supports_vision': 'Model menyokong penglihatan (multimodal)',
-  'st.provider.field.vision_auto': 'Automatik (daripada Ollama)',
+  'st.provider.field.vision_auto': 'Automatik',
   'st.provider.field.vision_force_on': 'Paksa hidup',
   'st.provider.field.vision_detected_vision': 'Dikesan secara automatik: Penglihatan',
   'st.provider.field.vision_detected_text': 'Dikesan secara automatik: Teks sahaja',

--- a/src/chrome/src/ui/locales/nl.js
+++ b/src/chrome/src/ui/locales/nl.js
@@ -643,7 +643,7 @@ export default {
   'st.provider.field.model_optional': 'Model (optioneel)',
   'st.provider.field.context_window': 'Contextvenster (tokens)',
   'st.provider.field.supports_vision': 'Model ondersteunt visie (multimodaal)',
-  'st.provider.field.vision_auto': 'Automatisch (van Ollama)',
+  'st.provider.field.vision_auto': 'Automatisch',
   'st.provider.field.vision_force_on': 'Geforceerd aan',
   'st.provider.field.vision_detected_vision': 'Automatisch gedetecteerd: Visie',
   'st.provider.field.vision_detected_text': 'Automatisch gedetecteerd: Alleen tekst',

--- a/src/chrome/src/ui/locales/pl.js
+++ b/src/chrome/src/ui/locales/pl.js
@@ -486,7 +486,7 @@ export default {
   'st.provider.field.model_optional': 'Model (opcjonalnie)',
   'st.provider.field.context_window': 'Okno kontekstu (tokeny)',
   'st.provider.field.supports_vision': 'Model obsługuje wizję (multimodalność)',
-  'st.provider.field.vision_auto': 'Automatycznie (z Ollama)',
+  'st.provider.field.vision_auto': 'Automatycznie',
   'st.provider.field.vision_force_on': 'Wymuś włączenie',
   'st.provider.field.vision_detected_vision': 'Wykryto automatycznie: Obsługa obrazu',
   'st.provider.field.vision_detected_text': 'Wykryto automatycznie: Tylko tekst',

--- a/src/chrome/src/ui/locales/pt.js
+++ b/src/chrome/src/ui/locales/pt.js
@@ -730,7 +730,7 @@ export default {
   'st.provider.field.model_optional': "Modelo (opcional)",
   'st.provider.field.context_window': "Janela de contexto (tokens)",
   'st.provider.field.supports_vision': "Modelo apoia visão (multimodal)",
-  'st.provider.field.vision_auto': 'Automático (pelo Ollama)',
+  'st.provider.field.vision_auto': 'Automático',
   'st.provider.field.vision_force_on': 'Forçar ativação',
   'st.provider.field.vision_detected_vision': 'Detectado automaticamente: Visão',
   'st.provider.field.vision_detected_text': 'Detectado automaticamente: Somente texto',

--- a/src/chrome/src/ui/locales/ru.js
+++ b/src/chrome/src/ui/locales/ru.js
@@ -277,7 +277,7 @@ export default {
   'st.provider.field.model': 'Модель',
   'st.provider.field.model_optional': 'Модель (необязательно)',
   'st.provider.field.supports_vision': 'Модель поддерживает зрение (мультимодальная)',
-  'st.provider.field.vision_auto': 'Автоматически (из Ollama)',
+  'st.provider.field.vision_auto': 'Автоматически',
   'st.provider.field.vision_force_on': 'Принудительно включить',
   'st.provider.field.vision_detected_vision': 'Определено автоматически: Поддержка изображений',
   'st.provider.field.vision_detected_text': 'Определено автоматически: Только текст',

--- a/src/chrome/src/ui/locales/th.js
+++ b/src/chrome/src/ui/locales/th.js
@@ -277,7 +277,7 @@ export default {
   'st.provider.field.model': 'โมเดล',
   'st.provider.field.model_optional': 'โมเดล (ไม่บังคับ)',
   'st.provider.field.supports_vision': 'โมเดลรองรับการมองเห็น (มัลติโมดัล)',
-  'st.provider.field.vision_auto': 'อัตโนมัติ (จาก Ollama)',
+  'st.provider.field.vision_auto': 'อัตโนมัติ',
   'st.provider.field.vision_force_on': 'บังคับเปิด',
   'st.provider.field.vision_detected_vision': 'ตรวจพบอัตโนมัติ: รองรับภาพ',
   'st.provider.field.vision_detected_text': 'ตรวจพบอัตโนมัติ: ข้อความเท่านั้น',

--- a/src/chrome/src/ui/locales/tl.js
+++ b/src/chrome/src/ui/locales/tl.js
@@ -277,7 +277,7 @@ export default {
   'st.provider.field.model': 'Modelo',
   'st.provider.field.model_optional': 'Modelo (opsyonal)',
   'st.provider.field.supports_vision': 'Sumusuporta ang modelo sa bisyon (multimodal)',
-  'st.provider.field.vision_auto': 'Awtomatiko (mula sa Ollama)',
+  'st.provider.field.vision_auto': 'Awtomatiko',
   'st.provider.field.vision_force_on': 'Sapilitang i-on',
   'st.provider.field.vision_detected_vision': 'Awtomatikong natukoy: Vision',
   'st.provider.field.vision_detected_text': 'Awtomatikong natukoy: Teksto lang',

--- a/src/chrome/src/ui/locales/tr.js
+++ b/src/chrome/src/ui/locales/tr.js
@@ -316,7 +316,7 @@ export default {
   'st.provider.field.model': 'Model',
   'st.provider.field.model_optional': 'Model (isteğe bağlı)',
   'st.provider.field.supports_vision': 'Model görme yeteneğini destekliyor (çok kipli)',
-  'st.provider.field.vision_auto': 'Otomatik (Ollama’dan)',
+  'st.provider.field.vision_auto': 'Otomatik',
   'st.provider.field.vision_force_on': 'Zorla açık',
   'st.provider.field.vision_detected_vision': 'Otomatik algılandı: Görsel',
   'st.provider.field.vision_detected_text': 'Otomatik algılandı: Yalnızca metin',

--- a/src/chrome/src/ui/locales/uk.js
+++ b/src/chrome/src/ui/locales/uk.js
@@ -277,7 +277,7 @@ export default {
   'st.provider.field.model': 'Модель',
   'st.provider.field.model_optional': 'Модель (необов\'язково)',
   'st.provider.field.supports_vision': 'Модель підтримує зір (мультимодальна)',
-  'st.provider.field.vision_auto': 'Автоматично (з Ollama)',
+  'st.provider.field.vision_auto': 'Автоматично',
   'st.provider.field.vision_force_on': 'Примусово ввімкнути',
   'st.provider.field.vision_detected_vision': 'Визначено автоматично: Підтримка зображень',
   'st.provider.field.vision_detected_text': 'Визначено автоматично: Лише текст',

--- a/src/chrome/src/ui/locales/vi.js
+++ b/src/chrome/src/ui/locales/vi.js
@@ -730,7 +730,7 @@ export default {
   'st.provider.field.model_optional': "Mô hình (tùy chọn)",
   'st.provider.field.context_window': "Cửa sổ ngữ cảnh (mã thông báo)",
   'st.provider.field.supports_vision': "Mô hình hỗ trợ tầm nhìn (đa phương thức)",
-  'st.provider.field.vision_auto': 'Tự động (từ Ollama)',
+  'st.provider.field.vision_auto': 'Tự động',
   'st.provider.field.vision_force_on': 'Buộc bật',
   'st.provider.field.vision_detected_vision': 'Tự động phát hiện: Thị giác',
   'st.provider.field.vision_detected_text': 'Tự động phát hiện: Chỉ văn bản',

--- a/src/chrome/src/ui/locales/zh.js
+++ b/src/chrome/src/ui/locales/zh.js
@@ -277,7 +277,7 @@ export default {
   'st.provider.field.model': '模型',
   'st.provider.field.model_optional': '模型（可选）',
   'st.provider.field.supports_vision': '模型支持视觉（多模态）',
-  'st.provider.field.vision_auto': '自动（来自 Ollama）',
+  'st.provider.field.vision_auto': '自动',
   'st.provider.field.vision_force_on': '强制开启',
   'st.provider.field.vision_detected_vision': '自动检测：支持视觉',
   'st.provider.field.vision_detected_text': '自动检测：仅文本',

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -49,8 +49,11 @@ import {
   sniffProviderIdFromBaseUrl,
 } from './provider-icons.js';
 import { ADDITIONAL_PROVIDER_UI } from '../providers/provider-catalog.js';
-import { AUTO_GROUP_TABS_KEY } from '../tab-group-preference.js';
+import { AUTO_VISION_PROVIDER_IDS, visionDetectionMatches } from '../providers/vision-capabilities.js';
 import { canonicalizeOllamaBaseUrl } from '../providers/context-windows.js';
+import { AUTO_GROUP_TABS_KEY } from '../tab-group-preference.js';
+
+const VISION_UI_PROVIDER_IDS = new Set(['ollama', ...AUTO_VISION_PROVIDER_IDS]);
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
@@ -312,12 +315,20 @@ let requestedActiveProviderId = '';
 
 if (globalThis.chrome?.storage?.onChanged) {
   chrome.storage.onChanged.addListener((changes, area) => {
-    const next = changes.providers?.newValue?.ollama;
-    if (area !== 'local' || !next || !providersData.ollama) return;
-    // Capability detection runs in the background after a user turn starts.
-    // Refresh only its result so unrelated unsaved provider drafts stay put.
-    providersData.ollama.visionDetection = next.visionDetection || null;
-    refreshOllamaVisionStatus();
+    if (area !== 'local' || !changes.providers?.newValue) return;
+    const nextOllama = changes.providers?.newValue?.ollama;
+    if (nextOllama && providersData.ollama) {
+      providersData.ollama.visionDetection = nextOllama.visionDetection || null;
+      refreshOllamaVisionStatus();
+    }
+    for (const id of AUTO_VISION_PROVIDER_IDS) {
+      const next = changes.providers.newValue[id];
+      if (!next || !providersData[id]) continue;
+      // Background detection may finish while the settings page contains
+      // unsaved drafts. Refresh only the detected result.
+      providersData[id].visionDetection = next.visionDetection || null;
+      refreshVisionStatus(id);
+    }
   });
 }
 
@@ -1971,7 +1982,7 @@ const PROMPT_TIER_FIELD = {
   ],
 };
 
-const OLLAMA_VISION_MODE_FIELD = {
+const VISION_MODE_FIELD = {
   key: 'visionMode',
   labelKey: 'st.provider.field.supports_vision',
   type: 'select',
@@ -1981,38 +1992,46 @@ const OLLAMA_VISION_MODE_FIELD = {
     { value: 'off', labelKey: 'st.providers.compat.value.off' },
   ],
 };
+const OLLAMA_VISION_MODE_FIELD = VISION_MODE_FIELD;
 
-function ollamaVisionDetectionMatches(config, detection = config?.visionDetection) {
-  const model = String(config?.model || '').trim().toLowerCase();
-  const detectedModel = String(detection?.model || '').trim().toLowerCase();
-  const baseUrl = canonicalizeOllamaBaseUrl(config?.baseUrl);
-  return detection?.source === 'ollama_show'
-    && !!model
-    && !!baseUrl
-    && model === detectedModel
-    && baseUrl === canonicalizeOllamaBaseUrl(detection?.baseUrl);
-}
-
-function ollamaVisionStatusKey(config) {
-  if (!ollamaVisionDetectionMatches(config)) return 'st.provider.field.vision_pending';
+function visionStatusKey(id, config) {
+  if (!providerVisionDetectionMatches(id, config)) return 'st.provider.field.vision_pending';
   return config.visionDetection.supportsVision
     ? 'st.provider.field.vision_detected_vision'
     : 'st.provider.field.vision_detected_text';
 }
 
-function refreshOllamaVisionStatus() {
-  const hint = document.querySelector('[data-ollama-vision-status]');
+function refreshVisionStatus(id) {
+  if (!VISION_UI_PROVIDER_IDS.has(id)) return;
+  const hint = id === 'ollama'
+    ? document.querySelector('[data-ollama-vision-status]')
+    : document.querySelector(`[data-vision-status="${id}"]`);
   if (!hint) return;
-  const mode = document.querySelector('select[data-provider="ollama"][data-key="visionMode"]')?.value || 'auto';
+  const mode = document.querySelector(`select[data-provider="${id}"][data-key="visionMode"]`)?.value || 'auto';
   hint.hidden = mode !== 'auto';
   if (hint.hidden) return;
   const config = {
-    ...providersData.ollama,
+    ...providersData[id],
     visionMode: mode,
-    model: document.querySelector('input[data-provider="ollama"][data-key="model"]')?.value,
-    baseUrl: document.querySelector('input[data-provider="ollama"][data-key="baseUrl"]')?.value,
+    model: document.querySelector(`input[data-provider="${id}"][data-key="model"]`)?.value,
+    baseUrl: document.querySelector(`input[data-provider="${id}"][data-key="baseUrl"]`)?.value,
   };
-  hint.textContent = t(ollamaVisionStatusKey(config));
+  hint.textContent = t(visionStatusKey(id, config));
+}
+
+function refreshOllamaVisionStatus() {
+  refreshVisionStatus('ollama');
+}
+
+function providerVisionDetectionMatches(id, config, detection = config?.visionDetection) {
+  if (id !== 'ollama') return visionDetectionMatches(id, config, detection, { allowTransient: true });
+  const model = String(config?.model || '').trim();
+  const baseUrl = canonicalizeOllamaBaseUrl(config?.baseUrl);
+  return !!model && !!baseUrl
+    && detection?.source === 'ollama_show'
+    && String(detection?.model || '').trim().toLowerCase() === model.toLowerCase()
+    && canonicalizeOllamaBaseUrl(detection?.baseUrl) === baseUrl
+    && typeof detection?.supportsVision === 'boolean';
 }
 
 const CONTEXT_WINDOW_FIELD = {
@@ -2308,7 +2327,7 @@ function renderProviders() {
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:8080' },
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'qwen/qwen3.5-9b' },
         CONTEXT_WINDOW_FIELD,
-        { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
+        VISION_MODE_FIELD,
         PROMPT_TIER_FIELD,
       ],
     },
@@ -2326,7 +2345,7 @@ function renderProviders() {
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:1234/v1' },
         { key: 'model', labelKey: 'st.provider.field.model_optional', type: 'text', placeholderKey: 'st.provider.field.model_loaded_hint' },
         CONTEXT_WINDOW_FIELD,
-        { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
+        VISION_MODE_FIELD,
         PROMPT_TIER_FIELD,
       ],
     },
@@ -2366,7 +2385,7 @@ function renderProviders() {
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-4' },
         CONTEXT_WINDOW_FIELD,
-        { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
+        VISION_MODE_FIELD,
         PROMPT_TIER_FIELD,
       ],
     },
@@ -2674,8 +2693,9 @@ function renderProviders() {
             <select data-provider="${id}" data-key="${field.key}" data-type="select">${optionsHTML}</select>
           </div>
         `;
-        if (id === 'ollama' && field.key === 'visionMode') {
-          fieldsHTML += `<div class="field-hint" data-ollama-vision-status${current === 'auto' ? '' : ' hidden'} style="margin:-4px 0 10px;font-size:12px;color:var(--text2);">${escapeHtml(t(ollamaVisionStatusKey(config)))}</div>`;
+        if (VISION_UI_PROVIDER_IDS.has(id) && field.key === 'visionMode') {
+          const statusAttribute = id === 'ollama' ? 'data-ollama-vision-status' : `data-vision-status="${id}"`;
+          fieldsHTML += `<div class="field-hint" ${statusAttribute}${current === 'auto' ? '' : ' hidden'} style="margin:-4px 0 10px;font-size:12px;color:var(--text2);">${escapeHtml(t(visionStatusKey(id, config)))}</div>`;
         }
       } else if (field.type === 'checkbox') {
         const isChecked = !!config[field.key];
@@ -2849,8 +2869,11 @@ function renderProviders() {
         input.value = sel.value;
       }
       refreshProviderCompatibilitySummary(providerId);
-      if (providerId === 'ollama') refreshOllamaVisionStatus();
+      refreshVisionStatus(providerId);
     });
+  });
+  document.querySelectorAll('select[data-key="visionMode"]').forEach((select) => {
+    select.addEventListener('change', () => refreshVisionStatus(select.dataset.provider));
   });
   document.querySelector('select[data-provider="ollama"][data-key="visionMode"]')?.addEventListener('change', refreshOllamaVisionStatus);
   document.querySelectorAll('.provider-compatibility select[data-provider], .provider-compatibility textarea[data-provider]').forEach((input) => {
@@ -2865,6 +2888,7 @@ function renderProviders() {
   document.querySelectorAll('input[data-key="model"], input[data-key="baseUrl"]').forEach((input) => {
     input.addEventListener('input', () => {
       refreshProviderCompatibilitySummary(input.dataset.provider);
+      refreshVisionStatus(input.dataset.provider);
       if (input.dataset.provider === 'ollama') refreshOllamaVisionStatus();
     });
   });
@@ -3074,7 +3098,7 @@ function applyProviderBaseUrl(id, baseUrl) {
   if (providersData[id]) providersData[id].baseUrl = baseUrl;
   const input = document.querySelector(`input[data-provider="${id}"][data-key="baseUrl"]`);
   if (input && input.value !== baseUrl) input.value = baseUrl;
-  if (id === 'ollama') refreshOllamaVisionStatus();
+  refreshVisionStatus(id);
 }
 
 function applyProviderContextWindow(id, contextWindow) {
@@ -3197,16 +3221,16 @@ async function saveProvider(id, { showFlash = true, markConfigured = true } = {}
   if (providersData[id]) {
     const priorVisionDetection = providersData[id].visionDetection;
     Object.assign(providersData[id], config);
-    if (id === 'ollama' && (
+    if (VISION_UI_PROVIDER_IDS.has(id) && (
       providersData[id].visionMode !== 'auto'
-      || !ollamaVisionDetectionMatches(providersData[id], priorVisionDetection)
+      || !providerVisionDetectionMatches(id, providersData[id], priorVisionDetection)
     )) {
       providersData[id].visionDetection = null;
     }
     if (markConfigured) providersData[id].configured = id !== 'webbrain_cloud';
   }
   refreshProviderCardStatus(id);
-  if (id === 'ollama') refreshOllamaVisionStatus();
+  refreshVisionStatus(id);
 
   if (showFlash) {
     if (apiKeyWarning) {

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -47,6 +47,7 @@ import {
 import { providerIconUrl } from './provider-icons.js';
 import { parseWatchSlashCommand, WATCH_COMMAND_USAGE } from './watch-command.js';
 import { createSidePanelWindowScope } from './sidepanel-window-scope.js';
+import { visionProviderKind } from '../providers/vision-capabilities.js';
 import {
   clearStagedScreenshots,
   loadStagedScreenshots,
@@ -7091,7 +7092,7 @@ function toggledVisionProviderConfig(providerId, config) {
     const { supportsVision: _legacy, ...withoutLegacy } = config;
     return { enabled, config: { ...withoutLegacy, visionMode: enabled ? 'on' : 'off' } };
   }
-  if (['llamacpp', 'lmstudio', 'localai'].includes(providerId)) {
+  if (visionProviderKind(providerId, config)) {
     const visionEnabled = config.visionMode === 'on'
       || (config.visionMode === 'auto' && config.visionDetection?.supportsVision === true);
     const enabled = !visionEnabled;

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -7078,28 +7078,30 @@ function requestConfigurationFile(tabId) {
   input.click();
 }
 
-function toggledVisionProviderConfig(providerId, config) {
-  if (providerId === 'ollama') {
-    const visionEnabled = config.visionMode === 'on' ||
-      (config.visionMode === 'auto' && config.visionDetection?.supportsVision === true);
-    const enabled = !visionEnabled;
-    return {
-      enabled,
-      config: { ...config, visionMode: enabled ? 'on' : 'off' },
-    };
-  }
-  const enabled = !config.supportsVision;
-  return {
-    enabled,
-    config: { ...config, supportsVision: enabled },
-  };
-}
-
 /**
  * Parse leading slash commands out of the user's message.
  * Returns the cleaned text (empty string if fully consumed).
  * May trigger async UI side effects (screenshot, export, etc.).
  */
+function toggledVisionProviderConfig(providerId, config) {
+  if (providerId === 'ollama') {
+    const visionEnabled = config.visionMode === 'on'
+      || (config.visionMode === 'auto' && config.visionDetection?.supportsVision === true);
+    const enabled = !visionEnabled;
+    const { supportsVision: _legacy, ...withoutLegacy } = config;
+    return { enabled, config: { ...withoutLegacy, visionMode: enabled ? 'on' : 'off' } };
+  }
+  if (['llamacpp', 'lmstudio', 'localai'].includes(providerId)) {
+    const visionEnabled = config.visionMode === 'on'
+      || (config.visionMode === 'auto' && config.visionDetection?.supportsVision === true);
+    const enabled = !visionEnabled;
+    const { supportsVision: _legacy, ...withoutLegacy } = config;
+    return { enabled, config: { ...withoutLegacy, visionMode: enabled ? 'on' : 'off' } };
+  }
+  const enabled = !config.supportsVision;
+  return { enabled, config: { ...config, supportsVision: enabled } };
+}
+
 async function parseSlashCommands(text, tabId = currentTabId, options = {}) {
   if (/^\s*\/watch(?:\s|$)/i.test(text) && !/^\s*\/watch\s+--help\s*$/i.test(text)) {
     const watchArgs = parseWatchSlashCommand(text);

--- a/src/firefox/README.md
+++ b/src/firefox/README.md
@@ -63,6 +63,11 @@ ollama serve
 # LocalAI: http://localhost:8080/v1
 ```
 
+For llama.cpp, LM Studio, and LocalAI, Vision defaults to **Auto**. WebBrain
+reads the selected model's server metadata before a turn and sends screenshots
+only when image input is reported. Settings also offers **Force on** and
+**Off** overrides; metadata failures remain text-only for that turn.
+
 ### Use it
 
 Click the WebBrain icon → the side panel opens. Type a message like:

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -17466,12 +17466,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     for (const att of attachments) {
       if (att.kind === 'image') {
         if (!provider?.supportsVision) {
-          const ollamaHint = String(provider?.config?.providerName || '').toLowerCase() === 'ollama'
-            ? ' If Ollama metadata is unavailable or incorrect, set its Vision capability to Force on in Settings.'
+          const overrideHint = provider?.config?.visionMode != null
+            ? ' If automatic detection is unavailable or incorrect, set Vision capability to Force on in Settings.'
             : '';
           return {
             ok: false,
-            error: `The active provider (${provider?.name || 'unknown'}) does not support image attachments. Switch to a vision-capable model (e.g. Claude 3+, GPT-4o) or remove the attached image and try again.${ollamaHint}`,
+            error: `The active provider (${provider?.name || 'unknown'}) does not support image attachments. Switch to a vision-capable model (e.g. Claude 3+, GPT-4o) or remove the attached image and try again.${overrideHint}`,
           };
         }
         let modelSourceDataUrl = att.dataUrl;
@@ -17593,10 +17593,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // New user turn: drop transient "allow once" / "deny once" permission grants.
     this.permissions.beginTurn(tabId);
 
-    // Resolve Ollama's model-bound vision capability before enrichment can
-    // capture pixels or attachment validation can inspect supportsVision.
-    // Metadata failures are deliberately non-fatal and leave auto mode
-    // text-only for this turn.
+    // Resolve model-bound local vision metadata before enrichment captures a
+    // screenshot or attachment validation consults provider.supportsVision.
+    // A metadata failure is non-fatal and leaves auto mode text-only this turn.
     try { await this.providerManager.prepareActiveProviderCapabilities?.(); } catch {}
 
     const selectionOnly = runOptions?.sourceGrounding === SELECTION_ONLY_SOURCE_GROUNDING;

--- a/src/firefox/src/providers/fetch-timeout.js
+++ b/src/firefox/src/providers/fetch-timeout.js
@@ -75,9 +75,12 @@ export async function fetchWithTimeout(url, options = {}) {
   try {
     const res = await fetch(url, { ...fetchOptions, signal: controller.signal });
     clearTimeout(timeoutId);
+    // Keep the caller signal linked after headers arrive so a stalled body
+    // read remains cancellable by the caller's stricter deadline.
     return res;
   } catch (e) {
     clearTimeout(timeoutId);
+    callerSignal?.removeEventListener('abort', abortFromCaller);
     if (callerSignal?.aborted) {
       throw callerSignal.reason instanceof Error
         ? callerSignal.reason

--- a/src/firefox/src/providers/llamacpp.js
+++ b/src/firefox/src/providers/llamacpp.js
@@ -1,5 +1,6 @@
 import { BaseLLMProvider } from './base.js';
 import { fetchWithTimeout } from './fetch-timeout.js';
+import { configuredVisionSupport } from './vision-capabilities.js';
 
 /**
  * Provider for local llama.cpp server (OpenAI-compatible API on localhost).
@@ -29,7 +30,7 @@ export class LlamaCppProvider extends BaseLLMProvider {
   }
 
   get supportsVision() {
-    return !!this.config.supportsVision;
+    return configuredVisionSupport('llamacpp', this.config);
   }
 
   get useCompactPrompt() {

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -16,6 +16,7 @@ import {
   visionCapabilityIdentity,
   visionDetectionMatches,
   visionDetectionSource,
+  visionProviderKind,
 } from './vision-capabilities.js';
 import {
   canonicalizeOllamaBaseUrl,
@@ -79,9 +80,8 @@ export class ProviderManager {
       !OLLAMA_VISION_MODES.has(rawStoredOllama.visionMode)
       || Object.hasOwn(rawStoredOllama, 'supportsVision')
     );
-    const genericVisionConfigMigrated = [...AUTO_VISION_PROVIDER_IDS].some((id) => {
-      const config = data.providers?.[id];
-      return !!config && (
+    const genericVisionConfigMigrated = Object.entries(data.providers || {}).some(([id, config]) => {
+      return !!visionProviderKind(id, config) && (
         !VISION_MODES.has(config.visionMode)
         || Object.hasOwn(config, 'supportsVision')
         || (!String(config.model || '').trim() && config.visionDetection != null)
@@ -602,16 +602,19 @@ export class ProviderManager {
       };
       delete migrated.ollama.supportsVision;
     }
-    for (const id of AUTO_VISION_PROVIDER_IDS) {
-      if (!migrated[id]) continue;
-      const legacySupportsVision = migrated[id].supportsVision;
-      const hasConfiguredModel = !!String(migrated[id].model || '').trim();
+    for (const [id, config] of Object.entries(migrated)) {
+      if (!visionProviderKind(id, config)) continue;
+      const legacySupportsVision = config.supportsVision;
+      const hasConfiguredModel = !!String(config.model || '').trim();
+      const isBuiltInAutoProvider = AUTO_VISION_PROVIDER_IDS.has(id);
       migrated[id] = {
-        ...migrated[id],
-        visionMode: VISION_MODES.has(migrated[id].visionMode)
-          ? migrated[id].visionMode
-          : (legacySupportsVision === false ? 'off' : 'auto'),
-        visionDetection: hasConfiguredModel ? (migrated[id].visionDetection || null) : null,
+        ...config,
+        visionMode: VISION_MODES.has(config.visionMode)
+          ? config.visionMode
+          : (legacySupportsVision === false
+            ? 'off'
+            : (legacySupportsVision === true && !isBuiltInAutoProvider ? 'on' : 'auto')),
+        visionDetection: hasConfiguredModel ? (config.visionDetection || null) : null,
       };
       delete migrated[id].supportsVision;
     }
@@ -706,10 +709,13 @@ export class ProviderManager {
         : 'auto';
       delete normalizedConfig.supportsVision;
     }
-    if (AUTO_VISION_PROVIDER_IDS.has(id)) {
+    if (visionProviderKind(id, normalizedConfig)) {
+      const legacySupportsVision = normalizedConfig.supportsVision;
       normalizedConfig.visionMode = VISION_MODES.has(normalizedConfig.visionMode)
         ? normalizedConfig.visionMode
-        : 'auto';
+        : (typeof legacySupportsVision === 'boolean'
+          ? (legacySupportsVision ? 'on' : 'off')
+          : 'auto');
       delete normalizedConfig.supportsVision;
     }
     switch (normalizedConfig.type) {
@@ -808,29 +814,33 @@ export class ProviderManager {
 
   async ensureVisionCapability(id) {
     const provider = this.providers.get(id);
-    if (!provider || !AUTO_VISION_PROVIDER_IDS.has(id)) return { ok: false, skipped: true };
+    const providerKind = visionProviderKind(id, provider?.config);
+    if (!provider || !providerKind) return { ok: false, skipped: true };
     const mode = VISION_MODES.has(provider.config.visionMode) ? provider.config.visionMode : 'auto';
     if (mode !== 'auto') return { ok: true, skipped: true, supportsVision: mode === 'on' };
-    const identity = visionCapabilityIdentity(id, provider.config);
+    const identity = visionCapabilityIdentity(providerKind, provider.config);
     if (!identity) return { ok: false, skipped: true };
     const hasConfiguredModel = !!identity.model;
-    if (hasConfiguredModel && visionDetectionMatches(id, provider.config)) {
+    if (hasConfiguredModel && visionDetectionMatches(providerKind, provider.config)) {
       return { ok: true, cached: true, supportsVision: provider.config.visionDetection.supportsVision };
     }
 
     const epoch = this._visionCapabilityEpochs.get(id) || 0;
-    let pending = this._visionCapabilityChecks.get(identity.key);
+    const checkKey = `${id}\n${identity.key}`;
+    let pending = this._visionCapabilityChecks.get(checkKey);
     if (!pending) {
-      pending = this._fetchVisionCapability(id, provider, identity);
-      this._visionCapabilityChecks.set(identity.key, pending);
+      pending = this._fetchVisionCapability(providerKind, provider, identity);
+      this._visionCapabilityChecks.set(checkKey, pending);
     }
     const result = await pending;
-    if ((!hasConfiguredModel || !result.ok) && this._visionCapabilityChecks.get(identity.key) === pending) {
-      this._visionCapabilityChecks.delete(identity.key);
+    if ((!hasConfiguredModel || !result.ok) && this._visionCapabilityChecks.get(checkKey) === pending) {
+      this._visionCapabilityChecks.delete(checkKey);
     }
     const current = this.providers.get(id);
-    const currentIdentity = visionCapabilityIdentity(id, current?.config);
+    const currentKind = visionProviderKind(id, current?.config);
+    const currentIdentity = visionCapabilityIdentity(currentKind, current?.config);
     if (!current || current.config.visionMode !== 'auto'
+      || currentKind !== providerKind
       || currentIdentity?.key !== identity.key
       || (this._visionCapabilityEpochs.get(id) || 0) !== epoch) {
       return { ...result, stale: true };
@@ -844,11 +854,11 @@ export class ProviderManager {
     }
 
     const detection = {
-      providerId: id,
+      providerId: providerKind,
       model: identity.model,
       baseUrl: identity.baseUrl,
       supportsVision: result.supportsVision,
-      source: visionDetectionSource(id),
+      source: visionDetectionSource(providerKind),
       ...(!hasConfiguredModel ? { transient: true } : {}),
     };
     this.providers.set(id, this._createProvider(id, { ...current.config, visionDetection: detection }));
@@ -949,7 +959,8 @@ export class ProviderManager {
 
   async prepareActiveProviderCapabilities() {
     if (this.activeProviderId === 'ollama') return this.ensureOllamaVisionCapability('ollama');
-    if (AUTO_VISION_PROVIDER_IDS.has(this.activeProviderId)) {
+    const activeProvider = this.providers.get(this.activeProviderId);
+    if (visionProviderKind(this.activeProviderId, activeProvider?.config)) {
       return this.ensureVisionCapability(this.activeProviderId);
     }
     return { ok: true, skipped: true };
@@ -1017,12 +1028,19 @@ export class ProviderManager {
         merged.visionDetection = null;
       }
     }
-    if (AUTO_VISION_PROVIDER_IDS.has(id)) {
-      merged.visionMode = VISION_MODES.has(merged.visionMode) ? merged.visionMode : 'auto';
+    const genericVisionKind = visionProviderKind(id, merged);
+    if (genericVisionKind) {
+      const explicitLegacyVision = Object.hasOwn(config, 'supportsVision') && !Object.hasOwn(config, 'visionMode')
+        ? config.supportsVision
+        : null;
+      merged.visionMode = typeof explicitLegacyVision === 'boolean'
+        ? (explicitLegacyVision ? 'on' : 'off')
+        : (VISION_MODES.has(merged.visionMode) ? merged.visionMode : 'auto');
       delete merged.supportsVision;
-      const currentIdentity = visionCapabilityIdentity(id, current);
-      const nextIdentity = visionCapabilityIdentity(id, merged);
-      if (currentIdentity?.key !== nextIdentity?.key || current.visionMode !== merged.visionMode) {
+      const currentKind = visionProviderKind(id, current);
+      const currentIdentity = visionCapabilityIdentity(currentKind, current);
+      const nextIdentity = visionCapabilityIdentity(genericVisionKind, merged);
+      if (currentKind !== genericVisionKind || currentIdentity?.key !== nextIdentity?.key || current.visionMode !== merged.visionMode) {
         merged.visionDetection = null;
         this._visionCapabilityEpochs.set(id, (this._visionCapabilityEpochs.get(id) || 0) + 1);
         for (const key of this._visionCapabilityChecks.keys()) {

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -8,6 +8,16 @@ import { AwsBedrockProvider } from './aws-bedrock.js';
 import { ADDITIONAL_PROVIDER_DEFAULTS } from './provider-catalog.js';
 import { fetchWithTimeout } from './fetch-timeout.js';
 import {
+  AUTO_VISION_PROVIDER_IDS,
+  VISION_MODES,
+  parseLlamaCppVisionSupport,
+  parseLmStudioVisionSupport,
+  parseLocalAiVisionSupport,
+  visionCapabilityIdentity,
+  visionDetectionMatches,
+  visionDetectionSource,
+} from './vision-capabilities.js';
+import {
   canonicalizeOllamaBaseUrl,
   lmStudioContextWindowIsLive,
   parseLlamaCppPropsContextWindow,
@@ -36,6 +46,7 @@ const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'hugg
 const PROVIDER_CREDENTIAL_KEYS = ['apiKey', 'accessKeyId', 'secretAccessKey', 'sessionToken'];
 const OLLAMA_VISION_MODES = new Set(['auto', 'on', 'off']);
 const OLLAMA_VISION_METADATA_TIMEOUT_MS = 3000;
+const VISION_METADATA_TIMEOUT_MS = 3000;
 
 /**
  * Manages LLM provider instances and persists configuration.
@@ -45,6 +56,8 @@ export class ProviderManager {
     this.providers = new Map();
     this.activeProviderId = null;
     this._ollamaVisionChecks = new Map();
+    this._visionCapabilityChecks = new Map();
+    this._visionCapabilityEpochs = new Map();
   }
 
   /**
@@ -66,6 +79,14 @@ export class ProviderManager {
       !OLLAMA_VISION_MODES.has(rawStoredOllama.visionMode)
       || Object.hasOwn(rawStoredOllama, 'supportsVision')
     );
+    const genericVisionConfigMigrated = [...AUTO_VISION_PROVIDER_IDS].some((id) => {
+      const config = data.providers?.[id];
+      return !!config && (
+        !VISION_MODES.has(config.visionMode)
+        || Object.hasOwn(config, 'supportsVision')
+        || (!String(config.model || '').trim() && config.visionDetection != null)
+      );
+    });
     const hadLegacyClaudeSubscription = Object.hasOwn(data.providers || {}, 'claude_subscription');
     const stored = this._migrateStoredProviderConfigs(data.providers || {});
     const legacyActiveProviderId = ['webbrain', 'openai_subscription'].includes(data.activeProvider)
@@ -73,7 +94,7 @@ export class ProviderManager {
       : data.activeProvider;
     const defaults = this._defaultConfigs();
     const configs = {};
-    let providerStateMigrated = ollamaVisionConfigMigrated;
+    let providerStateMigrated = ollamaVisionConfigMigrated || genericVisionConfigMigrated;
     for (const [id, config] of Object.entries(defaults)) {
       const storedConfig = stored[id];
       const hasConfiguredMarker = !!storedConfig && Object.hasOwn(storedConfig, 'configured');
@@ -173,14 +194,8 @@ export class ProviderManager {
         model: '',
         contextWindow: 16384,
         supportsAskStreaming: true,
-        // Default ON for local providers: in practice users who reach for
-        // local OpenAI-compatible backends in 2026 are running multimodal
-        // models (Qwen-VL, Llama 3.2-Vision, etc.). False-positives where a
-        // text-only model is loaded with vision=true still work — the agent
-        // just sends image_url blocks the model ignores. False-negatives
-        // (vision-capable model loaded with vision=false) silently lose the
-        // multimodal channel, which is the worse failure mode.
-        supportsVision: true,
+        visionMode: 'auto',
+        visionDetection: null,
         enabled: true,
       },
       ollama: {
@@ -207,7 +222,8 @@ export class ProviderManager {
         contextWindow: 16384,
         apiKey: 'lm-studio',
         supportsAskStreaming: true,
-        supportsVision: true,
+        visionMode: 'auto',
+        visionDetection: null,
         enabled: true,
       },
       jan: {
@@ -259,7 +275,8 @@ export class ProviderManager {
         contextWindow: 16384,
         apiKey: '',
         supportsAskStreaming: true,
-        supportsVision: true,
+        visionMode: 'auto',
+        visionDetection: null,
         enabled: true,
       },
       gpt4all: {
@@ -585,6 +602,19 @@ export class ProviderManager {
       };
       delete migrated.ollama.supportsVision;
     }
+    for (const id of AUTO_VISION_PROVIDER_IDS) {
+      if (!migrated[id]) continue;
+      const legacySupportsVision = migrated[id].supportsVision;
+      const hasConfiguredModel = !!String(migrated[id].model || '').trim();
+      migrated[id] = {
+        ...migrated[id],
+        visionMode: VISION_MODES.has(migrated[id].visionMode)
+          ? migrated[id].visionMode
+          : (legacySupportsVision === false ? 'off' : 'auto'),
+        visionDetection: hasConfiguredModel ? (migrated[id].visionDetection || null) : null,
+      };
+      delete migrated[id].supportsVision;
+    }
     // Existing installs stored omitToolsWhenImagesPresent:true for WebBrain
     // Cloud, which suppressed native tools on every screenshot turn and broke
     // tool calling. Force it off so the saved config picks up the new default.
@@ -676,6 +706,12 @@ export class ProviderManager {
         : 'auto';
       delete normalizedConfig.supportsVision;
     }
+    if (AUTO_VISION_PROVIDER_IDS.has(id)) {
+      normalizedConfig.visionMode = VISION_MODES.has(normalizedConfig.visionMode)
+        ? normalizedConfig.visionMode
+        : 'auto';
+      delete normalizedConfig.supportsVision;
+    }
     switch (normalizedConfig.type) {
       case 'llamacpp':
         return new LlamaCppProvider(normalizedConfig);
@@ -705,6 +741,119 @@ export class ProviderManager {
       throw new Error(`No active provider: ${this.activeProviderId}`);
     }
     return provider;
+  }
+
+  async _fetchVisionCapability(providerId, provider, identity) {
+    const root = identity.baseUrl.replace(/\/v1$/i, '');
+    const headers = this._modelListHeaders(provider);
+    const controller = new AbortController();
+    const fetchJson = async (url) => {
+      const response = await fetchWithTimeout(url, {
+        method: 'GET',
+        headers,
+        timeoutMs: VISION_METADATA_TIMEOUT_MS,
+        signal: controller.signal,
+      });
+      if (!response.ok) return { ok: false, status: response.status };
+      try {
+        return { ok: true, data: await response.json() };
+      } catch {
+        return { ok: false, malformed: true };
+      }
+    };
+    const request = (async () => {
+      try {
+        if (providerId === 'llamacpp') {
+          const query = identity.model ? `?model=${encodeURIComponent(identity.model)}` : '';
+          const result = await fetchJson(`${root}/props${query}`);
+          if (!result.ok) return result;
+          const supportsVision = parseLlamaCppVisionSupport(result.data);
+          return supportsVision == null ? { ok: false, malformed: true } : { ok: true, supportsVision };
+        }
+        if (providerId === 'lmstudio') {
+          const current = await fetchJson(`${root}/api/v1/models`);
+          if (current.ok) {
+            const supportsVision = parseLmStudioVisionSupport(current.data, identity.model, 'v1');
+            if (supportsVision != null) return { ok: true, supportsVision };
+          }
+          const legacy = await fetchJson(`${root}/api/v0/models`);
+          if (!legacy.ok) return legacy;
+          const supportsVision = parseLmStudioVisionSupport(legacy.data, identity.model, 'v0');
+          return supportsVision == null ? { ok: false, malformed: true } : { ok: true, supportsVision };
+        }
+        if (providerId === 'localai') {
+          const result = await fetchJson(`${root}/v1/models/capabilities`);
+          if (!result.ok) return result;
+          const supportsVision = parseLocalAiVisionSupport(result.data, identity.model);
+          return supportsVision == null ? { ok: false, malformed: true } : { ok: true, supportsVision };
+        }
+        return { ok: false, skipped: true };
+      } catch (error) {
+        return { ok: false, error: error?.message || String(error) };
+      }
+    })();
+    let timeoutId;
+    const timeout = new Promise((resolve) => {
+      timeoutId = setTimeout(() => {
+        controller.abort(new DOMException('Vision capability metadata timed out', 'TimeoutError'));
+        resolve({ ok: false, timeout: true });
+      }, VISION_METADATA_TIMEOUT_MS);
+    });
+    try {
+      return await Promise.race([request, timeout]);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  async ensureVisionCapability(id) {
+    const provider = this.providers.get(id);
+    if (!provider || !AUTO_VISION_PROVIDER_IDS.has(id)) return { ok: false, skipped: true };
+    const mode = VISION_MODES.has(provider.config.visionMode) ? provider.config.visionMode : 'auto';
+    if (mode !== 'auto') return { ok: true, skipped: true, supportsVision: mode === 'on' };
+    const identity = visionCapabilityIdentity(id, provider.config);
+    if (!identity) return { ok: false, skipped: true };
+    const hasConfiguredModel = !!identity.model;
+    if (hasConfiguredModel && visionDetectionMatches(id, provider.config)) {
+      return { ok: true, cached: true, supportsVision: provider.config.visionDetection.supportsVision };
+    }
+
+    const epoch = this._visionCapabilityEpochs.get(id) || 0;
+    let pending = this._visionCapabilityChecks.get(identity.key);
+    if (!pending) {
+      pending = this._fetchVisionCapability(id, provider, identity);
+      this._visionCapabilityChecks.set(identity.key, pending);
+    }
+    const result = await pending;
+    if ((!hasConfiguredModel || !result.ok) && this._visionCapabilityChecks.get(identity.key) === pending) {
+      this._visionCapabilityChecks.delete(identity.key);
+    }
+    const current = this.providers.get(id);
+    const currentIdentity = visionCapabilityIdentity(id, current?.config);
+    if (!current || current.config.visionMode !== 'auto'
+      || currentIdentity?.key !== identity.key
+      || (this._visionCapabilityEpochs.get(id) || 0) !== epoch) {
+      return { ...result, stale: true };
+    }
+    if (!result.ok) {
+      if (!hasConfiguredModel && current.config.visionDetection?.transient === true) {
+        const { visionDetection: _ignored, ...withoutDetection } = current.config;
+        this.providers.set(id, this._createProvider(id, withoutDetection));
+      }
+      return result;
+    }
+
+    const detection = {
+      providerId: id,
+      model: identity.model,
+      baseUrl: identity.baseUrl,
+      supportsVision: result.supportsVision,
+      source: visionDetectionSource(id),
+      ...(!hasConfiguredModel ? { transient: true } : {}),
+    };
+    this.providers.set(id, this._createProvider(id, { ...current.config, visionDetection: detection }));
+    if (hasConfiguredModel) await this.save();
+    return { ok: true, supportsVision: result.supportsVision, detection };
   }
 
   _ollamaVisionIdentity(config) {
@@ -799,8 +948,11 @@ export class ProviderManager {
   }
 
   async prepareActiveProviderCapabilities() {
-    if (this.activeProviderId !== 'ollama') return { ok: true, skipped: true };
-    return this.ensureOllamaVisionCapability('ollama');
+    if (this.activeProviderId === 'ollama') return this.ensureOllamaVisionCapability('ollama');
+    if (AUTO_VISION_PROVIDER_IDS.has(this.activeProviderId)) {
+      return this.ensureVisionCapability(this.activeProviderId);
+    }
+    return { ok: true, skipped: true };
   }
 
   /**
@@ -863,6 +1015,19 @@ export class ProviderManager {
       const nextIdentity = this._ollamaVisionIdentity(merged);
       if (currentIdentity?.key !== nextIdentity?.key || current.visionMode !== merged.visionMode) {
         merged.visionDetection = null;
+      }
+    }
+    if (AUTO_VISION_PROVIDER_IDS.has(id)) {
+      merged.visionMode = VISION_MODES.has(merged.visionMode) ? merged.visionMode : 'auto';
+      delete merged.supportsVision;
+      const currentIdentity = visionCapabilityIdentity(id, current);
+      const nextIdentity = visionCapabilityIdentity(id, merged);
+      if (currentIdentity?.key !== nextIdentity?.key || current.visionMode !== merged.visionMode) {
+        merged.visionDetection = null;
+        this._visionCapabilityEpochs.set(id, (this._visionCapabilityEpochs.get(id) || 0) + 1);
+        for (const key of this._visionCapabilityChecks.keys()) {
+          if (key.startsWith(`${id}\n`)) this._visionCapabilityChecks.delete(key);
+        }
       }
     }
     this.providers.set(id, this._createProvider(id, merged));

--- a/src/firefox/src/providers/openai.js
+++ b/src/firefox/src/providers/openai.js
@@ -7,6 +7,7 @@ import {
 } from './provider-compatibility.js';
 import { normalizeRuntimeTraceConfig } from '../trace/runtime-config.js';
 import { canonicalizeOllamaBaseUrl } from './context-windows.js';
+import { AUTO_VISION_PROVIDER_IDS, configuredVisionSupport } from './vision-capabilities.js';
 
 const OPENAI_RESPONSES_MIN_MAX_OUTPUT_TOKENS = 16;
 const KIMI_CURRENT_TOOL_REASONING_MODELS = new Set([
@@ -105,6 +106,9 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
         && model === detectedModel
         && baseUrl === detectedBaseUrl
         && detection?.supportsVision === true;
+    }
+    if (AUTO_VISION_PROVIDER_IDS.has(providerName)) {
+      return configuredVisionSupport(providerName, this.config);
     }
     // Explicit user opt-in always wins (used by LM Studio and any custom
     // OpenAI-compatible endpoint where the loaded model varies).

--- a/src/firefox/src/providers/vision-capabilities.js
+++ b/src/firefox/src/providers/vision-capabilities.js
@@ -7,6 +7,14 @@ const DETECTION_SOURCES = {
   localai: 'localai_capabilities',
 };
 
+export function visionProviderKind(providerId, config = {}) {
+  if (config?.type === 'llamacpp') return 'llamacpp';
+  const id = String(providerId || '').trim().toLowerCase();
+  if (AUTO_VISION_PROVIDER_IDS.has(id)) return id;
+  const providerName = String(config?.providerName || '').trim().toLowerCase();
+  return AUTO_VISION_PROVIDER_IDS.has(providerName) ? providerName : null;
+}
+
 export function canonicalizeVisionBaseUrl(value) {
   const raw = String(value || '').trim().replace(/\/+$/, '');
   if (!raw) return '';

--- a/src/firefox/src/providers/vision-capabilities.js
+++ b/src/firefox/src/providers/vision-capabilities.js
@@ -1,0 +1,113 @@
+export const AUTO_VISION_PROVIDER_IDS = new Set(['llamacpp', 'lmstudio', 'localai']);
+export const VISION_MODES = new Set(['auto', 'on', 'off']);
+
+const DETECTION_SOURCES = {
+  llamacpp: 'llamacpp_props',
+  lmstudio: 'lmstudio_models',
+  localai: 'localai_capabilities',
+};
+
+export function canonicalizeVisionBaseUrl(value) {
+  const raw = String(value || '').trim().replace(/\/+$/, '');
+  if (!raw) return '';
+  try {
+    const url = new URL(raw);
+    url.hash = '';
+    url.search = '';
+    return url.toString().replace(/\/+$/, '');
+  } catch {
+    return '';
+  }
+}
+
+export function visionCapabilityIdentity(providerId, config) {
+  if (!AUTO_VISION_PROVIDER_IDS.has(providerId)) return null;
+  const baseUrl = canonicalizeVisionBaseUrl(config?.baseUrl);
+  if (!baseUrl) return null;
+  const model = String(config?.model || '').trim();
+  return {
+    providerId,
+    baseUrl,
+    model,
+    key: `${providerId}\n${baseUrl}\n${model.toLowerCase()}`,
+  };
+}
+
+export function visionDetectionMatches(providerId, config, detection = config?.visionDetection, options = {}) {
+  const identity = visionCapabilityIdentity(providerId, config);
+  const transientEmptyModel = options.allowTransient === true
+    && !identity?.model
+    && detection?.transient === true
+    && !String(detection?.model || '').trim();
+  return !!identity
+    && (!!identity.model || transientEmptyModel)
+    && detection?.providerId === providerId
+    && detection?.source === DETECTION_SOURCES[providerId]
+    && canonicalizeVisionBaseUrl(detection?.baseUrl) === identity.baseUrl
+    && String(detection?.model || '').trim().toLowerCase() === identity.model.toLowerCase()
+    && typeof detection?.supportsVision === 'boolean';
+}
+
+export function configuredVisionSupport(providerId, config) {
+  const mode = VISION_MODES.has(config?.visionMode) ? config.visionMode : 'auto';
+  if (mode === 'on') return true;
+  if (mode === 'off') return false;
+  return visionDetectionMatches(providerId, config, config?.visionDetection, { allowTransient: true })
+    && config.visionDetection.supportsVision === true;
+}
+
+function modelId(entry) {
+  return String(entry?.key || entry?.id || entry?.model || entry?.name || '').trim();
+}
+
+function selectModel(entries, requestedModel, { preferLoaded = false } = {}) {
+  if (!Array.isArray(entries) || !entries.length) return null;
+  const requested = String(requestedModel || '').trim().toLowerCase();
+  if (requested) return entries.find(entry => modelId(entry).toLowerCase() === requested) || null;
+  if (preferLoaded) {
+    const loaded = entries.filter(entry =>
+      String(entry?.state || '').toLowerCase() === 'loaded'
+      || (Array.isArray(entry?.loaded_instances) && entry.loaded_instances.length > 0)
+    );
+    if (loaded.length === 1) return loaded[0];
+  }
+  return entries.length === 1 ? entries[0] : null;
+}
+
+export function parseLmStudioVisionSupport(payload, model, apiVersion = 'v1') {
+  const entries = apiVersion === 'v1' ? payload?.models : payload?.data;
+  const entry = selectModel(entries, model, { preferLoaded: true });
+  if (!entry) return null;
+  if (apiVersion === 'v1') {
+    return typeof entry?.capabilities?.vision === 'boolean'
+      ? entry.capabilities.vision
+      : null;
+  }
+  const type = String(entry?.type || '').trim().toLowerCase();
+  if (type === 'vlm') return true;
+  if (type === 'llm') return false;
+  return null;
+}
+
+export function parseLlamaCppVisionSupport(payload) {
+  return typeof payload?.modalities?.vision === 'boolean'
+    ? payload.modalities.vision
+    : null;
+}
+
+export function parseLocalAiVisionSupport(payload, model) {
+  const entry = selectModel(payload?.data, model);
+  if (!entry) return null;
+  if (Array.isArray(entry.input_modalities)) {
+    return entry.input_modalities.some(value => String(value).toLowerCase() === 'image');
+  }
+  if (Array.isArray(entry.capabilities)) {
+    return entry.capabilities.some(value => String(value).toLowerCase() === 'vision');
+  }
+  if (typeof entry?.capabilities?.vision === 'boolean') return entry.capabilities.vision;
+  return null;
+}
+
+export function visionDetectionSource(providerId) {
+  return DETECTION_SOURCES[providerId] || '';
+}

--- a/src/firefox/src/providers/vision-capabilities.js
+++ b/src/firefox/src/providers/vision-capabilities.js
@@ -29,7 +29,7 @@ export function visionCapabilityIdentity(providerId, config) {
     providerId,
     baseUrl,
     model,
-    key: `${providerId}\n${baseUrl}\n${model.toLowerCase()}`,
+    key: `${providerId}\n${baseUrl}\n${model}`,
   };
 }
 
@@ -44,7 +44,7 @@ export function visionDetectionMatches(providerId, config, detection = config?.v
     && detection?.providerId === providerId
     && detection?.source === DETECTION_SOURCES[providerId]
     && canonicalizeVisionBaseUrl(detection?.baseUrl) === identity.baseUrl
-    && String(detection?.model || '').trim().toLowerCase() === identity.model.toLowerCase()
+    && String(detection?.model || '').trim() === identity.model
     && typeof detection?.supportsVision === 'boolean';
 }
 
@@ -62,8 +62,8 @@ function modelId(entry) {
 
 function selectModel(entries, requestedModel, { preferLoaded = false } = {}) {
   if (!Array.isArray(entries) || !entries.length) return null;
-  const requested = String(requestedModel || '').trim().toLowerCase();
-  if (requested) return entries.find(entry => modelId(entry).toLowerCase() === requested) || null;
+  const requested = String(requestedModel || '').trim();
+  if (requested) return entries.find(entry => modelId(entry) === requested) || null;
   if (preferLoaded) {
     const loaded = entries.filter(entry =>
       String(entry?.state || '').toLowerCase() === 'loaded'

--- a/src/firefox/src/ui/locales/ar.js
+++ b/src/firefox/src/ui/locales/ar.js
@@ -269,7 +269,7 @@ export default {
   'st.provider.field.model': 'النموذج',
   'st.provider.field.model_optional': 'النموذج (اختياري)',
   'st.provider.field.supports_vision': 'النموذج يدعم الرؤية (متعدّد الوسائط)',
-  'st.provider.field.vision_auto': 'تلقائي (من Ollama)',
+  'st.provider.field.vision_auto': 'تلقائي',
   'st.provider.field.vision_force_on': 'فرض التشغيل',
   'st.provider.field.vision_detected_vision': 'تم الاكتشاف تلقائيًا: يدعم الرؤية',
   'st.provider.field.vision_detected_text': 'تم الاكتشاف تلقائيًا: نص فقط',

--- a/src/firefox/src/ui/locales/bn.js
+++ b/src/firefox/src/ui/locales/bn.js
@@ -714,7 +714,7 @@ export default {
   'st.provider.field.model_optional': "মডেল (ঐচ্ছিক)",
   'st.provider.field.context_window': "প্রসঙ্গ উইন্ডো (টোকেন)",
   'st.provider.field.supports_vision': "মডেল দৃষ্টি সমর্থন করে (মাল্টিমোডাল)",
-  'st.provider.field.vision_auto': 'স্বয়ংক্রিয় (Ollama থেকে)',
+  'st.provider.field.vision_auto': 'স্বয়ংক্রিয়',
   'st.provider.field.vision_force_on': 'জোর করে চালু',
   'st.provider.field.vision_detected_vision': 'স্বয়ংক্রিয়ভাবে শনাক্ত: ভিশন',
   'st.provider.field.vision_detected_text': 'স্বয়ংক্রিয়ভাবে শনাক্ত: শুধু টেক্সট',

--- a/src/firefox/src/ui/locales/de.js
+++ b/src/firefox/src/ui/locales/de.js
@@ -651,7 +651,7 @@ export default {
   'st.provider.field.model_optional': 'Modell (optional)',
   'st.provider.field.context_window': 'Kontextfenster (Tokens)',
   'st.provider.field.supports_vision': 'Modell unterstützt Vision (multimodal)',
-  'st.provider.field.vision_auto': 'Automatisch (von Ollama)',
+  'st.provider.field.vision_auto': 'Automatisch',
   'st.provider.field.vision_force_on': 'Erzwingen',
   'st.provider.field.vision_detected_vision': 'Automatisch erkannt: Bildverarbeitung',
   'st.provider.field.vision_detected_text': 'Automatisch erkannt: Nur Text',

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -715,7 +715,7 @@ export default {
   'st.provider.field.model_optional': 'Model (optional)',
   'st.provider.field.context_window': 'Context window (tokens)',
   'st.provider.field.supports_vision': 'Model supports vision (multimodal)',
-  'st.provider.field.vision_auto': 'Auto (from Ollama)',
+  'st.provider.field.vision_auto': 'Auto',
   'st.provider.field.vision_force_on': 'Force on',
   'st.provider.field.vision_detected_vision': 'Auto-detected: Vision',
   'st.provider.field.vision_detected_text': 'Auto-detected: Text only',

--- a/src/firefox/src/ui/locales/es.js
+++ b/src/firefox/src/ui/locales/es.js
@@ -269,7 +269,7 @@ export default {
   'st.provider.field.model': 'Modelo',
   'st.provider.field.model_optional': 'Modelo (opcional)',
   'st.provider.field.supports_vision': 'El modelo admite visión (multimodal)',
-  'st.provider.field.vision_auto': 'Automático (desde Ollama)',
+  'st.provider.field.vision_auto': 'Automático',
   'st.provider.field.vision_force_on': 'Forzar activación',
   'st.provider.field.vision_detected_vision': 'Detectado automáticamente: Visión',
   'st.provider.field.vision_detected_text': 'Detectado automáticamente: Solo texto',

--- a/src/firefox/src/ui/locales/fa.js
+++ b/src/firefox/src/ui/locales/fa.js
@@ -714,7 +714,7 @@ export default {
   'st.provider.field.model_optional': "مدل (اختیاری)",
   'st.provider.field.context_window': "پنجره زمینه (توکن ها)",
   'st.provider.field.supports_vision': "مدل از بینایی پشتیبانی می کند (چند وجهی)",
-  'st.provider.field.vision_auto': 'خودکار (از Ollama)',
+  'st.provider.field.vision_auto': 'خودکار',
   'st.provider.field.vision_force_on': 'اجباری روشن',
   'st.provider.field.vision_detected_vision': 'شناسایی خودکار: بینایی',
   'st.provider.field.vision_detected_text': 'شناسایی خودکار: فقط متن',

--- a/src/firefox/src/ui/locales/fr.js
+++ b/src/firefox/src/ui/locales/fr.js
@@ -269,7 +269,7 @@ export default {
   'st.provider.field.model': 'Modèle',
   'st.provider.field.model_optional': 'Modèle (facultatif)',
   'st.provider.field.supports_vision': 'Le modèle gère la vision (multimodal)',
-  'st.provider.field.vision_auto': 'Automatique (depuis Ollama)',
+  'st.provider.field.vision_auto': 'Automatique',
   'st.provider.field.vision_force_on': 'Forcer l’activation',
   'st.provider.field.vision_detected_vision': 'Détection automatique : vision',
   'st.provider.field.vision_detected_text': 'Détection automatique : texte uniquement',

--- a/src/firefox/src/ui/locales/he.js
+++ b/src/firefox/src/ui/locales/he.js
@@ -619,7 +619,7 @@ export default {
   "st.provider.field.model_optional": "מודל (אופציונלי)",
   "st.provider.field.context_window": "חלון הקשר (אסימונים)",
   "st.provider.field.supports_vision": "הדגם תומך בראייה (מולטימודאלי)",
-  'st.provider.field.vision_auto': 'אוטומטי (מ־Ollama)',
+  'st.provider.field.vision_auto': 'אוטומטי',
   'st.provider.field.vision_force_on': 'הפעלה מאולצת',
   'st.provider.field.vision_detected_vision': 'זוהה אוטומטית: ראייה',
   'st.provider.field.vision_detected_text': 'זוהה אוטומטית: טקסט בלבד',

--- a/src/firefox/src/ui/locales/hi.js
+++ b/src/firefox/src/ui/locales/hi.js
@@ -714,7 +714,7 @@ export default {
   'st.provider.field.model_optional': "मॉडल (वैकल्पिक)",
   'st.provider.field.context_window': "संदर्भ विंडो (टोकन)",
   'st.provider.field.supports_vision': "मॉडल दृष्टि का समर्थन करता है (मल्टीमॉडल)",
-  'st.provider.field.vision_auto': 'स्वचालित (Ollama से)',
+  'st.provider.field.vision_auto': 'स्वचालित',
   'st.provider.field.vision_force_on': 'बलपूर्वक चालू',
   'st.provider.field.vision_detected_vision': 'स्वतः पहचाना गया: विज़न',
   'st.provider.field.vision_detected_text': 'स्वतः पहचाना गया: केवल टेक्स्ट',

--- a/src/firefox/src/ui/locales/id.js
+++ b/src/firefox/src/ui/locales/id.js
@@ -269,7 +269,7 @@ export default {
   'st.provider.field.model': 'Model',
   'st.provider.field.model_optional': 'Model (opsional)',
   'st.provider.field.supports_vision': 'Model mendukung visi (multimodal)',
-  'st.provider.field.vision_auto': 'Otomatis (dari Ollama)',
+  'st.provider.field.vision_auto': 'Otomatis',
   'st.provider.field.vision_force_on': 'Paksa aktif',
   'st.provider.field.vision_detected_vision': 'Terdeteksi otomatis: Vision',
   'st.provider.field.vision_detected_text': 'Terdeteksi otomatis: Teks saja',

--- a/src/firefox/src/ui/locales/ja.js
+++ b/src/firefox/src/ui/locales/ja.js
@@ -269,7 +269,7 @@ export default {
   'st.provider.field.model': 'モデル',
   'st.provider.field.model_optional': 'モデル（任意）',
   'st.provider.field.supports_vision': 'モデルは画像認識（マルチモーダル）対応',
-  'st.provider.field.vision_auto': '自動（Ollama から）',
+  'st.provider.field.vision_auto': '自動',
   'st.provider.field.vision_force_on': '強制的にオン',
   'st.provider.field.vision_detected_vision': '自動検出：画像対応',
   'st.provider.field.vision_detected_text': '自動検出：テキストのみ',

--- a/src/firefox/src/ui/locales/ko.js
+++ b/src/firefox/src/ui/locales/ko.js
@@ -269,7 +269,7 @@ export default {
   'st.provider.field.model': '모델',
   'st.provider.field.model_optional': '모델 (선택)',
   'st.provider.field.supports_vision': '모델이 비전(멀티모달)을 지원합니다',
-  'st.provider.field.vision_auto': '자동(Ollama에서)',
+  'st.provider.field.vision_auto': '자동',
   'st.provider.field.vision_force_on': '강제로 켜기',
   'st.provider.field.vision_detected_vision': '자동 감지: 비전',
   'st.provider.field.vision_detected_text': '자동 감지: 텍스트 전용',

--- a/src/firefox/src/ui/locales/ms.js
+++ b/src/firefox/src/ui/locales/ms.js
@@ -269,7 +269,7 @@ export default {
   'st.provider.field.model': 'Model',
   'st.provider.field.model_optional': 'Model (pilihan)',
   'st.provider.field.supports_vision': 'Model menyokong penglihatan (multimodal)',
-  'st.provider.field.vision_auto': 'Automatik (daripada Ollama)',
+  'st.provider.field.vision_auto': 'Automatik',
   'st.provider.field.vision_force_on': 'Paksa hidup',
   'st.provider.field.vision_detected_vision': 'Dikesan secara automatik: Penglihatan',
   'st.provider.field.vision_detected_text': 'Dikesan secara automatik: Teks sahaja',

--- a/src/firefox/src/ui/locales/nl.js
+++ b/src/firefox/src/ui/locales/nl.js
@@ -627,7 +627,7 @@ export default {
   'st.provider.field.model_optional': 'Model (optioneel)',
   'st.provider.field.context_window': 'Contextvenster (tokens)',
   'st.provider.field.supports_vision': 'Model ondersteunt visie (multimodaal)',
-  'st.provider.field.vision_auto': 'Automatisch (van Ollama)',
+  'st.provider.field.vision_auto': 'Automatisch',
   'st.provider.field.vision_force_on': 'Geforceerd aan',
   'st.provider.field.vision_detected_vision': 'Automatisch gedetecteerd: Visie',
   'st.provider.field.vision_detected_text': 'Automatisch gedetecteerd: Alleen tekst',

--- a/src/firefox/src/ui/locales/pl.js
+++ b/src/firefox/src/ui/locales/pl.js
@@ -477,7 +477,7 @@ export default {
   'st.provider.field.model_optional': 'Model (opcjonalnie)',
   'st.provider.field.context_window': 'Okno kontekstu (tokeny)',
   'st.provider.field.supports_vision': 'Model obsługuje wizję (multimodalność)',
-  'st.provider.field.vision_auto': 'Automatycznie (z Ollama)',
+  'st.provider.field.vision_auto': 'Automatycznie',
   'st.provider.field.vision_force_on': 'Wymuś włączenie',
   'st.provider.field.vision_detected_vision': 'Wykryto automatycznie: Obsługa obrazu',
   'st.provider.field.vision_detected_text': 'Wykryto automatycznie: Tylko tekst',

--- a/src/firefox/src/ui/locales/pt.js
+++ b/src/firefox/src/ui/locales/pt.js
@@ -714,7 +714,7 @@ export default {
   'st.provider.field.model_optional': "Modelo (opcional)",
   'st.provider.field.context_window': "Janela de contexto (tokens)",
   'st.provider.field.supports_vision': "Modelo apoia visão (multimodal)",
-  'st.provider.field.vision_auto': 'Automático (pelo Ollama)',
+  'st.provider.field.vision_auto': 'Automático',
   'st.provider.field.vision_force_on': 'Forçar ativação',
   'st.provider.field.vision_detected_vision': 'Detectado automaticamente: Visão',
   'st.provider.field.vision_detected_text': 'Detectado automaticamente: Somente texto',

--- a/src/firefox/src/ui/locales/ru.js
+++ b/src/firefox/src/ui/locales/ru.js
@@ -269,7 +269,7 @@ export default {
   'st.provider.field.model': 'Модель',
   'st.provider.field.model_optional': 'Модель (необязательно)',
   'st.provider.field.supports_vision': 'Модель поддерживает зрение (мультимодальная)',
-  'st.provider.field.vision_auto': 'Автоматически (из Ollama)',
+  'st.provider.field.vision_auto': 'Автоматически',
   'st.provider.field.vision_force_on': 'Принудительно включить',
   'st.provider.field.vision_detected_vision': 'Определено автоматически: Поддержка изображений',
   'st.provider.field.vision_detected_text': 'Определено автоматически: Только текст',

--- a/src/firefox/src/ui/locales/th.js
+++ b/src/firefox/src/ui/locales/th.js
@@ -269,7 +269,7 @@ export default {
   'st.provider.field.model': 'โมเดล',
   'st.provider.field.model_optional': 'โมเดล (ไม่บังคับ)',
   'st.provider.field.supports_vision': 'โมเดลรองรับการมองเห็น (มัลติโมดัล)',
-  'st.provider.field.vision_auto': 'อัตโนมัติ (จาก Ollama)',
+  'st.provider.field.vision_auto': 'อัตโนมัติ',
   'st.provider.field.vision_force_on': 'บังคับเปิด',
   'st.provider.field.vision_detected_vision': 'ตรวจพบอัตโนมัติ: รองรับภาพ',
   'st.provider.field.vision_detected_text': 'ตรวจพบอัตโนมัติ: ข้อความเท่านั้น',

--- a/src/firefox/src/ui/locales/tl.js
+++ b/src/firefox/src/ui/locales/tl.js
@@ -269,7 +269,7 @@ export default {
   'st.provider.field.model': 'Modelo',
   'st.provider.field.model_optional': 'Modelo (opsyonal)',
   'st.provider.field.supports_vision': 'Sumusuporta ang modelo sa bisyon (multimodal)',
-  'st.provider.field.vision_auto': 'Awtomatiko (mula sa Ollama)',
+  'st.provider.field.vision_auto': 'Awtomatiko',
   'st.provider.field.vision_force_on': 'Sapilitang i-on',
   'st.provider.field.vision_detected_vision': 'Awtomatikong natukoy: Vision',
   'st.provider.field.vision_detected_text': 'Awtomatikong natukoy: Teksto lang',

--- a/src/firefox/src/ui/locales/tr.js
+++ b/src/firefox/src/ui/locales/tr.js
@@ -308,7 +308,7 @@ export default {
   'st.provider.field.model': 'Model',
   'st.provider.field.model_optional': 'Model (isteğe bağlı)',
   'st.provider.field.supports_vision': 'Model görme yeteneğini destekliyor (çok kipli)',
-  'st.provider.field.vision_auto': 'Otomatik (Ollama’dan)',
+  'st.provider.field.vision_auto': 'Otomatik',
   'st.provider.field.vision_force_on': 'Zorla açık',
   'st.provider.field.vision_detected_vision': 'Otomatik algılandı: Görsel',
   'st.provider.field.vision_detected_text': 'Otomatik algılandı: Yalnızca metin',

--- a/src/firefox/src/ui/locales/uk.js
+++ b/src/firefox/src/ui/locales/uk.js
@@ -269,7 +269,7 @@ export default {
   'st.provider.field.model': 'Модель',
   'st.provider.field.model_optional': 'Модель (необов\'язково)',
   'st.provider.field.supports_vision': 'Модель підтримує зір (мультимодальна)',
-  'st.provider.field.vision_auto': 'Автоматично (з Ollama)',
+  'st.provider.field.vision_auto': 'Автоматично',
   'st.provider.field.vision_force_on': 'Примусово ввімкнути',
   'st.provider.field.vision_detected_vision': 'Визначено автоматично: Підтримка зображень',
   'st.provider.field.vision_detected_text': 'Визначено автоматично: Лише текст',

--- a/src/firefox/src/ui/locales/vi.js
+++ b/src/firefox/src/ui/locales/vi.js
@@ -714,7 +714,7 @@ export default {
   'st.provider.field.model_optional': "Mô hình (tùy chọn)",
   'st.provider.field.context_window': "Cửa sổ ngữ cảnh (mã thông báo)",
   'st.provider.field.supports_vision': "Mô hình hỗ trợ tầm nhìn (đa phương thức)",
-  'st.provider.field.vision_auto': 'Tự động (từ Ollama)',
+  'st.provider.field.vision_auto': 'Tự động',
   'st.provider.field.vision_force_on': 'Buộc bật',
   'st.provider.field.vision_detected_vision': 'Tự động phát hiện: Thị giác',
   'st.provider.field.vision_detected_text': 'Tự động phát hiện: Chỉ văn bản',

--- a/src/firefox/src/ui/locales/zh.js
+++ b/src/firefox/src/ui/locales/zh.js
@@ -269,7 +269,7 @@ export default {
   'st.provider.field.model': '模型',
   'st.provider.field.model_optional': '模型（可选）',
   'st.provider.field.supports_vision': '模型支持视觉（多模态）',
-  'st.provider.field.vision_auto': '自动（来自 Ollama）',
+  'st.provider.field.vision_auto': '自动',
   'st.provider.field.vision_force_on': '强制开启',
   'st.provider.field.vision_detected_vision': '自动检测：支持视觉',
   'st.provider.field.vision_detected_text': '自动检测：仅文本',

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -49,8 +49,11 @@ import {
   sniffProviderIdFromBaseUrl,
 } from './provider-icons.js';
 import { ADDITIONAL_PROVIDER_UI } from '../providers/provider-catalog.js';
-import { AUTO_GROUP_TABS_KEY } from '../tab-group-preference.js';
+import { AUTO_VISION_PROVIDER_IDS, visionDetectionMatches } from '../providers/vision-capabilities.js';
 import { canonicalizeOllamaBaseUrl } from '../providers/context-windows.js';
+import { AUTO_GROUP_TABS_KEY } from '../tab-group-preference.js';
+
+const VISION_UI_PROVIDER_IDS = new Set(['ollama', ...AUTO_VISION_PROVIDER_IDS]);
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
@@ -307,12 +310,18 @@ let requestedActiveProviderId = '';
 
 if (globalThis.browser?.storage?.onChanged) {
   browser.storage.onChanged.addListener((changes, area) => {
-    const next = changes.providers?.newValue?.ollama;
-    if (area !== 'local' || !next || !providersData.ollama) return;
-    // Capability detection runs in the background after a user turn starts.
-    // Refresh only its result so unrelated unsaved provider drafts stay put.
-    providersData.ollama.visionDetection = next.visionDetection || null;
-    refreshOllamaVisionStatus();
+    if (area !== 'local' || !changes.providers?.newValue) return;
+    const nextOllama = changes.providers?.newValue?.ollama;
+    if (nextOllama && providersData.ollama) {
+      providersData.ollama.visionDetection = nextOllama.visionDetection || null;
+      refreshOllamaVisionStatus();
+    }
+    for (const id of AUTO_VISION_PROVIDER_IDS) {
+      const next = changes.providers.newValue[id];
+      if (!next || !providersData[id]) continue;
+      providersData[id].visionDetection = next.visionDetection || null;
+      refreshVisionStatus(id);
+    }
   });
 }
 
@@ -1712,7 +1721,7 @@ const PROMPT_TIER_FIELD = {
   ],
 };
 
-const OLLAMA_VISION_MODE_FIELD = {
+const VISION_MODE_FIELD = {
   key: 'visionMode',
   labelKey: 'st.provider.field.supports_vision',
   type: 'select',
@@ -1722,38 +1731,46 @@ const OLLAMA_VISION_MODE_FIELD = {
     { value: 'off', labelKey: 'st.providers.compat.value.off' },
   ],
 };
+const OLLAMA_VISION_MODE_FIELD = VISION_MODE_FIELD;
 
-function ollamaVisionDetectionMatches(config, detection = config?.visionDetection) {
-  const model = String(config?.model || '').trim().toLowerCase();
-  const detectedModel = String(detection?.model || '').trim().toLowerCase();
-  const baseUrl = canonicalizeOllamaBaseUrl(config?.baseUrl);
-  return detection?.source === 'ollama_show'
-    && !!model
-    && !!baseUrl
-    && model === detectedModel
-    && baseUrl === canonicalizeOllamaBaseUrl(detection?.baseUrl);
-}
-
-function ollamaVisionStatusKey(config) {
-  if (!ollamaVisionDetectionMatches(config)) return 'st.provider.field.vision_pending';
+function visionStatusKey(id, config) {
+  if (!providerVisionDetectionMatches(id, config)) return 'st.provider.field.vision_pending';
   return config.visionDetection.supportsVision
     ? 'st.provider.field.vision_detected_vision'
     : 'st.provider.field.vision_detected_text';
 }
 
-function refreshOllamaVisionStatus() {
-  const hint = document.querySelector('[data-ollama-vision-status]');
+function refreshVisionStatus(id) {
+  if (!VISION_UI_PROVIDER_IDS.has(id)) return;
+  const hint = id === 'ollama'
+    ? document.querySelector('[data-ollama-vision-status]')
+    : document.querySelector(`[data-vision-status="${id}"]`);
   if (!hint) return;
-  const mode = document.querySelector('select[data-provider="ollama"][data-key="visionMode"]')?.value || 'auto';
+  const mode = document.querySelector(`select[data-provider="${id}"][data-key="visionMode"]`)?.value || 'auto';
   hint.hidden = mode !== 'auto';
   if (hint.hidden) return;
   const config = {
-    ...providersData.ollama,
+    ...providersData[id],
     visionMode: mode,
-    model: document.querySelector('input[data-provider="ollama"][data-key="model"]')?.value,
-    baseUrl: document.querySelector('input[data-provider="ollama"][data-key="baseUrl"]')?.value,
+    model: document.querySelector(`input[data-provider="${id}"][data-key="model"]`)?.value,
+    baseUrl: document.querySelector(`input[data-provider="${id}"][data-key="baseUrl"]`)?.value,
   };
-  hint.textContent = t(ollamaVisionStatusKey(config));
+  hint.textContent = t(visionStatusKey(id, config));
+}
+
+function refreshOllamaVisionStatus() {
+  refreshVisionStatus('ollama');
+}
+
+function providerVisionDetectionMatches(id, config, detection = config?.visionDetection) {
+  if (id !== 'ollama') return visionDetectionMatches(id, config, detection, { allowTransient: true });
+  const model = String(config?.model || '').trim();
+  const baseUrl = canonicalizeOllamaBaseUrl(config?.baseUrl);
+  return !!model && !!baseUrl
+    && detection?.source === 'ollama_show'
+    && String(detection?.model || '').trim().toLowerCase() === model.toLowerCase()
+    && canonicalizeOllamaBaseUrl(detection?.baseUrl) === baseUrl
+    && typeof detection?.supportsVision === 'boolean';
 }
 
 const CONTEXT_WINDOW_FIELD = {
@@ -2049,7 +2066,7 @@ function renderProviders() {
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:8080' },
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'qwen/qwen3.5-9b' },
         CONTEXT_WINDOW_FIELD,
-        { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
+        VISION_MODE_FIELD,
         PROMPT_TIER_FIELD,
       ],
     },
@@ -2067,7 +2084,7 @@ function renderProviders() {
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:1234/v1' },
         { key: 'model', labelKey: 'st.provider.field.model_optional', type: 'text', placeholderKey: 'st.provider.field.model_loaded_hint' },
         CONTEXT_WINDOW_FIELD,
-        { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
+        VISION_MODE_FIELD,
         PROMPT_TIER_FIELD,
       ],
     },
@@ -2107,7 +2124,7 @@ function renderProviders() {
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-4' },
         CONTEXT_WINDOW_FIELD,
-        { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
+        VISION_MODE_FIELD,
         PROMPT_TIER_FIELD,
       ],
     },
@@ -2411,8 +2428,9 @@ function renderProviders() {
             <select data-provider="${id}" data-key="${field.key}" data-type="select">${optionsHTML}</select>
           </div>
         `;
-        if (id === 'ollama' && field.key === 'visionMode') {
-          fieldsHTML += `<div class="field-hint" data-ollama-vision-status${current === 'auto' ? '' : ' hidden'} style="margin:-4px 0 10px;font-size:12px;color:var(--text2);">${escapeHtml(t(ollamaVisionStatusKey(config)))}</div>`;
+        if (VISION_UI_PROVIDER_IDS.has(id) && field.key === 'visionMode') {
+          const statusAttribute = id === 'ollama' ? 'data-ollama-vision-status' : `data-vision-status="${id}"`;
+          fieldsHTML += `<div class="field-hint" ${statusAttribute}${current === 'auto' ? '' : ' hidden'} style="margin:-4px 0 10px;font-size:12px;color:var(--text2);">${escapeHtml(t(visionStatusKey(id, config)))}</div>`;
         }
       } else if (field.type === 'checkbox') {
         const isChecked = !!config[field.key];
@@ -2583,8 +2601,11 @@ function renderProviders() {
         input.value = sel.value;
       }
       refreshProviderCompatibilitySummary(providerId);
-      if (providerId === 'ollama') refreshOllamaVisionStatus();
+      refreshVisionStatus(providerId);
     });
+  });
+  document.querySelectorAll('select[data-key="visionMode"]').forEach((select) => {
+    select.addEventListener('change', () => refreshVisionStatus(select.dataset.provider));
   });
   document.querySelector('select[data-provider="ollama"][data-key="visionMode"]')?.addEventListener('change', refreshOllamaVisionStatus);
   document.querySelectorAll('.provider-compatibility select[data-provider], .provider-compatibility textarea[data-provider]').forEach((input) => {
@@ -2599,6 +2620,7 @@ function renderProviders() {
   document.querySelectorAll('input[data-key="model"], input[data-key="baseUrl"]').forEach((input) => {
     input.addEventListener('input', () => {
       refreshProviderCompatibilitySummary(input.dataset.provider);
+      refreshVisionStatus(input.dataset.provider);
       if (input.dataset.provider === 'ollama') refreshOllamaVisionStatus();
     });
   });
@@ -2801,7 +2823,7 @@ function applyProviderBaseUrl(id, baseUrl) {
   if (providersData[id]) providersData[id].baseUrl = baseUrl;
   const input = document.querySelector(`input[data-provider="${id}"][data-key="baseUrl"]`);
   if (input && input.value !== baseUrl) input.value = baseUrl;
-  if (id === 'ollama') refreshOllamaVisionStatus();
+  refreshVisionStatus(id);
 }
 
 function applyProviderContextWindow(id, contextWindow) {
@@ -2922,16 +2944,16 @@ async function saveProvider(id, { showFlash = true, markConfigured = true } = {}
   if (providersData[id]) {
     const priorVisionDetection = providersData[id].visionDetection;
     Object.assign(providersData[id], config);
-    if (id === 'ollama' && (
+    if (VISION_UI_PROVIDER_IDS.has(id) && (
       providersData[id].visionMode !== 'auto'
-      || !ollamaVisionDetectionMatches(providersData[id], priorVisionDetection)
+      || !providerVisionDetectionMatches(id, providersData[id], priorVisionDetection)
     )) {
       providersData[id].visionDetection = null;
     }
     if (markConfigured) providersData[id].configured = id !== 'webbrain_cloud';
   }
   refreshProviderCardStatus(id);
-  if (id === 'ollama') refreshOllamaVisionStatus();
+  refreshVisionStatus(id);
 
   if (showFlash) {
     if (apiKeyWarning) {

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -6926,19 +6926,21 @@ function requestConfigurationFile(tabId) {
 
 function toggledVisionProviderConfig(providerId, config) {
   if (providerId === 'ollama') {
-    const visionEnabled = config.visionMode === 'on' ||
-      (config.visionMode === 'auto' && config.visionDetection?.supportsVision === true);
+    const visionEnabled = config.visionMode === 'on'
+      || (config.visionMode === 'auto' && config.visionDetection?.supportsVision === true);
     const enabled = !visionEnabled;
-    return {
-      enabled,
-      config: { ...config, visionMode: enabled ? 'on' : 'off' },
-    };
+    const { supportsVision: _legacy, ...withoutLegacy } = config;
+    return { enabled, config: { ...withoutLegacy, visionMode: enabled ? 'on' : 'off' } };
+  }
+  if (['llamacpp', 'lmstudio', 'localai'].includes(providerId)) {
+    const visionEnabled = config.visionMode === 'on'
+      || (config.visionMode === 'auto' && config.visionDetection?.supportsVision === true);
+    const enabled = !visionEnabled;
+    const { supportsVision: _legacy, ...withoutLegacy } = config;
+    return { enabled, config: { ...withoutLegacy, visionMode: enabled ? 'on' : 'off' } };
   }
   const enabled = !config.supportsVision;
-  return {
-    enabled,
-    config: { ...config, supportsVision: enabled },
-  };
+  return { enabled, config: { ...config, supportsVision: enabled } };
 }
 
 async function parseSlashCommands(text, tabId = currentTabId, options = {}) {

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -47,6 +47,7 @@ import {
 import { providerIconUrl } from './provider-icons.js';
 import { parseWatchSlashCommand, WATCH_COMMAND_USAGE } from './watch-command.js';
 import { createSidePanelWindowScope } from './sidepanel-window-scope.js';
+import { visionProviderKind } from '../providers/vision-capabilities.js';
 import {
   SHORTCUT_COMMAND_STORAGE_KEY,
   shortcutCommandForWindow,
@@ -6932,7 +6933,7 @@ function toggledVisionProviderConfig(providerId, config) {
     const { supportsVision: _legacy, ...withoutLegacy } = config;
     return { enabled, config: { ...withoutLegacy, visionMode: enabled ? 'on' : 'off' } };
   }
-  if (['llamacpp', 'lmstudio', 'localai'].includes(providerId)) {
+  if (visionProviderKind(providerId, config)) {
     const visionEnabled = config.visionMode === 'on'
       || (config.visionMode === 'auto' && config.visionDetection?.supportsVision === true);
     const enabled = !visionEnabled;

--- a/test/run.js
+++ b/test/run.js
@@ -37617,6 +37617,11 @@ test('local vision metadata parsers require authoritative provider evidence', ()
 
 test('local vision identities preserve case-sensitive model IDs', () => {
   for (const vision of [VisionCapabilitiesCh, VisionCapabilitiesFx]) {
+    assert.equal(vision.visionProviderKind('custom_llama', { type: 'llamacpp' }), 'llamacpp');
+    assert.equal(vision.visionProviderKind('custom_lm', { type: 'openai', providerName: 'lmstudio' }), 'lmstudio');
+    assert.equal(vision.visionProviderKind('custom_local', { type: 'openai', providerName: 'localai' }), 'localai');
+    assert.equal(vision.visionProviderKind('custom_openai', { type: 'openai', providerName: 'custom' }), null);
+
     const upperConfig = {
       baseUrl: 'http://localhost:1234/v1',
       model: 'CaseModel',
@@ -37664,6 +37669,15 @@ test('llama.cpp, LM Studio, and LocalAI migrate to tri-state vision alongside Ol
       })[id];
       assert.equal(migratedBlank.visionDetection, null, `${id}: blank-model detections must not survive reload`);
     }
+    const migratedCustomOn = manager._migrateStoredProviderConfigs({
+      custom_llama: { type: 'llamacpp', model: 'fixed', supportsVision: true },
+    }).custom_llama;
+    assert.equal(migratedCustomOn.visionMode, 'on', 'custom llama.cpp legacy true remains an explicit override');
+    assert.equal(Object.hasOwn(migratedCustomOn, 'supportsVision'), false);
+    const migratedCustomOff = manager._migrateStoredProviderConfigs({
+      custom_lm: { type: 'openai', providerName: 'lmstudio', model: 'fixed', supportsVision: false },
+    }).custom_lm;
+    assert.equal(migratedCustomOff.visionMode, 'off', 'custom LM Studio legacy false remains an explicit override');
     assert.equal(defaults.jan.supportsVision, true, 'unprobed local providers retain their existing behavior');
   }
 });
@@ -37710,6 +37724,42 @@ test('local vision detection uses official metadata endpoints with Chrome/Firefo
     else globalThis.chrome = previousChrome;
     if (previousBrowser === undefined) delete globalThis.browser;
     else globalThis.browser = previousBrowser;
+  }
+});
+
+test('custom local provider IDs use their canonical vision detector and preserve explicit overrides', async () => {
+  const cases = [
+    ['custom_llama', { type: 'llamacpp', baseUrl: 'http://localhost:8080', model: 'llama-vlm' }, 'llamacpp'],
+    ['custom_lm', { type: 'openai', providerName: 'lmstudio', baseUrl: 'http://localhost:1234/v1', model: 'lm-vlm' }, 'lmstudio'],
+    ['custom_local', { type: 'openai', providerName: 'localai', baseUrl: 'http://localhost:8081/v1', model: 'local-vlm' }, 'localai'],
+  ];
+  for (const [label, PM] of [['chrome', ProviderManagerCh], ['firefox', ProviderManagerFx]]) {
+    for (const [id, config, expectedKind] of cases) {
+      const manager = new PM();
+      manager.save = async () => {};
+      manager.providers.set(id, manager._createProvider(id, {
+        ...config,
+        visionMode: 'auto',
+        visionDetection: null,
+      }));
+      manager.activeProviderId = id;
+      let detectorKind = null;
+      manager._fetchVisionCapability = async (kind) => {
+        detectorKind = kind;
+        return { ok: true, supportsVision: true };
+      };
+
+      const result = await manager.prepareActiveProviderCapabilities();
+      assert.equal(detectorKind, expectedKind, `${label}/${id}: custom ID should route to the canonical detector`);
+      assert.equal(result.supportsVision, true, `${label}/${id}: preflight should apply detected capability`);
+      assert.equal(manager.getActive().supportsVision, true, `${label}/${id}: provider getter should see canonical detection`);
+      assert.equal(manager.getActive().config.visionDetection.providerId, expectedKind,
+        `${label}/${id}: persisted detection should use the canonical provider kind`);
+
+      await manager.updateProvider(id, { supportsVision: false });
+      assert.equal(manager.getActive().config.visionMode, 'off', `${label}/${id}: legacy false update should become an override`);
+      assert.equal(manager.getActive().supportsVision, false, `${label}/${id}: explicit override should beat prior detection`);
+    }
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -784,6 +784,12 @@ const { LlamaCppProvider: LlamaCppProviderCh } = await import(
 const { LlamaCppProvider: LlamaCppProviderFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/providers/llamacpp.js').replace(/\\/g, '/')
 );
+const VisionCapabilitiesCh = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/providers/vision-capabilities.js').replace(/\\/g, '/')
+);
+const VisionCapabilitiesFx = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/providers/vision-capabilities.js').replace(/\\/g, '/')
+);
 const { AzureOpenAIProvider: AzureOpenAIProviderCh } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/providers/azure-openai.js').replace(/\\/g, '/')
 );
@@ -37581,6 +37587,164 @@ test('llama.cpp provider defaults to mid prompt tier for saved configs without c
     assert.equal(provider.config.category, 'local');
     assert.equal(provider.promptTier, 'mid');
     assert.equal(provider.contextWindow, 16384);
+  }
+});
+
+test('local vision metadata parsers require authoritative provider evidence', () => {
+  for (const vision of [VisionCapabilitiesCh, VisionCapabilitiesFx]) {
+    assert.equal(vision.parseLlamaCppVisionSupport({ modalities: { vision: true } }), true);
+    assert.equal(vision.parseLlamaCppVisionSupport({ modalities: { vision: false } }), false);
+    assert.equal(vision.parseLlamaCppVisionSupport({ modalities: {} }), null);
+
+    const lmModels = { models: [
+      { key: 'text-model', capabilities: { vision: false } },
+      { key: 'vision-model', capabilities: { vision: true } },
+    ] };
+    assert.equal(vision.parseLmStudioVisionSupport(lmModels, 'VISION-MODEL', 'v1'), true);
+    assert.equal(vision.parseLmStudioVisionSupport(lmModels, 'missing', 'v1'), null);
+    assert.equal(vision.parseLmStudioVisionSupport({ data: [{ id: 'legacy-vlm', type: 'vlm' }] }, 'legacy-vlm', 'v0'), true);
+
+    const localAi = { data: [
+      { id: 'text', input_modalities: ['text'] },
+      { id: 'vision', input_modalities: ['text', 'image'] },
+    ] };
+    assert.equal(vision.parseLocalAiVisionSupport(localAi, 'vision'), true);
+    assert.equal(vision.parseLocalAiVisionSupport(localAi, 'text'), false);
+    assert.equal(vision.parseLocalAiVisionSupport(localAi, 'missing'), null);
+  }
+});
+
+test('llama.cpp, LM Studio, and LocalAI migrate to tri-state vision alongside Ollama', () => {
+  for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
+    const manager = new PM();
+    const defaults = manager._defaultConfigs();
+    for (const id of ['ollama', 'llamacpp', 'lmstudio', 'localai']) {
+      assert.equal(defaults[id].visionMode, 'auto', `${id}: default mode`);
+      assert.equal(defaults[id].visionDetection, null, `${id}: default detection`);
+      assert.equal(Object.hasOwn(defaults[id], 'supportsVision'), false, `${id}: legacy boolean should be gone`);
+    }
+    for (const id of ['llamacpp', 'lmstudio', 'localai']) {
+      const migratedOff = manager._migrateStoredProviderConfigs({ [id]: { model: 'fixed', supportsVision: false } })[id];
+      assert.equal(migratedOff.visionMode, 'off');
+      const migratedAuto = manager._migrateStoredProviderConfigs({ [id]: { model: 'fixed', supportsVision: true } })[id];
+      assert.equal(migratedAuto.visionMode, 'auto');
+      const migratedBlank = manager._migrateStoredProviderConfigs({
+        [id]: { model: '', visionMode: 'auto', visionDetection: { supportsVision: true } },
+      })[id];
+      assert.equal(migratedBlank.visionDetection, null, `${id}: blank-model detections must not survive reload`);
+    }
+    assert.equal(defaults.jan.supportsVision, true, 'unprobed local providers retain their existing behavior');
+  }
+});
+
+test('local vision detection uses official metadata endpoints with Chrome/Firefox parity', async () => {
+  const previousFetch = globalThis.fetch;
+  const previousChrome = globalThis.chrome;
+  const previousBrowser = globalThis.browser;
+  const calls = [];
+  globalThis.chrome = { runtime: {}, storage: { local: { get: async () => ({}) }, onChanged: { addListener() {} } } };
+  globalThis.browser = { storage: { local: { get: async () => ({}) }, onChanged: { addListener() {} } } };
+  globalThis.fetch = async (url) => {
+    calls.push(String(url));
+    if (String(url).includes('/props')) return new Response(JSON.stringify({ modalities: { vision: false } }), { status: 200 });
+    if (String(url).endsWith('/api/v1/models')) {
+      return new Response(JSON.stringify({ models: [{ key: 'lm-vlm', capabilities: { vision: true } }] }), { status: 200 });
+    }
+    if (String(url).endsWith('/v1/models/capabilities')) {
+      return new Response(JSON.stringify({ data: [{ id: 'local-vlm', input_modalities: ['text', 'image'] }] }), { status: 200 });
+    }
+    return new Response('{}', { status: 404 });
+  };
+  try {
+    for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
+      const manager = new PM();
+      const provider = { config: { apiKey: '' } };
+      assert.deepEqual(await manager._fetchVisionCapability('llamacpp', provider, {
+        baseUrl: 'http://localhost:8080', model: 'router/model',
+      }), { ok: true, supportsVision: false });
+      assert.deepEqual(await manager._fetchVisionCapability('lmstudio', provider, {
+        baseUrl: 'http://localhost:1234/v1', model: 'lm-vlm',
+      }), { ok: true, supportsVision: true });
+      assert.deepEqual(await manager._fetchVisionCapability('localai', provider, {
+        baseUrl: 'http://localhost:8081/v1', model: 'local-vlm',
+      }), { ok: true, supportsVision: true });
+    }
+    assert.ok(calls.some(url => url.endsWith('/props?model=router%2Fmodel')));
+    assert.ok(calls.some(url => url.endsWith('/api/v1/models')));
+    assert.ok(calls.some(url => url.endsWith('/v1/models/capabilities')));
+  } finally {
+    if (previousFetch === undefined) delete globalThis.fetch;
+    else globalThis.fetch = previousFetch;
+    if (previousChrome === undefined) delete globalThis.chrome;
+    else globalThis.chrome = previousChrome;
+    if (previousBrowser === undefined) delete globalThis.browser;
+    else globalThis.browser = previousBrowser;
+  }
+});
+
+test('blank-model local vision checks are per-turn, single-flight, transient, and fail closed', async () => {
+  for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
+    const manager = new PM();
+    let saves = 0;
+    manager.save = async () => { saves++; };
+    manager.providers.set('lmstudio', manager._createProvider('lmstudio', {
+      type: 'openai', providerName: 'lmstudio', baseUrl: 'http://localhost:1234/v1',
+      model: '', visionMode: 'auto', visionDetection: null,
+    }));
+
+    let resolveFirst;
+    let fetchCalls = 0;
+    manager._fetchVisionCapability = async () => {
+      fetchCalls++;
+      return new Promise(resolve => { resolveFirst = resolve; });
+    };
+    const first = manager.ensureVisionCapability('lmstudio');
+    const joined = manager.ensureVisionCapability('lmstudio');
+    assert.equal(fetchCalls, 1, 'concurrent checks should share one request');
+    resolveFirst({ ok: true, supportsVision: false });
+    await Promise.all([first, joined]);
+    assert.equal(manager.providers.get('lmstudio').supportsVision, false);
+    assert.equal(manager.providers.get('lmstudio').config.visionDetection.transient, true);
+    assert.equal(manager._visionCapabilityChecks.size, 0, 'blank identity must be evicted after the turn');
+    assert.equal(saves, 0, 'blank-model detection must not be persisted');
+
+    manager._fetchVisionCapability = async () => {
+      fetchCalls++;
+      return { ok: true, supportsVision: true };
+    };
+    await manager.ensureVisionCapability('lmstudio');
+    assert.equal(fetchCalls, 2, 'next turn must recheck the server loaded-model slot');
+    assert.equal(manager.providers.get('lmstudio').supportsVision, true, 'hot-swapped vision model should take effect');
+    assert.equal(saves, 0);
+
+    manager._fetchVisionCapability = async () => {
+      fetchCalls++;
+      return { ok: false, timeout: true };
+    };
+    await manager.ensureVisionCapability('lmstudio');
+    assert.equal(fetchCalls, 3);
+    assert.equal(manager.providers.get('lmstudio').supportsVision, false, 'failed recheck must clear the prior transient true');
+    assert.equal(manager.providers.get('lmstudio').config.visionDetection, undefined);
+  }
+});
+
+test('tri-state local vision controls and pre-enrichment preparation stay mirrored', () => {
+  for (const prefix of ['src/chrome', 'src/firefox']) {
+    const agent = fs.readFileSync(path.join(ROOT, prefix, 'src/agent/agent.js'), 'utf8');
+    for (const marker of ['async _processMessageInner(', 'async _processMessageStreamInner(']) {
+      const start = agent.indexOf(marker);
+      const preparation = agent.indexOf('prepareActiveProviderCapabilities', start);
+      const enrichment = agent.indexOf('const enriched = await this._enrichUserMessageWithCurrentPage(', start);
+      assert.ok(preparation > start && preparation < enrichment, `${prefix}/${marker}: detection must precede enrichment`);
+    }
+    const settings = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/settings.js'), 'utf8');
+    for (const id of ['ollama', 'llamacpp', 'lmstudio', 'localai']) {
+      const start = settings.indexOf(`${id}: {`);
+      const block = settings.slice(start, settings.indexOf('\n    },', start));
+      assert.match(block, /VISION_MODE_FIELD/, `${prefix}/${id}: tri-state selector missing`);
+    }
+    const panel = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/sidepanel.js'), 'utf8');
+    assert.match(panel, /toggledVisionProviderConfig\(active, config\)/);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -25581,7 +25581,10 @@ test('sidepanel scopes async tab commands to the original tab', () => {
     const toggleStart = panel.indexOf('function toggledVisionProviderConfig(');
     const toggleEnd = panel.indexOf('\n\n', toggleStart);
     assert.ok(toggleStart >= 0 && toggleEnd > toggleStart, `${label}: /vision provider toggle helper should remain independently testable`);
-    const toggleVision = vm.runInNewContext(`(${panel.slice(toggleStart, toggleEnd)})`);
+    const visionProviderKind = label === 'chrome'
+      ? VisionCapabilitiesCh.visionProviderKind
+      : VisionCapabilitiesFx.visionProviderKind;
+    const toggleVision = vm.runInNewContext(`(${panel.slice(toggleStart, toggleEnd)})`, { visionProviderKind });
     const autoTextOnly = toggleVision('ollama', {
       visionMode: 'auto',
       visionDetection: { supportsVision: false },
@@ -25599,6 +25602,17 @@ test('sidepanel scopes async tab commands to the original tab', () => {
     const forcedOff = toggleVision('ollama', { visionMode: 'off' });
     assert.equal(forcedOff.enabled, true, `${label}: /vision should re-enable an Ollama provider in Off mode`);
     assert.equal(forcedOff.config.visionMode, 'on');
+    for (const [id, config] of [
+      ['custom_llama', { type: 'llamacpp' }],
+      ['custom_lm', { type: 'openai', providerName: 'lmstudio' }],
+      ['custom_local', { type: 'openai', providerName: 'localai' }],
+    ]) {
+      const customAuto = toggleVision(id, { ...config, visionMode: 'auto', supportsVision: false });
+      assert.equal(customAuto.enabled, true, `${label}: /vision should enable ${id} through its canonical provider kind`);
+      assert.equal(customAuto.config.visionMode, 'on', `${label}: /vision should Force on ${id}`);
+      assert.equal(Object.hasOwn(customAuto.config, 'supportsVision'), false,
+        `${label}: /vision should remove the legacy boolean for ${id}`);
+    }
     const regularProvider = toggleVision('openai', { supportsVision: false });
     assert.equal(regularProvider.enabled, true, `${label}: /vision should preserve boolean toggles for non-Ollama providers`);
     assert.equal(regularProvider.config.supportsVision, true);

--- a/test/run.js
+++ b/test/run.js
@@ -37600,7 +37600,8 @@ test('local vision metadata parsers require authoritative provider evidence', ()
       { key: 'text-model', capabilities: { vision: false } },
       { key: 'vision-model', capabilities: { vision: true } },
     ] };
-    assert.equal(vision.parseLmStudioVisionSupport(lmModels, 'VISION-MODEL', 'v1'), true);
+    assert.equal(vision.parseLmStudioVisionSupport(lmModels, 'vision-model', 'v1'), true);
+    assert.equal(vision.parseLmStudioVisionSupport(lmModels, 'VISION-MODEL', 'v1'), null);
     assert.equal(vision.parseLmStudioVisionSupport(lmModels, 'missing', 'v1'), null);
     assert.equal(vision.parseLmStudioVisionSupport({ data: [{ id: 'legacy-vlm', type: 'vlm' }] }, 'legacy-vlm', 'v0'), true);
 
@@ -37611,6 +37612,36 @@ test('local vision metadata parsers require authoritative provider evidence', ()
     assert.equal(vision.parseLocalAiVisionSupport(localAi, 'vision'), true);
     assert.equal(vision.parseLocalAiVisionSupport(localAi, 'text'), false);
     assert.equal(vision.parseLocalAiVisionSupport(localAi, 'missing'), null);
+  }
+});
+
+test('local vision identities preserve case-sensitive model IDs', () => {
+  for (const vision of [VisionCapabilitiesCh, VisionCapabilitiesFx]) {
+    const upperConfig = {
+      baseUrl: 'http://localhost:1234/v1',
+      model: 'CaseModel',
+      visionMode: 'auto',
+    };
+    const upperIdentity = vision.visionCapabilityIdentity('lmstudio', upperConfig);
+    const lowerIdentity = vision.visionCapabilityIdentity('lmstudio', { ...upperConfig, model: 'casemodel' });
+    assert.notEqual(upperIdentity.key, lowerIdentity.key, 'case-only model changes need distinct single-flight keys');
+
+    const detection = {
+      providerId: 'lmstudio',
+      model: 'CaseModel',
+      baseUrl: upperIdentity.baseUrl,
+      supportsVision: true,
+      source: 'lmstudio_models',
+    };
+    assert.equal(vision.visionDetectionMatches('lmstudio', upperConfig, detection), true);
+    assert.equal(vision.visionDetectionMatches('lmstudio', { ...upperConfig, model: 'casemodel' }, detection), false);
+
+    const caseDistinctModels = { models: [
+      { key: 'CaseModel', capabilities: { vision: true } },
+      { key: 'casemodel', capabilities: { vision: false } },
+    ] };
+    assert.equal(vision.parseLmStudioVisionSupport(caseDistinctModels, 'CaseModel', 'v1'), true);
+    assert.equal(vision.parseLmStudioVisionSupport(caseDistinctModels, 'casemodel', 'v1'), false);
   }
 });
 


### PR DESCRIPTION
## Summary

- add model/base-URL-scoped vision capability detection for llama.cpp, LM Studio, and LocalAI
- replace these providers' boolean Vision setting with Auto / Force on / Off in Chrome and Firefox
- resolve capability before screenshot enrichment, fail closed without blocking text requests, coalesce concurrent checks, retry transient failures, and reject stale results
- preserve dedicated vision-provider routing and leave Ollama, Jan, vLLM, SGLang, GPT4All, cloud providers, and routers unchanged
- document the behavior and localize the new settings/status labels across all shipped locales

## Metadata sources

- llama.cpp: `GET /props?model=...` → `modalities.vision`
- LM Studio: `GET /api/v1/models` → `capabilities.vision`, with legacy `/api/v0/models` type fallback
- LocalAI: `GET /v1/models/capabilities` → `input_modalities` / `capabilities`

Each metadata request has a 3-second deadline. Successful true/false detections are bound to the exact provider/model/base URL; connectivity, timeout, malformed JSON, and unavailable metadata remain text-only for that turn and are not permanently cached.

## Validation

- `npm test`
  - 33/33 rich-text toolbar guard tests
  - 1602/1602 unit/integration tests
  - 60/60 prompt-injection security checks
- `git diff --check`
- rebased onto current `origin/main` (`b4b25fe2`)
