### PR TITLE
Fix anchored accessibility pagination

### DIFF
--- a/src/chrome/src/agent/loop-detector.js
+++ b/src/chrome/src/agent/loop-detector.js
@@ -28,7 +28,7 @@ export class LoopDetector {
     this.recentNavUrls = new Map(); // tabId -> [normalized URL, ...]
     // A model can walk ref_1, ref_2, … forever while every call looks unique
     // to the exact-argument loop detector. Track that semantic read pattern.
-    this.axReadStates = new Map(); // tabId -> { total, suspicious, nextPage, seenPages, warned }
+    this.axReadStates = new Map(); // tabId -> { total, suspicious, nextPage, scopeKey, seenPages, warned }
     // Scroll calls can keep returning success even when no pane moved. Track
     // repeated dead-end attempts separately so changing the amount or
     // interleaving reads cannot evade the generic loop detector.
@@ -302,35 +302,45 @@ export class LoopDetector {
       total: 0,
       suspicious: 0,
       nextPage: null,
+      scopeKey: null,
       seenPages: new Set(),
       warned: false,
     };
+    const scopeKeyFor = (value = {}) => JSON.stringify({
+      filter: String(value?.filter || 'all'),
+      maxDepth: Number.isFinite(Number(value?.maxDepth)) ? Number(value.maxDepth) : null,
+      maxChars: Number.isFinite(Number(value?.maxChars)) ? Number(value.maxChars) : null,
+      refId: typeof value?.ref_id === 'string' ? value.ref_id.trim() : '',
+    });
     const page = Number(args?.page || 1);
     const hasRef = typeof args?.ref_id === 'string' && args.ref_id.trim() !== '';
-    const sequentialPage = !hasRef
-      && previous.total > 0
+    const currentScopeKey = scopeKeyFor(args);
+    const currentPageKey = `${currentScopeKey}|${page}`;
+    const sequentialPage = previous.total > 0
       && Number.isFinite(previous.nextPage)
       && page === previous.nextPage
-      && !previous.seenPages.has(page);
-    const repeatedRootOrPage = !hasRef && previous.total > 0 && !sequentialPage;
+      && currentScopeKey === previous.scopeKey
+      && !previous.seenPages.has(currentPageKey);
+    const repeatedRootOrPage = previous.total > 0 && !sequentialPage;
     const content = String(result?.pageContent || '').trim();
     const meaningfulLines = content ? content.split(/\r?\n/).filter(line => line.trim()).length : 0;
-    const suspicious = hasRef || repeatedRootOrPage || (hasRef && meaningfulLines <= 1);
+    const suspicious = !sequentialPage && (hasRef || repeatedRootOrPage || (hasRef && meaningfulLines <= 1));
 
     const state = {
       total: previous.total + 1,
       suspicious: previous.suspicious + (suspicious ? 1 : 0),
       nextPage: Number.isFinite(Number(result?.nextPage)) ? Number(result.nextPage) : null,
+      scopeKey: scopeKeyFor(result?.continuationArgs || args),
       seenPages: new Set(previous.seenPages),
       warned: previous.warned,
     };
-    state.seenPages.add(page);
+    state.seenPages.add(currentPageKey);
     this.axReadStates.set(tabId, state);
 
-    // A root read followed by the exact returned nextPage can legitimately span
-    // large applications. Keep the consecutive-read cap for every other AX
-    // pattern, but do not stop a valid sequential pagination step.
-    if (state.suspicious >= 6 || (state.total >= 12 && (state.suspicious > 0 || !sequentialPage))) {
+    // A root or anchored-subtree read followed by the exact returned nextPage
+    // can legitimately span large applications. Keep the consecutive-read cap
+    // for every other AX pattern, but do not stop a valid sequential step.
+    if (state.suspicious >= 6 || (state.total >= 12 && !sequentialPage)) {
       this.axReadStates.delete(tabId);
       return {
         kind: 'stop',

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -906,6 +906,7 @@
         filter: effFilter,
         maxDepth: opts.maxDepth,
         maxChars: effMaxChars,
+        ...(refId ? { ref_id: refId } : {}),
       };
       const viewport = { width: window.innerWidth, height: window.innerHeight };
       const lines = [];

--- a/src/firefox/src/agent/loop-detector.js
+++ b/src/firefox/src/agent/loop-detector.js
@@ -28,7 +28,7 @@ export class LoopDetector {
     this.recentNavUrls = new Map(); // tabId -> [normalized URL, ...]
     // A model can walk ref_1, ref_2, … forever while every call looks unique
     // to the exact-argument loop detector. Track that semantic read pattern.
-    this.axReadStates = new Map(); // tabId -> { total, suspicious, nextPage, seenPages, warned }
+    this.axReadStates = new Map(); // tabId -> { total, suspicious, nextPage, scopeKey, seenPages, warned }
     // Scroll calls can keep returning success even when no pane moved. Track
     // repeated dead-end attempts separately so changing the amount or
     // interleaving reads cannot evade the generic loop detector.
@@ -302,35 +302,45 @@ export class LoopDetector {
       total: 0,
       suspicious: 0,
       nextPage: null,
+      scopeKey: null,
       seenPages: new Set(),
       warned: false,
     };
+    const scopeKeyFor = (value = {}) => JSON.stringify({
+      filter: String(value?.filter || 'all'),
+      maxDepth: Number.isFinite(Number(value?.maxDepth)) ? Number(value.maxDepth) : null,
+      maxChars: Number.isFinite(Number(value?.maxChars)) ? Number(value.maxChars) : null,
+      refId: typeof value?.ref_id === 'string' ? value.ref_id.trim() : '',
+    });
     const page = Number(args?.page || 1);
     const hasRef = typeof args?.ref_id === 'string' && args.ref_id.trim() !== '';
-    const sequentialPage = !hasRef
-      && previous.total > 0
+    const currentScopeKey = scopeKeyFor(args);
+    const currentPageKey = `${currentScopeKey}|${page}`;
+    const sequentialPage = previous.total > 0
       && Number.isFinite(previous.nextPage)
       && page === previous.nextPage
-      && !previous.seenPages.has(page);
-    const repeatedRootOrPage = !hasRef && previous.total > 0 && !sequentialPage;
+      && currentScopeKey === previous.scopeKey
+      && !previous.seenPages.has(currentPageKey);
+    const repeatedRootOrPage = previous.total > 0 && !sequentialPage;
     const content = String(result?.pageContent || '').trim();
     const meaningfulLines = content ? content.split(/\r?\n/).filter(line => line.trim()).length : 0;
-    const suspicious = hasRef || repeatedRootOrPage || (hasRef && meaningfulLines <= 1);
+    const suspicious = !sequentialPage && (hasRef || repeatedRootOrPage || (hasRef && meaningfulLines <= 1));
 
     const state = {
       total: previous.total + 1,
       suspicious: previous.suspicious + (suspicious ? 1 : 0),
       nextPage: Number.isFinite(Number(result?.nextPage)) ? Number(result.nextPage) : null,
+      scopeKey: scopeKeyFor(result?.continuationArgs || args),
       seenPages: new Set(previous.seenPages),
       warned: previous.warned,
     };
-    state.seenPages.add(page);
+    state.seenPages.add(currentPageKey);
     this.axReadStates.set(tabId, state);
 
-    // A root read followed by the exact returned nextPage can legitimately span
-    // large applications. Keep the consecutive-read cap for every other AX
-    // pattern, but do not stop a valid sequential pagination step.
-    if (state.suspicious >= 6 || (state.total >= 12 && (state.suspicious > 0 || !sequentialPage))) {
+    // A root or anchored-subtree read followed by the exact returned nextPage
+    // can legitimately span large applications. Keep the consecutive-read cap
+    // for every other AX pattern, but do not stop a valid sequential step.
+    if (state.suspicious >= 6 || (state.total >= 12 && !sequentialPage)) {
       this.axReadStates.delete(tabId);
       return {
         kind: 'stop',

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -906,6 +906,7 @@
         filter: effFilter,
         maxDepth: opts.maxDepth,
         maxChars: effMaxChars,
+        ...(refId ? { ref_id: refId } : {}),
       };
       const viewport = { width: window.innerWidth, height: window.innerHeight };
       const lines = [];

--- a/test/run.js
+++ b/test/run.js
@@ -5912,6 +5912,7 @@ test('accessibility-tree schema and prompts preserve exact whole-document contin
   const chromeSource = fs.readFileSync(path.join(ROOT, 'src/chrome/src/content/accessibility-tree.js'), 'utf8');
   const firefoxSource = fs.readFileSync(path.join(ROOT, 'src/firefox/src/content/accessibility-tree.js'), 'utf8');
   assert.equal(chromeSource, firefoxSource, 'Chrome/Firefox accessibility paging drifted');
+  assert.match(chromeSource, /const continuationBase = \{[\s\S]*?\.\.\.\(refId \? \{ ref_id: refId \} : \{\}\),[\s\S]*?\};/, 'anchored tree continuationArgs drop the subtree ref_id');
   assert.match(chromeSource, /conversationExpansionState/, 'Gmail expansion evidence is not returned as structured metadata');
   assert.match(chromeSource, /closest\('\[role="listitem"\],\[role="article"\],\.adn,\.ads'\)/, 'message-body controls can spoof Gmail expansion evidence');
 
@@ -8082,6 +8083,43 @@ test('accessibility-tree nextPage pagination past the read cap is not suspicious
   d._checkAccessibilityReadLoop(tab, 'click_ax', { ref_id: 'ref_15' }, { success: true });
   assert.equal(d.axReadStates.has(tab), false);
   assert.equal(d._checkAccessibilityReadLoop(tab, 'get_accessibility_tree', { ref_id: 'ref_9' }, { pageContent: 'generic [ref_9]' }).kind, 'none');
+});
+
+test('accessibility-tree anchored nextPage pagination stays within one safe subtree scope', () => {
+  const d = new ConfiguredLoopDetector();
+  const tab = 24;
+  for (let page = 1; page <= 2; page++) {
+    const rootScope = { filter: 'visible', maxDepth: 12, maxChars: 3000 };
+    assert.equal(d._checkAccessibilityReadLoop(
+      tab,
+      'get_accessibility_tree',
+      { ...rootScope, ...(page > 1 ? { page } : {}) },
+      {
+        pageContent: `visible root page ${page}`,
+        nextPage: page + 1,
+        continuationArgs: { ...rootScope, page: page + 1 },
+      },
+    ).kind, 'none');
+  }
+  const scope = {
+    filter: 'all',
+    maxDepth: 15,
+    maxChars: 12000,
+    ref_id: 'ref_main',
+  };
+  for (let page = 1; page <= 15; page++) {
+    const result = d._checkAccessibilityReadLoop(
+      tab,
+      'get_accessibility_tree',
+      { ...scope, ...(page > 1 ? { page } : {}) },
+      {
+        pageContent: `main page ${page} [ref_main]`,
+        nextPage: page + 1,
+        continuationArgs: { ...scope, page: page + 1 },
+      },
+    );
+    assert.equal(result.kind, 'none', `exact anchored continuation page ${page} was treated as ref enumeration`);
+  }
 });
 
 test('accessibility-tree read cap still stops a non-sequential read after long pagination', () => {


### PR DESCRIPTION
## Summary

- preserve `ref_id` in accessibility-tree `continuationArgs` for anchored subtree pagination
- scope loop detection by filter, depth, page size, and subtree anchor
- allow exact sequential `nextPage` reads while retaining protection against arbitrary ref enumeration and repeated pages
- keep Chrome and Firefox behavior byte-identical and add regression coverage

## Root cause

The accessibility-tree loop detector treated every anchored `ref_id` read as suspicious, even when the model was following the exact returned pagination sequence. The content script also omitted the subtree `ref_id` from returned `continuationArgs`, so the continuation contract was incomplete. Large Gmail threads were therefore stopped partway through a valid read.

## Impact

Whole-thread and whole-document reads can now finish an anchored accessibility-tree pagination sequence without WebBrain falsely reporting an interaction loop. Non-sequential and ref-by-ref enumeration remains guarded.

## Validation

- `npm test` — 1632 passed, 0 failed
- security corpus — 60/60 checks passed
- Chrome/Firefox loop detector and accessibility-tree parity checks passed
