### PR TITLE
Fix thread actions and anchored pagination

### DIFF
--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -30,7 +30,7 @@ export const AGENT_TOOLS = [
           maxChars: { type: 'number', maximum: STANDARD_TREE_PAGE_CHARS, description: 'Maximum pageContent characters per structured page (default and maximum 6000). Capable non-Compact providers with at least 64k context advertise a 12000 maximum for whole-thread or whole-document reads. Larger trees return continuationArgs for the next page.' },
           ref_id: { type: 'string', description: 'Optional. Anchor the read at a previously-seen ref_id instead of document.body — returns just that element and its subtree. Useful for zooming into a nav, table, or dialog you already found.' },
           page: { type: 'number', description: 'Optional 1-based chunk number for any tree filter. When a result returns hasMore:true, reuse the exact continuationArgs so filter, maxDepth, and maxChars remain stable.' },
-          tree_revision: { type: 'string', description: 'Opaque tree snapshot revision returned inside continuationArgs. Never invent or modify it; reuse the exact continuationArgs so pages cannot mix different DOM snapshots.' },
+          tree_revision: { type: 'string', description: 'Opaque tree snapshot revision returned inside continuationArgs for page 2 and later. Omit it when starting or restarting page 1; otherwise never invent or modify it and reuse the exact continuationArgs.' },
         },
         required: [],
       },

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -1046,6 +1046,19 @@
     return candidates[0]?.candidate || null;
   }
 
+  function gmailConversationExpansionControlState(control) {
+    // Gmail's accessible label is localized, but these semantic jsname values
+    // remain stable across UI languages. Keep the English names as a fallback
+    // for older/alternate Gmail markup that does not expose jsname.
+    const jsname = String(control?.getAttribute?.('jsname') || '').trim();
+    if (jsname === 'xvWlrc') return 'expanded';
+    if (jsname === 'tRarif') return 'collapsed';
+    const name = String(getAccessibleName(control) || '').replace(/\s+/g, ' ').trim();
+    if (name === 'Collapse all') return 'expanded';
+    if (name === 'Expand all') return 'collapsed';
+    return null;
+  }
+
   function detectGmailConversationExpansionState(conversationRoot) {
     if (!isGmailConversationRoute() || !conversationRoot) return null;
     let collapsed = false;
@@ -1056,9 +1069,9 @@
         // buttons. Only Gmail chrome outside message/article containers can
         // provide the structured expansion evidence used by the agent guard.
         if (control.closest('[role="listitem"],[role="article"],.adn,.ads')) continue;
-        const name = String(getAccessibleName(control) || '').replace(/\s+/g, ' ').trim();
-        if (name === 'Collapse all') return 'expanded';
-        if (name === 'Expand all') collapsed = true;
+        const state = gmailConversationExpansionControlState(control);
+        if (state === 'expanded') return state;
+        if (state === 'collapsed') collapsed = true;
       }
     } catch (e) {}
     return collapsed ? 'collapsed' : null;
@@ -1072,8 +1085,7 @@
         // Only Gmail chrome outside untrusted message bodies may be invoked.
         // This deliberately cannot turn an Ask-mode read into a general click.
         if (control.closest('[role="listitem"],[role="article"],.adn,.ads')) continue;
-        const name = String(getAccessibleName(control) || '').replace(/\s+/g, ' ').trim();
-        if (name === 'Expand all') return control;
+        if (gmailConversationExpansionControlState(control) === 'collapsed') return control;
       }
     } catch (e) {}
     return null;

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -74,6 +74,7 @@
       // element with the same local traversal number.
       window.__wbElementMap = Object.create(null);
       window.__wbRefCounter = 0;
+      window.__wbAxTreeSnapshots = new Map();
       window.__wbAxRefScope = { pageUrl, id: mintRefScopeId() };
     }
     return window.__wbAxRefScope;
@@ -924,6 +925,71 @@
     return `fnv1a64:${hash.toString(16).padStart(16, '0')}`;
   }
 
+  const MAX_TREE_SNAPSHOTS = 3;
+
+  function treeSnapshotKey(scope, treeRevision) {
+    return JSON.stringify([
+      String(scope?.filter || 'all'),
+      Number(scope?.maxDepth),
+      Number(scope?.maxChars),
+      String(scope?.ref_id || ''),
+      String(treeRevision || ''),
+    ]);
+  }
+
+  function findTreeSnapshot(scope, treeRevision) {
+    if (!(window.__wbAxTreeSnapshots instanceof Map) || !treeRevision) return null;
+    const key = treeSnapshotKey(scope, treeRevision);
+    const snapshot = window.__wbAxTreeSnapshots.get(key) || null;
+    if (snapshot && !snapshotActionsAreCurrent(snapshot)) {
+      window.__wbAxTreeSnapshots.delete(key);
+      return null;
+    }
+    return snapshot;
+  }
+
+  function actionableTreeSnapshotSignatures(lines) {
+    const signatures = [];
+    const seen = new Set();
+    for (const line of lines) {
+      const match = String(line || '').match(/\[(ref_\d+)\]/);
+      const refId = match?.[1];
+      if (!refId || seen.has(refId)) continue;
+      seen.add(refId);
+      const el = window.__wbElementMap[refId]?.deref?.();
+      if (!el || !el.isConnected || !isInteractive(el)) continue;
+      signatures.push([refId, formatLine(el, 0)]);
+    }
+    return signatures;
+  }
+
+  function snapshotActionsAreCurrent(snapshot) {
+    if (!Array.isArray(snapshot?.actionSignatures)) return false;
+    for (const [refId, signature] of snapshot.actionSignatures) {
+      const el = window.__wbElementMap[refId]?.deref?.();
+      if (!el || !el.isConnected || !isInteractive(el) || formatLine(el, 0) !== signature) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function rememberTreeSnapshot(scope, treeRevision, output, lines) {
+    if (!treeRevision || !scope?.ref_id) return;
+    if (!(window.__wbAxTreeSnapshots instanceof Map)) window.__wbAxTreeSnapshots = new Map();
+    const key = treeSnapshotKey(scope, treeRevision);
+    window.__wbAxTreeSnapshots.delete(key);
+    window.__wbAxTreeSnapshots.set(key, {
+      output,
+      lines: lines.slice(),
+      treeRevision,
+      actionSignatures: actionableTreeSnapshotSignatures(lines),
+    });
+    while (window.__wbAxTreeSnapshots.size > MAX_TREE_SNAPSHOTS) {
+      window.__wbAxTreeSnapshots.delete(window.__wbAxTreeSnapshots.keys().next().value);
+    }
+  }
+
   function isGmailThreadIdentifier(value) {
     const segment = String(value || '').split('?')[0];
     return /^FMfc[A-Za-z0-9_-]+$/.test(segment) || /^[a-f0-9]{12,}$/i.test(segment);
@@ -998,6 +1064,52 @@
     return collapsed ? 'collapsed' : null;
   }
 
+  function findGmailConversationExpandAll(conversationRoot) {
+    if (!isGmailConversationRoute() || !conversationRoot) return null;
+    try {
+      for (const control of conversationRoot.querySelectorAll('button,[role="button"]')) {
+        if (!isVisible(control)) continue;
+        // Only Gmail chrome outside untrusted message bodies may be invoked.
+        // This deliberately cannot turn an Ask-mode read into a general click.
+        if (control.closest('[role="listitem"],[role="article"],.adn,.ads')) continue;
+        const name = String(getAccessibleName(control) || '').replace(/\s+/g, ' ').trim();
+        if (name === 'Expand all') return control;
+      }
+    } catch (e) {}
+    return null;
+  }
+
+  async function expandGmailConversationForRead(refId, timeoutMs) {
+    try {
+      ensureRefScope();
+      const conversationRoot = detectGmailConversationRoot();
+      if (!conversationRoot || getOrMintRef(conversationRoot) !== refId) {
+        return { attempted: false, expanded: false };
+      }
+      if (detectGmailConversationExpansionState(conversationRoot) === 'expanded') {
+        return { attempted: false, expanded: true };
+      }
+      const control = findGmailConversationExpandAll(conversationRoot);
+      if (!control) return { attempted: false, expanded: false };
+
+      control.click();
+      const timeout = Math.min(4000, Math.max(250, Number(timeoutMs) || 2500));
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < timeout) {
+        if (detectGmailConversationExpansionState(conversationRoot) === 'expanded') {
+          return { attempted: true, expanded: true };
+        }
+        await new Promise(resolve => setTimeout(resolve, 50));
+      }
+      return {
+        attempted: true,
+        expanded: detectGmailConversationExpansionState(conversationRoot) === 'expanded',
+      };
+    } catch (e) {
+      return { attempted: false, expanded: false };
+    }
+  }
+
   function generateAccessibilityTree(filter, maxDepth, maxChars, refId, page, expectedTreeRevision) {
     try {
       ensureRefScope();
@@ -1033,7 +1145,14 @@
         maxChars: effMaxChars,
         ...(refId ? { ref_id: refId } : {}),
       };
+      const gmailSnapshotEligible = !!refId
+        && !!conversationRootRefId
+        && refId === conversationRootRefId
+        && effFilter === 'all'
+        && Number(opts.maxDepth) >= 15;
       const viewport = { width: window.innerWidth, height: window.innerHeight };
+      const requestedPage = Math.max(1, Math.floor(Number(page) || 1));
+      const requestedTreeRevision = String(expectedTreeRevision || '').trim();
       const lines = [];
 
       if (refId) {
@@ -1053,6 +1172,27 @@
             pageContent: '',
             viewport,
           };
+        }
+        if (gmailSnapshotEligible && requestedPage > 1 && requestedTreeRevision) {
+          const snapshot = findTreeSnapshot(baseTreeScope, requestedTreeRevision);
+          if (snapshot) {
+            const continuationBase = {
+              ...baseTreeScope,
+              tree_revision: snapshot.treeRevision,
+            };
+            return {
+              ...sliceTreePage(
+                snapshot.output,
+                snapshot.lines,
+                effMaxChars,
+                requestedPage,
+                continuationBase,
+              ),
+              viewport,
+              treeRevision: snapshot.treeRevision,
+              ...conversationMetadata,
+            };
+          }
         }
         walk(el, 0, opts, lines);
       } else if (document.body) {
@@ -1155,13 +1295,31 @@
         ...baseTreeScope,
         ...(revisionBound ? { tree_revision: treeRevision } : {}),
       };
-      if (revisionBound && expectedTreeRevision && expectedTreeRevision !== treeRevision) {
+      if (gmailSnapshotEligible && (
+        requestedPage === 1
+        || !requestedTreeRevision
+        || requestedTreeRevision === treeRevision
+      )) {
+        rememberTreeSnapshot(baseTreeScope, treeRevision, output, lines);
+      }
+      if (revisionBound && requestedPage > 1
+          && requestedTreeRevision && requestedTreeRevision !== treeRevision) {
+        const restartArgs = {
+          ...baseTreeScope,
+          page: 1,
+        };
         return {
-          error: 'The anchored accessibility tree changed during pagination. Restart from page 1 with the current conversation root.',
+          error: 'The anchored accessibility snapshot changed or expired. Restart from page 1 with the exact returned continuationArgs.',
           pageContent: '',
           viewport,
           treeRevision,
           treeRevisionMismatch: true,
+          truncated: true,
+          hasMore: true,
+          page: requestedPage,
+          nextPage: 1,
+          continuationArgs: restartArgs,
+          restartArgs,
           ...conversationMetadata,
         };
       }
@@ -1308,6 +1466,7 @@
 
   window.__generateAccessibilityTree = generateAccessibilityTree;
   window.__generateAccessibilitySubtree = generateAccessibilitySubtree;
+  window.__wb_expand_gmail_conversation_for_read = expandGmailConversationForRead;
   window.__wb_ax_lookup = lookup;
   window.__wb_ax_ref = getOrMintRef;
   window.__wb_ax_name = getAccessibleName;

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -4386,7 +4386,7 @@
       // claudeplugin/assets/accessibility-tree.js). Output is a flat,
       // indented text representation; each line carries a stable ref_id
       // (persistent across calls as long as the element stays in the DOM).
-      'get_accessibility_tree': () => {
+      'get_accessibility_tree': async () => {
         try {
           if (typeof window.__generateAccessibilityTree !== 'function') {
             return { error: 'accessibility-tree.js not injected' };
@@ -4418,8 +4418,22 @@
               refScopeUrl,
             };
           }
+          // A complete, anchored Gmail thread read may reveal only Gmail's
+          // trusted top-level collapsed messages before building page 1. This
+          // keeps whole-thread reads complete in Ask as well as Act mode while
+          // exposing no general-purpose click capability to Ask mode.
+          const requestedPage = Math.max(1, Math.floor(Number(page) || 1));
+          const requestedDepth = maxDepth == null ? 15 : Number(maxDepth);
+          let conversationAutoExpanded = false;
+          if (ref_id && requestedPage === 1 && (filter || 'all') === 'all'
+              && Number.isFinite(requestedDepth) && requestedDepth >= 15
+              && typeof window.__wb_expand_gmail_conversation_for_read === 'function') {
+            const prepared = await window.__wb_expand_gmail_conversation_for_read(ref_id);
+            conversationAutoExpanded = prepared?.attempted === true && prepared?.expanded === true;
+          }
           return {
             ...window.__generateAccessibilityTree(filter, maxDepth, maxChars, ref_id, page, tree_revision),
+            ...(conversationAutoExpanded ? { conversationAutoExpanded: true } : {}),
             documentToken,
             refScopeUrl,
           };

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -5928,14 +5928,17 @@ function activeRetryPayloadForRequest(tabId, requestId = '') {
 
 function retryPayloadForRunAssistant(assistantEl) {
   const userEl = userMessageForRunAssistant(assistantEl);
-  const text = userEl ? getComposerHistoryTextFromMessage(userEl) : '';
-  if (!String(text || '').trim()) return null;
+  const displayText = String(userEl ? getComposerHistoryTextFromMessage(userEl) : '').trim();
+  if (!displayText) return null;
+  const internalPrompt = String(assistantEl?.dataset.retryAgentPrompt || '').trim();
+  const text = internalPrompt || displayText;
   const sourceGrounding = normalizeSelectionSourceGrounding(assistantEl?.dataset.retrySourceGrounding) || null;
   const selectionAction = sourceGrounding
     ? normalizeSelectionAction(assistantEl?.dataset.retrySelectionAction)
     : '';
   return {
     text,
+    displayText,
     mode: ['ask', 'act', 'dev'].includes(assistantEl?.dataset.runMode)
       ? assistantEl.dataset.runMode
       : agentMode,
@@ -8058,6 +8061,7 @@ async function sendMessage(extraChatParams = {}) {
     assistantEl.dataset.retrySourceGrounding = sourceGrounding || '';
     assistantEl.dataset.retrySelectionAction = selectionAction;
     assistantEl.dataset.retryAttachmentCount = String(attachmentsForSend.length);
+    if (agentPrompt) assistantEl.dataset.retryAgentPrompt = agentPrompt;
     userEl.dataset.runRequestId = requestId;
     assistantEl.dataset.lastRenderedSeq = '0';
     currentAssistantEl = assistantEl;

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -4732,8 +4732,12 @@ async function recommendedActionSourceStillCurrent(action, tabId) {
 
 async function runRecommendedAction(action) {
   const prompt = typeof action === 'string' ? action : action?.prompt;
+  const displayText = typeof action === 'string'
+    ? prompt
+    : String(action?.label || prompt || '').trim();
   const tabId = currentTabId;
   if (!prompt || tabId == null || isProcessing) return;
+  if (!displayText) return;
   if (!(await recommendedActionSourceStillCurrent(action, tabId)) || currentTabId !== tabId || isProcessing) {
     hideRecommendedActions();
     return;
@@ -4746,13 +4750,18 @@ async function runRecommendedAction(action) {
       return;
     }
   }
-  inputEl.value = prompt;
+  inputEl.value = displayText;
   autoResizeInput();
-  sendMessage(recommendedActionSendParams(action));
+  sendMessage(recommendedActionSendParams(action, { tabId, displayText }));
 }
 
-function recommendedActionSendParams(action) {
+function recommendedActionSendParams(action, { tabId = null, displayText = '' } = {}) {
   const params = action?.runOptions ? { recommendedAction: action.runOptions } : {};
+  if (typeof action?.prompt === 'string' && action.prompt.trim()) {
+    params.__agentPrompt = action.prompt.trim();
+    params.__agentDisplayText = String(displayText || '').trim();
+    params.__agentTabId = tabId;
+  }
   if (['ask', 'act', 'dev'].includes(action?.mode)) {
     params.__mode = action.mode;
   }
@@ -5824,6 +5833,7 @@ function rebindCostAllowanceButtons() {
 function retryPayloadFromButton(btn) {
   const text = String(btn?.dataset?.retryText || '').trim();
   if (!text) return null;
+  const displayText = String(btn?.dataset?.retryDisplayText || text).trim() || text;
   const mode = ['ask', 'act', 'dev'].includes(btn.dataset.retryMode)
     ? btn.dataset.retryMode
     : agentMode;
@@ -5836,6 +5846,7 @@ function retryPayloadFromButton(btn) {
     : '';
   return {
     text,
+    displayText,
     mode,
     apiMutationsAllowed: btn.dataset.retryApiMutationsAllowed === 'true',
     foreground: btn.dataset.retryForeground === 'true',
@@ -5866,10 +5877,15 @@ function bindErrorRetryButton(btn) {
     if (payload.apiMutationsAllowed) {
       grantApiMutationsForTab(currentTabId);
     }
-    inputEl.value = payload.text;
+    inputEl.value = payload.displayText;
     autoResizeInput();
     hideSlashCommandAutocomplete();
     const accepted = await sendMessage({
+      ...(payload.displayText !== payload.text ? {
+        __agentPrompt: payload.text,
+        __agentDisplayText: payload.displayText,
+        __agentTabId: currentTabId,
+      } : {}),
       __retry: {
         mode: payload.mode,
         apiMutationsAllowed: payload.apiMutationsAllowed,
@@ -7726,9 +7742,20 @@ async function sendMessage(extraChatParams = {}) {
     ? extraChatParams.__onContextMenuClaimRejected
     : null;
   const chatExtraParams = { ...(extraChatParams || {}) };
+  const agentPrompt = typeof chatExtraParams.__agentPrompt === 'string'
+    ? chatExtraParams.__agentPrompt.trim()
+    : '';
+  const agentDisplayText = typeof chatExtraParams.__agentDisplayText === 'string'
+    ? chatExtraParams.__agentDisplayText.trim()
+    : '';
+  const rawAgentTabId = Number(chatExtraParams.__agentTabId);
+  const agentTabId = Number.isFinite(rawAgentTabId) ? rawAgentTabId : null;
   delete chatExtraParams.__retry;
   delete chatExtraParams.__mode;
   delete chatExtraParams.__onContextMenuClaimRejected;
+  delete chatExtraParams.__agentPrompt;
+  delete chatExtraParams.__agentDisplayText;
+  delete chatExtraParams.__agentTabId;
   const isWorkflowRun = !!chatExtraParams.workflowId;
   const contextMenuClaim = chatExtraParams.contextMenuClaim;
   let contextMenuClaimOwned = Boolean(contextMenuClaim?.promptId && contextMenuClaim?.claimantId);
@@ -7761,6 +7788,14 @@ async function sendMessage(extraChatParams = {}) {
   delete chatExtraParams.selectionAction;
   if (selectionAction) chatExtraParams.selectionAction = selectionAction;
   await waitForVisibleSidePanelStateRefresh();
+  if (agentPrompt && (
+    !agentDisplayText
+    || agentTabId == null
+    || !sameTabId(currentTabId, agentTabId)
+    || !sameTabId(renderedTabId, agentTabId)
+    || inputEl.value.trim() !== agentDisplayText
+  )) return false;
+  if (agentPrompt && isProcessing) return false;
   if (contextMenuClaimOwned
       && (document.visibilityState === 'hidden'
         || !sameTabId(currentTabId, claimedContextMenuTabId)
@@ -7770,6 +7805,7 @@ async function sendMessage(extraChatParams = {}) {
   }
   stopListening();
   let text = inputEl.value.trim();
+  const submittedText = text;
   if (!text) {
     if (contextMenuClaimOwned) {
       await releaseOwnedContextMenuClaim({ reason: 'preflight-empty', retryAfterMs: 1_000 });
@@ -7777,7 +7813,7 @@ async function sendMessage(extraChatParams = {}) {
     }
     return;
   }
-  const submittedText = text;
+  if (agentPrompt) text = agentPrompt;
   const tabId = currentTabId;
   if (isConversationClearInProgress(tabId)) {
     await releaseOwnedContextMenuClaim({ reason: 'conversation-clear', retryAfterMs: 1_000 });
@@ -7874,7 +7910,7 @@ async function sendMessage(extraChatParams = {}) {
     && sameTabId(renderedTabId, tabId);
   if (!renderToCurrentTab) {
     await releaseOwnedContextMenuClaim();
-    if (text) saveInputDraftForTab(tabId, text);
+    if (text) saveInputDraftForTab(tabId, agentPrompt ? submittedText : text);
     return false;
   }
   // If the entire message was just the slash command, there's nothing
@@ -7906,7 +7942,7 @@ async function sendMessage(extraChatParams = {}) {
     && sameTabId(renderedTabId, tabId);
   if (!renderToCurrentTab) {
     await releaseOwnedContextMenuClaim();
-    if (text) saveInputDraftForTab(tabId, text);
+    if (text) saveInputDraftForTab(tabId, agentPrompt ? submittedText : text);
     setTabProcessing(tabId, false);
     setTabAbortRequested(tabId, false);
     syncSendButtonState();
@@ -7952,7 +7988,7 @@ async function sendMessage(extraChatParams = {}) {
     && sameTabId(renderedTabId, tabId);
   if (!renderToCurrentTab) {
     await releaseOwnedContextMenuClaim();
-    if (text) saveInputDraftForTab(tabId, text);
+    if (text) saveInputDraftForTab(tabId, agentPrompt ? submittedText : text);
     setTabProcessing(tabId, false);
     setTabAbortRequested(tabId, false);
     syncSendButtonState();
@@ -7990,6 +8026,7 @@ async function sendMessage(extraChatParams = {}) {
   }
   const retryPayload = {
     text,
+    displayText: agentPrompt ? submittedText : text,
     mode: modeForSend,
     apiMutationsAllowed: apiMutationsAllowedForSend,
     foreground: foregroundForSend,
@@ -8008,7 +8045,7 @@ async function sendMessage(extraChatParams = {}) {
       renderAttachmentPreviews();
     }
     resetChatNavigation();
-    userEl = addMessage('user', text, {
+    userEl = addMessage('user', agentPrompt ? submittedText : text, {
       attachments: attachmentsForSend,
       attachmentState: attachmentsForSend.length ? 'sending' : '',
     });
@@ -8103,8 +8140,8 @@ async function sendMessage(extraChatParams = {}) {
       // Restore the prompt only if the user hasn't started typing a new one
       // while the rejected turn was in flight.
       if (currentTabId === tabId && !inputEl.value.trim()) {
-        inputEl.value = text;
-        saveInputDraftForTab(tabId, text);
+        inputEl.value = agentPrompt ? submittedText : text;
+        saveInputDraftForTab(tabId, agentPrompt ? submittedText : text);
         autoResizeInput();
         updateSlashCommandAutocomplete();
       }
@@ -10204,6 +10241,7 @@ function configureRetryButton(btn, retryPayload) {
   }
   btn.dataset.retryId = retryId;
   btn.dataset.retryText = String(retryPayload.text || '');
+  btn.dataset.retryDisplayText = String(retryPayload.displayText || retryPayload.text || '');
   btn.dataset.retryMode = retryPayload.mode || 'ask';
   btn.dataset.retryApiMutationsAllowed = retryPayload.apiMutationsAllowed ? 'true' : 'false';
   btn.dataset.retryForeground = retryPayload.foreground ? 'true' : 'false';

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -30,7 +30,7 @@ export const AGENT_TOOLS = [
           maxChars: { type: 'number', maximum: STANDARD_TREE_PAGE_CHARS, description: 'Maximum pageContent characters per structured page (default and maximum 6000). Capable non-Compact providers with at least 64k context advertise a 12000 maximum for whole-thread or whole-document reads. Larger trees return continuationArgs for the next page.' },
           ref_id: { type: 'string', description: 'Optional. Anchor at a previously-seen ref_id instead of document.body.' },
           page: { type: 'number', description: 'Optional 1-based chunk number for any tree filter. When a result returns hasMore:true, reuse the exact continuationArgs so filter, maxDepth, and maxChars remain stable.' },
-          tree_revision: { type: 'string', description: 'Opaque tree snapshot revision returned inside continuationArgs. Never invent or modify it; reuse the exact continuationArgs so pages cannot mix different DOM snapshots.' },
+          tree_revision: { type: 'string', description: 'Opaque tree snapshot revision returned inside continuationArgs for page 2 and later. Omit it when starting or restarting page 1; otherwise never invent or modify it and reuse the exact continuationArgs.' },
         },
         required: [],
       },

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -1046,6 +1046,19 @@
     return candidates[0]?.candidate || null;
   }
 
+  function gmailConversationExpansionControlState(control) {
+    // Gmail's accessible label is localized, but these semantic jsname values
+    // remain stable across UI languages. Keep the English names as a fallback
+    // for older/alternate Gmail markup that does not expose jsname.
+    const jsname = String(control?.getAttribute?.('jsname') || '').trim();
+    if (jsname === 'xvWlrc') return 'expanded';
+    if (jsname === 'tRarif') return 'collapsed';
+    const name = String(getAccessibleName(control) || '').replace(/\s+/g, ' ').trim();
+    if (name === 'Collapse all') return 'expanded';
+    if (name === 'Expand all') return 'collapsed';
+    return null;
+  }
+
   function detectGmailConversationExpansionState(conversationRoot) {
     if (!isGmailConversationRoute() || !conversationRoot) return null;
     let collapsed = false;
@@ -1056,9 +1069,9 @@
         // buttons. Only Gmail chrome outside message/article containers can
         // provide the structured expansion evidence used by the agent guard.
         if (control.closest('[role="listitem"],[role="article"],.adn,.ads')) continue;
-        const name = String(getAccessibleName(control) || '').replace(/\s+/g, ' ').trim();
-        if (name === 'Collapse all') return 'expanded';
-        if (name === 'Expand all') collapsed = true;
+        const state = gmailConversationExpansionControlState(control);
+        if (state === 'expanded') return state;
+        if (state === 'collapsed') collapsed = true;
       }
     } catch (e) {}
     return collapsed ? 'collapsed' : null;
@@ -1072,8 +1085,7 @@
         // Only Gmail chrome outside untrusted message bodies may be invoked.
         // This deliberately cannot turn an Ask-mode read into a general click.
         if (control.closest('[role="listitem"],[role="article"],.adn,.ads')) continue;
-        const name = String(getAccessibleName(control) || '').replace(/\s+/g, ' ').trim();
-        if (name === 'Expand all') return control;
+        if (gmailConversationExpansionControlState(control) === 'collapsed') return control;
       }
     } catch (e) {}
     return null;

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -74,6 +74,7 @@
       // element with the same local traversal number.
       window.__wbElementMap = Object.create(null);
       window.__wbRefCounter = 0;
+      window.__wbAxTreeSnapshots = new Map();
       window.__wbAxRefScope = { pageUrl, id: mintRefScopeId() };
     }
     return window.__wbAxRefScope;
@@ -924,6 +925,71 @@
     return `fnv1a64:${hash.toString(16).padStart(16, '0')}`;
   }
 
+  const MAX_TREE_SNAPSHOTS = 3;
+
+  function treeSnapshotKey(scope, treeRevision) {
+    return JSON.stringify([
+      String(scope?.filter || 'all'),
+      Number(scope?.maxDepth),
+      Number(scope?.maxChars),
+      String(scope?.ref_id || ''),
+      String(treeRevision || ''),
+    ]);
+  }
+
+  function findTreeSnapshot(scope, treeRevision) {
+    if (!(window.__wbAxTreeSnapshots instanceof Map) || !treeRevision) return null;
+    const key = treeSnapshotKey(scope, treeRevision);
+    const snapshot = window.__wbAxTreeSnapshots.get(key) || null;
+    if (snapshot && !snapshotActionsAreCurrent(snapshot)) {
+      window.__wbAxTreeSnapshots.delete(key);
+      return null;
+    }
+    return snapshot;
+  }
+
+  function actionableTreeSnapshotSignatures(lines) {
+    const signatures = [];
+    const seen = new Set();
+    for (const line of lines) {
+      const match = String(line || '').match(/\[(ref_\d+)\]/);
+      const refId = match?.[1];
+      if (!refId || seen.has(refId)) continue;
+      seen.add(refId);
+      const el = window.__wbElementMap[refId]?.deref?.();
+      if (!el || !el.isConnected || !isInteractive(el)) continue;
+      signatures.push([refId, formatLine(el, 0)]);
+    }
+    return signatures;
+  }
+
+  function snapshotActionsAreCurrent(snapshot) {
+    if (!Array.isArray(snapshot?.actionSignatures)) return false;
+    for (const [refId, signature] of snapshot.actionSignatures) {
+      const el = window.__wbElementMap[refId]?.deref?.();
+      if (!el || !el.isConnected || !isInteractive(el) || formatLine(el, 0) !== signature) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function rememberTreeSnapshot(scope, treeRevision, output, lines) {
+    if (!treeRevision || !scope?.ref_id) return;
+    if (!(window.__wbAxTreeSnapshots instanceof Map)) window.__wbAxTreeSnapshots = new Map();
+    const key = treeSnapshotKey(scope, treeRevision);
+    window.__wbAxTreeSnapshots.delete(key);
+    window.__wbAxTreeSnapshots.set(key, {
+      output,
+      lines: lines.slice(),
+      treeRevision,
+      actionSignatures: actionableTreeSnapshotSignatures(lines),
+    });
+    while (window.__wbAxTreeSnapshots.size > MAX_TREE_SNAPSHOTS) {
+      window.__wbAxTreeSnapshots.delete(window.__wbAxTreeSnapshots.keys().next().value);
+    }
+  }
+
   function isGmailThreadIdentifier(value) {
     const segment = String(value || '').split('?')[0];
     return /^FMfc[A-Za-z0-9_-]+$/.test(segment) || /^[a-f0-9]{12,}$/i.test(segment);
@@ -998,6 +1064,52 @@
     return collapsed ? 'collapsed' : null;
   }
 
+  function findGmailConversationExpandAll(conversationRoot) {
+    if (!isGmailConversationRoute() || !conversationRoot) return null;
+    try {
+      for (const control of conversationRoot.querySelectorAll('button,[role="button"]')) {
+        if (!isVisible(control)) continue;
+        // Only Gmail chrome outside untrusted message bodies may be invoked.
+        // This deliberately cannot turn an Ask-mode read into a general click.
+        if (control.closest('[role="listitem"],[role="article"],.adn,.ads')) continue;
+        const name = String(getAccessibleName(control) || '').replace(/\s+/g, ' ').trim();
+        if (name === 'Expand all') return control;
+      }
+    } catch (e) {}
+    return null;
+  }
+
+  async function expandGmailConversationForRead(refId, timeoutMs) {
+    try {
+      ensureRefScope();
+      const conversationRoot = detectGmailConversationRoot();
+      if (!conversationRoot || getOrMintRef(conversationRoot) !== refId) {
+        return { attempted: false, expanded: false };
+      }
+      if (detectGmailConversationExpansionState(conversationRoot) === 'expanded') {
+        return { attempted: false, expanded: true };
+      }
+      const control = findGmailConversationExpandAll(conversationRoot);
+      if (!control) return { attempted: false, expanded: false };
+
+      control.click();
+      const timeout = Math.min(4000, Math.max(250, Number(timeoutMs) || 2500));
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < timeout) {
+        if (detectGmailConversationExpansionState(conversationRoot) === 'expanded') {
+          return { attempted: true, expanded: true };
+        }
+        await new Promise(resolve => setTimeout(resolve, 50));
+      }
+      return {
+        attempted: true,
+        expanded: detectGmailConversationExpansionState(conversationRoot) === 'expanded',
+      };
+    } catch (e) {
+      return { attempted: false, expanded: false };
+    }
+  }
+
   function generateAccessibilityTree(filter, maxDepth, maxChars, refId, page, expectedTreeRevision) {
     try {
       ensureRefScope();
@@ -1033,7 +1145,14 @@
         maxChars: effMaxChars,
         ...(refId ? { ref_id: refId } : {}),
       };
+      const gmailSnapshotEligible = !!refId
+        && !!conversationRootRefId
+        && refId === conversationRootRefId
+        && effFilter === 'all'
+        && Number(opts.maxDepth) >= 15;
       const viewport = { width: window.innerWidth, height: window.innerHeight };
+      const requestedPage = Math.max(1, Math.floor(Number(page) || 1));
+      const requestedTreeRevision = String(expectedTreeRevision || '').trim();
       const lines = [];
 
       if (refId) {
@@ -1053,6 +1172,27 @@
             pageContent: '',
             viewport,
           };
+        }
+        if (gmailSnapshotEligible && requestedPage > 1 && requestedTreeRevision) {
+          const snapshot = findTreeSnapshot(baseTreeScope, requestedTreeRevision);
+          if (snapshot) {
+            const continuationBase = {
+              ...baseTreeScope,
+              tree_revision: snapshot.treeRevision,
+            };
+            return {
+              ...sliceTreePage(
+                snapshot.output,
+                snapshot.lines,
+                effMaxChars,
+                requestedPage,
+                continuationBase,
+              ),
+              viewport,
+              treeRevision: snapshot.treeRevision,
+              ...conversationMetadata,
+            };
+          }
         }
         walk(el, 0, opts, lines);
       } else if (document.body) {
@@ -1155,13 +1295,31 @@
         ...baseTreeScope,
         ...(revisionBound ? { tree_revision: treeRevision } : {}),
       };
-      if (revisionBound && expectedTreeRevision && expectedTreeRevision !== treeRevision) {
+      if (gmailSnapshotEligible && (
+        requestedPage === 1
+        || !requestedTreeRevision
+        || requestedTreeRevision === treeRevision
+      )) {
+        rememberTreeSnapshot(baseTreeScope, treeRevision, output, lines);
+      }
+      if (revisionBound && requestedPage > 1
+          && requestedTreeRevision && requestedTreeRevision !== treeRevision) {
+        const restartArgs = {
+          ...baseTreeScope,
+          page: 1,
+        };
         return {
-          error: 'The anchored accessibility tree changed during pagination. Restart from page 1 with the current conversation root.',
+          error: 'The anchored accessibility snapshot changed or expired. Restart from page 1 with the exact returned continuationArgs.',
           pageContent: '',
           viewport,
           treeRevision,
           treeRevisionMismatch: true,
+          truncated: true,
+          hasMore: true,
+          page: requestedPage,
+          nextPage: 1,
+          continuationArgs: restartArgs,
+          restartArgs,
           ...conversationMetadata,
         };
       }
@@ -1308,6 +1466,7 @@
 
   window.__generateAccessibilityTree = generateAccessibilityTree;
   window.__generateAccessibilitySubtree = generateAccessibilitySubtree;
+  window.__wb_expand_gmail_conversation_for_read = expandGmailConversationForRead;
   window.__wb_ax_lookup = lookup;
   window.__wb_ax_ref = getOrMintRef;
   window.__wb_ax_name = getAccessibleName;

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -3612,7 +3612,7 @@
       // content_scripts puts it before content.js so window.__wb_ax_lookup
       // and window.__generateAccessibilityTree are defined by the time the
       // first message arrives.
-      'get_accessibility_tree': () => {
+      'get_accessibility_tree': async () => {
         try {
           if (typeof window.__generateAccessibilityTree !== 'function') {
             return { error: 'accessibility-tree.js not injected' };
@@ -3644,8 +3644,22 @@
               refScopeUrl,
             };
           }
+          // A complete, anchored Gmail thread read may reveal only Gmail's
+          // trusted top-level collapsed messages before building page 1. This
+          // keeps whole-thread reads complete in Ask as well as Act mode while
+          // exposing no general-purpose click capability to Ask mode.
+          const requestedPage = Math.max(1, Math.floor(Number(page) || 1));
+          const requestedDepth = maxDepth == null ? 15 : Number(maxDepth);
+          let conversationAutoExpanded = false;
+          if (ref_id && requestedPage === 1 && (filter || 'all') === 'all'
+              && Number.isFinite(requestedDepth) && requestedDepth >= 15
+              && typeof window.__wb_expand_gmail_conversation_for_read === 'function') {
+            const prepared = await window.__wb_expand_gmail_conversation_for_read(ref_id);
+            conversationAutoExpanded = prepared?.attempted === true && prepared?.expanded === true;
+          }
           return {
             ...window.__generateAccessibilityTree(filter, maxDepth, maxChars, ref_id, page, tree_revision),
+            ...(conversationAutoExpanded ? { conversationAutoExpanded: true } : {}),
             documentToken,
             refScopeUrl,
           };

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -5774,14 +5774,17 @@ function activeRetryPayloadForRequest(tabId, requestId = '') {
 
 function retryPayloadForRunAssistant(assistantEl) {
   const userEl = userMessageForRunAssistant(assistantEl);
-  const text = userEl ? getComposerHistoryTextFromMessage(userEl) : '';
-  if (!String(text || '').trim()) return null;
+  const displayText = String(userEl ? getComposerHistoryTextFromMessage(userEl) : '').trim();
+  if (!displayText) return null;
+  const internalPrompt = String(assistantEl?.dataset.retryAgentPrompt || '').trim();
+  const text = internalPrompt || displayText;
   const sourceGrounding = normalizeSelectionSourceGrounding(assistantEl?.dataset.retrySourceGrounding) || null;
   const selectionAction = sourceGrounding
     ? normalizeSelectionAction(assistantEl?.dataset.retrySelectionAction)
     : '';
   return {
     text,
+    displayText,
     mode: ['ask', 'act', 'dev'].includes(assistantEl?.dataset.runMode)
       ? assistantEl.dataset.runMode
       : agentMode,
@@ -7785,6 +7788,7 @@ async function sendMessage(extraChatParams = {}) {
     assistantEl.dataset.retrySourceGrounding = sourceGrounding || '';
     assistantEl.dataset.retrySelectionAction = selectionAction;
     assistantEl.dataset.retryAttachmentCount = String(attachmentsForSend.length);
+    if (agentPrompt) assistantEl.dataset.retryAgentPrompt = agentPrompt;
     userEl.dataset.runRequestId = requestId;
     assistantEl.dataset.lastRenderedSeq = '0';
     currentAssistantEl = assistantEl;

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -4578,8 +4578,12 @@ async function recommendedActionSourceStillCurrent(action, tabId) {
 
 async function runRecommendedAction(action) {
   const prompt = typeof action === 'string' ? action : action?.prompt;
+  const displayText = typeof action === 'string'
+    ? prompt
+    : String(action?.label || prompt || '').trim();
   const tabId = currentTabId;
   if (!prompt || tabId == null || isProcessing) return;
+  if (!displayText) return;
   if (!(await recommendedActionSourceStillCurrent(action, tabId)) || currentTabId !== tabId || isProcessing) {
     hideRecommendedActions();
     return;
@@ -4592,13 +4596,18 @@ async function runRecommendedAction(action) {
       return;
     }
   }
-  inputEl.value = prompt;
+  inputEl.value = displayText;
   autoResizeInput();
-  sendMessage(recommendedActionSendParams(action));
+  sendMessage(recommendedActionSendParams(action, { tabId, displayText }));
 }
 
-function recommendedActionSendParams(action) {
+function recommendedActionSendParams(action, { tabId = null, displayText = '' } = {}) {
   const params = action?.runOptions ? { recommendedAction: action.runOptions } : {};
+  if (typeof action?.prompt === 'string' && action.prompt.trim()) {
+    params.__agentPrompt = action.prompt.trim();
+    params.__agentDisplayText = String(displayText || '').trim();
+    params.__agentTabId = tabId;
+  }
   if (['ask', 'act', 'dev'].includes(action?.mode)) {
     params.__mode = action.mode;
   }
@@ -5670,6 +5679,7 @@ function rebindCostAllowanceButtons() {
 function retryPayloadFromButton(btn) {
   const text = String(btn?.dataset?.retryText || '').trim();
   if (!text) return null;
+  const displayText = String(btn?.dataset?.retryDisplayText || text).trim() || text;
   const mode = ['ask', 'act', 'dev'].includes(btn.dataset.retryMode)
     ? btn.dataset.retryMode
     : agentMode;
@@ -5682,6 +5692,7 @@ function retryPayloadFromButton(btn) {
     : '';
   return {
     text,
+    displayText,
     mode,
     apiMutationsAllowed: btn.dataset.retryApiMutationsAllowed === 'true',
     foreground: btn.dataset.retryForeground === 'true',
@@ -5712,10 +5723,15 @@ function bindErrorRetryButton(btn) {
     if (payload.apiMutationsAllowed) {
       grantApiMutationsForTab(currentTabId);
     }
-    inputEl.value = payload.text;
+    inputEl.value = payload.displayText;
     autoResizeInput();
     hideSlashCommandAutocomplete();
     const accepted = await sendMessage({
+      ...(payload.displayText !== payload.text ? {
+        __agentPrompt: payload.text,
+        __agentDisplayText: payload.displayText,
+        __agentTabId: currentTabId,
+      } : {}),
       __retry: {
         mode: payload.mode,
         apiMutationsAllowed: payload.apiMutationsAllowed,
@@ -7458,9 +7474,20 @@ async function sendMessage(extraChatParams = {}) {
     ? extraChatParams.__onContextMenuClaimRejected
     : null;
   const chatExtraParams = { ...(extraChatParams || {}) };
+  const agentPrompt = typeof chatExtraParams.__agentPrompt === 'string'
+    ? chatExtraParams.__agentPrompt.trim()
+    : '';
+  const agentDisplayText = typeof chatExtraParams.__agentDisplayText === 'string'
+    ? chatExtraParams.__agentDisplayText.trim()
+    : '';
+  const rawAgentTabId = Number(chatExtraParams.__agentTabId);
+  const agentTabId = Number.isFinite(rawAgentTabId) ? rawAgentTabId : null;
   delete chatExtraParams.__retry;
   delete chatExtraParams.__mode;
   delete chatExtraParams.__onContextMenuClaimRejected;
+  delete chatExtraParams.__agentPrompt;
+  delete chatExtraParams.__agentDisplayText;
+  delete chatExtraParams.__agentTabId;
   const isWorkflowRun = !!chatExtraParams.workflowId;
   const contextMenuClaim = chatExtraParams.contextMenuClaim;
   let contextMenuClaimOwned = Boolean(contextMenuClaim?.promptId && contextMenuClaim?.claimantId);
@@ -7493,6 +7520,14 @@ async function sendMessage(extraChatParams = {}) {
   delete chatExtraParams.selectionAction;
   if (selectionAction) chatExtraParams.selectionAction = selectionAction;
   await waitForVisibleSidePanelStateRefresh();
+  if (agentPrompt && (
+    !agentDisplayText
+    || agentTabId == null
+    || !sameTabId(currentTabId, agentTabId)
+    || !sameTabId(renderedTabId, agentTabId)
+    || inputEl.value.trim() !== agentDisplayText
+  )) return false;
+  if (agentPrompt && isProcessing) return false;
   if (contextMenuClaimOwned
       && (document.visibilityState === 'hidden'
         || !sameTabId(currentTabId, claimedContextMenuTabId)
@@ -7502,6 +7537,7 @@ async function sendMessage(extraChatParams = {}) {
   }
   stopListening();
   let text = inputEl.value.trim();
+  const submittedText = text;
   if (!text) {
     if (contextMenuClaimOwned) {
       await releaseOwnedContextMenuClaim({ reason: 'preflight-empty', retryAfterMs: 1_000 });
@@ -7509,7 +7545,7 @@ async function sendMessage(extraChatParams = {}) {
     }
     return;
   }
-  const submittedText = text;
+  if (agentPrompt) text = agentPrompt;
   const tabId = currentTabId;
   if (isConversationClearInProgress(tabId)) {
     await releaseOwnedContextMenuClaim({ reason: 'conversation-clear', retryAfterMs: 1_000 });
@@ -7603,7 +7639,7 @@ async function sendMessage(extraChatParams = {}) {
     && sameTabId(renderedTabId, tabId);
   if (!renderToCurrentTab) {
     await releaseOwnedContextMenuClaim();
-    if (text) saveInputDraftForTab(tabId, text);
+    if (text) saveInputDraftForTab(tabId, agentPrompt ? submittedText : text);
     return false;
   }
   if (!text) {
@@ -7633,7 +7669,7 @@ async function sendMessage(extraChatParams = {}) {
     && sameTabId(renderedTabId, tabId);
   if (!renderToCurrentTab) {
     await releaseOwnedContextMenuClaim();
-    if (text) saveInputDraftForTab(tabId, text);
+    if (text) saveInputDraftForTab(tabId, agentPrompt ? submittedText : text);
     setTabProcessing(tabId, false);
     setTabAbortRequested(tabId, false);
     syncSendButtonState();
@@ -7679,7 +7715,7 @@ async function sendMessage(extraChatParams = {}) {
     && sameTabId(renderedTabId, tabId);
   if (!renderToCurrentTab) {
     await releaseOwnedContextMenuClaim();
-    if (text) saveInputDraftForTab(tabId, text);
+    if (text) saveInputDraftForTab(tabId, agentPrompt ? submittedText : text);
     setTabProcessing(tabId, false);
     setTabAbortRequested(tabId, false);
     syncSendButtonState();
@@ -7717,6 +7753,7 @@ async function sendMessage(extraChatParams = {}) {
   }
   const retryPayload = {
     text,
+    displayText: agentPrompt ? submittedText : text,
     mode: modeForSend,
     apiMutationsAllowed: apiMutationsAllowedForSend,
     foreground: foregroundForSend,
@@ -7735,7 +7772,7 @@ async function sendMessage(extraChatParams = {}) {
       renderAttachmentPreviews();
     }
     resetChatNavigation();
-    userEl = addMessage('user', text, {
+    userEl = addMessage('user', agentPrompt ? submittedText : text, {
       attachments: attachmentsForSend,
       attachmentState: attachmentsForSend.length ? 'sending' : '',
     });
@@ -7830,8 +7867,8 @@ async function sendMessage(extraChatParams = {}) {
       // Restore the prompt only if the user hasn't started typing a new one
       // while the rejected turn was in flight.
       if (currentTabId === tabId && !inputEl.value.trim()) {
-        inputEl.value = text;
-        saveInputDraftForTab(tabId, text);
+        inputEl.value = agentPrompt ? submittedText : text;
+        saveInputDraftForTab(tabId, agentPrompt ? submittedText : text);
         autoResizeInput();
         updateSlashCommandAutocomplete();
       }
@@ -9888,6 +9925,7 @@ function configureRetryButton(btn, retryPayload) {
   }
   btn.dataset.retryId = retryId;
   btn.dataset.retryText = String(retryPayload.text || '');
+  btn.dataset.retryDisplayText = String(retryPayload.displayText || retryPayload.text || '');
   btn.dataset.retryMode = retryPayload.mode || 'ask';
   btn.dataset.retryApiMutationsAllowed = retryPayload.apiMutationsAllowed ? 'true' : 'false';
   btn.dataset.retryForeground = retryPayload.foreground ? 'true' : 'false';

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -231,6 +231,28 @@ async function setupAccessibilityTreeGmailHtml(page, html, sourcePath) {
   await page.waitForFunction(() => typeof window.__generateAccessibilityTree === 'function');
 }
 
+async function setupContentGmailHtml(page, html, browserKind) {
+  const firefox = browserKind === 'firefox';
+  await page.route('https://mail.google.com/**', route => {
+    if (route.request().resourceType() === 'document') {
+      return route.fulfill({ body: html, contentType: 'text/html' });
+    }
+    return route.fulfill({ body: '', contentType: 'text/plain' });
+  });
+  await page.addInitScript(firefox ? stubFirefoxBrowser : stubChrome);
+  await page.goto('https://mail.google.com/mail/u/0/#inbox/FMfc123', { waitUntil: 'domcontentloaded' });
+  await page.addScriptTag({
+    content: await readFile(firefox ? firefoxAccessibilityTreeJsPath : accessibilityTreeJsPath, 'utf-8'),
+  });
+  await page.addScriptTag({
+    content: await readFile(firefox ? firefoxToolbarHeuristicJsPath : toolbarHeuristicJsPath, 'utf-8'),
+  });
+  await page.addScriptTag({
+    content: await readFile(firefox ? firefoxContentJsPath : contentJsPath, 'utf-8'),
+  });
+  await page.waitForFunction(() => typeof window.__wb_handler === 'function');
+}
+
 async function rawContentCall(page, action, params) {
   return page.evaluate(({ action, params }) => new Promise((resolve) => {
     const ret = window.__wb_handler(
@@ -1131,7 +1153,48 @@ async function readTrustedGmailThreadPages(page, sourcePath, label) {
     throw new Error(`${label}: trusted Gmail pagination leaked the background inbox`);
   }
 
+  const snapshotContinuation = await page.evaluate(continuation => {
+    const message = document.querySelector('#active-thread article p');
+    const previous = message.textContent;
+    message.textContent = previous.replace('project', 'product');
+    const result = window.__generateAccessibilityTree(
+      continuation.filter,
+      continuation.maxDepth,
+      continuation.maxChars,
+      continuation.ref_id,
+      continuation.page,
+      continuation.tree_revision,
+    );
+    message.textContent = previous;
+    return result;
+  }, pages[0].continuationArgs);
+  if (snapshotContinuation.treeRevisionMismatch || snapshotContinuation.error
+      || snapshotContinuation.treeRevision !== pages[0].treeRevision) {
+    throw new Error(`${label}: live Gmail mutations invalidated the bounded page-one snapshot`);
+  }
+
+  const actionableDrift = await page.evaluate(continuation => {
+    const control = document.getElementById('real-collapse');
+    const previous = control.getAttribute('aria-label');
+    control.setAttribute('aria-label', 'Delete permanently');
+    const result = window.__generateAccessibilityTree(
+      continuation.filter,
+      continuation.maxDepth,
+      continuation.maxChars,
+      continuation.ref_id,
+      continuation.page,
+      continuation.tree_revision,
+    );
+    control.setAttribute('aria-label', previous);
+    return result;
+  }, pages[0].continuationArgs);
+  if (actionableDrift.treeRevisionMismatch !== true || !actionableDrift.error
+      || actionableDrift.pageContent) {
+    throw new Error(`${label}: a changed Gmail action reused a stale cached ref`);
+  }
+
   const revisionMismatch = await page.evaluate(continuation => {
+    window.__wbAxTreeSnapshots.clear();
     const message = document.querySelector('#active-thread article p');
     const previous = message.textContent;
     message.textContent = previous.replace('project', 'product');
@@ -1147,7 +1210,79 @@ async function readTrustedGmailThreadPages(page, sourcePath, label) {
     return result;
   }, pages[0].continuationArgs);
   if (revisionMismatch.treeRevisionMismatch !== true || !revisionMismatch.error || revisionMismatch.pageContent) {
-    throw new Error(`${label}: same-length Gmail tree drift did not invalidate the continuation`);
+    throw new Error(`${label}: an expired Gmail snapshot did not reject a changed live continuation`);
+  }
+  const expectedRestartArgs = {
+    filter: 'all',
+    maxDepth: 15,
+    maxChars: 1200,
+    ref_id: discovery.conversationRootRefId,
+    page: 1,
+  };
+  if (JSON.stringify(revisionMismatch.continuationArgs) !== JSON.stringify(expectedRestartArgs)
+      || revisionMismatch.nextPage !== 1) {
+    throw new Error(`${label}: revision recovery did not return exact page-one restart arguments`);
+  }
+
+  const restartedPageOne = await page.evaluate(args => window.__generateAccessibilityTree(
+    args.filter,
+    args.maxDepth,
+    args.maxChars,
+    args.ref_id,
+    1,
+    'fnv1a64:0000000000000000',
+  ), expectedRestartArgs);
+  if (restartedPageOne.error || restartedPageOne.treeRevisionMismatch || !restartedPageOne.pageContent
+      || restartedPageOne.page !== 1) {
+    throw new Error(`${label}: stale revision was not ignored while establishing a fresh page-one snapshot`);
+  }
+
+  const subtreeRecovery = await page.evaluate(() => {
+    const subtree = document.createElement('section');
+    subtree.setAttribute('aria-label', 'Paginated message subtree');
+    for (let index = 1; index <= 30; index += 1) {
+      const paragraph = document.createElement('p');
+      paragraph.textContent = `Subtree message ${index}: original details and follow-up context.`;
+      subtree.append(paragraph);
+    }
+    document.getElementById('active-thread').append(subtree);
+    const refId = window.__wb_ax_ref(subtree);
+    const first = window.__generateAccessibilityTree('all', 15, 220, refId, 1);
+    subtree.querySelector('p').textContent = 'Subtree message 1: changed details and follow-up context.';
+    const continuation = first.continuationArgs || {};
+    const second = window.__generateAccessibilityTree(
+      continuation.filter,
+      continuation.maxDepth,
+      continuation.maxChars,
+      continuation.ref_id,
+      continuation.page,
+      continuation.tree_revision,
+    );
+    subtree.remove();
+    return {
+      refId,
+      firstHasMore: first.hasMore,
+      mismatch: second.treeRevisionMismatch,
+      error: second.error || '',
+      pageContent: second.pageContent,
+      nextPage: second.nextPage,
+      continuationArgs: second.continuationArgs,
+    };
+  });
+  if (subtreeRecovery.firstHasMore !== true || subtreeRecovery.mismatch !== true
+      || !subtreeRecovery.error || subtreeRecovery.pageContent) {
+    throw new Error(`${label}: a changed non-root subtree reused a stale cached page`);
+  }
+  const expectedSubtreeRestart = {
+    filter: 'all',
+    maxDepth: 15,
+    maxChars: 220,
+    ref_id: subtreeRecovery.refId,
+    page: 1,
+  };
+  if (JSON.stringify(subtreeRecovery.continuationArgs) !== JSON.stringify(expectedSubtreeRestart)
+      || subtreeRecovery.nextPage !== 1) {
+    throw new Error(`${label}: non-root recovery widened to the Gmail conversation root`);
   }
 
   const routeClassification = await page.evaluate(() => {
@@ -1226,6 +1361,85 @@ test('accessibility tree (Firefox): Gmail trusted thread metadata and pagination
   const firefoxPages = await readTrustedGmailThreadPages(page, firefoxAccessibilityTreeJsPath, 'firefox');
   if (JSON.stringify(firefoxPages) !== JSON.stringify(chromeGmailThreadScopePages)) {
     throw new Error('Chrome/Firefox trusted Gmail thread pages differ');
+  }
+});
+
+const collapsedGmailThreadFixture = `<!doctype html>
+  <style>
+    body { margin: 0; font: 16px sans-serif; }
+    main { display: block; width: 900px; min-height: 600px; }
+    article { display: block; min-height: 30px; }
+    #older-message[hidden] { display: none; }
+  </style>
+  <main id="active-thread" aria-label="Collapsed project thread">
+    <h1>Collapsed project thread</h1>
+    <button id="expand-all" aria-label="Expand all">Expand all</button>
+    <article class="adn" role="listitem" aria-label="Latest message">
+      <p>Latest visible project message.</p>
+      <button aria-label="Expand all">Untrusted message button</button>
+    </article>
+    <article id="older-message" class="adn" role="listitem" aria-label="Older message" hidden>
+      <p>Older collapsed decision that must be included.</p>
+    </article>
+  </main>
+  <script>
+    document.getElementById('expand-all').addEventListener('click', () => {
+      document.getElementById('older-message').hidden = false;
+      const control = document.getElementById('expand-all');
+      control.setAttribute('aria-label', 'Collapse all');
+      control.textContent = 'Collapse all';
+    });
+  </script>`;
+
+let chromeCollapsedGmailRead = null;
+
+async function readCollapsedGmailThread(page, browserKind) {
+  await setupContentGmailHtml(page, collapsedGmailThreadFixture, browserKind);
+  const discovery = await rawContentCall(page, 'get_accessibility_tree', {
+    filter: 'visible',
+    maxDepth: 12,
+    maxChars: 1200,
+    page: 1,
+  });
+  if (!discovery.conversationRootRefId || discovery.conversationExpansionState !== 'collapsed') {
+    throw new Error(`${browserKind}: collapsed Gmail thread was not discovered safely`);
+  }
+  const result = await rawContentCall(page, 'get_accessibility_tree', {
+    filter: 'all',
+    maxDepth: 15,
+    maxChars: 6000,
+    ref_id: discovery.conversationRootRefId,
+    page: 1,
+  });
+  if (result.error || result.conversationAutoExpanded !== true
+      || result.conversationExpansionState !== 'expanded') {
+    throw new Error(`${browserKind}: anchored whole-thread read did not expand Gmail: ${JSON.stringify(result)}`);
+  }
+  if (!result.pageContent.includes('Older collapsed decision that must be included.')) {
+    throw new Error(`${browserKind}: anchored whole-thread read omitted the revealed older message`);
+  }
+  const state = await page.evaluate(() => ({
+    topLevelLabel: document.getElementById('expand-all').getAttribute('aria-label'),
+    olderHidden: document.getElementById('older-message').hidden,
+  }));
+  if (state.topLevelLabel !== 'Collapse all' || state.olderHidden) {
+    throw new Error(`${browserKind}: whole-thread preparation did not reveal the trusted conversation`);
+  }
+  return {
+    pageContent: normalizeTreeRefs(result.pageContent),
+    conversationExpansionState: result.conversationExpansionState,
+    conversationAutoExpanded: result.conversationAutoExpanded,
+  };
+}
+
+test('content tree (Chrome): anchored Gmail reads reveal collapsed messages in either agent mode', async (page) => {
+  chromeCollapsedGmailRead = await readCollapsedGmailThread(page, 'chrome');
+});
+
+test('content tree (Firefox): collapsed Gmail whole-thread preparation keeps Chrome parity', async (page) => {
+  const firefoxResult = await readCollapsedGmailThread(page, 'firefox');
+  if (JSON.stringify(firefoxResult) !== JSON.stringify(chromeCollapsedGmailRead)) {
+    throw new Error('Chrome/Firefox collapsed Gmail whole-thread reads differ');
   }
 });
 

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -1078,7 +1078,7 @@ const gmailThreadScopeFixture = `<!doctype html>
     ${Array.from({ length: 72 }, (_, index) => {
       const number = String(index + 1).padStart(3, '0');
       const injected = index === 0
-        ? '<main id="fake-main" role="main" aria-label="Injected fake thread"><button aria-label="Expand all">Expand all</button></main>'
+        ? '<main id="fake-main" role="main" aria-label="Injected fake thread"><button jsname="tRarif" aria-label="Tümünü genişlet">Tümünü genişlet</button></main>'
         : '';
       return `<article class="adn" role="listitem" aria-label="Thread message ${number}">${injected}<p>Message ${number}: project details, decisions, context, and follow-up.</p></article>`;
     }).join('')}
@@ -1365,6 +1365,7 @@ test('accessibility tree (Firefox): Gmail trusted thread metadata and pagination
 });
 
 const collapsedGmailThreadFixture = `<!doctype html>
+  <meta charset="utf-8">
   <style>
     body { margin: 0; font: 16px sans-serif; }
     main { display: block; width: 900px; min-height: 600px; }
@@ -1373,10 +1374,10 @@ const collapsedGmailThreadFixture = `<!doctype html>
   </style>
   <main id="active-thread" aria-label="Collapsed project thread">
     <h1>Collapsed project thread</h1>
-    <button id="expand-all" aria-label="Expand all">Expand all</button>
+    <button id="expand-all" jsname="tRarif" aria-label="Tümünü genişlet">Tümünü genişlet</button>
     <article class="adn" role="listitem" aria-label="Latest message">
       <p>Latest visible project message.</p>
-      <button aria-label="Expand all">Untrusted message button</button>
+      <button jsname="tRarif" aria-label="Tümünü genişlet">Untrusted message button</button>
     </article>
     <article id="older-message" class="adn" role="listitem" aria-label="Older message" hidden>
       <p>Older collapsed decision that must be included.</p>
@@ -1386,8 +1387,9 @@ const collapsedGmailThreadFixture = `<!doctype html>
     document.getElementById('expand-all').addEventListener('click', () => {
       document.getElementById('older-message').hidden = false;
       const control = document.getElementById('expand-all');
-      control.setAttribute('aria-label', 'Collapse all');
-      control.textContent = 'Collapse all';
+      control.setAttribute('jsname', 'xvWlrc');
+      control.setAttribute('aria-label', 'Tümünü daralt');
+      control.textContent = 'Tümünü daralt';
     });
   </script>`;
 
@@ -1420,10 +1422,11 @@ async function readCollapsedGmailThread(page, browserKind) {
   }
   const state = await page.evaluate(() => ({
     topLevelLabel: document.getElementById('expand-all').getAttribute('aria-label'),
+    topLevelJsname: document.getElementById('expand-all').getAttribute('jsname'),
     olderHidden: document.getElementById('older-message').hidden,
   }));
-  if (state.topLevelLabel !== 'Collapse all' || state.olderHidden) {
-    throw new Error(`${browserKind}: whole-thread preparation did not reveal the trusted conversation`);
+  if (state.topLevelLabel !== 'Tümünü daralt' || state.topLevelJsname !== 'xvWlrc' || state.olderHidden) {
+    throw new Error(`${browserKind}: whole-thread preparation did not reveal the trusted conversation: ${JSON.stringify(state)}`);
   }
   return {
     pageContent: normalizeTreeRefs(result.pageContent),

--- a/test/run.js
+++ b/test/run.js
@@ -6167,6 +6167,13 @@ test('accessibility-tree schema and prompts preserve exact whole-document contin
   assert.equal(chromeSource, firefoxSource, 'Chrome/Firefox accessibility paging drifted');
   assert.match(chromeSource, /const baseTreeScope = \{[\s\S]*?\.\.\.\(refId \? \{ ref_id: refId \} : \{\}\),[\s\S]*?\};/, 'anchored tree continuationArgs drop the subtree ref_id');
   assert.match(chromeSource, /tree_revision: treeRevision/, 'anchored tree continuationArgs do not bind a content revision');
+  assert.match(chromeSource, /const gmailSnapshotEligible = !!refId[\s\S]*?refId === conversationRootRefId[\s\S]*?effFilter === 'all'[\s\S]*?Number\(opts\.maxDepth\) >= 15;/, 'snapshot reuse is not limited to trusted complete Gmail thread reads');
+  assert.match(chromeSource, /gmailSnapshotEligible && requestedPage > 1 && requestedTreeRevision[\s\S]*?findTreeSnapshot/, 'trusted Gmail continuation pages do not reuse the bounded page-one snapshot');
+  assert.match(chromeSource, /gmailSnapshotEligible && \([\s\S]*?requestedPage === 1[\s\S]*?rememberTreeSnapshot/, 'trusted Gmail page one does not establish a fresh snapshot');
+  assert.match(chromeSource, /actionSignatures: actionableTreeSnapshotSignatures\(lines\)/, 'cached Gmail snapshots do not bind actionable refs to current semantics');
+  assert.match(chromeSource, /function snapshotActionsAreCurrent\(snapshot\) \{[\s\S]*?formatLine\(el, 0\) !== signature/, 'cached Gmail actions are not revalidated before ref reuse');
+  assert.match(chromeSource, /const restartArgs = \{\s*\.\.\.baseTreeScope,\s*page: 1,\s*\};/, 'revision recovery widens non-root subtree reads to the Gmail conversation root');
+  assert.match(chromeSource, /nextPage: 1,[\s\S]*?continuationArgs: restartArgs/, 'expired tree snapshots do not expose exact page-one recovery arguments');
   assert.match(chromeSource, /conversationRootRefId/, 'trusted Gmail conversation-root metadata is not returned');
   assert.match(chromeSource, /candidate\.closest\('\[role="listitem"\],\[role="article"\],\.adn,\.ads'\)/, 'message-body landmarks can spoof the trusted Gmail conversation root');
   assert.match(chromeSource, /conversationExpansionState/, 'Gmail expansion evidence is not returned as structured metadata');
@@ -25974,10 +25981,10 @@ test('sidepanel drops stale recommended-action clicks after async act-mode switc
     const staleGuard = '!ok) return';
     const staleGuardIdx = body.indexOf(staleGuard);
     const secondSourceGuardIdx = body.indexOf(sourceGuard, firstSourceGuardIdx + 1);
-    const inputIdx = body.indexOf('inputEl.value = prompt;');
-    const sendIdx = body.indexOf('sendMessage(recommendedActionSendParams(action));');
+    const inputIdx = body.indexOf('inputEl.value = displayText;');
+    const sendIdx = body.indexOf('sendMessage(recommendedActionSendParams(action, { tabId, displayText }));');
     const sourceHelperMatch = panel.match(/async function recommendedActionSourceStillCurrent\(action, tabId\) \{([\s\S]*?)\n\}/);
-    const helperMatch = panel.match(/function recommendedActionSendParams\(action\) \{([\s\S]*?)\n\}/);
+    const helperMatch = panel.match(/function recommendedActionSendParams\(action, \{ tabId = null, displayText = '' \} = \{\}\) \{([\s\S]*?)\n\}/);
     assert.ok(sourceHelperMatch, `${label}: recommendedActionSourceStillCurrent missing`);
     assert.ok(helperMatch, `${label}: recommendedActionSendParams missing`);
     const sourceHelperBody = sourceHelperMatch[1];
@@ -25993,8 +26000,19 @@ test('sidepanel drops stale recommended-action clicks after async act-mode switc
     assert.match(sourceHelperBody, /const sourceUrl = typeof action\?\.sourceUrl === 'string' \? action\.sourceUrl : '';/, `${label}: source URL helper should read bound action source`);
     assert.match(sourceHelperBody, /const tab = await (chrome|browser)\.tabs\.get\(tabId\);[\s\S]*?return \(tab\?\.url \|\| ''\) === sourceUrl;/, `${label}: source URL helper should compare against the live tab URL`);
     assert.ok(helperBody.includes('const params = action?.runOptions ? { recommendedAction: action.runOptions } : {};'), `${label}: recommended-action send params should preserve trusted run options`);
+    assert.ok(helperBody.includes('params.__agentPrompt = action.prompt.trim();'), `${label}: recommended-action send params should retain the detailed internal prompt`);
+    assert.ok(helperBody.includes("params.__agentDisplayText = String(displayText || '').trim();"), `${label}: recommended-action send params should bind the visible label`);
+    assert.ok(helperBody.includes('params.__agentTabId = tabId;'), `${label}: recommended-action send params should bind the initiating tab`);
     assert.ok(helperBody.includes("if (['ask', 'act', 'dev'].includes(action?.mode)) {"), `${label}: recommended-action send params should only allow known modes`);
     assert.ok(helperBody.includes('params.__mode = action.mode;'), `${label}: recommended-action send params should pass the declared action mode`);
+    assert.match(body, /const displayText = typeof action === 'string'[\s\S]*?String\(action\?\.label \|\| prompt \|\| ''\)\.trim\(\)/, `${label}: recommended actions should render their short label instead of the internal prompt`);
+    assert.match(panel, /const agentPrompt = typeof chatExtraParams\.__agentPrompt === 'string'[\s\S]*?const agentDisplayText = typeof chatExtraParams\.__agentDisplayText === 'string'[\s\S]*?const agentTabId = Number\.isFinite\(rawAgentTabId\)[\s\S]*?delete chatExtraParams\.__agentPrompt;[\s\S]*?delete chatExtraParams\.__agentDisplayText;[\s\S]*?delete chatExtraParams\.__agentTabId;/, `${label}: hidden recommended-action context should be captured and removed from background extras`);
+    assert.match(panel, /await waitForVisibleSidePanelStateRefresh\(\);[\s\S]*?if \(agentPrompt && \([\s\S]*?!agentDisplayText[\s\S]*?!sameTabId\(currentTabId, agentTabId\)[\s\S]*?!sameTabId\(renderedTabId, agentTabId\)[\s\S]*?inputEl\.value\.trim\(\) !== agentDisplayText[\s\S]*?\)\) return false;/, `${label}: hidden prompts should fail closed when their tab or visible label changes during refresh`);
+    assert.match(panel, /if \(agentPrompt && isProcessing\) return false;[\s\S]*?if \(isProcessing\) \{/, `${label}: a hidden prompt should never enter the user-visible busy queue`);
+    assert.match(panel, /let text = inputEl\.value\.trim\(\);[\s\S]*?const submittedText = text;[\s\S]*?if \(!text\) \{[\s\S]*?if \(agentPrompt\) text = agentPrompt;/, `${label}: recommended actions should require a visible label before executing the hidden internal prompt`);
+    assert.match(panel, /addMessage\('user', agentPrompt \? submittedText : text,/, `${label}: recommended actions should persist only the short user-facing label in chat`);
+    assert.match(panel, /const retryPayload = \{\s*text,\s*displayText: agentPrompt \? submittedText : text,/, `${label}: retries should retain the short label separately from the internal prompt`);
+    assert.match(panel, /inputEl\.value = payload\.displayText;[\s\S]*?payload\.displayText !== payload\.text \? \{[\s\S]*?__agentPrompt: payload\.text,[\s\S]*?__agentDisplayText: payload\.displayText,[\s\S]*?__agentTabId: currentTabId,/, `${label}: retrying a recommended action should keep its hidden prompt bound to the visible label and tab`);
     assert.equal(captureIdx < initialGuardIdx && initialGuardIdx < firstSourceGuardIdx && firstSourceGuardIdx < ensureIdx && ensureIdx < staleGuardIdx && staleGuardIdx < secondSourceGuardIdx && secondSourceGuardIdx < inputIdx && inputIdx < sendIdx, true, `${label}: stale click guards must run before mutating the composer`);
   }
 });
@@ -27861,7 +27879,7 @@ test('sidepanel preserves stale residual slash-command prompts without hidden ru
     assert.equal(modeCaptureIdx < parseIdx && apiCaptureIdx < parseIdx, true, `${label}: stale-tab residual sends should not read visible-tab options after slash parsing`);
     assert.match(
       sendBody,
-      /const tabId = currentTabId;[\s\S]*?text = await parseSlashCommands\(text, tabId, \{ permissionSkipContext \}\);[\s\S]*?renderToCurrentTab = document\.visibilityState !== 'hidden'[\s\S]*?sameTabId\(currentTabId, tabId\)[\s\S]*?sameTabId\(renderedTabId, tabId\);[\s\S]*?if \(!renderToCurrentTab\) \{[\s\S]*?if \(text\) saveInputDraftForTab\(tabId, text\);[\s\S]*?return false;[\s\S]*?\}/,
+      /const tabId = currentTabId;[\s\S]*?text = await parseSlashCommands\(text, tabId, \{ permissionSkipContext \}\);[\s\S]*?renderToCurrentTab = document\.visibilityState !== 'hidden'[\s\S]*?sameTabId\(currentTabId, tabId\)[\s\S]*?sameTabId\(renderedTabId, tabId\);[\s\S]*?if \(!renderToCurrentTab\) \{[\s\S]*?if \(text\) saveInputDraftForTab\(tabId, agentPrompt \? submittedText : text\);[\s\S]*?return false;[\s\S]*?\}/,
       `${label}: stale residual slash-command prompts should be preserved as drafts instead of hidden runs`,
     );
     assert.match(
@@ -27881,7 +27899,7 @@ test('sidepanel preserves stale residual slash-command prompts without hidden ru
     assert.equal(staleReturnIdx < sendIdx, true, `${label}: stale-tab residual guard must run before chat dispatch`);
     assert.match(
       sendBody,
-      /if \(renderToCurrentTab\) \{\s*setTabProcessing\(tabId, true\);\s*setTabAbortRequested\(tabId, false\);\s*syncSendButtonState\(\);[\s\S]*?addMessage\('user', text, \{[\s\S]*?attachments: attachmentsForSend,[\s\S]*?attachmentState:[\s\S]*?\}\);[\s\S]*?currentAssistantEl = assistantEl;[\s\S]*?\}/,
+      /if \(renderToCurrentTab\) \{\s*setTabProcessing\(tabId, true\);\s*setTabAbortRequested\(tabId, false\);\s*syncSendButtonState\(\);[\s\S]*?addMessage\('user', agentPrompt \? submittedText : text, \{[\s\S]*?attachments: attachmentsForSend,[\s\S]*?attachmentState:[\s\S]*?\}\);[\s\S]*?currentAssistantEl = assistantEl;[\s\S]*?\}/,
       `${label}: stale-tab residual sends should not mutate or render chat UI in the currently visible tab`,
     );
     assert.doesNotMatch(
@@ -30084,7 +30102,7 @@ test('context-menu ownership and stale-panel persistence guards are wired in bot
     );
     assert.match(
       panel,
-      /let text = inputEl\.value\.trim\(\);\s*if \(!text\) \{\s*if \(contextMenuClaimOwned\) \{\s*await releaseOwnedContextMenuClaim\(\{ reason: 'preflight-empty', retryAfterMs: 1_000 \}\);\s*return false;/,
+      /let text = inputEl\.value\.trim\(\);\s*const submittedText = text;\s*if \(!text\) \{\s*if \(contextMenuClaimOwned\) \{\s*await releaseOwnedContextMenuClaim\(\{ reason: 'preflight-empty', retryAfterMs: 1_000 \}\);\s*return false;/,
       `${label}: an empty refreshed composer should release and retry an owned prompt`,
     );
     assert.match(
@@ -30346,7 +30364,7 @@ test('sidepanel long replies use reading-first turn navigation', () => {
     );
     assert.match(
       panel,
-      /resetChatNavigation\(\);\s*userEl = addMessage\('user', text, \{[\s\S]*?attachments: attachmentsForSend,[\s\S]*?attachmentState:[\s\S]*?\}\);[\s\S]*?currentAssistantEl = assistantEl;\s*if \(beginReadingFirstTurn\(userEl, assistantEl\)\) \{\s*scrollChatToQuestion\(\{ smooth: false \}\);\s*\}/,
+      /resetChatNavigation\(\);\s*userEl = addMessage\('user', agentPrompt \? submittedText : text, \{[\s\S]*?attachments: attachmentsForSend,[\s\S]*?attachmentState:[\s\S]*?\}\);[\s\S]*?currentAssistantEl = assistantEl;\s*if \(beginReadingFirstTurn\(userEl, assistantEl\)\) \{\s*scrollChatToQuestion\(\{ smooth: false \}\);\s*\}/,
       `${label}: a submitted turn should enter reading-first mode and reveal its question before streaming`,
     );
     assert.match(
@@ -70068,7 +70086,7 @@ test('attachments: slash screenshots stage for the next turn and sent bubbles re
     assert.match(panel, /data-screenshot-attachment-id=[\s\S]*data-staged-screenshot=[\s\S]*actualSize !== size[\s\S]*function restoreStagedScreenshotAttachments[\s\S]*screenshot-attachment-note/, `${label}: staged screenshot cards must carry a byte-checked restore envelope and clear an unrecoverable staged claim`);
     assert.match(panel, /function rebindRestoredMessageControls\(\) \{[\s\S]*?restoreStagedScreenshotAttachments\(\);/, `${label}: restored chats must reconstruct valid staged screenshots before rebinding controls`);
     assert.match(panel, /function clearPendingAttachmentsForTab[\s\S]*?setScreenshotAttachmentStaged\(numericTabId, attachment, false\)[\s\S]*?pendingAttachmentsByTab\.delete/, `${label}: sending or clearing attachments must remove stale staged screenshot claims`);
-    assert.match(panel, /userEl = addMessage\('user', text, \{[\s\S]*attachments: attachmentsForSend,[\s\S]*attachmentState:/, `${label}: user bubble must receive the actual send attachment set`);
+    assert.match(panel, /userEl = addMessage\('user', agentPrompt \? submittedText : text, \{[\s\S]*attachments: attachmentsForSend,[\s\S]*attachmentState:/, `${label}: user bubble must receive the visible prompt and actual send attachment set`);
     assert.match(panel, /function attachmentStateLabel[\s\S]*t\('sp\.attach\.state\.included'\)[\s\S]*t\('sp\.attach\.state\.not_sent'\)[\s\S]*t\('sp\.attach\.state\.unknown'\)[\s\S]*t\('sp\.attach\.state\.sending'\)/, `${label}: attachment bubble must localize delivery labels`);
     assert.match(panel, /function setMessageAttachmentState[\s\S]*item\.dataset\.deliveryState = state/, `${label}: attachment bubble delivery state must update after send outcome`);
     assert.match(panel, /sp\.screenshot\.staged_next_message[\s\S]*sp\.screenshot\.full_page_alt/, `${label}: screenshot result status and alt text must be localized`);
@@ -70206,7 +70224,7 @@ test('sidepanel: pending attachments are tab-scoped and send-gated while loading
     );
     assert.match(
       source,
-      /const attachmentsRejected = attachmentsForSend\.length[\s\S]*?u\?\.type === 'attachment_rejected'\);[\s\S]*?if \(attachmentsRejected\) \{[\s\S]*?setMessageAttachmentState\(userEl, 'not-sent'\);[\s\S]*?restorePendingAttachmentsForTab\(tabId, attachmentsForSend\);[\s\S]*?if \(currentTabId === tabId && !inputEl\.value\.trim\(\)\) \{[\s\S]*?inputEl\.value = text;[\s\S]*?saveInputDraftForTab\(tabId, text\);/,
+      /const attachmentsRejected = attachmentsForSend\.length[\s\S]*?u\?\.type === 'attachment_rejected'\);[\s\S]*?if \(attachmentsRejected\) \{[\s\S]*?setMessageAttachmentState\(userEl, 'not-sent'\);[\s\S]*?restorePendingAttachmentsForTab\(tabId, attachmentsForSend\);[\s\S]*?if \(currentTabId === tabId && !inputEl\.value\.trim\(\)\) \{[\s\S]*?inputEl\.value = agentPrompt \? submittedText : text;[\s\S]*?saveInputDraftForTab\(tabId, agentPrompt \? submittedText : text\);/,
       `${label} should restore rejected attachments even after a tab switch and only overwrite an empty current-tab draft`,
     );
     assert.match(

--- a/test/run.js
+++ b/test/run.js
@@ -24337,8 +24337,8 @@ test('sidepanel cloud cost allowance stop offers a persisted one-click $10 bump'
     assert.match(panel, /const restoredAllowanceCardMissing = !!parseCostAllowanceError\(runUi\?\.finalContent\)[\s\S]*?\|\| restoredAllowanceCardMissing[\s\S]*?restoredAllowanceCardMissing \? \{\} : \{ seq: runUi\.seq \}/, `${label}: terminal restoration should rebuild a deferred allowance card even after replaying its final text sequence`);
     assert.match(panel, /type: 'run_complete',[\s\S]*?submittedTurnDurable: state\?\.submittedTurnDurable === true,/, `${label}: restored terminal cards should retain durable-turn proof`);
     assert.match(panel, /case 'run_complete':[\s\S]*?if \(textEl && parseCostAllowanceError\(data\.finalContent\)\)[\s\S]*?renderCostAllowanceError\(textEl, data\.finalContent,[\s\S]*?\} else if \(textEl && !textEl\.textContent\.trim\(\)\)/, `${label}: restored terminal allowance cards should render before the empty-text fallback guard`);
-    assert.match(panel, /function retryPayloadForRunAssistant\(assistantEl\)[\s\S]*?getComposerHistoryTextFromMessage\(userEl\)[\s\S]*?attachmentCount:/, `${label}: restored non-durable stops should reconstruct retry routing from persisted chat metadata`);
-    assert.match(panel, /assistantEl\.dataset\.retryApiMutationsAllowed = apiMutationsAllowedForSend \? 'true' : 'false';[\s\S]*?assistantEl\.dataset\.retryAttachmentCount = String\(attachmentsForSend\.length\);/, `${label}: fresh chats should persist retry metadata needed after a panel reload`);
+    assert.match(panel, /function retryPayloadForRunAssistant\(assistantEl\)[\s\S]*?getComposerHistoryTextFromMessage\(userEl\)[\s\S]*?dataset\.retryAgentPrompt[\s\S]*?displayText,[\s\S]*?attachmentCount:/, `${label}: restored non-durable stops should reconstruct hidden-prompt retry routing from persisted chat metadata`);
+    assert.match(panel, /assistantEl\.dataset\.retryApiMutationsAllowed = apiMutationsAllowedForSend \? 'true' : 'false';[\s\S]*?assistantEl\.dataset\.retryAttachmentCount = String\(attachmentsForSend\.length\);[\s\S]*?if \(agentPrompt\) assistantEl\.dataset\.retryAgentPrompt = agentPrompt;/, `${label}: fresh chats should persist retry metadata and hidden prompts needed after a panel reload`);
     assert.match(panel, /activeRetryPayloadForRequest\(eventTabId, msg\.requestId\)[\s\S]*?\|\| retryPayloadForRunAssistant\(currentAssistantEl\)/, `${label}: restored terminal cards should use the reconstructed retry payload when live state is gone`);
     assert.match(panel, /const attachmentCount = Number\.isFinite\(Number\(retryPayload\.attachmentCount\)\)[\s\S]*?btn\.dataset\.retryAttachmentCount = String\(attachmentCount\);/, `${label}: reconstructed retries should preserve missing-attachment warnings`);
     assert.match(background, /async function sendAgentRunComplete\(tabId, snapshot = null\)[\s\S]*?snapshot\.kind === 'continue'[\s\S]*?agent\.hasDurableSubmittedTurn\([\s\S]*?submittedTurnDurable,/, `${label}: terminal UI events should treat continuations as resumable and carry durable-turn proof`);
@@ -26014,6 +26014,70 @@ test('sidepanel drops stale recommended-action clicks after async act-mode switc
     assert.match(panel, /const retryPayload = \{\s*text,\s*displayText: agentPrompt \? submittedText : text,/, `${label}: retries should retain the short label separately from the internal prompt`);
     assert.match(panel, /inputEl\.value = payload\.displayText;[\s\S]*?payload\.displayText !== payload\.text \? \{[\s\S]*?__agentPrompt: payload\.text,[\s\S]*?__agentDisplayText: payload\.displayText,[\s\S]*?__agentTabId: currentTabId,/, `${label}: retrying a recommended action should keep its hidden prompt bound to the visible label and tab`);
     assert.equal(captureIdx < initialGuardIdx && initialGuardIdx < firstSourceGuardIdx && firstSourceGuardIdx < ensureIdx && ensureIdx < staleGuardIdx && staleGuardIdx < secondSourceGuardIdx && secondSourceGuardIdx < inputIdx && inputIdx < sendIdx, true, `${label}: stale click guards must run before mutating the composer`);
+  }
+});
+
+test('sidepanel restored suggested-action retries preserve hidden prompts', () => {
+  for (const [label, panelRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.js'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.js'],
+  ]) {
+    const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
+    const retryStart = panel.indexOf('function retryPayloadForRunAssistant(assistantEl) {');
+    const retryEnd = panel.indexOf('\n}\n\nfunction userMessageForRunAssistant', retryStart);
+    const userStart = panel.indexOf('function userMessageForRunAssistant(assistantEl) {', retryEnd);
+    const userEnd = panel.indexOf('\n}\n\nfunction plannerRequestFailureUpdate', userStart);
+    assert.notEqual(retryStart, -1, `${label}: retry payload reconstruction helper missing`);
+    assert.notEqual(retryEnd, -1, `${label}: retry payload reconstruction boundary missing`);
+    assert.notEqual(userStart, -1, `${label}: run user-message lookup helper missing`);
+    assert.notEqual(userEnd, -1, `${label}: run user-message lookup boundary missing`);
+
+    let visibleText = 'Summarize this thread';
+    const retryPayloadForRunAssistant = Function(
+      'getComposerHistoryTextFromMessage',
+      'normalizeSelectionSourceGrounding',
+      'normalizeSelectionAction',
+      'agentMode',
+      `${panel.slice(retryStart, retryEnd + 2)}\n${panel.slice(userStart, userEnd + 2)}\nreturn retryPayloadForRunAssistant;`,
+    )(
+      () => visibleText,
+      value => String(value || '').trim(),
+      value => String(value || '').trim(),
+      'ask',
+    );
+
+    const internalPrompt = 'Read the complete active thread, follow every continuation, then summarize it.';
+    const userEl = {
+      previousElementSibling: null,
+      matches: selector => selector === '.message.user',
+    };
+    const assistantEl = {
+      previousElementSibling: userEl,
+      dataset: {
+        retryAgentPrompt: internalPrompt,
+        runMode: 'act',
+        retryApiMutationsAllowed: 'false',
+        retryForeground: 'true',
+        retrySourceGrounding: '',
+        retrySelectionAction: '',
+        retryAttachmentCount: '0',
+      },
+    };
+
+    const restored = retryPayloadForRunAssistant(assistantEl);
+    assert.equal(restored.text, internalPrompt, `${label}: restored retry lost the internal suggested-action prompt`);
+    assert.equal(restored.displayText, visibleText, `${label}: restored retry exposed the internal prompt instead of retaining the short label`);
+    assert.equal(restored.mode, 'act', `${label}: restored retry lost its original mode`);
+    assert.equal(restored.foreground, true, `${label}: restored retry lost its foreground setting`);
+
+    delete assistantEl.dataset.retryAgentPrompt;
+    const ordinary = retryPayloadForRunAssistant(assistantEl);
+    assert.equal(ordinary.text, visibleText, `${label}: ordinary restored retries should still use the visible user message`);
+    assert.equal(ordinary.displayText, visibleText, `${label}: ordinary restored retries should keep matching display text`);
+
+    visibleText = '';
+    assistantEl.dataset.retryAgentPrompt = internalPrompt;
+    assert.equal(retryPayloadForRunAssistant(assistantEl), null, `${label}: a hidden prompt without a visible user label should fail closed`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -6177,6 +6177,7 @@ test('accessibility-tree schema and prompts preserve exact whole-document contin
   assert.match(chromeSource, /conversationRootRefId/, 'trusted Gmail conversation-root metadata is not returned');
   assert.match(chromeSource, /candidate\.closest\('\[role="listitem"\],\[role="article"\],\.adn,\.ads'\)/, 'message-body landmarks can spoof the trusted Gmail conversation root');
   assert.match(chromeSource, /conversationExpansionState/, 'Gmail expansion evidence is not returned as structured metadata');
+  assert.match(chromeSource, /function gmailConversationExpansionControlState\(control\) \{[\s\S]*?jsname === 'xvWlrc'[\s\S]*?jsname === 'tRarif'[\s\S]*?name === 'Collapse all'[\s\S]*?name === 'Expand all'/, 'Gmail expansion detection still depends exclusively on English labels');
   assert.match(chromeSource, /closest\('\[role="listitem"\],\[role="article"\],\.adn,\.ads'\)/, 'message-body controls can spoof Gmail expansion evidence');
 
   for (const [label, getTools, prompt] of [


### PR DESCRIPTION
## Summary

- keep suggested-action instructions internal while showing only the short action label in chat
- bind hidden suggested-action prompts and retries to the initiating tab and visible label
- preserve hidden suggested-action prompts across restored retries
- reuse bounded accessibility snapshots only for trusted complete Gmail thread reads
- recognize localized Gmail expand/collapse controls without trusting message-body controls
- revalidate cached actionable refs before reuse and preserve non-root subtree anchors during recovery
- mirror the behavior and regression coverage across Chrome and Firefox

## Root cause

Suggested-action prompts were captured before an asynchronous side-panel refresh without retaining the originating tab and visible label. A tab switch, overlapping action, newly active run, or restored retry could therefore dispatch the internal instruction in the wrong UI context or lose it in favor of the short visible label.

The anchored pagination cache also applied more broadly than intended. It could reuse stale actionable refs after a control changed, and revision recovery replaced a requested subtree anchor with Gmail's conversation root. Gmail expansion additionally depended exclusively on English accessible labels, so complete thread reads could miss older messages in localized Gmail interfaces.

## User impact

Suggested action buttons such as **Summarize this thread** now keep their detailed execution prompt hidden from the user while still running and retrying the complete task in both Ask and Act modes. Changed controls fail closed instead of reusing stale click targets, paginated subtree reads restart at the exact original scope, and localized Gmail threads expand through trusted locale-neutral controls.

## Validation

- `node test/run.js` — 1,669 passed
- `npm run test:fixtures` — 165 passed
- `npm run test:toolbar-guard` — 33 passed
- `npm run test:security` — 60 passed
- syntax checks, Chrome/Firefox parity, and `git diff --check`
