### PR TITLE
Fix clipped plan review steps

### DIFF
--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -5059,6 +5059,8 @@ function setPlanReviewStructuredControlsDisabled(card, disabled) {
 
 const planReviewScrollRestoreFrames = new WeakMap();
 const planReviewScrollSnapshots = new WeakMap();
+const planReviewAutosizeFrames = new WeakMap();
+const planReviewContainerWidths = new WeakMap();
 
 function restorePlanReviewScrollTop(container, scrollTop) {
   const previousScrollBehavior = container.style.scrollBehavior;
@@ -5106,6 +5108,33 @@ function autosizePlanReviewField(el) {
     }
   });
   planReviewScrollRestoreFrames.set(el, frame);
+}
+
+function autosizePlanReviewFields(root) {
+  root?.querySelectorAll?.('.plan-review-summary-input, .plan-review-step-input')
+    .forEach(autosizePlanReviewField);
+}
+
+function schedulePlanReviewFieldsAutosize(root) {
+  if (!root?.querySelectorAll || planReviewAutosizeFrames.has(root)) return;
+  const frame = requestAnimationFrame(() => {
+    planReviewAutosizeFrames.delete(root);
+    autosizePlanReviewFields(root);
+  });
+  planReviewAutosizeFrames.set(root, frame);
+}
+
+function handlePlanReviewContainerResize(entries) {
+  for (const entry of entries || []) {
+    const root = entry?.target;
+    if (!root?.querySelectorAll) continue;
+    const width = Number(entry?.contentRect?.width);
+    if (Number.isFinite(width)) {
+      if (planReviewContainerWidths.get(root) === width) continue;
+      planReviewContainerWidths.set(root, width);
+    }
+    schedulePlanReviewFieldsAutosize(root);
+  }
 }
 
 function getPlanReviewDraftFromDom(card) {
@@ -5531,6 +5560,10 @@ function bindPlanReviewEditorControls(card, view) {
       try { input?.focus(); } catch {}
     });
   }
+
+  // Cards are initially mounted while detached, and restored cards can be
+  // rebound before layout settles. Measure on the next frame in both cases.
+  schedulePlanReviewFieldsAutosize(card);
 }
 
 function setPlanReviewRawEditing(card, enabled, { focus = false } = {}) {
@@ -10987,9 +11020,17 @@ chatNavigationDismissEl?.addEventListener('click', () => {
   setChatNavigationVisible(false);
 });
 
-globalThis.addEventListener?.('resize', scheduleChatNavigationUpdate);
+function scheduleSidepanelResponsiveUpdates() {
+  scheduleChatNavigationUpdate();
+  schedulePlanReviewFieldsAutosize(messagesEl);
+}
+
+globalThis.addEventListener?.('resize', scheduleSidepanelResponsiveUpdates);
 if (globalThis.ResizeObserver && messagesEl) {
-  const chatNavigationResizeObserver = new ResizeObserver(scheduleChatNavigationUpdate);
+  const chatNavigationResizeObserver = new ResizeObserver((entries) => {
+    scheduleChatNavigationUpdate();
+    handlePlanReviewContainerResize(entries);
+  });
   chatNavigationResizeObserver.observe(messagesEl);
 }
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -4905,6 +4905,8 @@ function setPlanReviewStructuredControlsDisabled(card, disabled) {
 
 const planReviewScrollRestoreFrames = new WeakMap();
 const planReviewScrollSnapshots = new WeakMap();
+const planReviewAutosizeFrames = new WeakMap();
+const planReviewContainerWidths = new WeakMap();
 
 function restorePlanReviewScrollTop(container, scrollTop) {
   const previousScrollBehavior = container.style.scrollBehavior;
@@ -4952,6 +4954,33 @@ function autosizePlanReviewField(el) {
     }
   });
   planReviewScrollRestoreFrames.set(el, frame);
+}
+
+function autosizePlanReviewFields(root) {
+  root?.querySelectorAll?.('.plan-review-summary-input, .plan-review-step-input')
+    .forEach(autosizePlanReviewField);
+}
+
+function schedulePlanReviewFieldsAutosize(root) {
+  if (!root?.querySelectorAll || planReviewAutosizeFrames.has(root)) return;
+  const frame = requestAnimationFrame(() => {
+    planReviewAutosizeFrames.delete(root);
+    autosizePlanReviewFields(root);
+  });
+  planReviewAutosizeFrames.set(root, frame);
+}
+
+function handlePlanReviewContainerResize(entries) {
+  for (const entry of entries || []) {
+    const root = entry?.target;
+    if (!root?.querySelectorAll) continue;
+    const width = Number(entry?.contentRect?.width);
+    if (Number.isFinite(width)) {
+      if (planReviewContainerWidths.get(root) === width) continue;
+      planReviewContainerWidths.set(root, width);
+    }
+    schedulePlanReviewFieldsAutosize(root);
+  }
 }
 
 function getPlanReviewDraftFromDom(card) {
@@ -5377,6 +5406,10 @@ function bindPlanReviewEditorControls(card, view) {
       try { input?.focus(); } catch {}
     });
   }
+
+  // Cards are initially mounted while detached, and restored cards can be
+  // rebound before layout settles. Measure on the next frame in both cases.
+  schedulePlanReviewFieldsAutosize(card);
 }
 
 function setPlanReviewRawEditing(card, enabled, { focus = false } = {}) {
@@ -10664,9 +10697,17 @@ chatNavigationDismissEl?.addEventListener('click', () => {
   setChatNavigationVisible(false);
 });
 
-globalThis.addEventListener?.('resize', scheduleChatNavigationUpdate);
+function scheduleSidepanelResponsiveUpdates() {
+  scheduleChatNavigationUpdate();
+  schedulePlanReviewFieldsAutosize(messagesEl);
+}
+
+globalThis.addEventListener?.('resize', scheduleSidepanelResponsiveUpdates);
 if (globalThis.ResizeObserver && messagesEl) {
-  const chatNavigationResizeObserver = new ResizeObserver(scheduleChatNavigationUpdate);
+  const chatNavigationResizeObserver = new ResizeObserver((entries) => {
+    scheduleChatNavigationUpdate();
+    handlePlanReviewContainerResize(entries);
+  });
   chatNavigationResizeObserver.observe(messagesEl);
 }
 

--- a/test/run.js
+++ b/test/run.js
@@ -67427,7 +67427,7 @@ function loadPlanReviewAutosizeHelper(panelRel, runtime) {
     'document',
     'requestAnimationFrame',
     'cancelAnimationFrame',
-    `${block}\nreturn { autosizePlanReviewField, capturePlanReviewScrollSnapshot };`,
+    `${block}\nreturn { autosizePlanReviewField, autosizePlanReviewFields, schedulePlanReviewFieldsAutosize, handlePlanReviewContainerResize, capturePlanReviewScrollSnapshot };`,
   )(
     runtime.document,
     runtime.requestAnimationFrame,
@@ -67632,6 +67632,95 @@ test('plan review: textarea autosize preserves an active off-bottom scroll posit
       source,
       /summaryInput\.addEventListener\('beforeinput', \(\) => capturePlanReviewScrollSnapshot\(summaryInput\)\);/,
       `${file} should snapshot summary-editor scroll before the browser edits the value`,
+    );
+  }
+});
+
+test('plan review: structured fields reflow after detached mount and width changes', () => {
+  for (const file of [
+    'src/chrome/src/ui/sidepanel.js',
+    'src/firefox/src/ui/sidepanel.js',
+  ]) {
+    const frames = new Map();
+    let nextFrame = 1;
+    const document = { activeElement: null };
+    const runtime = {
+      document,
+      requestAnimationFrame(callback) {
+        const id = nextFrame++;
+        frames.set(id, callback);
+        return id;
+      },
+      cancelAnimationFrame(id) {
+        frames.delete(id);
+      },
+    };
+    const {
+      schedulePlanReviewFieldsAutosize,
+      handlePlanReviewContainerResize,
+    } = loadPlanReviewAutosizeHelper(file, runtime);
+    let connected = false;
+    let availableWidth = 420;
+    const fields = [
+      { tagName: 'TEXTAREA', style: {} },
+      { tagName: 'TEXTAREA', style: {} },
+    ];
+    for (const field of fields) {
+      Object.defineProperty(field, 'scrollHeight', {
+        get() {
+          if (!connected) return 0;
+          return availableWidth <= 240 ? 72 : 28;
+        },
+      });
+    }
+    const root = {
+      querySelectorAll(selector) {
+        assert.equal(selector, '.plan-review-summary-input, .plan-review-step-input', file);
+        return fields;
+      },
+    };
+    const flushFrames = () => {
+      const pending = [...frames.values()];
+      frames.clear();
+      for (const callback of pending) callback();
+    };
+
+    // Mount/bind can happen before the card is attached. The deferred frame
+    // must measure after attachment instead of pinning the one-line minimum.
+    schedulePlanReviewFieldsAutosize(root);
+    assert.equal(frames.size, 1, `${file} should defer initial measurement`);
+    connected = true;
+    flushFrames();
+    assert.deepEqual(fields.map(field => field.style.height), ['28px', '28px'], file);
+
+    // Narrowing wraps the same values, so both summary and step controls must
+    // be remeasured to reveal all lines.
+    availableWidth = 220;
+    handlePlanReviewContainerResize([{ target: root, contentRect: { width: 220, height: 100 } }]);
+    assert.equal(frames.size, 1, `${file} should schedule after a width change`);
+    flushFrames();
+    assert.deepEqual(fields.map(field => field.style.height), ['72px', '72px'], file);
+
+    // Textarea height changes also resize the observed container. Ignore that
+    // notification when its width is unchanged to prevent observer churn.
+    handlePlanReviewContainerResize([{ target: root, contentRect: { width: 220, height: 188 } }]);
+    assert.equal(frames.size, 0, `${file} should ignore height-only resize notifications`);
+
+    const source = fs.readFileSync(path.join(ROOT, file), 'utf8');
+    assert.match(
+      source,
+      /function bindPlanReviewEditorControls\([\s\S]*?schedulePlanReviewFieldsAutosize\(card\);\s*\}/,
+      `${file} should schedule autosize from the initial and restored card binder`,
+    );
+    assert.match(
+      source,
+      /new ResizeObserver\(\(entries\) => \{[\s\S]*?handlePlanReviewContainerResize\(entries\)/,
+      `${file} should route container ResizeObserver entries through width deduplication`,
+    );
+    assert.match(
+      source,
+      /addEventListener\?\.\('resize', scheduleSidepanelResponsiveUpdates\)/,
+      `${file} should keep a window-resize fallback`,
     );
   }
 });


### PR DESCRIPTION
## Summary

- Recalculate structured plan-review textarea heights after initial mount and history restoration.
- Reflow summary and step fields when the sidepanel width changes, with width deduplication to avoid ResizeObserver churn.
- Mirror the behavior in Chrome and Firefox and add regression coverage for detached mounting, narrow reflow, and height-only resize notifications.

## Root cause

Plan-review textareas kept the height measured at their original width. When the sidepanel became narrower, the text wrapped but the fixed height did not change; because overflow is hidden, later lines were clipped from view.

## Validation

- `node --check src/chrome/src/ui/sidepanel.js`
- `node --check src/firefox/src/ui/sidepanel.js`
- `git diff --check`
- Plan-review regression passes for Chrome and Firefox within `node test/run.js`
- Rich-text toolbar guard: 33/33 passed
- Security corpus: 60/60 passed
- `node test/run.js`: 1,678 passed, with 2 pre-existing release-baseline failures (CHANGELOG 30.0.3 vs package 30.0.4, and missing `dist/webbrain-chrome-30.0.4.zip`)
