### PR TITLE
Trim the response-language policy prompt cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ This changelog was generated from the repository Git history and release tags. V
 
 ### Fixed
 - Keep ordinary and forced-recovery answers in the trusted user-request language while allowing explicit translation targets, user-edited plan targets, multilingual deliverables, and source-faithful quotations to use their requested languages.
+- Shrink the response-language instruction on ordinary turns from about 150 tokens to about 40, stop repeating it in the `done` tool schema when the system prompt already carries it, and keep an explicitly empty planner deliverable list instead of discarding it as malformed. Translation, multilingual, approved-plan-override, and forced-delivery turns keep the full wording.
 
 ## [30.0.5] - 2026-08-13
 

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -93,7 +93,9 @@ When **Continue** resumes an interrupted run, WebBrain carries the normalized po
 
 If planning is unavailable, WebBrain infers framing from the language of the latest genuine user request. It uses the interface locale only as a soft fallback when that request language is unclear, and continues to honor explicit language or translation instructions.
 
-An incomplete or malformed planner language policy is treated the same way as an unavailable policy. In particular, a missing source-preservation decision never defaults to translating quoted or extracted text.
+An incomplete or malformed planner language policy is treated the same way as an unavailable policy. In particular, a missing source-preservation decision never defaults to translating quoted or extracted text. A planner answer that names deliverable languages but supplies only invalid locale codes also fails closed, while an explicitly empty deliverable list is kept as the coherent answer it is: no fixed target, so the deliverable follows the framing language or an explicit instruction in the request.
+
+The policy is written into the system prompt once per run, in one of two renderings. An ordinary policy, meaning the deliverable language matches the framing language and source text stays as it is, gets a single line of about 40 tokens. Translation targets, multilingual deliverables, approved-plan overrides, and continuations resumed by the synthetic Continue control keep the full block, because those are the cases where the precise wording earns its cost. On the compact prompt tier the short rendering is used wherever it can carry the policy without losing the deliverable language, since the compact base prompt is only around 1,500 tokens. Forced terminal delivery always gets the full block and repeats it in the `done` schema; ordinary turns do not, so the instruction appears once per request rather than twice.
 
 ### DOM Translation
 

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -12770,25 +12770,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       || normalizeResponseLanguagePolicy(null, fallbackLocale);
   }
 
-  _withResponseLanguageToolGuidance(tabId, tools, fallbackLocale = 'en') {
-    if (!Array.isArray(tools) || tools.length === 0) return tools;
-    const guidance = formatResponseLanguagePolicyInstruction(
-      this._responseLanguagePolicy(tabId, fallbackLocale),
-      fallbackLocale,
-    ).replace(/\s+/g, ' ').trim();
-    return tools.map((tool) => {
-      const name = tool?.function?.name;
-      if (name !== 'done' && name !== 'done_json') return tool;
-      return {
-        ...tool,
-        function: {
-          ...tool.function,
-          description: `${tool.function.description} ${guidance}`,
-        },
-      };
-    });
-  }
-
   _devModeBlockedMessage(provider = null) {
     const providerName = provider?.name || provider?.config?.model || 'the active provider';
     return `Dev mode requires a Mid or Full prompt tier. ${providerName} is currently configured as Compact, so Dev mode is blocked for this provider. Switch to a Mid/Full-tier provider or change this provider's prompt tier, then try Dev again.`;
@@ -12854,9 +12835,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       prompt += `\n\n[CAPTCHA SOLVER — the user has configured CapSolver. When a CAPTCHA or verification dialog blocks a step, read the page/tree without dismissing it. The runtime will route a supported widget to \`solve_captcha\` once and block page-changing actions until a fresh root accessibility-tree read confirms the dialog cleared. If no supported widget is detected, the solve fails, or the dialog remains after solving, stop and ask the user to complete it manually; never dismiss and resubmit or retry solve_captcha.]`;
     }
 
+    // Ordinary turns get the one-line rendering; the full block is reserved for
+    // policies that need the precise wording (translation targets, multilingual
+    // deliverables, approved-plan overrides) and for the forced terminal
+    // delivery prompts. Compact tier shortens everything it safely can — its
+    // base prompt is ~1.5k tokens, so the long block was ~10% of the budget.
     const responseLanguagePolicy = tabId == null ? null : this.responseLanguagePolicies.get(tabId);
     if (responseLanguagePolicy) {
-      prompt += `\n\n${formatResponseLanguagePolicyInstruction(responseLanguagePolicy)}`;
+      prompt += `\n\n${formatResponseLanguagePolicyInstruction(responseLanguagePolicy, 'en', {
+        form: tier === 'compact' ? 'brief' : 'auto',
+      })}`;
     }
 
     // Keep this last so the opt-in strict setting overrides loaded skills,
@@ -24492,7 +24480,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       outputSchema: cloudRunContext?.outputSchema ?? null,
       watchBeep: this.scheduledRunPolicies.get(tabId)?.watch?.beep === true,
     });
-    tools = this._withResponseLanguageToolGuidance(tabId, tools, runOptions?.locale || 'en');
     // The selected text is already present in the trusted run envelope.
     // Advertising page/network tools would let an injected selection induce a
     // second source and defeat the selection-only boundary.
@@ -24665,7 +24652,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         outputSchema: cloudRunContext?.outputSchema ?? null,
         watchBeep: this.scheduledRunPolicies.get(tabId)?.watch?.beep === true,
       });
-      tools = this._withResponseLanguageToolGuidance(tabId, tools, runOptions?.locale || 'en');
       if (selectionOnly) tools = [];
       allowedToolNames = new Set(tools.map(t => t.function.name));
       toolSchemas = new Map(tools.map(t => [t.function.name, t.function.parameters]));
@@ -25337,7 +25323,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       outputSchema: cloudRunContext?.outputSchema ?? null,
       watchBeep: this.scheduledRunPolicies.get(tabId)?.watch?.beep === true,
     });
-    tools = this._withResponseLanguageToolGuidance(tabId, tools, runOptions?.locale || 'en');
     // Match the non-streaming path: selection-grounded turns are tool-free so
     // page or network content cannot be introduced after the source anchor.
     if (selectionOnly) tools = [];
@@ -25384,7 +25369,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         outputSchema: cloudRunContext?.outputSchema ?? null,
         watchBeep: this.scheduledRunPolicies.get(tabId)?.watch?.beep === true,
       });
-      tools = this._withResponseLanguageToolGuidance(tabId, tools, runOptions?.locale || 'en');
       if (selectionOnly) tools = [];
       allowedToolNames = new Set(tools.map(t => t.function.name));
       toolSchemas = new Map(tools.map(t => [t.function.name, t.function.parameters]));

--- a/src/chrome/src/agent/planner.js
+++ b/src/chrome/src/agent/planner.js
@@ -430,7 +430,7 @@ function responseLanguageLabel(locale) {
 
 /**
  * Short single-line rendering of an ordinary policy. Used on normal turns so
- * the common case ("answer in the user's language") costs ~30 tokens instead of
+ * the common case ("answer in the user's language") costs ~45 tokens instead of
  * the ~150-token full block, which matters most on the compact prompt tier
  * where the base prompt is only ~1.5k tokens. Returns '' when the policy needs
  * the precise long wording — an approved-plan override always does.
@@ -454,7 +454,10 @@ function formatBriefResponseLanguagePolicy(policy, opts) {
   const sourceRule = policy.preserve_source_text
     ? ' Keep quoted or extracted text in its source language'
     : ' Translate source text only when the request requires it';
-  return `[Response language] ${framingRule}${deliverableRule}${sourceRule}; never translate code, identifiers, URLs, product names, or personal names.`;
+  // The exception matters as much as the rule: without it a compact-tier model
+  // reads an unconditional "never" and leaves an explicitly requested product
+  // name or transliteration untouched.
+  return `[Response language] ${framingRule}${deliverableRule}${sourceRule}; leave code, identifiers, URLs, product names, and personal names unchanged unless the user explicitly asks to translate or transliterate them.`;
 }
 
 /**

--- a/src/chrome/src/agent/planner.js
+++ b/src/chrome/src/agent/planner.js
@@ -390,7 +390,6 @@ export function normalizeResponseLanguagePolicy(value, fallbackLocale = 'en') {
   ) {
     return fallbackResponseLanguagePolicy(fallbackLocale);
   }
-  const framingLocale = requestedFramingLocale || normalizePlannerLocale(fallbackLocale);
   const framingLocaleIsFallback = value._framing_locale_is_fallback === true;
   const deliverableLocales = [];
   const seen = new Set();
@@ -402,11 +401,16 @@ export function normalizeResponseLanguagePolicy(value, fallbackLocale = 'en') {
     deliverableLocales.push(locale);
   }
   const preserveSourceText = value.preserve_source_text === true;
-  if (deliverableLocales.length === 0 && !preserveSourceText) {
+  // Fail closed when the planner named deliverable languages but none survived
+  // validation — "translate freely into nothing" is not a usable policy. An
+  // explicitly empty list is a coherent answer (no fixed target; the deliverable
+  // follows the framing language or an explicit instruction in the request), so
+  // it is kept rather than replaced with the source-preserving fallback.
+  if (value.deliverable_locales.length > 0 && deliverableLocales.length === 0) {
     return fallbackResponseLanguagePolicy(fallbackLocale);
   }
   return {
-    framing_locale: framingLocale,
+    framing_locale: requestedFramingLocale,
     deliverable_locales: deliverableLocales,
     preserve_source_text: preserveSourceText,
     ...(framingLocaleIsFallback ? { _framing_locale_is_fallback: true } : {}),
@@ -424,11 +428,66 @@ function responseLanguageLabel(locale) {
     : normalized;
 }
 
-export function formatResponseLanguagePolicyInstruction(value, fallbackLocale = 'en') {
+/**
+ * Short single-line rendering of an ordinary policy. Used on normal turns so
+ * the common case ("answer in the user's language") costs ~30 tokens instead of
+ * the ~150-token full block, which matters most on the compact prompt tier
+ * where the base prompt is only ~1.5k tokens. Returns '' when the policy needs
+ * the precise long wording — an approved-plan override always does.
+ */
+function formatBriefResponseLanguagePolicy(policy, opts) {
+  if (opts.approvedPlanLanguageOverride) return '';
+  const framing = responseLanguageLabel(policy.framing_locale);
+  const deliverables = policy.deliverable_locales.map(responseLanguageLabel);
+  const framingRule = opts.trustedContinuationFallback
+    ? `The synthetic Continue control is not a user request — match the language of the most recent genuine user request; if unclear, use ${framing}.`
+    : policy._framing_locale_is_fallback === true
+      ? `Match the language of the latest genuine user request; if unclear, use ${framing}.`
+      : `Respond in ${framing}.`;
+  const nonFramingDeliverables = deliverables.length === 1
+    && policy.deliverable_locales[0] === policy.framing_locale
+    ? []
+    : deliverables;
+  const deliverableRule = nonFramingDeliverables.length
+    ? ` Write the authored deliverable itself in ${nonFramingDeliverables.join(nonFramingDeliverables.length === 2 ? ' and ' : ', ')}, which overrides the framing language.`
+    : '';
+  const sourceRule = policy.preserve_source_text
+    ? ' Keep quoted or extracted text in its source language'
+    : ' Translate source text only when the request requires it';
+  return `[Response language] ${framingRule}${deliverableRule}${sourceRule}; never translate code, identifiers, URLs, product names, or personal names.`;
+}
+
+/**
+ * @param {object} options
+ * @param {'full'|'auto'|'brief'} [options.form] 'full' (default) always emits the
+ *   complete block — used on forced terminal delivery, where the model gets one
+ *   shot and no planner context. 'auto' shortens ordinary policies and keeps the
+ *   full wording for translation, multilingual, and override cases. 'brief'
+ *   shortens everything it safely can.
+ */
+export function formatResponseLanguagePolicyInstruction(value, fallbackLocale = 'en', options = {}) {
   const approvedPlanLanguageOverride = value?.approved_plan_language_override === true;
   const policy = normalizeResponseLanguagePolicy(value, fallbackLocale);
   const trustedContinuationFallback = value?._trusted_continuation_fallback === true
     && policy._framing_locale_is_fallback === true;
+  const form = options.form || 'full';
+  if (form !== 'full') {
+    // A continuation started by the synthetic Continue control keeps the long
+    // wording: that turn is exactly where a stray language can be picked up,
+    // and it only happens after the step limit, so the tokens are rare.
+    const ordinary = policy.preserve_source_text
+      && !trustedContinuationFallback
+      && policy.deliverable_locales.length <= 1
+      && (policy.deliverable_locales.length === 0
+        || policy.deliverable_locales[0] === policy.framing_locale);
+    if (form === 'brief' || ordinary) {
+      const brief = formatBriefResponseLanguagePolicy(policy, {
+        approvedPlanLanguageOverride,
+        trustedContinuationFallback,
+      });
+      if (brief) return brief;
+    }
+  }
   const framing = responseLanguageLabel(policy.framing_locale);
   const deliverables = policy.deliverable_locales.map(responseLanguageLabel);
   const deliverableRule = approvedPlanLanguageOverride

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -11173,25 +11173,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       || normalizeResponseLanguagePolicy(null, fallbackLocale);
   }
 
-  _withResponseLanguageToolGuidance(tabId, tools, fallbackLocale = 'en') {
-    if (!Array.isArray(tools) || tools.length === 0) return tools;
-    const guidance = formatResponseLanguagePolicyInstruction(
-      this._responseLanguagePolicy(tabId, fallbackLocale),
-      fallbackLocale,
-    ).replace(/\s+/g, ' ').trim();
-    return tools.map((tool) => {
-      const name = tool?.function?.name;
-      if (name !== 'done' && name !== 'done_json') return tool;
-      return {
-        ...tool,
-        function: {
-          ...tool.function,
-          description: `${tool.function.description} ${guidance}`,
-        },
-      };
-    });
-  }
-
   _devModeBlockedMessage(provider = null) {
     const providerName = provider?.name || provider?.config?.model || 'the active provider';
     return `Dev mode requires a Mid or Full prompt tier. ${providerName} is currently configured as Compact, so Dev mode is blocked for this provider. Switch to a Mid/Full-tier provider or change this provider's prompt tier, then try Dev again.`;
@@ -11232,9 +11213,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (this.captchaSolverEnabled) {
       prompt += `\n\n[CAPTCHA SOLVER — the user has configured CapSolver. When a CAPTCHA or verification dialog blocks a step, read the page/tree without dismissing it. The runtime will route a supported widget to \`solve_captcha\` once and block page-changing actions until a fresh root accessibility-tree read confirms the dialog cleared. If no supported widget is detected, the solve fails, or the dialog remains after solving, stop and ask the user to complete it manually; never dismiss and resubmit or retry solve_captcha.]`;
     }
+    // Ordinary turns get the one-line rendering; the full block is reserved for
+    // policies that need the precise wording (translation targets, multilingual
+    // deliverables, approved-plan overrides) and for the forced terminal
+    // delivery prompts. Compact tier shortens everything it safely can — its
+    // base prompt is ~1.5k tokens, so the long block was ~10% of the budget.
     const responseLanguagePolicy = tabId == null ? null : this.responseLanguagePolicies.get(tabId);
     if (responseLanguagePolicy) {
-      prompt += `\n\n${formatResponseLanguagePolicyInstruction(responseLanguagePolicy)}`;
+      prompt += `\n\n${formatResponseLanguagePolicyInstruction(responseLanguagePolicy, 'en', {
+        form: tier === 'compact' ? 'brief' : 'auto',
+      })}`;
     }
     // Keep this last so the opt-in strict setting overrides loaded skills,
     // including read-only workflows that discover a secret before set_field
@@ -19074,7 +19062,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       outputSchema: cloudRunContext?.outputSchema ?? null,
       watchBeep: this.scheduledRunPolicies.get(tabId)?.watch?.beep === true,
     });
-    tools = this._withResponseLanguageToolGuidance(tabId, tools, runOptions?.locale || 'en');
     // The selected text is already present in the trusted run envelope.
     // Advertising page/network tools would let an injected selection induce a
     // second source and defeat the selection-only boundary.
@@ -19242,7 +19229,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         outputSchema: cloudRunContext?.outputSchema ?? null,
         watchBeep: this.scheduledRunPolicies.get(tabId)?.watch?.beep === true,
       });
-      tools = this._withResponseLanguageToolGuidance(tabId, tools, runOptions?.locale || 'en');
       if (selectionOnly) tools = [];
       allowedToolNames = new Set(tools.map(t => t.function.name));
       toolSchemas = new Map(tools.map(t => [t.function.name, t.function.parameters]));
@@ -19893,7 +19879,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       outputSchema: cloudRunContext?.outputSchema ?? null,
       watchBeep: this.scheduledRunPolicies.get(tabId)?.watch?.beep === true,
     });
-    tools = this._withResponseLanguageToolGuidance(tabId, tools, runOptions?.locale || 'en');
     // Match the non-streaming path: selection-grounded turns are tool-free so
     // page or network content cannot be introduced after the source anchor.
     if (selectionOnly) tools = [];
@@ -19939,7 +19924,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         outputSchema: cloudRunContext?.outputSchema ?? null,
         watchBeep: this.scheduledRunPolicies.get(tabId)?.watch?.beep === true,
       });
-      tools = this._withResponseLanguageToolGuidance(tabId, tools, runOptions?.locale || 'en');
       if (selectionOnly) tools = [];
       allowedToolNames = new Set(tools.map(t => t.function.name));
       toolSchemas = new Map(tools.map(t => [t.function.name, t.function.parameters]));

--- a/src/firefox/src/agent/planner.js
+++ b/src/firefox/src/agent/planner.js
@@ -430,7 +430,7 @@ function responseLanguageLabel(locale) {
 
 /**
  * Short single-line rendering of an ordinary policy. Used on normal turns so
- * the common case ("answer in the user's language") costs ~30 tokens instead of
+ * the common case ("answer in the user's language") costs ~45 tokens instead of
  * the ~150-token full block, which matters most on the compact prompt tier
  * where the base prompt is only ~1.5k tokens. Returns '' when the policy needs
  * the precise long wording — an approved-plan override always does.
@@ -454,7 +454,10 @@ function formatBriefResponseLanguagePolicy(policy, opts) {
   const sourceRule = policy.preserve_source_text
     ? ' Keep quoted or extracted text in its source language'
     : ' Translate source text only when the request requires it';
-  return `[Response language] ${framingRule}${deliverableRule}${sourceRule}; never translate code, identifiers, URLs, product names, or personal names.`;
+  // The exception matters as much as the rule: without it a compact-tier model
+  // reads an unconditional "never" and leaves an explicitly requested product
+  // name or transliteration untouched.
+  return `[Response language] ${framingRule}${deliverableRule}${sourceRule}; leave code, identifiers, URLs, product names, and personal names unchanged unless the user explicitly asks to translate or transliterate them.`;
 }
 
 /**

--- a/src/firefox/src/agent/planner.js
+++ b/src/firefox/src/agent/planner.js
@@ -390,7 +390,6 @@ export function normalizeResponseLanguagePolicy(value, fallbackLocale = 'en') {
   ) {
     return fallbackResponseLanguagePolicy(fallbackLocale);
   }
-  const framingLocale = requestedFramingLocale || normalizePlannerLocale(fallbackLocale);
   const framingLocaleIsFallback = value._framing_locale_is_fallback === true;
   const deliverableLocales = [];
   const seen = new Set();
@@ -402,11 +401,16 @@ export function normalizeResponseLanguagePolicy(value, fallbackLocale = 'en') {
     deliverableLocales.push(locale);
   }
   const preserveSourceText = value.preserve_source_text === true;
-  if (deliverableLocales.length === 0 && !preserveSourceText) {
+  // Fail closed when the planner named deliverable languages but none survived
+  // validation — "translate freely into nothing" is not a usable policy. An
+  // explicitly empty list is a coherent answer (no fixed target; the deliverable
+  // follows the framing language or an explicit instruction in the request), so
+  // it is kept rather than replaced with the source-preserving fallback.
+  if (value.deliverable_locales.length > 0 && deliverableLocales.length === 0) {
     return fallbackResponseLanguagePolicy(fallbackLocale);
   }
   return {
-    framing_locale: framingLocale,
+    framing_locale: requestedFramingLocale,
     deliverable_locales: deliverableLocales,
     preserve_source_text: preserveSourceText,
     ...(framingLocaleIsFallback ? { _framing_locale_is_fallback: true } : {}),
@@ -424,11 +428,66 @@ function responseLanguageLabel(locale) {
     : normalized;
 }
 
-export function formatResponseLanguagePolicyInstruction(value, fallbackLocale = 'en') {
+/**
+ * Short single-line rendering of an ordinary policy. Used on normal turns so
+ * the common case ("answer in the user's language") costs ~30 tokens instead of
+ * the ~150-token full block, which matters most on the compact prompt tier
+ * where the base prompt is only ~1.5k tokens. Returns '' when the policy needs
+ * the precise long wording — an approved-plan override always does.
+ */
+function formatBriefResponseLanguagePolicy(policy, opts) {
+  if (opts.approvedPlanLanguageOverride) return '';
+  const framing = responseLanguageLabel(policy.framing_locale);
+  const deliverables = policy.deliverable_locales.map(responseLanguageLabel);
+  const framingRule = opts.trustedContinuationFallback
+    ? `The synthetic Continue control is not a user request — match the language of the most recent genuine user request; if unclear, use ${framing}.`
+    : policy._framing_locale_is_fallback === true
+      ? `Match the language of the latest genuine user request; if unclear, use ${framing}.`
+      : `Respond in ${framing}.`;
+  const nonFramingDeliverables = deliverables.length === 1
+    && policy.deliverable_locales[0] === policy.framing_locale
+    ? []
+    : deliverables;
+  const deliverableRule = nonFramingDeliverables.length
+    ? ` Write the authored deliverable itself in ${nonFramingDeliverables.join(nonFramingDeliverables.length === 2 ? ' and ' : ', ')}, which overrides the framing language.`
+    : '';
+  const sourceRule = policy.preserve_source_text
+    ? ' Keep quoted or extracted text in its source language'
+    : ' Translate source text only when the request requires it';
+  return `[Response language] ${framingRule}${deliverableRule}${sourceRule}; never translate code, identifiers, URLs, product names, or personal names.`;
+}
+
+/**
+ * @param {object} options
+ * @param {'full'|'auto'|'brief'} [options.form] 'full' (default) always emits the
+ *   complete block — used on forced terminal delivery, where the model gets one
+ *   shot and no planner context. 'auto' shortens ordinary policies and keeps the
+ *   full wording for translation, multilingual, and override cases. 'brief'
+ *   shortens everything it safely can.
+ */
+export function formatResponseLanguagePolicyInstruction(value, fallbackLocale = 'en', options = {}) {
   const approvedPlanLanguageOverride = value?.approved_plan_language_override === true;
   const policy = normalizeResponseLanguagePolicy(value, fallbackLocale);
   const trustedContinuationFallback = value?._trusted_continuation_fallback === true
     && policy._framing_locale_is_fallback === true;
+  const form = options.form || 'full';
+  if (form !== 'full') {
+    // A continuation started by the synthetic Continue control keeps the long
+    // wording: that turn is exactly where a stray language can be picked up,
+    // and it only happens after the step limit, so the tokens are rare.
+    const ordinary = policy.preserve_source_text
+      && !trustedContinuationFallback
+      && policy.deliverable_locales.length <= 1
+      && (policy.deliverable_locales.length === 0
+        || policy.deliverable_locales[0] === policy.framing_locale);
+    if (form === 'brief' || ordinary) {
+      const brief = formatBriefResponseLanguagePolicy(policy, {
+        approvedPlanLanguageOverride,
+        trustedContinuationFallback,
+      });
+      if (brief) return brief;
+    }
+  }
   const framing = responseLanguageLabel(policy.framing_locale);
   const deliverables = policy.deliverable_locales.map(responseLanguageLabel);
   const deliverableRule = approvedPlanLanguageOverride

--- a/test/run.js
+++ b/test/run.js
@@ -8534,7 +8534,8 @@ test('ordinary response-language policies use the short rendering and never ride
     full._setResponseLanguagePolicy(tabId, ordinary, 'tr');
     const ordinaryPrompt = full.conversations.get(tabId)?.[0]?.content || '';
     assert.match(ordinaryPrompt, /\[Response language\] Respond in Turkish \(tr\)\./, `${label}: ordinary policy did not use the short rendering`);
-    assert.match(ordinaryPrompt, /never translate code, identifiers, URLs/i, `${label}: short rendering dropped the stable-token exception`);
+    assert.match(ordinaryPrompt, /leave code, identifiers, URLs, product names, and personal names unchanged/i, `${label}: short rendering dropped the stable-token rule`);
+    assert.match(ordinaryPrompt, /unless the user explicitly asks to translate or transliterate them/i, `${label}: short rendering turned the stable-token rule into an unconditional ban`);
     assert.doesNotMatch(ordinaryPrompt, /RESPONSE LANGUAGE POLICY/, `${label}: ordinary policy still paid for the long block`);
 
     // The done schema no longer repeats what the system prompt already carries.

--- a/test/run.js
+++ b/test/run.js
@@ -8494,11 +8494,8 @@ test('delivery recovery exposes only done and persists a partial terminal result
   }
 });
 
-test('active response-language policy reaches normal system and done-tool prompts without breaking translation jobs', () => {
-  for (const [label, AgentClass, getTools] of [
-    ['chrome', AgentCh, getToolsForModeCh],
-    ['firefox', AgentFx, getToolsForModeFx],
-  ]) {
+test('active response-language policy reaches the normal system prompt without breaking translation jobs', () => {
+  for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
     const tabId = 916;
     const agent = new AgentClass({ getActive: () => ({ promptTier: 'full' }) });
     agent.conversationModes.set(tabId, 'act');
@@ -8513,17 +8510,45 @@ test('active response-language policy reaches normal system and done-tool prompt
     assert.match(systemPrompt, /Use English \(en\) for explanatory framing/i, `${label}: normal system prompt lost framing language`);
     assert.match(systemPrompt, /authored deliverables in Spanish \(es\)/i, `${label}: normal system prompt overrode the translation target`);
 
-    const guidedTools = agent._withResponseLanguageToolGuidance(tabId, getTools('act', { tier: 'full' }), 'en');
-    const done = guidedTools.find(tool => tool?.function?.name === 'done');
-    assert.match(done?.function?.description || '', /authored deliverables in Spanish \(es\)/i, `${label}: normal done tool lost the translation target`);
-
     agent._setResponseLanguagePolicy(tabId, null, 'tr');
     const fallbackPrompt = agent.conversations.get(tabId)?.[0]?.content || '';
-    assert.match(fallbackPrompt, /Infer explanatory framing from the language of the latest genuine user request/i, `${label}: planner bypass stopped deriving framing from the user request`);
-    assert.match(fallbackPrompt, /Only when the request language is unclear, use Turkish \(tr\) as the fallback/i, `${label}: UI locale was not retained as a soft fallback`);
-    assert.doesNotMatch(fallbackPrompt, /Use Turkish \(tr\) for explanatory framing/i, `${label}: Ask-mode fallback became a hard UI-locale requirement`);
-    assert.match(fallbackPrompt, /No fixed authored-deliverable language was inferred/i, `${label}: planner fallback became a blanket Turkish deliverable constraint`);
-    assert.match(fallbackPrompt, /explicit language or translation instruction/i, `${label}: planner fallback lost the translation exception`);
+    assert.match(fallbackPrompt, /Match the language of the latest genuine user request/i, `${label}: planner bypass stopped deriving framing from the user request`);
+    assert.match(fallbackPrompt, /if unclear, use Turkish \(tr\)/i, `${label}: UI locale was not retained as a soft fallback`);
+    assert.doesNotMatch(fallbackPrompt, /Respond in Turkish \(tr\)/i, `${label}: Ask-mode fallback became a hard UI-locale requirement`);
+    assert.doesNotMatch(fallbackPrompt, /authored deliverable itself in/i, `${label}: planner fallback became a blanket Turkish deliverable constraint`);
+  }
+});
+
+test('ordinary response-language policies use the short rendering and never ride on normal-turn tool schemas', () => {
+  for (const [label, AgentClass, getTools] of [
+    ['chrome', AgentCh, getToolsForModeCh],
+    ['firefox', AgentFx, getToolsForModeFx],
+  ]) {
+    const tabId = 917;
+    const ordinary = { framing_locale: 'tr', deliverable_locales: ['tr'], preserve_source_text: true };
+    const translation = { framing_locale: 'en', deliverable_locales: ['es'], preserve_source_text: false };
+
+    const full = new AgentClass({ getActive: () => ({ promptTier: 'full' }) });
+    full.conversationModes.set(tabId, 'act');
+    full.conversations.set(tabId, [{ role: 'system', content: 'stale prompt' }]);
+    full._setResponseLanguagePolicy(tabId, ordinary, 'tr');
+    const ordinaryPrompt = full.conversations.get(tabId)?.[0]?.content || '';
+    assert.match(ordinaryPrompt, /\[Response language\] Respond in Turkish \(tr\)\./, `${label}: ordinary policy did not use the short rendering`);
+    assert.match(ordinaryPrompt, /never translate code, identifiers, URLs/i, `${label}: short rendering dropped the stable-token exception`);
+    assert.doesNotMatch(ordinaryPrompt, /RESPONSE LANGUAGE POLICY/, `${label}: ordinary policy still paid for the long block`);
+
+    // The done schema no longer repeats what the system prompt already carries.
+    const doneTool = getTools('act', { tier: 'full' }).find(tool => tool?.function?.name === 'done');
+    assert.doesNotMatch(doneTool?.function?.description || '', /Response language/i, `${label}: normal-turn done schema regained duplicate language guidance`);
+
+    const compact = new AgentClass({ getActive: () => ({ promptTier: 'compact' }) });
+    compact.conversationModes.set(tabId, 'act');
+    compact.conversations.set(tabId, [{ role: 'system', content: 'stale prompt' }]);
+    compact._setResponseLanguagePolicy(tabId, translation, 'en');
+    const compactPrompt = compact.conversations.get(tabId)?.[0]?.content || '';
+    assert.doesNotMatch(compactPrompt, /RESPONSE LANGUAGE POLICY/, `${label}: compact tier still carried the long block`);
+    assert.match(compactPrompt, /Respond in English \(en\)\./, `${label}: compact tier lost the framing language`);
+    assert.match(compactPrompt, /deliverable itself in Spanish \(es\)/i, `${label}: compact tier lost the translation target`);
   }
 });
 
@@ -56287,14 +56312,19 @@ test('trusted continuation carries consequential evidence without repeating the 
       `${AgentClass.name}: fallback continuation did not anchor framing to the original request`,
     );
     assert.match(
-      requests[1].doneDescription,
+      requests[1].systemPrompt,
       /must not influence response or deliverable language/,
-      `${AgentClass.name}: continuation tools treated the synthetic turn as a language instruction`,
+      `${AgentClass.name}: continuation prompt treated the synthetic turn as a language instruction`,
     );
     assert.match(
-      requests[1].doneDescription,
+      requests[1].systemPrompt,
       /No fixed authored-deliverable language was inferred/,
       `${AgentClass.name}: fallback continuation invented a fixed deliverable language`,
+    );
+    assert.doesNotMatch(
+      requests[1].doneDescription,
+      /authored-deliverable language|explanatory framing/,
+      `${AgentClass.name}: normal-turn done schema duplicated the system prompt's language policy`,
     );
     assert.doesNotMatch(
       requests[1].systemPrompt,
@@ -56604,9 +56634,14 @@ test('streamed runs preserve consequential evidence for a trusted continuation',
       `${AgentClass.name}: streamed continuation system prompt lost the prior framing language`,
     );
     assert.match(
-      requests[1].doneDescription,
+      requests[1].systemPrompt,
       /Write authored deliverables in Spanish \(es\)/,
-      `${AgentClass.name}: streamed continuation tools lost the prior deliverable language`,
+      `${AgentClass.name}: streamed continuation lost the prior deliverable language`,
+    );
+    assert.doesNotMatch(
+      requests[1].doneDescription,
+      /Spanish \(es\)/,
+      `${AgentClass.name}: normal-turn done schema duplicated the system prompt's language policy`,
     );
   }
 });
@@ -63942,6 +63977,18 @@ test('response-language policy keeps framing, translation targets, and source pr
     assert.match(translationInstruction, /authored deliverables in Spanish \(es\)/i, `${label}: translation target missing`);
     assert.match(translationInstruction, /takes precedence over the framing language/i, `${label}: translation precedence missing`);
     assert.match(translationInstruction, /Do not translate code, identifiers, URLs/i, `${label}: stable-token exception missing`);
+
+    // An explicitly empty deliverable list is a coherent planner answer, unlike
+    // a list whose entries were all invalid. Only the latter fails closed.
+    assert.deepEqual(
+      normalize({
+        framing_locale: 'en',
+        deliverable_locales: [],
+        preserve_source_text: false,
+      }, 'tr'),
+      { framing_locale: 'en', deliverable_locales: [], preserve_source_text: false },
+      `${label}: an explicit "no fixed deliverable language" answer was discarded as malformed`,
+    );
 
     const preserved = normalize({
       framing_locale: 'en',


### PR DESCRIPTION
Follow-up to #257. The language fix itself was right; what it cost per turn was not.

## What was happening

The derived policy went into the system prompt on every turn and was stapled onto the `done` tool description again in the same request, with no prompt-tier gate anywhere. Measured against the base prompts:

| Where | Added | Base | Growth |
|---|---|---|---|
| System prompt, full tier | ~150 tok | 11,179 | 1.5% |
| System prompt, compact tier | ~150 tok | 1,551 | ~10% |
| `done` description | ~150 tok | | duplicate of the above |

Compact tier exists to strip prompt weight for small local models, and every other optional section respects it (`webMcpEnabled && (!this._isActionMode(mode) || tier !== 'compact')`). This one did not. Those are also the models most likely to over-attend to an all-caps `[RESPONSE LANGUAGE POLICY]` header and start narrating language choices instead of answering.

In the common case, an English user asking in English, the 150 tokens were spent twice to say "answer in English."

## What changed

`formatResponseLanguagePolicyInstruction` takes a `form` option:

- `full` (default) always emits the complete block. Forced terminal delivery and the protected-page recovery prompt keep it, since that turn has one shot and no planner context. That is the path #257 was actually fixing.
- `auto` shortens an ordinary policy, meaning the deliverable language matches the framing language and source text stays put, to one line of about 40 tokens. Translation targets, multilingual deliverables, approved-plan overrides, and continuations resumed by the synthetic Continue control keep the full wording.
- `brief` shortens everything it can without dropping the deliverable language.

Normal turns use `auto`, compact tier uses `brief`:

```
[Response language] Respond in Turkish (tr). Keep quoted or extracted text in its
source language; never translate code, identifiers, URLs, product names, or
personal names.
```

A compact-tier translation job still names its target:

```
[Response language] Respond in English (en). Write the authored deliverable itself
in Spanish (es), which overrides the framing language. Translate source text only
when the request requires it; never translate code, identifiers, URLs, product
names, or personal names.
```

`_withResponseLanguageToolGuidance` is gone along with its four call sites per build. `_deliveryRecoveryDoneTool` still appends the policy to the forced `done` description, so the recovery path keeps both copies on purpose.

Per-case cost, in tokens:

| Case | Before | Full tier now | Compact tier now |
|---|---|---|---|
| Ordinary answer | 150 | 43 | 43 |
| Planner bypass / Ask fallback | 192 | 58 | 58 |
| Translation job | 143 | 143 | 67 |

Halve those again for the `done` duplication that normal turns no longer pay.

## Normalizer

```js
if (deliverableLocales.length === 0 && !preserveSourceText) return fallback(...)
```

This ran after invalid entries were filtered out, so it could not tell "the planner named languages and none were valid" from "the planner said there is no fixed target." The first should fail closed and still does. The second is a coherent answer and is now kept. The check moved to the raw array, and a dead `requestedFramingLocale || ...` branch went with it.

## Not included

I tried condensing `PLANNER_RESPONSE_LANGUAGE_RULES`, which is about 305 tokens in both planner prompts and 12% of the compact intent planner. The existing tests pin nearly that whole prose block verbatim, so rewriting it means rewriting the spec rather than trimming fat. Reverted; worth doing deliberately if you want it.

## Validation

`npm test`: 1,692 passed, 0 failed, including 60/60 prompt-injection checks. Two continuation assertions moved from `doneDescription` to `systemPrompt` and now also assert the `done` schema stays clean, and one test split into two covering the short rendering and the compact tier. Chrome and Firefox parity verified by diffing the changed regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
