### PR TITLE
Reduce Ling WebGPU buffer pressure

### DIFF
--- a/src/chrome/src/offscreen/inference-worker.js
+++ b/src/chrome/src/offscreen/inference-worker.js
@@ -22,6 +22,13 @@ let modelOperationQueue = Promise.resolve();
 const TRANSFORMERS_CACHE_NAME = 'transformers-cache';
 const TEXT_DOWNLOAD_EVENT = 'text-download-state';
 const WEBGPU_TEXT_MAX_NEW_TOKENS = 256;
+const WEBGPU_TEXT_SESSION_OPTIONS = Object.freeze({
+  extra: Object.freeze({
+    // ORT's default bucket cache can retain rounded-up transient buffers. That
+    // is especially costly for Ling's dynamic prefill/decode shapes on Metal.
+    'ep.webgpuexecutionprovider.storageBufferCacheMode': 'simple',
+  }),
+});
 const readyTextModelKeys = new Set();
 const textDownloadFiles = new Map();
 const nativeFetch = typeof globalThis.fetch === 'function' ? globalThis.fetch.bind(globalThis) : null;
@@ -365,6 +372,7 @@ async function getTextRuntime(modelId, dtype, device, { localFilesOnly = false }
       pipeline = await library.pipeline('text-generation', modelId, {
         device,
         dtype,
+        session_options: WEBGPU_TEXT_SESSION_OPTIONS,
         local_files_only: localFilesOnly,
         progress_callback: event => postProgress(modelId, event),
       });

--- a/test/run.js
+++ b/test/run.js
@@ -40931,6 +40931,8 @@ test('WebGPU worker follows the Ling text-generation and LiquidAI vision contrac
   assert.match(worker, /pipeline\('text-generation', modelId/);
   assert.match(worker, /dtype = payload\?\.dtype \|\| 'q4f16'/);
   assert.match(worker, /const WEBGPU_TEXT_MAX_NEW_TOKENS = 256/);
+  assert.match(worker, /'ep\.webgpuexecutionprovider\.storageBufferCacheMode': 'simple'/);
+  assert.match(worker, /session_options: WEBGPU_TEXT_SESSION_OPTIONS/);
   assert.match(worker, /addEventListener\?\.\('uncapturederror'/);
   assert.match(worker, /GPU detail:/);
   assert.match(worker, /tokenizer_encode_kwargs: \{ enable_thinking: false \}/);
@@ -40985,6 +40987,7 @@ test('WebGPU worker replays Ling tool history without coupling text and vision l
   const previousHoldTextDownload = globalThis.__holdWebgpuTextDownload;
   const previousReleaseTextDownload = globalThis.__releaseWebgpuTextDownload;
   const previousGenerationOptions = globalThis.__webgpuGenerationOptions;
+  const previousPipelineOptions = globalThis.__webgpuPipelineOptions;
   let workerListener = null;
   const posted = [];
   try {
@@ -41050,8 +41053,9 @@ test('WebGPU worker replays Ling tool history without coupling text and vision l
           };
         },
       };
-      export async function pipeline() {
+      export async function pipeline(task, modelId, options) {
         globalThis.__webgpuRuntimeCounts.textLoads++;
+        globalThis.__webgpuPipelineOptions = { task, modelId, options };
         if (globalThis.__holdWebgpuTextDownload) {
           await new Promise(resolve => { globalThis.__releaseWebgpuTextDownload = resolve; });
         }
@@ -41107,6 +41111,11 @@ test('WebGPU worker replays Ling tool history without coupling text and vision l
     assert.match(beforeDownload.error, /not downloaded/);
     await dispatch('download-text', textPayload);
     await dispatch('text-chat', textPayload);
+    assert.equal(
+      globalThis.__webgpuPipelineOptions.options.session_options.extra['ep.webgpuexecutionprovider.storageBufferCacheMode'],
+      'simple',
+      'Ling must avoid ORT WebGPU bucket-cache amplification',
+    );
     assert.equal(globalThis.__webgpuGenerationOptions.max_new_tokens, 256, 'Ling generation must keep a browser-safe output budget');
     await dispatch('chat', visionPayload);
     await dispatch('text-chat', textPayload);
@@ -41164,6 +41173,8 @@ test('WebGPU worker replays Ling tool history without coupling text and vision l
     else globalThis.__releaseWebgpuTextDownload = previousReleaseTextDownload;
     if (previousGenerationOptions === undefined) delete globalThis.__webgpuGenerationOptions;
     else globalThis.__webgpuGenerationOptions = previousGenerationOptions;
+    if (previousPipelineOptions === undefined) delete globalThis.__webgpuPipelineOptions;
+    else globalThis.__webgpuPipelineOptions = previousPipelineOptions;
   }
 });
 


### PR DESCRIPTION
Configure Ling's ONNX Runtime WebGPU session to use exact-size storage-buffer caching instead of the default bucket cache, reducing transient allocation amplification on Apple Metal. Adds regression coverage for the session option. Tests: npm test (33 toolbar, 1694 core, 60 security).