### PR TITLE
Keep Ling WebGPU session options mutable

### DIFF
--- a/src/chrome/src/offscreen/inference-worker.js
+++ b/src/chrome/src/offscreen/inference-worker.js
@@ -22,13 +22,15 @@ let modelOperationQueue = Promise.resolve();
 const TRANSFORMERS_CACHE_NAME = 'transformers-cache';
 const TEXT_DOWNLOAD_EVENT = 'text-download-state';
 const WEBGPU_TEXT_MAX_NEW_TOKENS = 256;
-const WEBGPU_TEXT_SESSION_OPTIONS = Object.freeze({
-  extra: Object.freeze({
-    // ORT's default bucket cache can retain rounded-up transient buffers. That
-    // is especially costly for Ling's dynamic prefill/decode shapes on Metal.
-    'ep.webgpuexecutionprovider.storageBufferCacheMode': 'simple',
-  }),
-});
+function createWebGpuTextSessionOptions() {
+  return {
+    extra: {
+      // ORT's default bucket cache can retain rounded-up transient buffers. That
+      // is especially costly for Ling's dynamic prefill/decode shapes on Metal.
+      'ep.webgpuexecutionprovider.storageBufferCacheMode': 'simple',
+    },
+  };
+}
 const readyTextModelKeys = new Set();
 const textDownloadFiles = new Map();
 const nativeFetch = typeof globalThis.fetch === 'function' ? globalThis.fetch.bind(globalThis) : null;
@@ -372,7 +374,8 @@ async function getTextRuntime(modelId, dtype, device, { localFilesOnly = false }
       pipeline = await library.pipeline('text-generation', modelId, {
         device,
         dtype,
-        session_options: WEBGPU_TEXT_SESSION_OPTIONS,
+        // ORT mutates this object while appending its default session config.
+        session_options: createWebGpuTextSessionOptions(),
         local_files_only: localFilesOnly,
         progress_callback: event => postProgress(modelId, event),
       });

--- a/test/run.js
+++ b/test/run.js
@@ -40932,7 +40932,7 @@ test('WebGPU worker follows the Ling text-generation and LiquidAI vision contrac
   assert.match(worker, /dtype = payload\?\.dtype \|\| 'q4f16'/);
   assert.match(worker, /const WEBGPU_TEXT_MAX_NEW_TOKENS = 256/);
   assert.match(worker, /'ep\.webgpuexecutionprovider\.storageBufferCacheMode': 'simple'/);
-  assert.match(worker, /session_options: WEBGPU_TEXT_SESSION_OPTIONS/);
+  assert.match(worker, /session_options: createWebGpuTextSessionOptions\(\)/);
   assert.match(worker, /addEventListener\?\.\('uncapturederror'/);
   assert.match(worker, /GPU detail:/);
   assert.match(worker, /tokenizer_encode_kwargs: \{ enable_thinking: false \}/);
@@ -41055,6 +41055,8 @@ test('WebGPU worker replays Ling tool history without coupling text and vision l
       };
       export async function pipeline(task, modelId, options) {
         globalThis.__webgpuRuntimeCounts.textLoads++;
+        options.session_options.extra.session ??= {};
+        options.session_options.extra.session.use_ort_model_bytes_directly ??= '1';
         globalThis.__webgpuPipelineOptions = { task, modelId, options };
         if (globalThis.__holdWebgpuTextDownload) {
           await new Promise(resolve => { globalThis.__releaseWebgpuTextDownload = resolve; });


### PR DESCRIPTION
Fix the Ling startup failure introduced by #262. ONNX Runtime appends extra.session defaults during WebGPU session construction, so the Ling session options must remain mutable. The exact-size storage-buffer cache setting is preserved, and the worker regression test now reproduces ONNX Runtime's mutation. Tests: npm test (33 toolbar, 1694 core, 60 security).