### PR TITLE
Add LFM2.5 WebGPU reasoning preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Bedrock, Mistral, DeepSeek, xAI Grok, MiniMax, Kimi, Qwen, z.ai GLM, Groq,
 Together, Cloudflare, Nvidia NIM, Hugging Face, Fireworks, OpenRouter, and more.
 Settings ships **106 built-in provider cards on Chromium** (105 on Firefox),
 including an endpoint-free local WebGPU option with Ling 3.0 Tiny, Qwen3 0.6B,
-Gemma 4 E2B QAT Mobile, Ternary Bonsai 1.7B, and custom Hugging Face ONNX repositories —
+Gemma 4 E2B QAT Mobile, Ternary Bonsai 1.7B, LFM2.5 2.6B, and custom Hugging Face ONNX repositories —
 see the [full catalog](docs/providers-and-models.md#extended-provider-catalog).
 
 ## Features

--- a/docs/fr/providers-and-models.md
+++ b/docs/fr/providers-and-models.md
@@ -46,7 +46,7 @@ class BaseLLMProvider {
 | `localai` | `openai` | local | (modèle chargé) | Métadonnées auto / surcharge |
 | `gpt4all` | `openai` | local | (modèle chargé) | Oui (activé par défaut) |
 | `local_openai_proxy` | `openai` | local | (requis) | Désactivée / bascule manuelle |
-| `webgpu` (Chromium) | `webgpu` | local | Ling 3.0 Tiny (défaut), Qwen3 0.6B, Gemma 4 E2B QAT Mobile, Ternary Bonsai 1.7B ou dépôt HF personnalisé | Non |
+| `webgpu` (Chromium) | `webgpu` | local | Ling 3.0 Tiny (défaut), Qwen3 0.6B, Gemma 4 E2B QAT Mobile, Ternary Bonsai 1.7B, LFM2.5 2.6B ou dépôt HF personnalisé | Non |
 | `azure_openai` | `azure_openai` | cloud | (déploiement) | Bascule manuelle |
 | `aws_bedrock` | `aws_bedrock` | cloud | (ID de modèle) | Non |
 | `openai` | `openai` | cloud | `gpt-5.6-terra` | Regex nom de modèle |

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -46,7 +46,7 @@ class BaseLLMProvider {
 | `localai` | `openai` | local | (loaded model) | Auto metadata / override |
 | `gpt4all` | `openai` | local | (loaded model) | Yes (default on) |
 | `local_openai_proxy` | `openai` | local | (required) | Off / manual toggle |
-| `webgpu` (Chromium) | `webgpu` | local | Ling 3.0 Tiny (default), Qwen3 0.6B, Gemma 4 E2B QAT Mobile, Ternary Bonsai 1.7B, or custom HF repo | No |
+| `webgpu` (Chromium) | `webgpu` | local | Ling 3.0 Tiny (default), Qwen3 0.6B, Gemma 4 E2B QAT Mobile, Ternary Bonsai 1.7B, LFM2.5 2.6B, or custom HF repo | No |
 | `azure_openai` | `azure_openai` | cloud | (deployment) | Manual toggle |
 | `aws_bedrock` | `aws_bedrock` | cloud | (model id) | No |
 | `openai` | `openai` | cloud | `gpt-5.6-terra` | Model-name regex |
@@ -154,6 +154,7 @@ model selector offers
 [`onnx-community/Qwen3-0.6B-ONNX`](https://huggingface.co/onnx-community/Qwen3-0.6B-ONNX/),
 [`onnx-community/gemma-4-E2B-it-qat-mobile-ONNX`](https://huggingface.co/onnx-community/gemma-4-E2B-it-qat-mobile-ONNX/),
 [`onnx-community/Ternary-Bonsai-1.7B-ONNX`](https://huggingface.co/onnx-community/Ternary-Bonsai-1.7B-ONNX/),
+[`LiquidAI/LFM2.5-2.6B-ONNX`](https://huggingface.co/LiquidAI/LFM2.5-2.6B-ONNX/),
 or a custom Hugging Face repository. Custom repositories must be compatible
 with Transformers.js text generation and provide a `q4f16` ONNX variant. The
 selected model runs through the packaged Transformers.js 4.2 runtime in a
@@ -162,8 +163,11 @@ Compact prompt tier with a conservative 16k practical context setting. Ling
 downloads approximately 4.85 GB of model data; Qwen3 0.6B downloads about
 570 MB. Gemma's text-only path downloads its `q2f16` embeddings and decoder,
 about 2.32 GB; its image and audio encoders are not loaded. Ternary Bonsai uses
-its `q2f16` graph and downloads about 480 MB. Each repository is cached
-separately in Chrome. **Test Connection**
+its `q2f16` graph and downloads about 480 MB. LFM2.5 2.6B downloads about
+1.55 GB and uses its official pure
+reasoning template; WebBrain keeps text before `</think>` out of the visible
+answer and reports an error if reasoning exhausts the output budget. Each
+repository is cached separately in Chrome. **Test Connection**
 checks only the packaged runtime and hardware WebGPU adapter, so it does not
 trigger a model download. There is no API key, base URL, localhost server, or
 OpenAI-compatible endpoint. Firefox does not expose the card because its build

--- a/docs/zh-CN/providers-and-models.md
+++ b/docs/zh-CN/providers-and-models.md
@@ -46,7 +46,7 @@ class BaseLLMProvider {
 | `localai` | `openai` | 本地 | （已加载模型） | 自动元数据 / 覆盖 |
 | `gpt4all` | `openai` | 本地 | （已加载模型） | 是（默认开启） |
 | `local_openai_proxy` | `openai` | 本地 | （必填） | 默认关闭 / 手动开关 |
-| `webgpu`（Chromium） | `webgpu` | 本地 | Ling 3.0 Tiny（默认）、Qwen3 0.6B、Gemma 4 E2B QAT Mobile、Ternary Bonsai 1.7B 或自定义 HF 仓库 | 否 |
+| `webgpu`（Chromium） | `webgpu` | 本地 | Ling 3.0 Tiny（默认）、Qwen3 0.6B、Gemma 4 E2B QAT Mobile、Ternary Bonsai 1.7B、LFM2.5 2.6B 或自定义 HF 仓库 | 否 |
 | `azure_openai` | `azure_openai` | 云端 | （部署） | 手动开关 |
 | `aws_bedrock` | `aws_bedrock` | 云端 | （模型 ID） | 否 |
 | `openai` | `openai` | 云端 | `gpt-5.6-terra` | 模型名正则 |

--- a/src/chrome/src/offscreen/inference-worker.js
+++ b/src/chrome/src/offscreen/inference-worker.js
@@ -23,6 +23,8 @@ let modelOperationQueue = Promise.resolve();
 const TRANSFORMERS_CACHE_NAME = 'transformers-cache';
 const TEXT_DOWNLOAD_EVENT = 'text-download-state';
 const WEBGPU_TEXT_MAX_NEW_TOKENS = 256;
+const WEBGPU_LFM25_MODEL_ID = 'LiquidAI/LFM2.5-2.6B-ONNX';
+const WEBGPU_LFM25_MAX_NEW_TOKENS = 512;
 function createWebGpuTextSessionOptions() {
   return {
     extra: {
@@ -749,13 +751,35 @@ export function prepareTextMessages(messages) {
   });
 }
 
-function splitThinking(content) {
+export function splitThinking(content, { openingTagInPrompt = false } = {}) {
   const source = String(content || '').trim();
   const match = /^<think>\s*([\s\S]*?)\s*<\/think>\s*([\s\S]*)$/i.exec(source);
-  if (!match) return { content: source, reasoningContent: null };
+  if (match) {
+    return {
+      content: String(match[2] || '').trim(),
+      reasoningContent: String(match[1] || '').trim() || null,
+      incompleteReasoning: false,
+    };
+  }
+  if (!openingTagInPrompt) {
+    return { content: source, reasoningContent: null, incompleteReasoning: false };
+  }
+
+  // LFM2.5's official template places `<think>` in the generation prompt.
+  // Transformers.js therefore returns only the generated suffix: reasoning,
+  // `</think>`, then the user-facing answer.
+  const closingTag = /<\/think>/i.exec(source);
+  if (!closingTag) {
+    return {
+      content: '',
+      reasoningContent: source || null,
+      incompleteReasoning: !!source,
+    };
+  }
   return {
-    content: String(match[2] || '').trim(),
-    reasoningContent: String(match[1] || '').trim() || null,
+    content: source.slice(closingTag.index + closingTag[0].length).trim(),
+    reasoningContent: source.slice(0, closingTag.index).trim() || null,
+    incompleteReasoning: false,
   };
 }
 
@@ -764,24 +788,33 @@ async function runText(payload) {
   if (!modelId) throw new Error('No text-generation model was specified.');
   const device = payload?.device || 'webgpu';
   const dtype = payload?.dtype || 'q4f16';
+  const usesLfm25ReasoningTemplate = modelId === WEBGPU_LFM25_MODEL_ID;
   if (!await isTextModelReady(modelId, dtype)) {
     throw new Error(`${modelId} is not downloaded. Open Settings > Providers > WebGPU to download it before chatting.`);
   }
   const runtime = await getTextRuntime(modelId, dtype, device, { localFilesOnly: true });
   const requestedTokens = Number(payload?.options?.maxTokens);
-  const maxNewTokens = Number.isFinite(requestedTokens)
-    ? Math.max(1, Math.min(WEBGPU_TEXT_MAX_NEW_TOKENS, Math.round(requestedTokens)))
+  const maxTokenLimit = usesLfm25ReasoningTemplate
+    ? WEBGPU_LFM25_MAX_NEW_TOKENS
     : WEBGPU_TEXT_MAX_NEW_TOKENS;
+  const maxNewTokens = Number.isFinite(requestedTokens)
+    ? Math.max(1, Math.min(maxTokenLimit, Math.round(requestedTokens)))
+    : maxTokenLimit;
   const tools = Array.isArray(payload?.options?.tools) ? payload.options.tools : [];
   lastWebGpuDeviceError = '';
   lastWebGpuDeviceLost = '';
   let output;
   try {
     output = await runtime.pipeline(prepareTextMessages(payload?.messages), {
-      do_sample: false,
+      do_sample: usesLfm25ReasoningTemplate,
+      ...(usesLfm25ReasoningTemplate
+        ? { temperature: 0.1, top_k: 50, repetition_penalty: 1.1 }
+        : {}),
       max_new_tokens: maxNewTokens,
       tools: tools.length ? tools : undefined,
-      tokenizer_encode_kwargs: { enable_thinking: false },
+      tokenizer_encode_kwargs: usesLfm25ReasoningTemplate
+        ? { preserve_thinking: false }
+        : { enable_thinking: false },
     });
   } catch (error) {
     if (isWebGpuExecutionFailure(error)) throw await enrichWebGpuExecutionError(error);
@@ -794,7 +827,11 @@ async function runText(payload) {
   if (typeof content !== 'string') {
     throw new Error('The WebGPU model returned no generated text.');
   }
-  return splitThinking(content);
+  const result = splitThinking(content, { openingTagInPrompt: usesLfm25ReasoningTemplate });
+  if (result.incompleteReasoning) {
+    throw new Error(`${modelId} used its generation budget before finishing reasoning. Retry with a shorter prompt.`);
+  }
+  return { content: result.content, reasoningContent: result.reasoningContent };
 }
 
 async function probeRuntime() {

--- a/src/chrome/src/providers/webgpu.js
+++ b/src/chrome/src/providers/webgpu.js
@@ -8,6 +8,7 @@ export const WEBGPU_MODEL_ID = 'webbrain-one/Ling-3.0-tiny-ONNX';
 export const WEBGPU_QWEN_MODEL_ID = 'onnx-community/Qwen3-0.6B-ONNX';
 export const WEBGPU_GEMMA_MODEL_ID = 'onnx-community/gemma-4-E2B-it-qat-mobile-ONNX';
 export const WEBGPU_BONSAI_MODEL_ID = 'onnx-community/Ternary-Bonsai-1.7B-ONNX';
+export const WEBGPU_LFM25_MODEL_ID = 'LiquidAI/LFM2.5-2.6B-ONNX';
 export const WEBGPU_DTYPE = 'q4f16';
 export const WEBGPU_BONSAI_DTYPE = 'q2f16';
 export const WEBGPU_GEMMA_DTYPE = Object.freeze({
@@ -21,6 +22,7 @@ export const WEBGPU_MODEL_PRESETS = Object.freeze([
   Object.freeze({ id: WEBGPU_QWEN_MODEL_ID, label: 'Qwen3 0.6B', size: '570 MB', dtype: WEBGPU_DTYPE, dtypeLabel: WEBGPU_DTYPE }),
   Object.freeze({ id: WEBGPU_GEMMA_MODEL_ID, label: 'Gemma 4 E2B QAT Mobile', size: '2.32 GB', dtype: WEBGPU_GEMMA_DTYPE, dtypeLabel: 'q2f16 text' }),
   Object.freeze({ id: WEBGPU_BONSAI_MODEL_ID, label: 'Ternary Bonsai 1.7B', size: '480 MB', dtype: WEBGPU_BONSAI_DTYPE, dtypeLabel: WEBGPU_BONSAI_DTYPE }),
+  Object.freeze({ id: WEBGPU_LFM25_MODEL_ID, label: 'LFM2.5 2.6B', size: '1.55 GB', dtype: WEBGPU_DTYPE, dtypeLabel: WEBGPU_DTYPE }),
 ]);
 export const WEBGPU_MODEL_NOT_READY_ERROR = `${WEBGPU_MODEL_ID} is not downloaded. Open Settings > Providers > WebGPU to download it before chatting.`;
 // Chrome-only selection state. Keep this separate from the synced

--- a/src/chrome/vendor/transformers/README.md
+++ b/src/chrome/vendor/transformers/README.md
@@ -14,7 +14,10 @@ variant on first use and stores it in the browser cache. Ling and Qwen use the
 repository's standard `q4f16` graph (about 4.85 GB and 570 MB respectively).
 Gemma 4 E2B QAT Mobile uses its text-only `q2f16` embeddings and decoder (about
 2.32 GB), without loading its image or audio encoders. Ternary Bonsai 1.7B uses
-its `q2f16` graph (about 480 MB). LFM2.5-VL uses:
+its `q2f16` graph (about 480 MB). LFM2.5 2.6B uses the standard `q4f16` graph
+(about 1.55 GB). The LFM2.5 text preset
+uses its official reasoning template and a 512-token generation budget;
+reasoning before `</think>` is kept out of visible answers. LFM2.5-VL uses:
 
 - `embed_tokens`: FP16
 - `vision_encoder`: FP16

--- a/test/run.js
+++ b/test/run.js
@@ -784,6 +784,7 @@ const {
   WEBGPU_DTYPE,
   WEBGPU_GEMMA_DTYPE,
   WEBGPU_GEMMA_MODEL_ID,
+  WEBGPU_LFM25_MODEL_ID,
   WEBGPU_MODEL_ID,
   WEBGPU_MODEL_PRESETS,
   WEBGPU_QWEN_MODEL_ID,
@@ -40849,6 +40850,7 @@ test('Chrome exposes separate endpoint-free WebGPU text and vision providers', a
     const bonsaiProvider = new WebGPUProvider({ model: WEBGPU_BONSAI_MODEL_ID, dtype: WEBGPU_DTYPE });
     assert.equal(bonsaiProvider.model, WEBGPU_BONSAI_MODEL_ID);
     assert.equal(bonsaiProvider.dtype, WEBGPU_BONSAI_DTYPE, 'the Ternary Bonsai preset must select its WebGPU q2f16 graph');
+    assert.equal(new WebGPUProvider({ model: WEBGPU_LFM25_MODEL_ID }).model, WEBGPU_LFM25_MODEL_ID);
     assert.equal(new WebGPUProvider({ model: 'custom-owner/custom-model' }).model, 'custom-owner/custom-model');
     assert.equal(
       new WebGPUProvider({ model: 'https://huggingface.co/onnx-community/Qwen3-0.6B-ONNX/' }).model,
@@ -40859,6 +40861,7 @@ test('Chrome exposes separate endpoint-free WebGPU text and vision providers', a
       WEBGPU_QWEN_MODEL_ID,
       WEBGPU_GEMMA_MODEL_ID,
       WEBGPU_BONSAI_MODEL_ID,
+      WEBGPU_LFM25_MODEL_ID,
     ]);
     assert.equal(normalizeWebgpuModelId(' onnx-community/Qwen3-0.6B-ONNX '), WEBGPU_QWEN_MODEL_ID);
     assert.throws(() => new WebGPUProvider({ model: 'not-a-repository' }), /owner\/repository/);
@@ -40982,12 +40985,14 @@ test('WebGPU worker follows local text-generation and LiquidAI vision contracts'
   assert.match(worker, /function textDtypeKey\(dtype\)/);
   assert.match(worker, /Object\.entries\(dtype\)\.sort/);
   assert.match(worker, /const WEBGPU_TEXT_MAX_NEW_TOKENS = 256/);
+  assert.match(worker, /const WEBGPU_LFM25_MAX_NEW_TOKENS = 512/);
   assert.match(worker, /'ep\.webgpuexecutionprovider\.storageBufferCacheMode': 'simple'/);
   assert.match(worker, /session_options: createWebGpuTextSessionOptions\(\)/);
   assert.match(worker, /addEventListener\?\.\('uncapturederror'/);
   assert.match(worker, /GPU detail:/);
   assert.doesNotMatch(worker, /cannot execute Ling/);
-  assert.match(worker, /tokenizer_encode_kwargs: \{ enable_thinking: false \}/);
+  assert.match(worker, /preserve_thinking: false/);
+  assert.match(worker, /enable_thinking: false/);
   assert.match(worker, /tools: tools\.length \? tools : undefined/);
   assert.match(host, /'webgpu-chat'/);
   assert.match(host, /'webgpu-download-start'/);
@@ -41041,7 +41046,7 @@ test('WebGPU worker follows local text-generation and LiquidAI vision contracts'
   assert.match(fs.readFileSync(path.join(vendorDir, 'ThirdPartyNotices.onnxruntime.txt'), 'utf8'), /^THIRD PARTY SOFTWARE NOTICES AND INFORMATION/);
 });
 
-test('WebGPU worker replays Ling tool history without coupling text and vision lifecycles', async () => {
+test('WebGPU worker replays text tool history and applies model-specific generation contracts', async () => {
   const previousSelf = globalThis.self;
   const previousCounts = globalThis.__webgpuRuntimeCounts;
   const previousHoldTextDownload = globalThis.__holdWebgpuTextDownload;
@@ -41060,7 +41065,7 @@ test('WebGPU worker replays Ling tool history without coupling text and vision l
       },
     };
     const workerUrl = `${pathToFileURL(path.join(ROOT, 'src/chrome/src/offscreen/inference-worker.js')).href}?tool-history-test`;
-    const { prepareTextMessages } = await import(workerUrl);
+    const { prepareTextMessages, splitThinking } = await import(workerUrl);
     const messages = [
       {
         role: 'assistant',
@@ -41082,6 +41087,21 @@ test('WebGPU worker replays Ling tool history without coupling text and vision l
     assert.equal(prepared[0].content, '');
     assert.equal(prepared[1].content, '{"success":true}');
     assert.equal(messages[0].tool_calls[0].function.arguments, '{"ref_id":"ref_7","force":true}', 'normalization must not mutate persisted history');
+    assert.deepEqual(splitThinking('<think>private trace</think>Visible answer'), {
+      content: 'Visible answer',
+      reasoningContent: 'private trace',
+      incompleteReasoning: false,
+    });
+    assert.deepEqual(splitThinking('implicit private trace</think>Visible answer', { openingTagInPrompt: true }), {
+      content: 'Visible answer',
+      reasoningContent: 'implicit private trace',
+      incompleteReasoning: false,
+    });
+    assert.deepEqual(splitThinking('unfinished private trace', { openingTagInPrompt: true }), {
+      content: '',
+      reasoningContent: 'unfinished private trace',
+      incompleteReasoning: true,
+    });
 
     globalThis.__webgpuRuntimeCounts = {
       visionProcessorLoads: 0,
@@ -41123,7 +41143,10 @@ test('WebGPU worker replays Ling tool history without coupling text and vision l
         }
         const instance = async (input, options) => {
           globalThis.__webgpuGenerationOptions = options;
-          return [{ generated_text: [...input, { role: 'assistant', content: 'text answer' }] }];
+          const content = modelId === 'LiquidAI/LFM2.5-2.6B-ONNX'
+            ? 'private model reasoning</think>Hello!'
+            : 'text answer';
+          return [{ generated_text: [...input, { role: 'assistant', content }] }];
         };
         instance.model = {};
         instance.tokenizer = {};
@@ -41279,6 +41302,24 @@ test('WebGPU worker replays Ling tool history without coupling text and vision l
       dtype: { embed_tokens: 'q4f16', decoder_model_merged: 'q4f16' },
     });
     assert.equal(wrongObjectDtypeStatus.status, 'not-downloaded', 'different dtype maps must have separate ready markers');
+
+    const lfmPayload = {
+      ...textPayload,
+      modelId: WEBGPU_LFM25_MODEL_ID,
+    };
+    await dispatch('download-text', lfmPayload);
+    const lfmResponse = await dispatch('text-chat', lfmPayload);
+    assert.equal(lfmResponse.content, 'Hello!');
+    assert.equal(lfmResponse.reasoningContent, 'private model reasoning');
+    assert.deepEqual(globalThis.__webgpuGenerationOptions, {
+      do_sample: true,
+      temperature: 0.1,
+      top_k: 50,
+      repetition_penalty: 1.1,
+      max_new_tokens: 512,
+      tools: undefined,
+      tokenizer_encode_kwargs: { preserve_thinking: false },
+    }, 'LFM2.5 must use LiquidAI generation settings and its reasoning-template argument');
   } finally {
     if (previousSelf === undefined) delete globalThis.self;
     else globalThis.self = previousSelf;


### PR DESCRIPTION
## Summary

- adds `LiquidAI/LFM2.5-2.6B-ONNX` to the WebGPU model selector using its standard `q4f16` graph
- applies LiquidAI's recommended 512-token sampling settings for this preset
- preserves the repository's official pure-reasoning chat template while separating reasoning from the visible answer
- rejects generations that exhaust their budget before `</think>` instead of exposing partial reasoning
- documents the approximately 1.55 GB download and adds regression coverage

## Root cause

The official LFM2.5 template places the opening `<think>` token in the generation prompt. Transformers.js returns only the generated suffix, so the prior generic parser saw reasoning text followed by `</think>` but no leading `<think>` and treated the entire trace as visible content.

## Scope

This branch is stacked on the selectable WebGPU model foundation in #265. It contains neither Gemma nor Ternary and does not add custom dtype controls.

## Validation

- `npm test`
- 1,695 core tests passed
- 33 toolbar guard tests passed
- 60 security checks passed