### PR TITLE
Default WebGPU to compact prompts

### DIFF
--- a/src/chrome/src/providers/webgpu.js
+++ b/src/chrome/src/providers/webgpu.js
@@ -135,6 +135,7 @@ export class WebGPUProvider extends WebGPUOffscreenProvider {
       model,
       device: 'webgpu',
       dtype,
+      promptTier: config.promptTier || 'compact',
       supportsVision: false,
       supportsAskStreaming: false,
     });

--- a/test/run.js
+++ b/test/run.js
@@ -40843,6 +40843,9 @@ test('Chrome exposes separate endpoint-free WebGPU text and vision providers', a
     assert.equal(webgpuConfig.dtype, WEBGPU_DTYPE);
     const generalProvider = manager._createProvider('webgpu', webgpuConfig);
     assert.ok(generalProvider instanceof WebGPUProvider);
+    assert.equal(generalProvider.promptTier, 'compact');
+    assert.equal(new WebGPUProvider({ model: WEBGPU_MODEL_ID }).promptTier, 'compact');
+    assert.equal(new WebGPUProvider({ model: WEBGPU_MODEL_ID, promptTier: 'full' }).promptTier, 'full');
     assert.equal(new WebGPUProvider({ model: WEBGPU_QWEN_MODEL_ID }).model, WEBGPU_QWEN_MODEL_ID);
     const gemmaProvider = new WebGPUProvider({ model: WEBGPU_GEMMA_MODEL_ID, dtype: WEBGPU_DTYPE });
     assert.equal(gemmaProvider.model, WEBGPU_GEMMA_MODEL_ID);


### PR DESCRIPTION
## Summary

- default directly constructed WebGPU providers to the Compact prompt tier
- preserve explicit Mid or Full prompt-tier selections
- cover both the default and explicit-override behavior in the provider tests

## Why

The provider manager already supplied `promptTier: 'compact'`, but a WebGPU provider instantiated without that manager config inherited the generic local-provider fallback of Mid. Defining the fallback at the WebGPU provider boundary keeps every construction path consistent.

## User impact

WebGPU uses the smaller-model Compact prompt by default. Existing explicit prompt-tier choices remain unchanged.

## Validation

- `npm test`
  - 33 toolbar guard tests passed
  - 1,695 core tests passed
  - 60 security checks passed