### PR TITLE
Handle LFM directional scroll aliases

### DIFF
--- a/src/chrome/src/agent/tool-call-parser.js
+++ b/src/chrome/src/agent/tool-call-parser.js
@@ -222,6 +222,13 @@ function parseLfmValue(source) {
   return { ok: false };
 }
 
+const LFM_DIRECTIONAL_SCROLL_ALIASES = Object.freeze({
+  scrollup: 'up',
+  scrolldown: 'down',
+  scrolltop: 'top',
+  scrollbottom: 'bottom',
+});
+
 /**
  * Parse LFM2/LFM2.5's documented native format:
  * <|tool_call_start|>[tool_name(key='value', flag=False)]<|tool_call_end|>
@@ -245,7 +252,10 @@ function parseLfmToolCalls(text, allowedNames) {
   const calls = [];
   for (const part of callParts) {
     const match = /^([A-Za-z_]\w*)\s*\(([\s\S]*)\)$/.exec(part.trim());
-    if (!match || !allowedNames.has(match[1])) return [];
+    if (!match) return [];
+    const aliasDirection = LFM_DIRECTIONAL_SCROLL_ALIASES[match[1]] || '';
+    const toolName = aliasDirection ? 'scroll' : match[1];
+    if (!allowedNames.has(toolName)) return [];
     const args = Object.create(null);
     if (match[2].trim()) {
       const argParts = splitLfmTopLevel(match[2], ',');
@@ -260,7 +270,11 @@ function parseLfmToolCalls(text, allowedNames) {
         args[key] = parsed.value;
       }
     }
-    calls.push({ name: match[1], arguments: args });
+    if (aliasDirection) {
+      if (Object.hasOwn(args, 'direction') && args.direction !== aliasDirection) return [];
+      args.direction = aliasDirection;
+    }
+    calls.push({ name: toolName, arguments: args });
   }
   return calls;
 }

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -1968,7 +1968,7 @@ TOOLS — use ONLY these:
 - inspect_viewport: Read-only visual inspection for ads, images, canvas, charts, and layout.
 - read_page: Prose fallback for articles.
 - get_window_info: Read window/viewport size.
-- scroll: Scroll up/down.
+- scroll({direction:"up"|"down"|"top"|"bottom"}): Scroll the page or active pane. Use scroll({direction:"down"}) to scroll down; do not invent scrolldown/scrollup tools.
 - extract_data: Get tables, headings, images.
 - click_ax({ref_id}): Click by ref_id from the tree. PREFERRED.
 - set_checked({ref_id, checked}): Idempotently set and verify a native checkbox. Never toggle checkboxes repeatedly with click_ax.

--- a/src/firefox/src/agent/tool-call-parser.js
+++ b/src/firefox/src/agent/tool-call-parser.js
@@ -222,6 +222,13 @@ function parseLfmValue(source) {
   return { ok: false };
 }
 
+const LFM_DIRECTIONAL_SCROLL_ALIASES = Object.freeze({
+  scrollup: 'up',
+  scrolldown: 'down',
+  scrolltop: 'top',
+  scrollbottom: 'bottom',
+});
+
 /**
  * Parse LFM2/LFM2.5's documented native format:
  * <|tool_call_start|>[tool_name(key='value', flag=False)]<|tool_call_end|>
@@ -245,7 +252,10 @@ function parseLfmToolCalls(text, allowedNames) {
   const calls = [];
   for (const part of callParts) {
     const match = /^([A-Za-z_]\w*)\s*\(([\s\S]*)\)$/.exec(part.trim());
-    if (!match || !allowedNames.has(match[1])) return [];
+    if (!match) return [];
+    const aliasDirection = LFM_DIRECTIONAL_SCROLL_ALIASES[match[1]] || '';
+    const toolName = aliasDirection ? 'scroll' : match[1];
+    if (!allowedNames.has(toolName)) return [];
     const args = Object.create(null);
     if (match[2].trim()) {
       const argParts = splitLfmTopLevel(match[2], ',');
@@ -260,7 +270,11 @@ function parseLfmToolCalls(text, allowedNames) {
         args[key] = parsed.value;
       }
     }
-    calls.push({ name: match[1], arguments: args });
+    if (aliasDirection) {
+      if (Object.hasOwn(args, 'direction') && args.direction !== aliasDirection) return [];
+      args.direction = aliasDirection;
+    }
+    calls.push({ name: toolName, arguments: args });
   }
   return calls;
 }

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -1443,7 +1443,7 @@ TOOLS - use only these:
 - inspect_viewport: Read-only visual inspection for ads, images, canvas, charts, and layout.
 - read_page: Prose fallback for articles and long-form text.
 - get_window_info: Read window/viewport size.
-- scroll: Scroll up/down.
+- scroll({direction:"up"|"down"|"top"|"bottom"}): Scroll the page or active pane. Use scroll({direction:"down"}) to scroll down; do not invent scrolldown/scrollup tools.
 - extract_data: Get tables, headings, images, or links.
 - click_ax({ref_id}): Click by ref_id from the tree. Preferred.
 - set_checked({ref_id, checked}): Idempotently set and verify a native checkbox. Never toggle checkboxes repeatedly with click_ax.

--- a/test/run.js
+++ b/test/run.js
@@ -60414,7 +60414,7 @@ test('text tool-call parser is production code with format and allowlist coverag
     fs.readFileSync(path.join(ROOT, 'src/firefox/src/agent/tool-call-parser.js'), 'utf8'),
     'chrome and firefox tool-call parsers must remain byte-identical',
   );
-  const allowed = new Set(['click', 'click_ax', 'navigate', 'read_page']);
+  const allowed = new Set(['click', 'click_ax', 'navigate', 'read_page', 'scroll']);
   const cases = [
     {
       label: 'tool_call JSON with nested arguments',
@@ -60438,6 +60438,11 @@ test('text tool-call parser is production code with format and allowlist coverag
         name: 'read_page',
         args: { includeChrome: false, offset: 4000, limit: 6000 },
       }],
+    },
+    {
+      label: 'LFM2.5 deterministic scrolldown alias',
+      raw: '<|tool_call_start|>[scrolldown()]<|tool_call_end|>',
+      expected: [{ name: 'scroll', args: { direction: 'down' } }],
     },
     {
       label: 'LFM2.5 native batch with escaped strings and nested JSON',
@@ -60630,6 +60635,10 @@ test('text tool-call parser is production code with format and allowlist coverag
         '<|tool_call_start|>[read_page(offset=0, offset=1)]<|tool_call_end|>',
       ],
       [
+        'directional alias contradicts its explicit direction',
+        '<|tool_call_start|>[scrolldown(direction=\'up\')]<|tool_call_end|>',
+      ],
+      [
         'narrated native call',
         'For example: <|tool_call_start|>[read_page()]<|tool_call_end|>',
       ],
@@ -60644,6 +60653,14 @@ test('text tool-call parser is production code with format and allowlist coverag
         `unsafe LFM2.5 call was dispatched (${label})`,
       );
     }
+    assert.deepEqual(
+      parser.parseToolCallsFromText(
+        '<|tool_call_start|>[scrolldown()]<|tool_call_end|>',
+        new Set(['read_page']),
+      ),
+      [],
+      'LFM2.5 scroll alias bypassed the canonical scroll allowlist',
+    );
 
     // A parsed call replaces the model's prose entirely (the caller sets
     // result.content = null), so a call the model was describing rather than


### PR DESCRIPTION
## What changed
- normalize LFM's invented `scrolldown()`, `scrollup()`, `scrolltop()`, and `scrollbottom()` calls to WebBrain's canonical `scroll({direction})` tool
- require the canonical `scroll` tool to be allowlisted and reject contradictory explicit directions
- show the exact scroll signature in the compact prompt to reduce future alias invention
- add the reported token block as a regression test in the mirrored Chrome/Firefox parser suite

## Root cause
LFM produced valid native tool-call wrapper tokens, but used `scrolldown` as a function name. WebBrain exposes only `scroll` with a required `direction` argument, so the strict native-call parser correctly rejected the unknown function and the raw block became visible.

## Validation
- `npm test`
  - 33 rich-text toolbar checks
  - 1,695 core tests
  - 60 security checks
- exact reported output resolves to `scroll({direction:down})`
- Chrome/Firefox parser files verified byte-identical
- `git diff --check`