### PR TITLE
Keep Emergency Box open when switching Minimal and Basic

### DIFF
--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -3464,7 +3464,7 @@ async function handleMessage(msg, sender) {
     }
 
     case 'get_webgpu_download_status':
-      return await providerManager.getWebgpuDownloadStatus();
+      return await providerManager.getWebgpuDownloadStatus(msg);
     case 'start_webgpu_download':
       return await providerManager.startWebgpuDownload(msg);
     case 'pause_webgpu_download':

--- a/src/chrome/src/offscreen/bonsai-worker.js
+++ b/src/chrome/src/offscreen/bonsai-worker.js
@@ -477,11 +477,7 @@ async function hasStoredGguf(dataUrl) {
   if (!cacheKey || typeof caches === 'undefined') return false;
   try {
     const cache = await caches.open(CACHE_NAME);
-    const cached = await cache.match(cacheKey);
-    if (!cached) return false;
-    await persistGgufToOpfs(dataUrl, cached);
-    await cache.delete(cacheKey).catch(() => {});
-    return Boolean(await opfsWeightResponse(dataUrl));
+    return Boolean(await cache.match(cacheKey));
   } catch {
     return false;
   }

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -1278,8 +1278,8 @@ export class ProviderManager {
     return provider;
   }
 
-  async getWebgpuDownloadStatus() {
-    return this._webgpuProvider().downloadStatus();
+  async getWebgpuDownloadStatus(msg = {}) {
+    return this._webgpuProvider().downloadStatus(msg);
   }
 
   /** Configure a shipped Apocalypse text preset and start LFM's cache fill. */

--- a/src/chrome/src/providers/webgpu.js
+++ b/src/chrome/src/providers/webgpu.js
@@ -235,12 +235,13 @@ export class WebGPUProvider extends WebGPUOffscreenProvider {
     return this._testWebGPU();
   }
 
-  async downloadStatus() {
+  async downloadStatus(options = {}) {
+    const target = this._textDownloadTarget(options);
     const response = await this._dispatch({
       type: 'webgpu-download-status',
-      model: this.model,
-      runtime: webgpuModelRuntime(this.model),
-      dtype: this.dtype,
+      model: target.model,
+      runtime: target.runtime,
+      dtype: target.dtype,
     });
     if (!response || response.error) {
       throw new Error(response?.error || 'Unable to read the WebGPU model download status.');

--- a/src/chrome/src/ui/apocalypse-mode.js
+++ b/src/chrome/src/ui/apocalypse-mode.js
@@ -526,7 +526,7 @@ async function ensureFixedWebgpuProvider({ markConfigured = false, force = false
   if (markConfigured) fixedWebgpuProviderMarkedReady = true;
 }
 
-async function refreshWebgpuDownloadStatus() {
+async function refreshWebgpuDownloadStatus({ probeSibling = false } = {}) {
   if (!supportsWebgpuVision) return;
   const requestId = ++webgpuDownloadStatusRequest;
   try {
@@ -555,7 +555,7 @@ async function refreshWebgpuDownloadStatus() {
     }
     updateWebgpuTextPresetUi();
     setWebgpuDownloadState(state);
-    await refreshSiblingWebgpuTextStatus(state?.modelId, requestId);
+    if (probeSibling) await refreshSiblingWebgpuTextStatus(state?.modelId, requestId);
     if (requestId !== webgpuDownloadStatusRequest) return;
     if (state?.ready === true) await ensureFixedWebgpuProvider({ markConfigured: true });
   } catch (error) {
@@ -595,7 +595,7 @@ async function onWebgpuTextPresetChange() {
   updateOverallModelsReadiness();
   try {
     await ensureFixedWebgpuProvider();
-    await refreshWebgpuDownloadStatus();
+    await refreshWebgpuDownloadStatus({ probeSibling: true });
   } catch (error) {
     setWebgpuDownloadState({ status: 'error', error: error.message });
   }
@@ -1246,7 +1246,7 @@ async function poll() {
 
 await Promise.all([
   refresh().catch(error => notice(error.message, 'error')),
-  refreshWebgpuDownloadStatus(),
+  refreshWebgpuDownloadStatus({ probeSibling: true }),
   loadBasicWikipediaAutoStartPreference(),
 ]);
 const params = new URLSearchParams(globalThis.location.search);

--- a/src/chrome/src/ui/apocalypse-mode.js
+++ b/src/chrome/src/ui/apocalypse-mode.js
@@ -23,6 +23,8 @@ import { createOfflineRagReadinessController } from './offline-rag-readiness.js'
 import {
   WEBGPU_DTYPE,
   WEBGPU_MODEL_ID,
+  WEBGPU_MODEL_PRESETS,
+  isShippedWebgpuPreset,
   webgpuModelDtype,
   webgpuModelPreset,
 } from '../providers/webgpu.js';
@@ -299,6 +301,28 @@ function updateEmergencyBoxGate(readinessKind) {
   }
 }
 
+function recordWebgpuTextState(state) {
+  const normalized = normalizeWebgpuDownloadState(state);
+  if (!normalized.modelId) return normalized;
+  const liveStatus = String(state?.status || normalized.status);
+  webgpuTextStateByModel.set(normalized.modelId, {
+    ...normalized,
+    status: WEBGPU_TEXT_BUSY_STATUSES.has(liveStatus) ? liveStatus : normalized.status,
+  });
+  return normalized;
+}
+
+function anyShippedWebgpuTextReady() {
+  if (webgpuDownloadState.ready === true && isShippedWebgpuPreset(webgpuDownloadState.modelId || selectedWebgpuModelId())) {
+    return true;
+  }
+  for (const state of webgpuTextStateByModel.values()) {
+    if (!isShippedWebgpuPreset(state.modelId)) continue;
+    if (state.ready === true || state.status === 'ready') return true;
+  }
+  return false;
+}
+
 function updateOverallModelsReadiness() {
   if (!supportsWebgpuVision || !elements['models-readiness']) return;
   const textStatus = webgpuDownloadState.status;
@@ -307,13 +331,15 @@ function updateOverallModelsReadiness() {
     || (basicWikipediaStartInFlight ? 'starting' : (basicWikipediaStartError || basicWikipediaCatalogError) ? 'error' : 'not-downloaded');
   const corpusStatus = corpusRecord?.status || (corpusDownloadInFlight ? 'downloading' : 'not-installed');
   const semanticStatus = semanticState?.status || (semanticDownloadInFlight ? 'downloading' : 'model-missing');
+  const textReadyForKit = anyShippedWebgpuTextReady();
+  const textErrorBlocksKit = textStatus === 'error' && !textReadyForKit;
 
   let kind = 'pending';
   let key = 'ap.models.status.incomplete';
   if (snapshot?.enabled !== true) {
     kind = 'disabled';
     key = 'ap.models.status.disabled';
-  } else if (textStatus === 'error' || visionStatus === 'error' || wikipediaStatus === 'error' || corpusStatus === 'error' || semanticStatus === 'error') {
+  } else if (textErrorBlocksKit || visionStatus === 'error' || wikipediaStatus === 'error' || corpusStatus === 'error' || semanticStatus === 'error') {
     kind = 'error';
     key = 'ap.models.status.error';
   } else if (webgpuDownloadState.ready === true && visionStatus === 'ready' && wikipediaStatus === 'ready' && corpusStatus === 'ready' && semanticStatus === 'ready' && !anyOtherWebgpuTextBusy()) {
@@ -331,7 +357,20 @@ function updateOverallModelsReadiness() {
   }
   elements['models-readiness'].dataset.kind = kind;
   elements['models-readiness-label'].textContent = t(key);
-  updateEmergencyBoxGate(kind);
+  const emergencyKind = snapshot?.enabled === true
+    && textReadyForKit
+    && visionStatus === 'ready'
+    && wikipediaStatus === 'ready'
+    && corpusStatus === 'ready'
+    && semanticStatus === 'ready'
+    && !textErrorBlocksKit
+    && visionStatus !== 'error'
+    && wikipediaStatus !== 'error'
+    && corpusStatus !== 'error'
+    && semanticStatus !== 'error'
+    ? 'ready'
+    : kind;
+  updateEmergencyBoxGate(emergencyKind);
 }
 
 function updateWebgpuDownloadPanel() {
@@ -416,14 +455,7 @@ function anyOtherWebgpuTextPaused() {
 }
 
 function setWebgpuDownloadState(state) {
-  const normalized = normalizeWebgpuDownloadState(state);
-  if (normalized.modelId) {
-    const liveStatus = String(state?.status || normalized.status);
-    webgpuTextStateByModel.set(normalized.modelId, {
-      ...normalized,
-      status: WEBGPU_TEXT_BUSY_STATUSES.has(liveStatus) ? liveStatus : normalized.status,
-    });
-  }
+  const normalized = recordWebgpuTextState(state);
   if (normalized.modelId && normalized.modelId !== selectedWebgpuModelId()) {
     updateOverallModelsReadiness();
     return;
@@ -523,13 +555,30 @@ async function refreshWebgpuDownloadStatus() {
     }
     updateWebgpuTextPresetUi();
     setWebgpuDownloadState(state);
+    await refreshSiblingWebgpuTextStatus(state?.modelId, requestId);
+    if (requestId !== webgpuDownloadStatusRequest) return;
     if (state?.ready === true) await ensureFixedWebgpuProvider({ markConfigured: true });
   } catch (error) {
     if (requestId === webgpuDownloadStatusRequest) setWebgpuDownloadState({ status: 'error', error: error.message });
   }
 }
 
+async function refreshSiblingWebgpuTextStatus(currentModelId, requestId = webgpuDownloadStatusRequest) {
+  const current = String(currentModelId || selectedWebgpuModelId() || '');
+  for (const preset of WEBGPU_MODEL_PRESETS) {
+    if (preset.id === current) continue;
+    if (requestId !== webgpuDownloadStatusRequest) return;
+    const sibling = await providerCommand('get_webgpu_download_status', {
+      model: preset.id,
+      dtype: preset.dtype,
+    }).catch(() => null);
+    if (requestId !== webgpuDownloadStatusRequest) return;
+    if (sibling && !sibling.error) setWebgpuDownloadState(sibling);
+  }
+}
+
 async function onWebgpuTextPresetChange() {
+  recordWebgpuTextState(webgpuDownloadState);
   webgpuPresetHydrated = true;
   fixedWebgpuProviderConfigured = false;
   fixedWebgpuProviderMarkedReady = false;
@@ -543,6 +592,7 @@ async function onWebgpuTextPresetChange() {
     error: '',
   };
   updateWebgpuDownloadPanel();
+  updateOverallModelsReadiness();
   try {
     await ensureFixedWebgpuProvider();
     await refreshWebgpuDownloadStatus();

--- a/test/run.js
+++ b/test/run.js
@@ -50607,9 +50607,20 @@ test('Chrome exposes separate endpoint-free WebGPU text and vision providers', a
       messages: [{ role: 'user', content: 'Hello' }],
       options: { maxTokens: 123, tools },
     });
+    const siblingStatus = await generalProvider.downloadStatus({
+      model: WEBGPU_BONSAI27_MODEL_ID,
+      dtype: 'q1',
+    });
+    assert.equal(siblingStatus.ready, true);
+    assert.deepEqual(sentMessages[3], {
+      type: 'webgpu-download-status',
+      model: WEBGPU_BONSAI27_MODEL_ID,
+      runtime: 'bitgpu',
+      dtype: 'q1',
+    });
     const textDisposed = await generalProvider.dispose();
     assert.deepEqual(textDisposed, { ok: true, disposed: true });
-    assert.deepEqual(sentMessages[3], { type: 'webgpu-dispose' });
+    assert.deepEqual(sentMessages[4], { type: 'webgpu-dispose' });
 
     const provider = await manager.getLocalVisionFallbackProvider();
     assert.ok(provider instanceof WebGPUVisionProvider);
@@ -50628,7 +50639,7 @@ test('Chrome exposes separate endpoint-free WebGPU text and vision providers', a
     const result = await provider.chat(messages, { maxTokens: 321 });
     assert.equal(result.content, 'A settings page is visible.');
     assert.equal(result.toolCalls, null);
-    assert.deepEqual(sentMessages[4], {
+    assert.deepEqual(sentMessages[5], {
       type: 'webgpu-vision-chat',
       model: WEBGPU_VISION_MODEL_ID,
       device: 'webgpu',
@@ -50639,13 +50650,13 @@ test('Chrome exposes separate endpoint-free WebGPU text and vision providers', a
 
     const disposed = await manager.disposeWebgpuVisionRuntime();
     assert.deepEqual(disposed, { ok: true, disposed: true });
-    assert.deepEqual(sentMessages[5], { type: 'webgpu-vision-dispose' });
+    assert.deepEqual(sentMessages[6], { type: 'webgpu-vision-dispose' });
 
     manager.providers.set('webgpu', generalProvider);
     manager.providers.set('remote', { config: { type: 'openai', model: 'remote-model' } });
     manager.activeProviderId = 'webgpu';
     await manager.setActive('remote');
-    assert.deepEqual(sentMessages[6], { type: 'webgpu-dispose' });
+    assert.deepEqual(sentMessages[7], { type: 'webgpu-dispose' });
 
     textModelReady = false;
     await assert.rejects(
@@ -51232,8 +51243,14 @@ test('WebGPU worker follows local text-generation and LiquidAI vision contracts'
     'the basic Wikipedia card must select its exact catalog archive');
   assert.match(apocalypseScript, /const ready = wikipedia[\s\S]*?if \(ready\.length\) return ready\[0\]/,
     'a verified replacement Wikipedia edition must continue to satisfy aggregate readiness');
-  assert.match(apocalypseScript, /updateEmergencyBoxGate\(kind\)/,
-    'aggregate readiness must update the Emergency Box gate');
+  assert.match(apocalypseScript, /updateEmergencyBoxGate\(emergencyKind\)/,
+    'Emergency Box must stay available when any shipped text model is still on disk');
+  assert.match(apocalypseScript, /function anyShippedWebgpuTextReady\(\)/,
+    'Emergency Box must treat Minimal and Basic as interchangeable text-model readiness');
+  assert.match(apocalypseScript, /function refreshSiblingWebgpuTextStatus/,
+    'Apocalypse Mode must probe the unselected shipped text model without switching to it');
+  assert.match(apocalypseScript, /recordWebgpuTextState\(webgpuDownloadState\)/,
+    'switching Minimal/Basic must remember the previous text model before clearing the selected panel');
   for (const state of ['ready', 'downloading', 'paused', 'incomplete', 'disabled', 'error']) {
     assert.match(apocalypseScript, new RegExp(`ap\\.models\\.status\\.${state}`),
       `aggregate model readiness is missing its ${state} state`);
@@ -51268,6 +51285,8 @@ test('WebGPU worker follows local text-generation and LiquidAI vision contracts'
   assert.match(apocalypseScript, /webgpuPresetHydrated/);
   assert.match(apocalypseScript, /normalized\.modelId !== selectedWebgpuModelId\(\)/);
   assert.match(apocalypseScript, /function anyOtherWebgpuTextBusy/);
+  assert.match(background, /getWebgpuDownloadStatus\(msg\)/,
+    'download-status probes must be able to inspect an unselected shipped text model');
   assert.match(apocalypseScript, /ap\.webgpu\.rag\.pro/);
   assert.match(apocalypseHtml, /data-webgpu-text-copy/);
   assert.doesNotMatch(apocalypseHtml, /id="webgpu-(?:model|context-window|prompt-tier|save|activate)/);

--- a/test/run.js
+++ b/test/run.js
@@ -51249,6 +51249,20 @@ test('WebGPU worker follows local text-generation and LiquidAI vision contracts'
     'Emergency Box must treat Minimal and Basic as interchangeable text-model readiness');
   assert.match(apocalypseScript, /function refreshSiblingWebgpuTextStatus/,
     'Apocalypse Mode must probe the unselected shipped text model without switching to it');
+  assert.match(apocalypseScript, /async function refreshWebgpuDownloadStatus\(\{ probeSibling = false \} = \{\}\)/,
+    'unselected text-model status must not ride the two-second Apocalypse poll');
+  assert.match(apocalypseScript, /if \(probeSibling\) await refreshSiblingWebgpuTextStatus/,
+    'sibling WebGPU status probes must be opt-in');
+  const apocalypsePoll = apocalypseScript.slice(
+    apocalypseScript.indexOf('async function poll()'),
+    apocalypseScript.indexOf('\n\nawait Promise.all([', apocalypseScript.indexOf('async function poll()')),
+  );
+  assert.match(apocalypsePoll, /refreshWebgpuDownloadStatus\(\)/,
+    'the Apocalypse poll must keep refreshing the selected text model');
+  assert.doesNotMatch(apocalypsePoll, /probeSibling/,
+    'opening Apocalypse Mode must not poll-migrate the unselected 3.8 GB Basic model');
+  assert.match(apocalypseScript, /refreshWebgpuDownloadStatus\(\{ probeSibling: true \}\)/,
+    'first load and preset switches still need a one-shot sibling readiness probe');
   assert.match(apocalypseScript, /recordWebgpuTextState\(webgpuDownloadState\)/,
     'switching Minimal/Basic must remember the previous text model before clearing the selected panel');
   for (const state of ['ready', 'downloading', 'paused', 'incomplete', 'disabled', 'error']) {
@@ -51389,6 +51403,14 @@ test('WebGPU worker follows local text-generation and LiquidAI vision contracts'
   assert.match(bonsaiWorker, /if \(!validator\) \{[\s\S]*?removeOpfsWeight\(url\)[\s\S]*?nativeFetch\(url, fetchOptions\)/,
     'a saved partial without a usable validator must be discarded before a full fetch');
   assert.match(bonsaiWorker, /textDownloadCancelMode === 'pause'[\s\S]*?writeOpfsPartial/);
+  const hasStoredGguf = bonsaiWorker.slice(
+    bonsaiWorker.indexOf('async function hasStoredGguf'),
+    bonsaiWorker.indexOf('async function isTextModelReady'),
+  );
+  assert.match(hasStoredGguf, /cache\.match\(cacheKey\)/,
+    'Bonsai readiness must still see a legacy Cache Storage GGUF');
+  assert.doesNotMatch(hasStoredGguf, /persistGgufToOpfs/,
+    'Bonsai status checks must not migrate a Cache Storage GGUF into OPFS');
   const bonsaiReadyCheck = bonsaiWorker.slice(
     bonsaiWorker.indexOf('async function isTextModelReady'),
     bonsaiWorker.indexOf('async function markTextModelReady'),
@@ -51396,6 +51418,8 @@ test('WebGPU worker follows local text-generation and LiquidAI vision contracts'
   assert.match(bonsaiReadyCheck, /if \(!marker\) return false/);
   assert.doesNotMatch(bonsaiReadyCheck, /cache\.put/,
     'status checks must not manufacture the Bonsai runtime-ready marker');
+  assert.doesNotMatch(bonsaiReadyCheck, /persistGgufToOpfs/,
+    'status checks must not copy the unselected Basic model as a side effect');
   assert.match(bonsaiWorker, /parsed\.protocol === 'http:' \|\| parsed\.protocol === 'https:'/);
   assert.match(bonsaiWorker, /await cache\.put\(cacheKey/);
   assert.doesNotMatch(bonsaiWorker, /cache\.put\(url/);


### PR DESCRIPTION
## Summary
- Emergency Box locked after switching Apocalypse text models because the gate required the currently selected model to be ready.
- Keep the box available when any shipped text model (Minimal or Basic) is still on disk, and probe the unselected preset without switching to it.

## Test plan
- [ ] In Apocalypse Mode with Minimal downloaded and the rest of basic setup ready, confirm Emergency Box is unlocked
- [ ] Switch to Basic without downloading it; Emergency Box should stay available
- [ ] Switch back to Minimal; Emergency Box should stay available
- [ ] With neither text model downloaded, Emergency Box should stay locked
- [ ] `node test/run.js`


Made with [Cursor](https://cursor.com)