### PR TITLE
Keep Clarify open while typing a custom answer

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -9997,6 +9997,27 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return true;
   }
 
+  /**
+   * Restart a waited clarify timeout while the user is composing a custom
+   * answer. Instant and Off modes have no renewable deadline.
+   */
+  noteClarifyInputActivity(tabId, clarifyId) {
+    const entry = this._pendingClarifications.get(tabId)?.get(clarifyId);
+    if (!entry || entry.settled || typeof entry.restartTimeout !== 'function') return null;
+    if (!entry.restartTimeout()) return null;
+    const update = {
+      clarifyId,
+      timeoutSec: entry.timeoutSec,
+      deadlineTs: entry.deadlineTs,
+    };
+    try {
+      if (typeof entry.onUpdate === 'function') {
+        entry.onUpdate('clarify_timeout_extended', update);
+      }
+    } catch { /* UI emit must never break the run */ }
+    return update;
+  }
+
   async requireExplicitClarificationAuthorization(tabId) {
     await this._hydrate(tabId);
     return await this._recordClarificationAuthorization(tabId, 'timeout');
@@ -19572,19 +19593,27 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // 0 = instant auto-select; >0 = wait N s; -1 = Off (wait forever).
       const timeoutSec = this._normalizeClarifyTimeoutSec(this.clarifyTimeoutSec);
       const waitSec = timeoutSec > 0 ? timeoutSec : 0;
-      const deadlineTs = waitSec > 0 ? Date.now() + waitSec * 1000 : 0;
 
       const tabPending = this._pendingClarifications.get(tabId) || new Map();
       this._pendingClarifications.set(tabId, tabPending);
 
       const responsePromise = new Promise((resolve) => {
-        const entry = { resolve, ts: Date.now(), timer: null, settled: false };
+        const entry = {
+          resolve,
+          ts: Date.now(),
+          timer: null,
+          settled: false,
+          timeoutSec: waitSec,
+          deadlineTs: 0,
+          restartTimeout: null,
+          onUpdate,
+        };
         // Arm auto-select when Instant (0) or a positive wait; Off (-1) waits forever.
         // Instant uses source=auto (user intentionally set auto-approve, e.g. headless).
         // A waited timeout uses source=timeout (passive no-reply — not confirmation).
         if (timeoutSec >= 0) {
           const autoSource = timeoutSec === 0 ? 'auto' : 'timeout';
-          entry.timer = setTimeout(() => {
+          const autoSelect = () => {
             entry.timer = null;
             // Prefer the first suggested option; free-text-only prompts get a
             // clear timeout marker so the agent can continue without hanging.
@@ -19597,7 +19626,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               }
             } catch { /* UI emit must never break the run */ }
             this._settleClarification(entry, { answer, source: autoSource });
-          }, waitSec * 1000);
+          };
+          entry.restartTimeout = () => {
+            if (entry.settled || !(entry.timeoutSec > 0)) return false;
+            this._clearClarifyTimer(entry);
+            entry.deadlineTs = Date.now() + entry.timeoutSec * 1000;
+            entry.timer = setTimeout(autoSelect, entry.timeoutSec * 1000);
+            return true;
+          };
+          if (timeoutSec === 0) entry.timer = setTimeout(autoSelect, 0);
+          else entry.restartTimeout();
         }
         tabPending.set(clarifyId, entry);
       });
@@ -19610,7 +19648,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             options,
             reason,
             timeoutSec: waitSec,
-            deadlineTs: deadlineTs || undefined,
+            deadlineTs: tabPending.get(clarifyId)?.deadlineTs || undefined,
           });
         } catch { /* UI emit must never break the run */ }
       }

--- a/src/chrome/src/agent/scheduler.js
+++ b/src/chrome/src/agent/scheduler.js
@@ -1619,6 +1619,26 @@ export class ScheduledJobManager {
         }).catch((e) => {
           console.warn('[WebBrain] failed to mark scheduled job as waiting for input:', e);
         });
+      } else if (type === 'clarify_timeout_extended') {
+        const clarifyId = String(data?.clarifyId || '');
+        const deadlineTs = Number(data?.deadlineTs);
+        const timeoutSec = Number(data?.timeoutSec);
+        if (clarifyId && Number.isFinite(deadlineTs) && deadlineTs > 0) {
+          this._updateJobIf(job.id, (prev) => (
+            prev.status === 'needs_user_input'
+            && String(prev.pendingClarify?.clarifyId || '') === clarifyId
+          ), (prev) => ({
+            pendingClarify: {
+              ...prev.pendingClarify,
+              deadlineTs: Math.floor(deadlineTs),
+              ...(Number.isFinite(timeoutSec) && timeoutSec > 0
+                ? { timeoutSec: Math.min(1200, Math.floor(timeoutSec)) }
+                : {}),
+            },
+          })).catch((e) => {
+            console.warn('[WebBrain] failed to extend scheduled clarify timeout:', e);
+          });
+        }
       } else if (type === 'clarify_auto') {
         // Auto-timeout settled the clarify; the agent is running again. Clear
         // needs_user_input / pendingClarify so the job UI and rehydrated cards
@@ -1640,7 +1660,7 @@ export class ScheduledJobManager {
       }
       // Tag scheduled clarify prompts (and their auto-timeout follow-ups) with
       // the job id so the sidepanel can scope cards and lock on timeout.
-      const withJob = (type === 'clarify' || type === 'clarify_auto')
+      const withJob = (type === 'clarify' || type === 'clarify_timeout_extended' || type === 'clarify_auto')
         ? { ...data, scheduledJobId: job.id }
         : data;
       this.sendUpdate(tabId, type, withJob);

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -3333,6 +3333,17 @@ async function handleMessage(msg, sender) {
     case 'run_scheduled_job_now':
       return await scheduler.runNow(msg.jobId);
 
+    case 'clarify_input_activity': {
+      // Keep a waited clarify open while the user is composing the custom
+      // "Something else" answer. The agent owns the authoritative timer.
+      const tabId = msg.tabId || sender.tab?.id;
+      if (!tabId) return { ok: false, error: 'No tab ID' };
+      const clarifyId = String(msg.clarifyId || '');
+      if (!clarifyId) return { ok: false, error: 'clarifyId required' };
+      const update = agent.noteClarifyInputActivity(tabId, clarifyId);
+      return { ok: !!update, matched: !!update, ...update };
+    }
+
     case 'clarify_response': {
       // Side panel posts the user's answer to a pending clarify() tool
       // call. The agent's executeTool() handler is awaiting this exact

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -4932,6 +4932,9 @@ function rebindClarifyCards() {
     card.querySelectorAll('.clarify-input').forEach(input => {
       if (input.dataset.bound) return;
       input.dataset.bound = 'true';
+      input.addEventListener('input', () => {
+        keepClarifyAliveWhileTyping(card, tabId, clarifyId, input);
+      });
       input.addEventListener('keydown', (e) => {
         if (e.key === 'Enter' && input.value.trim()) {
           e.preventDefault();
@@ -9181,6 +9184,12 @@ function handleAgentUpdateMessage(msg) {
       lockClarifyCardFromAuto(data);
       break;
 
+    case 'clarify_timeout_extended':
+      // Custom-answer typing renewed the authoritative agent deadline. Keep
+      // this card (and restored copies) on the same countdown.
+      applyClarifyTimeoutExtension(data);
+      break;
+
     case 'plan_review':
       invalidatePlanReviewCards({
         tabId: msg.tabId ?? currentTabId,
@@ -9470,6 +9479,9 @@ function renderClarifyCard(data) {
   input.placeholder = options.length
     ? (typeof t === 'function' ? t('sp.clarify.input_placeholder_with_options') : 'Or type a different answer…')
     : (typeof t === 'function' ? t('sp.clarify.input_placeholder') : 'Type your answer…');
+  input.addEventListener('input', () => {
+    keepClarifyAliveWhileTyping(card, tabId, clarifyId, input);
+  });
   input.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' && input.value.trim()) {
       e.preventDefault();
@@ -9507,6 +9519,10 @@ function renderClarifyCard(data) {
 
 function clearClarifyCountdown(card) {
   if (!card) return;
+  if (card._clarifyActivityTimer) {
+    try { clearTimeout(card._clarifyActivityTimer); } catch {}
+    card._clarifyActivityTimer = null;
+  }
   if (card._clarifyCountdownTimer) {
     try { clearInterval(card._clarifyCountdownTimer); } catch {}
     card._clarifyCountdownTimer = null;
@@ -9533,7 +9549,8 @@ function startClarifyCountdown(card, { tabId, clarifyId, deadlineTs, firstOption
       clearClarifyCountdown(card);
       return;
     }
-    const remainingMs = Math.max(0, deadlineTs - Date.now());
+    const activeDeadlineTs = Number(card.dataset.deadlineTs) || deadlineTs;
+    const remainingMs = Math.max(0, activeDeadlineTs - Date.now());
     const remainingSec = Math.ceil(remainingMs / 1000);
     timerEl.textContent = typeof t === 'function'
       ? t('sp.clarify.auto_timeout', { seconds: remainingSec })
@@ -9547,6 +9564,72 @@ function startClarifyCountdown(card, { tabId, clarifyId, deadlineTs, firstOption
   };
   tick();
   card._clarifyCountdownTimer = setInterval(tick, 250);
+}
+
+function applyClarifyTimeoutExtension(data) {
+  const clarifyId = String(data?.clarifyId || '');
+  const deadlineTs = Number(data?.deadlineTs);
+  const timeoutSec = Number(data?.timeoutSec);
+  if (!clarifyId || !Number.isFinite(deadlineTs) || deadlineTs <= 0) return;
+  for (const card of document.querySelectorAll('.clarify-card')) {
+    if (String(card.dataset.clarifyId || '') !== clarifyId) continue;
+    if (card.classList.contains('clarify-answered')) continue;
+    const currentDeadlineTs = Number(card.dataset.deadlineTs) || 0;
+    if (deadlineTs < currentDeadlineTs) continue;
+    card.dataset.deadlineTs = String(Math.floor(deadlineTs));
+    if (Number.isFinite(timeoutSec) && timeoutSec > 0) {
+      card.dataset.timeoutSec = String(Math.floor(timeoutSec));
+    }
+    if (!card._clarifyCountdownTimer) {
+      const rawTabId = card.dataset.scheduledTabId ?? card.dataset.tabId;
+      const tabId = rawTabId != null && rawTabId !== '' ? Number(rawTabId) : currentTabId;
+      const firstOption = card.dataset.firstOption
+        || card.querySelector('.clarify-option')?.dataset?.value
+        || card.querySelector('.clarify-option')?.textContent
+        || '(no response — timed out)';
+      if (tabId != null && !Number.isNaN(tabId)) {
+        startClarifyCountdown(card, { tabId, clarifyId, deadlineTs, firstOption });
+      }
+    }
+  }
+  schedulePersist();
+}
+
+/**
+ * Treat custom-answer input as activity, not silence. Renew immediately on
+ * the first keystroke and periodically while typing so the agent cannot
+ * auto-select an option out from under an in-progress answer.
+ */
+function keepClarifyAliveWhileTyping(card, tabId, clarifyId, input) {
+  if (!card || card.classList.contains('clarify-answered') || !input?.value?.length) return;
+  const timeoutSec = Number(card.dataset.timeoutSec);
+  if (!Number.isFinite(timeoutSec) || timeoutSec <= 0) return;
+
+  const sendActivity = () => {
+    card._clarifyActivityTimer = null;
+    if (card.classList.contains('clarify-answered') || !input.value.length) return;
+    const activityTs = Date.now();
+    card._lastClarifyActivitySentAt = activityTs;
+    card.dataset.deadlineTs = String(Math.floor(activityTs + timeoutSec * 1000));
+    schedulePersist();
+    sendToBackground('clarify_input_activity', { tabId, clarifyId })
+      .then((response) => {
+        if (response?.matched) applyClarifyTimeoutExtension(response);
+      })
+      .catch(() => { /* the live run may have settled between keystrokes */ });
+  };
+
+  const now = Date.now();
+  const minIntervalMs = Math.max(250, Math.min(5000, timeoutSec * 500));
+  const lastSentAt = Number(card._lastClarifyActivitySentAt) || 0;
+  const elapsedMs = now - lastSentAt;
+  if (!lastSentAt || elapsedMs >= minIntervalMs) {
+    if (card._clarifyActivityTimer) clearTimeout(card._clarifyActivityTimer);
+    sendActivity();
+    return;
+  }
+  if (card._clarifyActivityTimer) clearTimeout(card._clarifyActivityTimer);
+  card._clarifyActivityTimer = setTimeout(sendActivity, minIntervalMs - elapsedMs);
 }
 
 /**

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -8039,6 +8039,27 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return true;
   }
 
+  /**
+   * Restart a waited clarify timeout while the user is composing a custom
+   * answer. Instant and Off modes have no renewable deadline.
+   */
+  noteClarifyInputActivity(tabId, clarifyId) {
+    const entry = this._pendingClarifications.get(tabId)?.get(clarifyId);
+    if (!entry || entry.settled || typeof entry.restartTimeout !== 'function') return null;
+    if (!entry.restartTimeout()) return null;
+    const update = {
+      clarifyId,
+      timeoutSec: entry.timeoutSec,
+      deadlineTs: entry.deadlineTs,
+    };
+    try {
+      if (typeof entry.onUpdate === 'function') {
+        entry.onUpdate('clarify_timeout_extended', update);
+      }
+    } catch { /* UI emit must never break the run */ }
+    return update;
+  }
+
   async requireExplicitClarificationAuthorization(tabId) {
     await this._hydrate(tabId);
     return await this._recordClarificationAuthorization(tabId, 'timeout');
@@ -16826,19 +16847,27 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // 0 = instant auto-select; >0 = wait N s; -1 = Off (wait forever).
       const timeoutSec = this._normalizeClarifyTimeoutSec(this.clarifyTimeoutSec);
       const waitSec = timeoutSec > 0 ? timeoutSec : 0;
-      const deadlineTs = waitSec > 0 ? Date.now() + waitSec * 1000 : 0;
 
       const tabPending = this._pendingClarifications.get(tabId) || new Map();
       this._pendingClarifications.set(tabId, tabPending);
 
       const responsePromise = new Promise((resolve) => {
-        const entry = { resolve, ts: Date.now(), timer: null, settled: false };
+        const entry = {
+          resolve,
+          ts: Date.now(),
+          timer: null,
+          settled: false,
+          timeoutSec: waitSec,
+          deadlineTs: 0,
+          restartTimeout: null,
+          onUpdate,
+        };
         // Arm auto-select when Instant (0) or a positive wait; Off (-1) waits forever.
         // Instant uses source=auto (user intentionally set auto-approve, e.g. headless).
         // A waited timeout uses source=timeout (passive no-reply — not confirmation).
         if (timeoutSec >= 0) {
           const autoSource = timeoutSec === 0 ? 'auto' : 'timeout';
-          entry.timer = setTimeout(() => {
+          const autoSelect = () => {
             entry.timer = null;
             // Prefer the first suggested option; free-text-only prompts get a
             // clear timeout marker so the agent can continue without hanging.
@@ -16851,7 +16880,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               }
             } catch { /* UI emit must never break the run */ }
             this._settleClarification(entry, { answer, source: autoSource });
-          }, waitSec * 1000);
+          };
+          entry.restartTimeout = () => {
+            if (entry.settled || !(entry.timeoutSec > 0)) return false;
+            this._clearClarifyTimer(entry);
+            entry.deadlineTs = Date.now() + entry.timeoutSec * 1000;
+            entry.timer = setTimeout(autoSelect, entry.timeoutSec * 1000);
+            return true;
+          };
+          if (timeoutSec === 0) entry.timer = setTimeout(autoSelect, 0);
+          else entry.restartTimeout();
         }
         tabPending.set(clarifyId, entry);
       });
@@ -16864,7 +16902,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             options,
             reason,
             timeoutSec: waitSec,
-            deadlineTs: deadlineTs || undefined,
+            deadlineTs: tabPending.get(clarifyId)?.deadlineTs || undefined,
           });
         } catch { /* UI emit must never break the run */ }
       }

--- a/src/firefox/src/agent/scheduler.js
+++ b/src/firefox/src/agent/scheduler.js
@@ -1595,6 +1595,26 @@ export class ScheduledJobManager {
         }).catch((e) => {
           console.warn('[WebBrain] failed to mark scheduled job as waiting for input:', e);
         });
+      } else if (type === 'clarify_timeout_extended') {
+        const clarifyId = String(data?.clarifyId || '');
+        const deadlineTs = Number(data?.deadlineTs);
+        const timeoutSec = Number(data?.timeoutSec);
+        if (clarifyId && Number.isFinite(deadlineTs) && deadlineTs > 0) {
+          this._updateJobIf(job.id, (prev) => (
+            prev.status === 'needs_user_input'
+            && String(prev.pendingClarify?.clarifyId || '') === clarifyId
+          ), (prev) => ({
+            pendingClarify: {
+              ...prev.pendingClarify,
+              deadlineTs: Math.floor(deadlineTs),
+              ...(Number.isFinite(timeoutSec) && timeoutSec > 0
+                ? { timeoutSec: Math.min(1200, Math.floor(timeoutSec)) }
+                : {}),
+            },
+          })).catch((e) => {
+            console.warn('[WebBrain] failed to extend scheduled clarify timeout:', e);
+          });
+        }
       } else if (type === 'clarify_auto') {
         // Auto-timeout settled the clarify; the agent is running again. Clear
         // needs_user_input / pendingClarify so the job UI and rehydrated cards
@@ -1616,7 +1636,7 @@ export class ScheduledJobManager {
       }
       // Tag scheduled clarify prompts (and their auto-timeout follow-ups) with
       // the job id so the sidepanel can scope cards and lock on timeout.
-      const withJob = (type === 'clarify' || type === 'clarify_auto')
+      const withJob = (type === 'clarify' || type === 'clarify_timeout_extended' || type === 'clarify_auto')
         ? { ...data, scheduledJobId: job.id }
         : data;
       this.sendUpdate(tabId, type, withJob);

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -2808,6 +2808,17 @@ async function handleMessage(msg, sender) {
     case 'run_scheduled_job_now':
       return await scheduler.runNow(msg.jobId);
 
+    case 'clarify_input_activity': {
+      // Keep a waited clarify open while the user is composing the custom
+      // "Something else" answer. The agent owns the authoritative timer.
+      const tabId = msg.tabId || sender.tab?.id;
+      if (!tabId) return { ok: false, error: 'No tab ID' };
+      const clarifyId = String(msg.clarifyId || '');
+      if (!clarifyId) return { ok: false, error: 'clarifyId required' };
+      const update = agent.noteClarifyInputActivity(tabId, clarifyId);
+      return { ok: !!update, matched: !!update, ...update };
+    }
+
     case 'clarify_response': {
       // Side panel posts the user's answer to a pending clarify() tool
       // call. The agent's executeTool() handler is awaiting this exact

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -4767,6 +4767,9 @@ function rebindClarifyCards() {
     card.querySelectorAll('.clarify-input').forEach(input => {
       if (input.dataset.bound) return;
       input.dataset.bound = 'true';
+      input.addEventListener('input', () => {
+        keepClarifyAliveWhileTyping(card, tabId, clarifyId, input);
+      });
       input.addEventListener('keydown', (e) => {
         if (e.key === 'Enter' && input.value.trim()) {
           e.preventDefault();
@@ -8657,6 +8660,12 @@ function handleAgentUpdateMessage(msg) {
       lockClarifyCardFromAuto(data);
       break;
 
+    case 'clarify_timeout_extended':
+      // Custom-answer typing renewed the authoritative agent deadline. Keep
+      // this card (and restored copies) on the same countdown.
+      applyClarifyTimeoutExtension(data);
+      break;
+
     case 'upload_picker':
       renderUploadPickerCard(data, msg.tabId ?? currentTabId);
       break;
@@ -8950,6 +8959,9 @@ function renderClarifyCard(data) {
   input.placeholder = options.length
     ? (typeof t === 'function' ? t('sp.clarify.input_placeholder_with_options') : 'Or type a different answer…')
     : (typeof t === 'function' ? t('sp.clarify.input_placeholder') : 'Type your answer…');
+  input.addEventListener('input', () => {
+    keepClarifyAliveWhileTyping(card, tabId, clarifyId, input);
+  });
   input.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' && input.value.trim()) {
       e.preventDefault();
@@ -8987,6 +8999,10 @@ function renderClarifyCard(data) {
 
 function clearClarifyCountdown(card) {
   if (!card) return;
+  if (card._clarifyActivityTimer) {
+    try { clearTimeout(card._clarifyActivityTimer); } catch {}
+    card._clarifyActivityTimer = null;
+  }
   if (card._clarifyCountdownTimer) {
     try { clearInterval(card._clarifyCountdownTimer); } catch {}
     card._clarifyCountdownTimer = null;
@@ -9013,7 +9029,8 @@ function startClarifyCountdown(card, { tabId, clarifyId, deadlineTs, firstOption
       clearClarifyCountdown(card);
       return;
     }
-    const remainingMs = Math.max(0, deadlineTs - Date.now());
+    const activeDeadlineTs = Number(card.dataset.deadlineTs) || deadlineTs;
+    const remainingMs = Math.max(0, activeDeadlineTs - Date.now());
     const remainingSec = Math.ceil(remainingMs / 1000);
     timerEl.textContent = typeof t === 'function'
       ? t('sp.clarify.auto_timeout', { seconds: remainingSec })
@@ -9027,6 +9044,72 @@ function startClarifyCountdown(card, { tabId, clarifyId, deadlineTs, firstOption
   };
   tick();
   card._clarifyCountdownTimer = setInterval(tick, 250);
+}
+
+function applyClarifyTimeoutExtension(data) {
+  const clarifyId = String(data?.clarifyId || '');
+  const deadlineTs = Number(data?.deadlineTs);
+  const timeoutSec = Number(data?.timeoutSec);
+  if (!clarifyId || !Number.isFinite(deadlineTs) || deadlineTs <= 0) return;
+  for (const card of document.querySelectorAll('.clarify-card')) {
+    if (String(card.dataset.clarifyId || '') !== clarifyId) continue;
+    if (card.classList.contains('clarify-answered')) continue;
+    const currentDeadlineTs = Number(card.dataset.deadlineTs) || 0;
+    if (deadlineTs < currentDeadlineTs) continue;
+    card.dataset.deadlineTs = String(Math.floor(deadlineTs));
+    if (Number.isFinite(timeoutSec) && timeoutSec > 0) {
+      card.dataset.timeoutSec = String(Math.floor(timeoutSec));
+    }
+    if (!card._clarifyCountdownTimer) {
+      const rawTabId = card.dataset.scheduledTabId ?? card.dataset.tabId;
+      const tabId = rawTabId != null && rawTabId !== '' ? Number(rawTabId) : currentTabId;
+      const firstOption = card.dataset.firstOption
+        || card.querySelector('.clarify-option')?.dataset?.value
+        || card.querySelector('.clarify-option')?.textContent
+        || '(no response — timed out)';
+      if (tabId != null && !Number.isNaN(tabId)) {
+        startClarifyCountdown(card, { tabId, clarifyId, deadlineTs, firstOption });
+      }
+    }
+  }
+  schedulePersist();
+}
+
+/**
+ * Treat custom-answer input as activity, not silence. Renew immediately on
+ * the first keystroke and periodically while typing so the agent cannot
+ * auto-select an option out from under an in-progress answer.
+ */
+function keepClarifyAliveWhileTyping(card, tabId, clarifyId, input) {
+  if (!card || card.classList.contains('clarify-answered') || !input?.value?.length) return;
+  const timeoutSec = Number(card.dataset.timeoutSec);
+  if (!Number.isFinite(timeoutSec) || timeoutSec <= 0) return;
+
+  const sendActivity = () => {
+    card._clarifyActivityTimer = null;
+    if (card.classList.contains('clarify-answered') || !input.value.length) return;
+    const activityTs = Date.now();
+    card._lastClarifyActivitySentAt = activityTs;
+    card.dataset.deadlineTs = String(Math.floor(activityTs + timeoutSec * 1000));
+    schedulePersist();
+    sendToBackground('clarify_input_activity', { tabId, clarifyId })
+      .then((response) => {
+        if (response?.matched) applyClarifyTimeoutExtension(response);
+      })
+      .catch(() => { /* the live run may have settled between keystrokes */ });
+  };
+
+  const now = Date.now();
+  const minIntervalMs = Math.max(250, Math.min(5000, timeoutSec * 500));
+  const lastSentAt = Number(card._lastClarifyActivitySentAt) || 0;
+  const elapsedMs = now - lastSentAt;
+  if (!lastSentAt || elapsedMs >= minIntervalMs) {
+    if (card._clarifyActivityTimer) clearTimeout(card._clarifyActivityTimer);
+    sendActivity();
+    return;
+  }
+  if (card._clarifyActivityTimer) clearTimeout(card._clarifyActivityTimer);
+  card._clarifyActivityTimer = setTimeout(sendActivity, minIntervalMs - elapsedMs);
 }
 
 /**

--- a/test/run.js
+++ b/test/run.js
@@ -37101,6 +37101,8 @@ test('clarify tool auto-timeout is configurable and mirrored across browsers', (
     assert.match(agent, /_normalizeClarifyTimeoutSec/, `${label}: agent should normalize clarify timeout (instant / wait / off)`);
     assert.match(agent, /if \(sec > 1200\) return -1/, `${label}: stored values above 1200 should normalize to Off (-1)`);
     assert.match(agent, /_settleClarification/, `${label}: clarify responses should settle once and clear timers`);
+    assert.match(agent, /noteClarifyInputActivity/, `${label}: custom-answer typing should renew a waited clarify timeout`);
+    assert.match(agent, /onUpdate\('clarify_timeout_extended'/, `${label}: renewed deadlines should be published to the UI`);
     assert.match(agent, /timeoutSec === 0 \? 'auto' : 'timeout'/, `${label}: Instant should use source=auto; waited timeout uses source=timeout`);
     assert.match(agent, /source: autoSource/, `${label}: clarify_auto / settle should pass auto or timeout via autoSource`);
     assert.match(agent, /source === 'timeout'/, `${label}: waited timeout should keep the non-confirmation tool note`);
@@ -37145,9 +37147,10 @@ test('clarify tool auto-timeout is configurable and mirrored across browsers', (
     );
     assert.match(
       scheduler,
-      /type === 'clarify' \|\| type === 'clarify_auto'/,
-      `${label}: scheduled clarify_auto updates should carry scheduledJobId`,
+      /type === 'clarify' \|\| type === 'clarify_timeout_extended' \|\| type === 'clarify_auto'/,
+      `${label}: scheduled clarify deadline updates should carry scheduledJobId`,
     );
+    assert.match(scheduler, /type === 'clarify_timeout_extended'[\s\S]*?pendingClarify:[\s\S]*?deadlineTs:/, `${label}: scheduled clarifies should persist renewed deadlines`);
     assert.match(
       panel,
       /isAutoClarify = source === 'timeout' \|\| source === 'auto'/,
@@ -37164,6 +37167,7 @@ test('clarify tool auto-timeout is configurable and mirrored across browsers', (
     assert.match(bg, /if \(sec > 1200\) return -1/, `${label}: background should treat >1200 as Off`);
     assert.match(bg, /clarifyTimeoutSemanticsV2/, `${label}: background should migrate old 0=Off semantics once`);
     assert.match(bg, /CLARIFY_TIMEOUT_OFF_SLIDER = 1205/, `${label}: Off slider sentinel should be 1205`);
+    assert.match(bg, /case 'clarify_input_activity':[\s\S]*?agent\.noteClarifyInputActivity/, `${label}: background should route custom-answer activity to the agent timer`);
 
     assert.match(settingsHtml, /id="range-clarify-timeout"[^>]*min="0"[^>]*max="1205"[^>]*value="60"/, `${label}: settings should expose 0–1205 clarify timeout slider (1205=Off)`);
     assert.match(settings, /clarifyTimeoutSec/, `${label}: settings should persist clarifyTimeoutSec`);
@@ -37175,6 +37179,8 @@ test('clarify tool auto-timeout is configurable and mirrored across browsers', (
     assert.match(panel, /case 'clarify_auto':/, `${label}: sidepanel should handle clarify_auto`);
     assert.match(panel, /lockClarifyCardFromAuto/, `${label}: sidepanel should lock cards on auto-select`);
     assert.match(panel, /dataset\.deadlineTs/, `${label}: clarify cards should persist deadline for restore`);
+    assert.match(panel, /input\.addEventListener\('input',[\s\S]*?keepClarifyAliveWhileTyping/, `${label}: custom-answer input should keep a waited clarify alive`);
+    assert.match(panel, /activeDeadlineTs = Number\(card\.dataset\.deadlineTs\)/, `${label}: countdown should read renewed deadlines`);
     assert.match(panel, /startClarifyCountdown\(card, \{ tabId, clarifyId, deadlineTs, firstOption \}\)/, `${label}: rebind should restart countdown from restored metadata`);
     assert.match(locale, /st\.display\.clarify_timeout\.label/, `${label}: English locale should include clarify timeout label`);
     assert.match(locale, /st\.display\.clarify_timeout\.off/, `${label}: English locale should include Off label`);
@@ -37183,6 +37189,68 @@ test('clarify tool auto-timeout is configurable and mirrored across browsers', (
     assert.match(locale, /above 1200s/, `${label}: English locale should document Off above 1200s`);
     assert.match(locale, /sp\.clarify\.auto_timeout/, `${label}: English locale should include countdown string`);
     assert.match(idLocale, /\{seconds\} dtk/, `${label}: Indonesian countdown should use seconds unit, not bare d`);
+  }
+});
+
+test('clarify custom-answer activity restarts the authoritative waited timeout', async () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const originalDateNow = Date.now;
+  let now = 10_000;
+  let nextTimerId = 1;
+  const timers = new Map();
+  globalThis.setTimeout = (callback, delay) => {
+    const id = nextTimerId++;
+    timers.set(id, { callback, delay });
+    return id;
+  };
+  globalThis.clearTimeout = (id) => {
+    timers.delete(id);
+  };
+  Date.now = () => now;
+
+  try {
+    for (const [index, AgentClass] of [AgentCh, AgentFx].entries()) {
+      const agent = new AgentClass({});
+      const tabId = 4810 + index;
+      agent.clarifyTimeoutSec = 5;
+      const updates = [];
+      const resultPromise = agent.executeTool(
+        tabId,
+        'clarify',
+        { question: 'Which option?', options: ['First', 'Something else'] },
+        (type, data) => updates.push({ type, data }),
+      );
+      // executeTool performs one async preflight before reaching clarify.
+      await new Promise(resolve => originalSetTimeout(resolve, 0));
+      const clarify = updates.find((update) => update.type === 'clarify')?.data;
+      assert.ok(clarify?.clarifyId, `${AgentClass.name}: clarify prompt was not emitted`);
+      const firstTimerId = [...timers.keys()][0];
+      assert.equal(timers.get(firstTimerId)?.delay, 5000, `${AgentClass.name}: initial waited timeout was not armed`);
+
+      now += 4000;
+      const renewed = agent.noteClarifyInputActivity(tabId, clarify.clarifyId);
+      assert.equal(renewed?.deadlineTs, now + 5000, `${AgentClass.name}: typing did not renew the full timeout`);
+      assert.equal(timers.has(firstTimerId), false, `${AgentClass.name}: original timeout remained armed while typing`);
+      const renewedTimerId = [...timers.keys()][0];
+      assert.equal(timers.get(renewedTimerId)?.delay, 5000, `${AgentClass.name}: renewed timeout used the wrong delay`);
+      assert.equal(
+        updates.at(-1)?.type,
+        'clarify_timeout_extended',
+        `${AgentClass.name}: renewed deadline was not emitted`,
+      );
+
+      timers.get(renewedTimerId).callback();
+      timers.delete(renewedTimerId);
+      const result = await resultPromise;
+      assert.equal(result.source, 'timeout', `${AgentClass.name}: renewed timer did not preserve waited-timeout semantics`);
+      assert.equal(agent.noteClarifyInputActivity(tabId, clarify.clarifyId), null, `${AgentClass.name}: settled clarify accepted stale typing activity`);
+      now += 1000;
+    }
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+    Date.now = originalDateNow;
   }
 });
 


### PR DESCRIPTION
## Summary

- renew the authoritative Clarify timeout while a person types a custom answer
- keep the visible countdown, restored cards, and scheduled Clarify state aligned with the renewed deadline
- mirror the behavior across Chrome and Firefox
- add regression coverage for timer renewal and stale activity

## Tests

- node test/run.js (1,922 passed, 0 failed)
- syntax checks for all modified JavaScript files
- git diff --check