### PR TITLE
Reconcile repeated-item progress placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog was generated from the repository Git history and release tags. V
 ## [33.1.1] - 2026-08-22
 
 ### Changed
+- Reconcile planner expected-item placeholders with classifier and concrete progress rows, preserving one ordered canonical row per repeated-task target across Chrome, Firefox, and restored sessions.
 - 33.1.0
 - Add WebBrain VL 2 benchmark blog posts
 - webbrain-vl-2-450m

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -26,7 +26,7 @@ import {
 } from './rich-text-toolbar-guard.js';
 import { RichTextToolbarProbe } from './rich-text-toolbar-probe.js';
 import { isCredentialField, CREDENTIAL_NOTE_STRICT, STRICT_SECRET_SYSTEM_NOTE } from './credential-fields.js';
-import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLedgerDowngrade, isTerminalLedgerStatus, isValidLedgerStatus, ledgerDoneBlock, ledgerRowKey, normalizeLedgerStatus, progressCounts, selectLedgerRows, unresolvedLedgerRows, upsertLedgerItems } from './progress-ledger.js';
+import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLedgerDowngrade, isTerminalLedgerStatus, isValidLedgerStatus, ledgerDoneBlock, ledgerRowKey, normalizeLedgerStatus, progressCounts, progressIdentitiesAreUnique, progressIdentityKeys, reconcileLedgerItems, reconcilePersistedLedgerRows, selectLedgerRows, unresolvedLedgerRows, upsertLedgerItems } from './progress-ledger.js';
 import { buildGithubStargazerProgressItems } from './observers/github-stargazers.js';
 import { analyzeMastodonPage, mastodonHandoffInstruction, mastodonProgressGuard } from './observers/mastodon.js';
 import { isProgressActionAllowed, isProgressIntentActive, normalizeProgressAction, normalizeProgressIntent } from './progress-intent.js';
@@ -10125,7 +10125,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           this.submittedRunRequestIds.set(tabId, String(entry.submittedRunRequestId));
         }
         if (Array.isArray(entry.progressLedger)) {
-          this.progressLedgers.set(tabId, entry.progressLedger);
+          const reconciledLedger = reconcilePersistedLedgerRows(entry.progressLedger);
+          this.progressLedgers.set(tabId, reconciledLedger.rows);
         }
         if (entry.progressSession && typeof entry.progressSession === 'object') {
           this.progressSessions.set(tabId, entry.progressSession);
@@ -15812,7 +15813,22 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const canonicalItems = this._canonicalizeProgressItems(items);
     const activeSession = this._currentProgressSession(tabId);
     const currentRows = this.progressLedgers.get(tabId) || [];
-    const terminalRequirements = canonicalItems
+    // Only internal callers may select a trusted ledger source. Tool arguments
+    // are model-controlled and must not be able to impersonate the classifier.
+    const updateSource = opts.source || 'model';
+    const reconciliationSessionId = opts.sessionId
+      || args.sessionId
+      || args.session_id
+      || activeSession?.sessionId
+      || '';
+    const reconciliation = reconcileLedgerItems(currentRows, canonicalItems, {
+      source: updateSource,
+      sessionId: reconciliationSessionId,
+      pageScope: opts.pageScope || activeSession?.pageScope || '',
+      taskKey: this._progressTaskKeyHash(tabId),
+    });
+    const reconciledItems = reconciliation.items;
+    const terminalRequirements = reconciledItems
       .filter(item => isTerminalLedgerStatus(item?.status))
       .map(item => {
         const requirementSessionId = opts.sessionId
@@ -15896,7 +15912,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         ids: observationOnlyRequirementIds.slice(0, 20),
       };
     }
-    const mastodonGuard = this._mastodonProgressUpdateGuard(tabId, canonicalItems);
+    const mastodonGuard = this._mastodonProgressUpdateGuard(tabId, reconciledItems);
     if (mastodonGuard) {
       return {
         success: false,
@@ -15905,18 +15921,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         ids: mastodonGuard.ids,
       };
     }
-    // Only internal callers may select a trusted ledger source. Tool arguments
-    // are model-controlled and must not be able to impersonate the classifier.
-    const updateSource = opts.source || 'model';
     const sessionOpts = { ...opts, sessionId: opts.sessionId || args.sessionId || args.session_id, source: updateSource };
-    const session = this._sessionForProgressUpdate(tabId, canonicalItems, sessionOpts);
+    const session = this._sessionForProgressUpdate(tabId, reconciledItems, sessionOpts);
     const sessionId = sessionOpts.sessionId || session?.sessionId || '';
     const pageScope = opts.pageScope || session?.pageScope || '';
     const scopedItems = sessionId
-      ? canonicalItems.map(item => (item && typeof item === 'object' && !Array.isArray(item)
+      ? reconciledItems.map(item => (item && typeof item === 'object' && !Array.isArray(item)
         ? { ...item, sessionId, ...(pageScope ? { pageScope } : {}) }
         : item))
-      : canonicalItems;
+      : reconciledItems;
     const current = this.progressLedgers.get(tabId) || [];
     const taskKey = this._progressTaskKeyHash(tabId);
     const result = upsertLedgerItems(current, scopedItems, {
@@ -15958,6 +15971,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       counts: progressCounts(visibleRows),
       unresolved: unresolvedLedgerRows(visibleRows, { limit: 20 }),
       ...(sessionId ? { sessionId } : {}),
+      ...(reconciliation.reconciled.length ? { reconciled: reconciliation.reconciled } : {}),
       ...(blockedDowngrades.length ? {
         warnings: blockedDowngrades.map(b => `row ${b.id} is already ${b.keptStatus}; status change to ${b.requestedStatus} ignored. Pass reopen:true only if the user explicitly asked to redo it.`),
       } : {}),
@@ -16202,10 +16216,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const allowedActions = session.allowedActions.map(normalizeProgressAction).filter(Boolean);
     const action = allowedActions[0];
     if (!action) return null;
-    const existingKeys = new Set((this.progressLedgers.get(tabId) || [])
-      .map(ledgerRowKey)
-      .filter(Boolean));
-    const items = session.targets.map((target, index) => ({
+    const targetItems = session.targets.map((target, index) => ({
       id: `requirement:${index + 1}:${String(target || '').trim()}`,
       label: String(target || '').trim(),
       target: String(target || '').trim(),
@@ -16215,7 +16226,58 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         completionRequirement: true,
         classifierTarget: true,
       },
-    })).filter(item => item.label
+    })).filter(item => item.label);
+    if (targetItems.length !== session.targets.length) return null;
+
+    const currentRows = this.progressLedgers.get(tabId) || [];
+    const expectedRows = this._rowsForProgressSession(tabId, session.sessionId, currentRows)
+      .filter(row => Number.isInteger(Number(row?.fields?.expectedOrdinal)))
+      .sort((a, b) => Number(a.fields.expectedOrdinal) - Number(b.fields.expectedOrdinal));
+    if (expectedRows.length) {
+      if (expectedRows.length !== targetItems.length) {
+        return {
+          success: false,
+          bindingDeferred: true,
+          error: `Classifier found ${targetItems.length} targets for ${expectedRows.length} expected rows; kept the ordered expected rows without adding a duplicate requirement set.`,
+        };
+      }
+      const uniqueTargets = progressIdentitiesAreUnique(targetItems);
+      if (!uniqueTargets) {
+        return {
+          success: false,
+          bindingDeferred: true,
+          error: 'Classifier targets were empty or ambiguous; kept the ordered expected rows without adding a duplicate requirement set.',
+        };
+      }
+      const alreadyBound = expectedRows.every((row, index) => {
+        const targetKeys = new Set(progressIdentityKeys(targetItems[index]));
+        return row?.fields?.classifierTarget === true
+          && progressIdentityKeys(row).some(key => targetKeys.has(key));
+      });
+      if (alreadyBound) return null;
+      const boundItems = expectedRows.map((row, index) => ({
+        id: row.id,
+        label: targetItems[index].label,
+        target: targetItems[index].target,
+        action,
+        status: row.status || 'pending',
+        fields: {
+          ...(row.fields || {}),
+          expectedOrdinal: Number(row.fields.expectedOrdinal),
+          completionRequirement: true,
+          classifierTarget: true,
+        },
+      }));
+      return this._progressUpdate(tabId, { items: boundItems }, {
+        source: 'classifier',
+        sessionId: session.sessionId,
+        pageScope: session.pageScope || '',
+      });
+    }
+    const existingKeys = new Set((this.progressLedgers.get(tabId) || [])
+      .map(ledgerRowKey)
+      .filter(Boolean));
+    const items = targetItems.filter(item => item.label
       && !existingKeys.has(ledgerRowKey({ ...item, sessionId: session.sessionId })));
     if (!items.length) return null;
     return this._progressUpdate(tabId, { items }, {
@@ -16239,12 +16301,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   _seedExpectedProgressItems(tabId, session, expectedItems) {
     if (!session?.sessionId || !expectedItems) return null;
+    const action = session.allowedActions?.[0] || 'process_item';
+    const requiresCompletionEvidence = !['collect_email', 'collect_profile', 'process_item', 'visit', 'open'].includes(action);
     const items = Array.from({ length: expectedItems.count }, (_, index) => ({
       id: `expected:${index + 1}`,
       label: `${expectedItems.item_type} ${index + 1}`,
-      action: session.allowedActions?.[0] || 'process_item',
+      action,
       status: 'pending',
-      fields: { expectedOrdinal: index + 1 },
+      fields: {
+        expectedOrdinal: index + 1,
+        ...(requiresCompletionEvidence ? { completionRequirement: true } : {}),
+      },
     }));
     return this._progressUpdate(tabId, { items }, {
       source: 'classifier',
@@ -16258,12 +16325,24 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const expected = this.progressExpectedItems.get(tabId);
     if (!expected) return null;
     const rows = this._currentTaskLedgerRows(tabId)
-      .filter(row => /^expected:\d+$/.test(String(row?.id || '')))
-      .sort((a, b) => Number(String(a.id).split(':')[1]) - Number(String(b.id).split(':')[1]));
+      .map(row => {
+        const trustedOrdinal = Number(row?.fields?.expectedOrdinal);
+        const legacyMatch = String(row?.id || '').match(/^expected:(\d+)$/);
+        const ordinal = Number.isInteger(trustedOrdinal) && trustedOrdinal > 0
+          ? trustedOrdinal
+          : Number(legacyMatch?.[1] || 0);
+        return ordinal > 0 ? { row, ordinal } : null;
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.ordinal - b.ordinal);
     if (rows.length !== expected.count) {
       return { blocked: true, error: `Expected ${expected.count} ${expected.item_type} rows, but the ledger contains ${rows.length}. Seed and process every ordered row before success.` };
     }
-    const incomplete = rows.filter(row => String(row.status || '').toLowerCase() !== 'processed'
+    if (rows.some(({ ordinal }, index) => ordinal !== index + 1)) {
+      return { blocked: true, error: `Expected exactly one ordered row for every ${expected.item_type} position from 1 through ${expected.count}; duplicate or missing ordinals remain.` };
+    }
+    const orderedRows = rows.map(({ row }) => row);
+    const incomplete = orderedRows.filter(row => String(row.status || '').toLowerCase() !== 'processed'
       || expected.required_fields.some(field => {
         const value = row?.fields?.[field];
         return value == null || String(value).trim() === '';
@@ -16277,7 +16356,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     const identityField = expected.required_fields[0];
     if (identityField) {
-      const values = rows.map(row => String(row?.fields?.[identityField] || '').trim().toLowerCase());
+      const values = orderedRows.map(row => String(row?.fields?.[identityField] || '').trim().toLowerCase());
       if (new Set(values).size !== values.length) {
         return { blocked: true, error: `Expected ${expected.count} non-duplicated ${identityField} values; duplicate rows remain.` };
       }
@@ -16326,8 +16405,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         targets: classified?.targets || [],
         reason: classified?.reason || 'approved planner enabled repeated-item progress tracking',
       }, { taskText, pageScope, source: classified ? 'classifier' : 'planner' });
-      this._seedClassifierProgressTargets(tabId, session);
       this._seedExpectedProgressItems(tabId, session, expectedItems);
+      this._seedClassifierProgressTargets(tabId, session);
       this._syncProgressSessionPrompt(tabId);
       return session;
     }
@@ -16364,38 +16443,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       ? this._rowsForProgressSession(tabId, session.sessionId)
       : [];
     return unresolvedLedgerRows(rows);
-  }
-
-  _progressLedgerLookupKey(value) {
-    return String(value || '')
-      .trim()
-      .replace(/^follow:/i, '')
-      .replace(/^\s*(?:follow|unfollow)\s+/i, '')
-      .replace(/^\s*@/, '')
-      .toLowerCase();
-  }
-
-  _reconcileAutoProgressItem(tabId, item) {
-    if (!item || String(item.action || '').toLowerCase() !== 'follow') return item;
-    const itemKeys = new Set([item.id, item.label, item.target]
-      .map(value => this._progressLedgerLookupKey(value))
-      .filter(Boolean));
-    if (!itemKeys.size) return item;
-    const session = this._currentProgressSession(tabId);
-    const match = this._activeProgressLedgerRows(tabId).find(row => {
-      if (session?.sessionId && String(row?.sessionId || '') !== session.sessionId) return false;
-      if (String(row?.action || '').toLowerCase() !== 'follow') return false;
-      return [row.id, row.label, row.target]
-        .map(value => this._progressLedgerLookupKey(value))
-        .some(key => key && itemKeys.has(key));
-    });
-    if (!match?.id || match.id === item.id) return item;
-    return {
-      ...item,
-      id: match.id,
-      label: match.label || item.label,
-      url: item.url || match.url,
-    };
   }
 
   _progressAutoRecordedNote(item = {}) {
@@ -16638,11 +16685,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       || detectProgressAction(name, args, result, { allowedActions: session.allowedActions });
     if (!item) return null;
     if (!isProgressActionAllowed(session, item.action)) return null;
-    const reconciled = this._reconcileAutoProgressItem(tabId, item);
-    const update = this._progressUpdate(tabId, { items: [reconciled] }, { source: 'auto', sessionId: session.sessionId, pageScope: session.pageScope });
+    const update = this._progressUpdate(tabId, { items: [item] }, { source: 'auto', sessionId: session.sessionId, pageScope: session.pageScope });
     if (!update?.success) return null;
     return {
-      item: update.updated?.[0] || reconciled,
+      item: update.updated?.[0] || item,
       counts: update.counts || progressCounts(this._currentTaskLedgerRows(tabId)),
       unresolved: unresolvedLedgerRows(this._currentTaskLedgerRows(tabId), { limit: 8 }),
     };

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -16235,6 +16235,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       .sort((a, b) => Number(a.fields.expectedOrdinal) - Number(b.fields.expectedOrdinal));
     if (expectedRows.length) {
       if (expectedRows.length !== targetItems.length) {
+        this._logDebug({
+          type: 'progress_binding_deferred',
+          reason: 'count_mismatch',
+          expected: expectedRows.length,
+          targets: targetItems.length,
+        });
         return {
           success: false,
           bindingDeferred: true,
@@ -16243,6 +16249,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
       const uniqueTargets = progressIdentitiesAreUnique(targetItems);
       if (!uniqueTargets) {
+        this._logDebug({
+          type: 'progress_binding_deferred',
+          reason: 'ambiguous_targets',
+          targets: targetItems.length,
+        });
         return {
           success: false,
           bindingDeferred: true,

--- a/src/chrome/src/agent/progress-ledger.js
+++ b/src/chrome/src/agent/progress-ledger.js
@@ -380,6 +380,17 @@ function mergedProgressStatus(canonicalStatus, duplicateStatus) {
   return 'pending';
 }
 
+function mergeCanonicalProgressFields(canonicalFields, duplicateFields) {
+  const canonical = canonicalFields && typeof canonicalFields === 'object' ? canonicalFields : {};
+  const duplicate = duplicateFields && typeof duplicateFields === 'object' ? duplicateFields : {};
+  const out = { ...duplicate };
+  for (const [key, value] of Object.entries(canonical)) {
+    const collected = value !== undefined && value !== null && value !== '';
+    if (collected || !Object.prototype.hasOwnProperty.call(out, key)) out[key] = value;
+  }
+  return out;
+}
+
 function mergeCanonicalProgressRows(canonical, duplicate) {
   const status = mergedProgressStatus(canonical?.status, duplicate?.status);
   if (!status) return null;
@@ -397,8 +408,7 @@ function mergeCanonicalProgressRows(canonical, duplicate) {
     ...(duplicate?.action ? { action: duplicate.action } : {}),
     source: duplicate?.source || canonical?.source || 'model',
     fields: {
-      ...(canonical?.fields || {}),
-      ...(duplicate?.fields || {}),
+      ...mergeCanonicalProgressFields(canonical?.fields, duplicate?.fields),
       ...(canonical?.fields?.completionRequirement === true || duplicate?.fields?.completionRequirement === true
         ? { completionRequirement: true } : {}),
       ...(canonical?.fields?.classifierTarget === true || duplicate?.fields?.classifierTarget === true

--- a/src/chrome/src/agent/progress-ledger.js
+++ b/src/chrome/src/agent/progress-ledger.js
@@ -8,7 +8,7 @@ const CLICK_ACTION_TOOLS = new Set(['click', 'click_ax', 'iframe_click']);
 const APP_OWNED_BOOLEAN_FIELD_KEYS = new Set(['completionRequirement', 'classifierTarget']);
 const APP_OWNED_INTEGER_FIELD_KEYS = new Set(['expectedOrdinal']);
 const ACTION_RE = /^\s*(follow|unfollow|star|unstar|watch|unwatch|connect|subscribe|unsubscribe|save|unsave|like|unlike|block|unblock|report|send|submit|add|remove)\b(?:\s+(.+?))?\s*$/i;
-const IDENTITY_ACTION_PREFIX_RE = /^\s*(?:follow|unfollow|star|unstar|watch|unwatch|connect|subscribe|unsubscribe|save|unsave|like|unlike|block|unblock|report|send|submit|add|remove|collect_email|collect_profile|process_item|visit|open)\s*[:\-]?\s+/i;
+const IDENTITY_ACTION_PREFIX_RE = /^\s*(?:follow|unfollow|star|unstar|watch|unwatch|connect|subscribe|unsubscribe|save|unsave|like|unlike|block|unblock|report|send|submit|add|remove|collect_email|collect_profile|process_item|visit|open)(?:\s*:\s*|\s+)(?!$)/i;
 const GENERIC_TARGET_RE = /^(button|link|item|result|profile|user|member|person|this|that|it|here|there|more|submit|save|send|add|remove|follow|unfollow|changes?|message|comment|reply|post|form|details|settings|preferences)$/i;
 
 export function normalizeLedgerStatus(value, fallback = 'pending') {

--- a/src/chrome/src/agent/progress-ledger.js
+++ b/src/chrome/src/agent/progress-ledger.js
@@ -463,8 +463,9 @@ export function reconcilePersistedLedgerRows(rows = []) {
       const identitiesAreUnique = progressIdentitiesAreUnique(concreteRows);
       const ordinalsAreComplete = unboundExpected.every((row, index) => Number(row.fields.expectedOrdinal) === index + 1);
       const compatible = unboundExpected.every((row, index) => actionsCompatible(row, concreteRows[index]));
+      const identityAgreement = unboundExpected.every((row, index) => identityMatchScore(row, concreteRows[index]) > 0);
       const merged = unboundExpected.map((row, index) => mergeCanonicalProgressRows(row, concreteRows[index]));
-      if (identitiesAreUnique && ordinalsAreComplete && compatible && merged.every(Boolean)) {
+      if (identitiesAreUnique && ordinalsAreComplete && compatible && identityAgreement && merged.every(Boolean)) {
         const replacementByKey = new Map(unboundExpected.map((row, index) => [ledgerRowKey(row), merged[index]]));
         const removedKeys = new Set(concreteRows.map(ledgerRowKey));
         next = next

--- a/src/chrome/src/agent/progress-ledger.js
+++ b/src/chrome/src/agent/progress-ledger.js
@@ -327,7 +327,10 @@ export function reconcileLedgerItems(rows = [], items = [], opts = {}) {
     if (availableExpected.length && batchFitsAvailable) {
       const identitiesAreUnique = progressIdentitiesAreUnique(newIncoming.map(({ item }) => item));
       const compatible = newIncoming.every(({ item }, index) => actionsCompatible(availableExpected[index], item));
-      if (identitiesAreUnique && compatible) {
+      const identityVerified = source !== 'auto' || newIncoming.every(({ item }, index) => (
+        identityMatchScore(availableExpected[index], item) > 0
+      ));
+      if (identitiesAreUnique && compatible && identityVerified) {
         newIncoming.forEach(({ index }, expectedIndex) => batchBindings.set(index, availableExpected[expectedIndex]));
       }
     }
@@ -350,7 +353,10 @@ export function reconcileLedgerItems(rows = [], items = [], opts = {}) {
       return {
         ...rawItem,
         id: batchCanonical.id,
-        target: rawItem?.target || incoming.target || incoming.label,
+        target: rawItem?.target
+          || incoming.target
+          || sanitizeText(String(incoming.label || '').replace(IDENTITY_ACTION_PREFIX_RE, ''), 180)
+          || incoming.label,
         sessionId: batchCanonical.sessionId || incoming.sessionId || sessionId,
       };
     }

--- a/src/chrome/src/agent/progress-ledger.js
+++ b/src/chrome/src/agent/progress-ledger.js
@@ -5,8 +5,10 @@ const sanitizeText = (value, max = 240) => sanitizeSharedText(value, max, { coll
 const VALID_STATUSES = new Set(['pending', 'acted', 'processed', 'skipped', 'failed']);
 const TERMINAL_STATUSES = new Set(['processed', 'skipped', 'failed']);
 const CLICK_ACTION_TOOLS = new Set(['click', 'click_ax', 'iframe_click']);
-const APP_OWNED_FIELD_KEYS = new Set(['completionRequirement', 'classifierTarget']);
+const APP_OWNED_BOOLEAN_FIELD_KEYS = new Set(['completionRequirement', 'classifierTarget']);
+const APP_OWNED_INTEGER_FIELD_KEYS = new Set(['expectedOrdinal']);
 const ACTION_RE = /^\s*(follow|unfollow|star|unstar|watch|unwatch|connect|subscribe|unsubscribe|save|unsave|like|unlike|block|unblock|report|send|submit|add|remove)\b(?:\s+(.+?))?\s*$/i;
+const IDENTITY_ACTION_PREFIX_RE = /^\s*(?:follow|unfollow|star|unstar|watch|unwatch|connect|subscribe|unsubscribe|save|unsave|like|unlike|block|unblock|report|send|submit|add|remove|collect_email|collect_profile|process_item|visit|open)\s*[:\-]?\s+/i;
 const GENERIC_TARGET_RE = /^(button|link|item|result|profile|user|member|person|this|that|it|here|there|more|submit|save|send|add|remove|follow|unfollow|changes?|message|comment|reply|post|form|details|settings|preferences)$/i;
 
 export function normalizeLedgerStatus(value, fallback = 'pending') {
@@ -68,14 +70,128 @@ function stableIdFor(action, target, url) {
   return sanitizeText(compact, 160);
 }
 
+function normalizeIdentityText(value) {
+  let text = cleanTarget(value);
+  if (!text) return '';
+  try { text = text.normalize('NFKC'); } catch {}
+  text = text
+    .replace(IDENTITY_ACTION_PREFIX_RE, '')
+    .replace(/^\s*@/, '')
+    .replace(/\/+$/, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+  return text && !GENERIC_TARGET_RE.test(text) ? text : '';
+}
+
+function identityEntries(item) {
+  const entries = new Map();
+  const add = (key, strength) => {
+    if (!key) return;
+    entries.set(key, Math.max(strength, entries.get(key) || 0));
+  };
+  const addUrl = (value) => {
+    const raw = sanitizeText(value, 500);
+    if (!raw) return;
+    try {
+      const url = new URL(raw);
+      if (!/^https?:$/i.test(url.protocol)) return;
+      const host = url.hostname.toLowerCase();
+      const pathname = url.pathname.replace(/\/{2,}/g, '/').replace(/\/+$/, '') || '/';
+      add(`url:${host}${pathname.toLowerCase()}`, 4);
+      const parts = pathname.split('/').filter(Boolean);
+      if (!parts.length) return;
+      let tail = '';
+      try { tail = decodeURIComponent(parts[parts.length - 1] || ''); } catch { tail = parts[parts.length - 1] || ''; }
+      tail = normalizeIdentityText(tail);
+      if (!tail) return;
+      add(`profile:${host}/${tail}`, 3);
+      if (/^[^@\s]+@[^@\s]+$/.test(tail)) {
+        add(`acct:${tail}`, 3);
+      } else if ((parts[parts.length - 1] || '').startsWith('@')) {
+        add(`acct:${tail}@${host}`, 3);
+      }
+      add(`text:${tail}`, 1);
+    } catch {}
+  };
+  const addText = (value, strength = 1) => {
+    const raw = sanitizeText(value, 500);
+    if (!raw) return;
+    if (/^https?:\/\//i.test(raw)) {
+      addUrl(raw);
+      return;
+    }
+    const text = normalizeIdentityText(raw);
+    if (!text) return;
+    add(`text:${text}`, strength);
+    if (/^[^@\s]+@[^@\s]+$/.test(text)) add(`acct:${text}`, Math.max(3, strength));
+  };
+
+  const id = sanitizeText(item?.id, 180);
+  if (id && !/^(?:expected|requirement):/i.test(id)) addText(id, 2);
+  addText(item?.target, 2);
+  addText(item?.label, 1);
+  addUrl(item?.url || item?.href);
+  return entries;
+}
+
+export function progressIdentityKeys(item) {
+  return [...identityEntries(item).keys()];
+}
+
+export function progressIdentitiesAreUnique(items = []) {
+  const strongestKeys = (Array.isArray(items) ? items : []).map(item => {
+    const entries = identityEntries(item);
+    const strongest = Math.max(0, ...entries.values());
+    return new Set([...entries]
+      .filter(([, strength]) => strength === strongest)
+      .map(([key]) => key));
+  });
+  return strongestKeys.every(keys => keys.size > 0)
+    && strongestKeys.every((keys, index) => strongestKeys.every((other, otherIndex) => (
+      index === otherIndex || ![...keys].some(key => other.has(key))
+    )));
+}
+
+function identityMatchScore(left, right) {
+  const leftEntries = identityEntries(left);
+  const rightEntries = identityEntries(right);
+  let score = 0;
+  for (const [key, leftStrength] of leftEntries) {
+    const rightStrength = rightEntries.get(key);
+    if (rightStrength) score = Math.max(score, Math.min(leftStrength, rightStrength));
+  }
+  return score;
+}
+
+function isCanonicalProgressRow(row) {
+  const ordinal = Number(row?.fields?.expectedOrdinal);
+  return row?.fields?.completionRequirement === true
+    || row?.fields?.classifierTarget === true
+    || (Number.isInteger(ordinal) && ordinal > 0);
+}
+
+function actionsCompatible(left, right) {
+  const leftAction = sanitizeText(left?.action, 80).toLowerCase();
+  const rightAction = sanitizeText(right?.action, 80).toLowerCase();
+  return !leftAction || !rightAction || leftAction === rightAction;
+}
+
 function sanitizeFields(fields, opts = {}) {
   if (!fields || typeof fields !== 'object' || Array.isArray(fields)) return undefined;
   const out = {};
   for (const [key, value] of Object.entries(fields).slice(0, 20)) {
     const k = sanitizeText(key, 80);
     if (!k) continue;
-    if (APP_OWNED_FIELD_KEYS.has(k)) {
+    if (APP_OWNED_BOOLEAN_FIELD_KEYS.has(k)) {
       if (opts.allowAppOwnedFields === true && value === true) out[k] = true;
+      continue;
+    }
+    if (APP_OWNED_INTEGER_FIELD_KEYS.has(k)) {
+      const ordinal = Number(value);
+      if (opts.allowAppOwnedFields === true && Number.isInteger(ordinal) && ordinal > 0 && ordinal <= 1000) {
+        out[k] = ordinal;
+      }
       continue;
     }
     const cleaned = sanitizeFieldValue(value);
@@ -130,6 +246,7 @@ export function normalizeLedgerItem(item, opts = {}) {
   return {
     id,
     label,
+    ...(target ? { target } : {}),
     ...(url ? { url } : {}),
     status,
     ...(action ? { action } : {}),
@@ -143,6 +260,235 @@ export function normalizeLedgerItem(item, opts = {}) {
     firstSeenAt: Number.isFinite(Number(item.firstSeenAt)) ? Number(item.firstSeenAt) : now,
     updatedAt: now,
   };
+}
+
+export function reconcileLedgerItems(rows = [], items = [], opts = {}) {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const source = sanitizeText(opts.source || 'model', 40) || 'model';
+  const sessionId = sanitizeText(opts.sessionId || '', 120);
+  const reconciled = [];
+  const rawItems = Array.isArray(items) ? items : [];
+  const normalizedItems = rawItems.map(rawItem => normalizeLedgerItem(rawItem, {
+    source,
+    sessionId,
+    pageScope: opts.pageScope,
+    taskKey: opts.taskKey,
+    now: opts.now,
+  }));
+  const semanticBindingFor = incoming => {
+    if (!incoming) return null;
+    const exactRow = safeRows.find(row => ledgerRowKey(row) === ledgerRowKey(incoming));
+    if (exactRow && actionsCompatible(exactRow, incoming)) return null;
+    let bestScore = 0;
+    let matches = [];
+    for (const row of safeRows) {
+      const autoMayReuseRow = source === 'auto' && !isTerminalLedgerStatus(row?.status);
+      if ((!isCanonicalProgressRow(row) && !autoMayReuseRow) || !actionsCompatible(row, incoming)) continue;
+      const rowSessionId = sanitizeText(row?.sessionId || row?.session_id || '', 120);
+      if (rowSessionId !== incoming.sessionId) continue;
+      const score = identityMatchScore(row, incoming);
+      if (score > bestScore) {
+        bestScore = score;
+        matches = [row];
+      } else if (score > 0 && score === bestScore) {
+        matches.push(row);
+      }
+    }
+    return bestScore && matches.length === 1 && matches[0]?.id ? matches[0] : null;
+  };
+  const semanticBindings = new Map();
+  normalizedItems.forEach((item, index) => {
+    const canonical = semanticBindingFor(item);
+    if (canonical) semanticBindings.set(index, canonical);
+  });
+  const batchBindings = new Map();
+  if (source !== 'classifier' && sessionId) {
+    const exactIncomingKeys = new Set(normalizedItems.filter(Boolean).map(ledgerRowKey));
+    const availableExpected = safeRows
+      .filter(row => {
+        const ordinal = Number(row?.fields?.expectedOrdinal);
+        const rowSessionId = sanitizeText(row?.sessionId || row?.session_id || '', 120);
+        return Number.isInteger(ordinal) && ordinal > 0
+          && row?.fields?.classifierTarget !== true
+          && !row?.target
+          && !row?.url
+          && rowSessionId === sessionId
+          && !exactIncomingKeys.has(ledgerRowKey(row));
+      })
+      .sort((a, b) => Number(a.fields.expectedOrdinal) - Number(b.fields.expectedOrdinal));
+    const newIncoming = normalizedItems
+      .map((item, index) => ({ item, index }))
+      .filter(({ item, index }) => item
+        && !semanticBindings.has(index)
+        && !safeRows.some(row => ledgerRowKey(row) === ledgerRowKey(item) && actionsCompatible(row, item)));
+    const canBindPartialBatch = source === 'model' || source === 'observe';
+    const batchFitsAvailable = newIncoming.length === availableExpected.length
+      || (canBindPartialBatch && newIncoming.length > 0 && newIncoming.length < availableExpected.length);
+    if (availableExpected.length && batchFitsAvailable) {
+      const identitiesAreUnique = progressIdentitiesAreUnique(newIncoming.map(({ item }) => item));
+      const compatible = newIncoming.every(({ item }, index) => actionsCompatible(availableExpected[index], item));
+      if (identitiesAreUnique && compatible) {
+        newIncoming.forEach(({ index }, expectedIndex) => batchBindings.set(index, availableExpected[expectedIndex]));
+      }
+    }
+  }
+
+  const nextItems = rawItems.map((rawItem, itemIndex) => {
+    const incoming = normalizedItems[itemIndex];
+    const semanticCanonical = semanticBindings.get(itemIndex);
+    if (incoming && semanticCanonical?.id) {
+      reconciled.push({ incomingId: incoming.id, canonicalId: semanticCanonical.id });
+      return {
+        ...rawItem,
+        id: semanticCanonical.id,
+        sessionId: semanticCanonical.sessionId || incoming.sessionId || sessionId,
+      };
+    }
+    const batchCanonical = batchBindings.get(itemIndex);
+    if (incoming && batchCanonical?.id) {
+      reconciled.push({ incomingId: incoming.id, canonicalId: batchCanonical.id });
+      return {
+        ...rawItem,
+        id: batchCanonical.id,
+        target: rawItem?.target || incoming.target || incoming.label,
+        sessionId: batchCanonical.sessionId || incoming.sessionId || sessionId,
+      };
+    }
+    if (!incoming) return rawItem;
+    const exactRow = safeRows.find(row => ledgerRowKey(row) === ledgerRowKey(incoming));
+    if (exactRow && actionsCompatible(exactRow, incoming)) return rawItem;
+    return rawItem;
+  });
+  return { items: nextItems, reconciled };
+}
+
+function mergedProgressStatus(canonicalStatus, duplicateStatus) {
+  const canonical = normalizeStatus(canonicalStatus, 'pending');
+  const duplicate = normalizeStatus(duplicateStatus, 'pending');
+  if (isTerminalLedgerStatus(canonical) && isTerminalLedgerStatus(duplicate)) {
+    return canonical === duplicate ? canonical : '';
+  }
+  if (isTerminalLedgerStatus(canonical)) return canonical;
+  if (isTerminalLedgerStatus(duplicate)) return duplicate;
+  if (canonical === 'acted' || duplicate === 'acted') return 'acted';
+  return 'pending';
+}
+
+function mergeCanonicalProgressRows(canonical, duplicate) {
+  const status = mergedProgressStatus(canonical?.status, duplicate?.status);
+  if (!status) return null;
+  const ordinal = Number(canonical?.fields?.expectedOrdinal);
+  const firstSeenAt = [canonical?.firstSeenAt, duplicate?.firstSeenAt]
+    .map(Number).filter(Number.isFinite);
+  const updatedAt = [canonical?.updatedAt, duplicate?.updatedAt]
+    .map(Number).filter(Number.isFinite);
+  return {
+    ...canonical,
+    label: duplicate?.label || canonical?.label,
+    ...(duplicate?.target ? { target: duplicate.target } : {}),
+    ...(duplicate?.url ? { url: duplicate.url } : {}),
+    status,
+    ...(duplicate?.action ? { action: duplicate.action } : {}),
+    source: duplicate?.source || canonical?.source || 'model',
+    fields: {
+      ...(canonical?.fields || {}),
+      ...(duplicate?.fields || {}),
+      ...(canonical?.fields?.completionRequirement === true || duplicate?.fields?.completionRequirement === true
+        ? { completionRequirement: true } : {}),
+      ...(canonical?.fields?.classifierTarget === true || duplicate?.fields?.classifierTarget === true
+        ? { classifierTarget: true } : {}),
+      ...(Number.isInteger(ordinal) && ordinal > 0 ? { expectedOrdinal: ordinal } : {}),
+    },
+    attempts: Math.max(Number(canonical?.attempts || 0), Number(duplicate?.attempts || 0)),
+    ...(firstSeenAt.length ? { firstSeenAt: Math.min(...firstSeenAt) } : {}),
+    ...(updatedAt.length ? { updatedAt: Math.max(...updatedAt) } : {}),
+  };
+}
+
+export function reconcilePersistedLedgerRows(rows = []) {
+  let next = Array.isArray(rows)
+    ? rows.map(row => ({ ...row, fields: row?.fields ? { ...row.fields } : undefined }))
+    : [];
+  const reconciled = [];
+  const sessionIds = new Set(next
+    .map(row => sanitizeText(row?.sessionId || row?.session_id || '', 120))
+    .filter(Boolean));
+
+  for (const sessionId of sessionIds) {
+    const inSession = row => sanitizeText(row?.sessionId || row?.session_id || '', 120) === sessionId;
+    const expected = next.filter(row => inSession(row) && Number.isInteger(Number(row?.fields?.expectedOrdinal)))
+      .sort((a, b) => Number(a.fields.expectedOrdinal) - Number(b.fields.expectedOrdinal));
+    const requirements = next.filter(row => inSession(row)
+      && row?.fields?.classifierTarget === true
+      && /^requirement:/i.test(String(row?.id || '')))
+      .sort((a, b) => Number(String(a.id).match(/^requirement:(\d+)/i)?.[1] || 0)
+        - Number(String(b.id).match(/^requirement:(\d+)/i)?.[1] || 0));
+    if (expected.length && expected.length === requirements.length) {
+      const targetsAreUnique = progressIdentitiesAreUnique(requirements);
+      const ordinalsAreComplete = expected.every((row, index) => Number(row.fields.expectedOrdinal) === index + 1);
+      const compatible = expected.every((row, index) => actionsCompatible(row, requirements[index]));
+      const merged = expected.map((row, index) => mergeCanonicalProgressRows(row, requirements[index]));
+      if (targetsAreUnique && ordinalsAreComplete && compatible && merged.every(Boolean)) {
+        const replacementByKey = new Map(expected.map((row, index) => [ledgerRowKey(row), merged[index]]));
+        const removedKeys = new Set(requirements.map(ledgerRowKey));
+        next = next
+          .filter(row => !removedKeys.has(ledgerRowKey(row)))
+          .map(row => replacementByKey.get(ledgerRowKey(row)) || row);
+        requirements.forEach((row, index) => reconciled.push({ incomingId: row.id, canonicalId: expected[index].id }));
+      }
+    }
+
+    const unboundExpected = next.filter(row => inSession(row)
+      && Number.isInteger(Number(row?.fields?.expectedOrdinal))
+      && row?.fields?.classifierTarget !== true)
+      .sort((a, b) => Number(a.fields.expectedOrdinal) - Number(b.fields.expectedOrdinal));
+    const concreteRows = next.filter(row => inSession(row) && !isCanonicalProgressRow(row));
+    if (unboundExpected.length && unboundExpected.length === concreteRows.length) {
+      const identitiesAreUnique = progressIdentitiesAreUnique(concreteRows);
+      const ordinalsAreComplete = unboundExpected.every((row, index) => Number(row.fields.expectedOrdinal) === index + 1);
+      const compatible = unboundExpected.every((row, index) => actionsCompatible(row, concreteRows[index]));
+      const merged = unboundExpected.map((row, index) => mergeCanonicalProgressRows(row, concreteRows[index]));
+      if (identitiesAreUnique && ordinalsAreComplete && compatible && merged.every(Boolean)) {
+        const replacementByKey = new Map(unboundExpected.map((row, index) => [ledgerRowKey(row), merged[index]]));
+        const removedKeys = new Set(concreteRows.map(ledgerRowKey));
+        next = next
+          .filter(row => !removedKeys.has(ledgerRowKey(row)))
+          .map(row => replacementByKey.get(ledgerRowKey(row)) || row);
+        concreteRows.forEach((row, index) => reconciled.push({ incomingId: row.id, canonicalId: unboundExpected[index].id }));
+      }
+    }
+
+    const canonicalRows = next.filter(row => inSession(row)
+      && Number.isInteger(Number(row?.fields?.expectedOrdinal))
+      && row?.fields?.classifierTarget === true);
+    for (const duplicate of [...next]) {
+      if (!inSession(duplicate) || isCanonicalProgressRow(duplicate)) continue;
+      let bestScore = 0;
+      let matches = [];
+      for (const canonical of canonicalRows) {
+        if (!actionsCompatible(canonical, duplicate)) continue;
+        const score = identityMatchScore(canonical, duplicate);
+        if (score > bestScore) {
+          bestScore = score;
+          matches = [canonical];
+        } else if (score > 0 && score === bestScore) {
+          matches.push(canonical);
+        }
+      }
+      if (!bestScore || matches.length !== 1) continue;
+      const canonical = matches[0];
+      const merged = mergeCanonicalProgressRows(canonical, duplicate);
+      if (!merged) continue;
+      const canonicalKey = ledgerRowKey(canonical);
+      const duplicateKey = ledgerRowKey(duplicate);
+      next = next.filter(row => ledgerRowKey(row) !== duplicateKey)
+        .map(row => ledgerRowKey(row) === canonicalKey ? merged : row);
+      const canonicalIndex = canonicalRows.indexOf(canonical);
+      if (canonicalIndex >= 0) canonicalRows[canonicalIndex] = merged;
+      reconciled.push({ incomingId: duplicate.id, canonicalId: canonical.id });
+    }
+  }
+  return { rows: next, changed: reconciled.length > 0, reconciled };
 }
 
 export function progressCounts(rows = []) {
@@ -182,6 +528,7 @@ export function upsertLedgerItems(rows = [], items = [], opts = {}) {
   const now = Number.isFinite(opts.now) ? opts.now : Date.now();
   const source = sanitizeText(opts.source || 'model', 40) || 'model';
   const next = Array.isArray(rows) ? rows.map(row => ({ ...row, fields: row?.fields ? { ...row.fields } : undefined })) : [];
+  const reconciliation = reconcileLedgerItems(next, items, { ...opts, source, now });
   const indexByKey = new Map();
   next.forEach((row, idx) => {
     const key = ledgerRowKey(row);
@@ -190,7 +537,7 @@ export function upsertLedgerItems(rows = [], items = [], opts = {}) {
 
   const updated = [];
   const blockedDowngrades = [];
-  for (const rawItem of Array.isArray(items) ? items : []) {
+  for (const rawItem of reconciliation.items) {
     const incoming = normalizeLedgerItem(rawItem, { source, now, sessionId: opts.sessionId, pageScope: opts.pageScope, taskKey: opts.taskKey });
     if (!incoming) continue;
     const key = ledgerRowKey(incoming);
@@ -211,6 +558,7 @@ export function upsertLedgerItems(rows = [], items = [], opts = {}) {
     const merged = {
       ...existing,
       label: incoming.label || existing.label,
+      ...(incoming.target ? { target: incoming.target } : {}),
       ...(incoming.url ? { url: incoming.url } : {}),
       status: keepTerminal ? existing.status : incoming.status,
       ...(incoming.action ? { action: incoming.action } : {}),
@@ -234,7 +582,14 @@ export function upsertLedgerItems(rows = [], items = [], opts = {}) {
     updated.push(merged);
   }
 
-  return { rows: next, updated, counts: progressCounts(next), changed: updated.length > 0, blockedDowngrades };
+  return {
+    rows: next,
+    updated,
+    counts: progressCounts(next),
+    changed: updated.length > 0,
+    blockedDowngrades,
+    reconciled: reconciliation.reconciled,
+  };
 }
 
 export function formatLedgerRow(row) {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -26,7 +26,7 @@ import {
 } from './rich-text-toolbar-guard.js';
 import { RichTextToolbarProbe } from './rich-text-toolbar-probe.js';
 import { isCredentialField, CREDENTIAL_NOTE_STRICT, STRICT_SECRET_SYSTEM_NOTE } from './credential-fields.js';
-import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLedgerDowngrade, isTerminalLedgerStatus, isValidLedgerStatus, ledgerDoneBlock, ledgerRowKey, normalizeLedgerStatus, progressCounts, selectLedgerRows, unresolvedLedgerRows, upsertLedgerItems } from './progress-ledger.js';
+import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLedgerDowngrade, isTerminalLedgerStatus, isValidLedgerStatus, ledgerDoneBlock, ledgerRowKey, normalizeLedgerStatus, progressCounts, progressIdentitiesAreUnique, progressIdentityKeys, reconcileLedgerItems, reconcilePersistedLedgerRows, selectLedgerRows, unresolvedLedgerRows, upsertLedgerItems } from './progress-ledger.js';
 import { buildGithubStargazerProgressItems } from './observers/github-stargazers.js';
 import { analyzeMastodonPage, mastodonHandoffInstruction, mastodonProgressGuard } from './observers/mastodon.js';
 import { isProgressActionAllowed, isProgressIntentActive, normalizeProgressAction, normalizeProgressIntent } from './progress-intent.js';
@@ -1346,7 +1346,8 @@ export class Agent extends LoopDetector {
           this.submittedRunRequestIds.set(tabId, String(entry.submittedRunRequestId));
         }
         if (Array.isArray(entry.progressLedger)) {
-          this.progressLedgers.set(tabId, entry.progressLedger);
+          const reconciledLedger = reconcilePersistedLedgerRows(entry.progressLedger);
+          this.progressLedgers.set(tabId, reconciledLedger.rows);
         }
         if (entry.progressSession && typeof entry.progressSession === 'object') {
           this.progressSessions.set(tabId, entry.progressSession);
@@ -13473,7 +13474,22 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const canonicalItems = this._canonicalizeProgressItems(items);
     const activeSession = this._currentProgressSession(tabId);
     const currentRows = this.progressLedgers.get(tabId) || [];
-    const terminalRequirements = canonicalItems
+    // Only internal callers may select a trusted ledger source. Tool arguments
+    // are model-controlled and must not be able to impersonate the classifier.
+    const updateSource = opts.source || 'model';
+    const reconciliationSessionId = opts.sessionId
+      || args.sessionId
+      || args.session_id
+      || activeSession?.sessionId
+      || '';
+    const reconciliation = reconcileLedgerItems(currentRows, canonicalItems, {
+      source: updateSource,
+      sessionId: reconciliationSessionId,
+      pageScope: opts.pageScope || activeSession?.pageScope || '',
+      taskKey: this._progressTaskKeyHash(tabId),
+    });
+    const reconciledItems = reconciliation.items;
+    const terminalRequirements = reconciledItems
       .filter(item => isTerminalLedgerStatus(item?.status))
       .map(item => {
         const requirementSessionId = opts.sessionId
@@ -13557,7 +13573,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         ids: observationOnlyRequirementIds.slice(0, 20),
       };
     }
-    const mastodonGuard = this._mastodonProgressUpdateGuard(tabId, canonicalItems);
+    const mastodonGuard = this._mastodonProgressUpdateGuard(tabId, reconciledItems);
     if (mastodonGuard) {
       return {
         success: false,
@@ -13566,18 +13582,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         ids: mastodonGuard.ids,
       };
     }
-    // Only internal callers may select a trusted ledger source. Tool arguments
-    // are model-controlled and must not be able to impersonate the classifier.
-    const updateSource = opts.source || 'model';
     const sessionOpts = { ...opts, sessionId: opts.sessionId || args.sessionId || args.session_id, source: updateSource };
-    const session = this._sessionForProgressUpdate(tabId, canonicalItems, sessionOpts);
+    const session = this._sessionForProgressUpdate(tabId, reconciledItems, sessionOpts);
     const sessionId = sessionOpts.sessionId || session?.sessionId || '';
     const pageScope = opts.pageScope || session?.pageScope || '';
     const scopedItems = sessionId
-      ? canonicalItems.map(item => (item && typeof item === 'object' && !Array.isArray(item)
+      ? reconciledItems.map(item => (item && typeof item === 'object' && !Array.isArray(item)
         ? { ...item, sessionId, ...(pageScope ? { pageScope } : {}) }
         : item))
-      : canonicalItems;
+      : reconciledItems;
     const current = this.progressLedgers.get(tabId) || [];
     const taskKey = this._progressTaskKeyHash(tabId);
     const result = upsertLedgerItems(current, scopedItems, {
@@ -13619,6 +13632,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       counts: progressCounts(visibleRows),
       unresolved: unresolvedLedgerRows(visibleRows, { limit: 20 }),
       ...(sessionId ? { sessionId } : {}),
+      ...(reconciliation.reconciled.length ? { reconciled: reconciliation.reconciled } : {}),
       ...(blockedDowngrades.length ? {
         warnings: blockedDowngrades.map(b => `row ${b.id} is already ${b.keptStatus}; status change to ${b.requestedStatus} ignored. Pass reopen:true only if the user explicitly asked to redo it.`),
       } : {}),
@@ -13863,10 +13877,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const allowedActions = session.allowedActions.map(normalizeProgressAction).filter(Boolean);
     const action = allowedActions[0];
     if (!action) return null;
-    const existingKeys = new Set((this.progressLedgers.get(tabId) || [])
-      .map(ledgerRowKey)
-      .filter(Boolean));
-    const items = session.targets.map((target, index) => ({
+    const targetItems = session.targets.map((target, index) => ({
       id: `requirement:${index + 1}:${String(target || '').trim()}`,
       label: String(target || '').trim(),
       target: String(target || '').trim(),
@@ -13876,7 +13887,58 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         completionRequirement: true,
         classifierTarget: true,
       },
-    })).filter(item => item.label
+    })).filter(item => item.label);
+    if (targetItems.length !== session.targets.length) return null;
+
+    const currentRows = this.progressLedgers.get(tabId) || [];
+    const expectedRows = this._rowsForProgressSession(tabId, session.sessionId, currentRows)
+      .filter(row => Number.isInteger(Number(row?.fields?.expectedOrdinal)))
+      .sort((a, b) => Number(a.fields.expectedOrdinal) - Number(b.fields.expectedOrdinal));
+    if (expectedRows.length) {
+      if (expectedRows.length !== targetItems.length) {
+        return {
+          success: false,
+          bindingDeferred: true,
+          error: `Classifier found ${targetItems.length} targets for ${expectedRows.length} expected rows; kept the ordered expected rows without adding a duplicate requirement set.`,
+        };
+      }
+      const uniqueTargets = progressIdentitiesAreUnique(targetItems);
+      if (!uniqueTargets) {
+        return {
+          success: false,
+          bindingDeferred: true,
+          error: 'Classifier targets were empty or ambiguous; kept the ordered expected rows without adding a duplicate requirement set.',
+        };
+      }
+      const alreadyBound = expectedRows.every((row, index) => {
+        const targetKeys = new Set(progressIdentityKeys(targetItems[index]));
+        return row?.fields?.classifierTarget === true
+          && progressIdentityKeys(row).some(key => targetKeys.has(key));
+      });
+      if (alreadyBound) return null;
+      const boundItems = expectedRows.map((row, index) => ({
+        id: row.id,
+        label: targetItems[index].label,
+        target: targetItems[index].target,
+        action,
+        status: row.status || 'pending',
+        fields: {
+          ...(row.fields || {}),
+          expectedOrdinal: Number(row.fields.expectedOrdinal),
+          completionRequirement: true,
+          classifierTarget: true,
+        },
+      }));
+      return this._progressUpdate(tabId, { items: boundItems }, {
+        source: 'classifier',
+        sessionId: session.sessionId,
+        pageScope: session.pageScope || '',
+      });
+    }
+    const existingKeys = new Set((this.progressLedgers.get(tabId) || [])
+      .map(ledgerRowKey)
+      .filter(Boolean));
+    const items = targetItems.filter(item => item.label
       && !existingKeys.has(ledgerRowKey({ ...item, sessionId: session.sessionId })));
     if (!items.length) return null;
     return this._progressUpdate(tabId, { items }, {
@@ -13900,12 +13962,17 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
   _seedExpectedProgressItems(tabId, session, expectedItems) {
     if (!session?.sessionId || !expectedItems) return null;
+    const action = session.allowedActions?.[0] || 'process_item';
+    const requiresCompletionEvidence = !['collect_email', 'collect_profile', 'process_item', 'visit', 'open'].includes(action);
     const items = Array.from({ length: expectedItems.count }, (_, index) => ({
       id: `expected:${index + 1}`,
       label: `${expectedItems.item_type} ${index + 1}`,
-      action: session.allowedActions?.[0] || 'process_item',
+      action,
       status: 'pending',
-      fields: { expectedOrdinal: index + 1 },
+      fields: {
+        expectedOrdinal: index + 1,
+        ...(requiresCompletionEvidence ? { completionRequirement: true } : {}),
+      },
     }));
     return this._progressUpdate(tabId, { items }, {
       source: 'classifier',
@@ -13919,12 +13986,24 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const expected = this.progressExpectedItems.get(tabId);
     if (!expected) return null;
     const rows = this._currentTaskLedgerRows(tabId)
-      .filter(row => /^expected:\d+$/.test(String(row?.id || '')))
-      .sort((a, b) => Number(String(a.id).split(':')[1]) - Number(String(b.id).split(':')[1]));
+      .map(row => {
+        const trustedOrdinal = Number(row?.fields?.expectedOrdinal);
+        const legacyMatch = String(row?.id || '').match(/^expected:(\d+)$/);
+        const ordinal = Number.isInteger(trustedOrdinal) && trustedOrdinal > 0
+          ? trustedOrdinal
+          : Number(legacyMatch?.[1] || 0);
+        return ordinal > 0 ? { row, ordinal } : null;
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.ordinal - b.ordinal);
     if (rows.length !== expected.count) {
       return { blocked: true, error: `Expected ${expected.count} ${expected.item_type} rows, but the ledger contains ${rows.length}. Seed and process every ordered row before success.` };
     }
-    const incomplete = rows.filter(row => String(row.status || '').toLowerCase() !== 'processed'
+    if (rows.some(({ ordinal }, index) => ordinal !== index + 1)) {
+      return { blocked: true, error: `Expected exactly one ordered row for every ${expected.item_type} position from 1 through ${expected.count}; duplicate or missing ordinals remain.` };
+    }
+    const orderedRows = rows.map(({ row }) => row);
+    const incomplete = orderedRows.filter(row => String(row.status || '').toLowerCase() !== 'processed'
       || expected.required_fields.some(field => {
         const value = row?.fields?.[field];
         return value == null || String(value).trim() === '';
@@ -13938,7 +14017,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     const identityField = expected.required_fields[0];
     if (identityField) {
-      const values = rows.map(row => String(row?.fields?.[identityField] || '').trim().toLowerCase());
+      const values = orderedRows.map(row => String(row?.fields?.[identityField] || '').trim().toLowerCase());
       if (new Set(values).size !== values.length) {
         return { blocked: true, error: `Expected ${expected.count} non-duplicated ${identityField} values; duplicate rows remain.` };
       }
@@ -13987,8 +14066,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         targets: classified?.targets || [],
         reason: classified?.reason || 'approved planner enabled repeated-item progress tracking',
       }, { taskText, pageScope, source: classified ? 'classifier' : 'planner' });
-      this._seedClassifierProgressTargets(tabId, session);
       this._seedExpectedProgressItems(tabId, session, expectedItems);
+      this._seedClassifierProgressTargets(tabId, session);
       this._syncProgressSessionPrompt(tabId);
       return session;
     }
@@ -14025,38 +14104,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       ? this._rowsForProgressSession(tabId, session.sessionId)
       : [];
     return unresolvedLedgerRows(rows);
-  }
-
-  _progressLedgerLookupKey(value) {
-    return String(value || '')
-      .trim()
-      .replace(/^follow:/i, '')
-      .replace(/^\s*(?:follow|unfollow)\s+/i, '')
-      .replace(/^\s*@/, '')
-      .toLowerCase();
-  }
-
-  _reconcileAutoProgressItem(tabId, item) {
-    if (!item || String(item.action || '').toLowerCase() !== 'follow') return item;
-    const itemKeys = new Set([item.id, item.label, item.target]
-      .map(value => this._progressLedgerLookupKey(value))
-      .filter(Boolean));
-    if (!itemKeys.size) return item;
-    const session = this._currentProgressSession(tabId);
-    const match = this._activeProgressLedgerRows(tabId).find(row => {
-      if (session?.sessionId && String(row?.sessionId || '') !== session.sessionId) return false;
-      if (String(row?.action || '').toLowerCase() !== 'follow') return false;
-      return [row.id, row.label, row.target]
-        .map(value => this._progressLedgerLookupKey(value))
-        .some(key => key && itemKeys.has(key));
-    });
-    if (!match?.id || match.id === item.id) return item;
-    return {
-      ...item,
-      id: match.id,
-      label: match.label || item.label,
-      url: item.url || match.url,
-    };
   }
 
   _progressAutoRecordedNote(item = {}) {
@@ -14299,11 +14346,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       || detectProgressAction(name, args, result, { allowedActions: session.allowedActions });
     if (!item) return null;
     if (!isProgressActionAllowed(session, item.action)) return null;
-    const reconciled = this._reconcileAutoProgressItem(tabId, item);
-    const update = this._progressUpdate(tabId, { items: [reconciled] }, { source: 'auto', sessionId: session.sessionId, pageScope: session.pageScope });
+    const update = this._progressUpdate(tabId, { items: [item] }, { source: 'auto', sessionId: session.sessionId, pageScope: session.pageScope });
     if (!update?.success) return null;
     return {
-      item: update.updated?.[0] || reconciled,
+      item: update.updated?.[0] || item,
       counts: update.counts || progressCounts(this._currentTaskLedgerRows(tabId)),
       unresolved: unresolvedLedgerRows(this._currentTaskLedgerRows(tabId), { limit: 8 }),
     };

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -13896,6 +13896,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       .sort((a, b) => Number(a.fields.expectedOrdinal) - Number(b.fields.expectedOrdinal));
     if (expectedRows.length) {
       if (expectedRows.length !== targetItems.length) {
+        this._logDebug({
+          type: 'progress_binding_deferred',
+          reason: 'count_mismatch',
+          expected: expectedRows.length,
+          targets: targetItems.length,
+        });
         return {
           success: false,
           bindingDeferred: true,
@@ -13904,6 +13910,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
       const uniqueTargets = progressIdentitiesAreUnique(targetItems);
       if (!uniqueTargets) {
+        this._logDebug({
+          type: 'progress_binding_deferred',
+          reason: 'ambiguous_targets',
+          targets: targetItems.length,
+        });
         return {
           success: false,
           bindingDeferred: true,

--- a/src/firefox/src/agent/progress-ledger.js
+++ b/src/firefox/src/agent/progress-ledger.js
@@ -380,6 +380,17 @@ function mergedProgressStatus(canonicalStatus, duplicateStatus) {
   return 'pending';
 }
 
+function mergeCanonicalProgressFields(canonicalFields, duplicateFields) {
+  const canonical = canonicalFields && typeof canonicalFields === 'object' ? canonicalFields : {};
+  const duplicate = duplicateFields && typeof duplicateFields === 'object' ? duplicateFields : {};
+  const out = { ...duplicate };
+  for (const [key, value] of Object.entries(canonical)) {
+    const collected = value !== undefined && value !== null && value !== '';
+    if (collected || !Object.prototype.hasOwnProperty.call(out, key)) out[key] = value;
+  }
+  return out;
+}
+
 function mergeCanonicalProgressRows(canonical, duplicate) {
   const status = mergedProgressStatus(canonical?.status, duplicate?.status);
   if (!status) return null;
@@ -397,8 +408,7 @@ function mergeCanonicalProgressRows(canonical, duplicate) {
     ...(duplicate?.action ? { action: duplicate.action } : {}),
     source: duplicate?.source || canonical?.source || 'model',
     fields: {
-      ...(canonical?.fields || {}),
-      ...(duplicate?.fields || {}),
+      ...mergeCanonicalProgressFields(canonical?.fields, duplicate?.fields),
       ...(canonical?.fields?.completionRequirement === true || duplicate?.fields?.completionRequirement === true
         ? { completionRequirement: true } : {}),
       ...(canonical?.fields?.classifierTarget === true || duplicate?.fields?.classifierTarget === true

--- a/src/firefox/src/agent/progress-ledger.js
+++ b/src/firefox/src/agent/progress-ledger.js
@@ -8,7 +8,7 @@ const CLICK_ACTION_TOOLS = new Set(['click', 'click_ax', 'iframe_click']);
 const APP_OWNED_BOOLEAN_FIELD_KEYS = new Set(['completionRequirement', 'classifierTarget']);
 const APP_OWNED_INTEGER_FIELD_KEYS = new Set(['expectedOrdinal']);
 const ACTION_RE = /^\s*(follow|unfollow|star|unstar|watch|unwatch|connect|subscribe|unsubscribe|save|unsave|like|unlike|block|unblock|report|send|submit|add|remove)\b(?:\s+(.+?))?\s*$/i;
-const IDENTITY_ACTION_PREFIX_RE = /^\s*(?:follow|unfollow|star|unstar|watch|unwatch|connect|subscribe|unsubscribe|save|unsave|like|unlike|block|unblock|report|send|submit|add|remove|collect_email|collect_profile|process_item|visit|open)\s*[:\-]?\s+/i;
+const IDENTITY_ACTION_PREFIX_RE = /^\s*(?:follow|unfollow|star|unstar|watch|unwatch|connect|subscribe|unsubscribe|save|unsave|like|unlike|block|unblock|report|send|submit|add|remove|collect_email|collect_profile|process_item|visit|open)(?:\s*:\s*|\s+)(?!$)/i;
 const GENERIC_TARGET_RE = /^(button|link|item|result|profile|user|member|person|this|that|it|here|there|more|submit|save|send|add|remove|follow|unfollow|changes?|message|comment|reply|post|form|details|settings|preferences)$/i;
 
 export function normalizeLedgerStatus(value, fallback = 'pending') {

--- a/src/firefox/src/agent/progress-ledger.js
+++ b/src/firefox/src/agent/progress-ledger.js
@@ -463,8 +463,9 @@ export function reconcilePersistedLedgerRows(rows = []) {
       const identitiesAreUnique = progressIdentitiesAreUnique(concreteRows);
       const ordinalsAreComplete = unboundExpected.every((row, index) => Number(row.fields.expectedOrdinal) === index + 1);
       const compatible = unboundExpected.every((row, index) => actionsCompatible(row, concreteRows[index]));
+      const identityAgreement = unboundExpected.every((row, index) => identityMatchScore(row, concreteRows[index]) > 0);
       const merged = unboundExpected.map((row, index) => mergeCanonicalProgressRows(row, concreteRows[index]));
-      if (identitiesAreUnique && ordinalsAreComplete && compatible && merged.every(Boolean)) {
+      if (identitiesAreUnique && ordinalsAreComplete && compatible && identityAgreement && merged.every(Boolean)) {
         const replacementByKey = new Map(unboundExpected.map((row, index) => [ledgerRowKey(row), merged[index]]));
         const removedKeys = new Set(concreteRows.map(ledgerRowKey));
         next = next

--- a/src/firefox/src/agent/progress-ledger.js
+++ b/src/firefox/src/agent/progress-ledger.js
@@ -327,7 +327,10 @@ export function reconcileLedgerItems(rows = [], items = [], opts = {}) {
     if (availableExpected.length && batchFitsAvailable) {
       const identitiesAreUnique = progressIdentitiesAreUnique(newIncoming.map(({ item }) => item));
       const compatible = newIncoming.every(({ item }, index) => actionsCompatible(availableExpected[index], item));
-      if (identitiesAreUnique && compatible) {
+      const identityVerified = source !== 'auto' || newIncoming.every(({ item }, index) => (
+        identityMatchScore(availableExpected[index], item) > 0
+      ));
+      if (identitiesAreUnique && compatible && identityVerified) {
         newIncoming.forEach(({ index }, expectedIndex) => batchBindings.set(index, availableExpected[expectedIndex]));
       }
     }
@@ -350,7 +353,10 @@ export function reconcileLedgerItems(rows = [], items = [], opts = {}) {
       return {
         ...rawItem,
         id: batchCanonical.id,
-        target: rawItem?.target || incoming.target || incoming.label,
+        target: rawItem?.target
+          || incoming.target
+          || sanitizeText(String(incoming.label || '').replace(IDENTITY_ACTION_PREFIX_RE, ''), 180)
+          || incoming.label,
         sessionId: batchCanonical.sessionId || incoming.sessionId || sessionId,
       };
     }

--- a/src/firefox/src/agent/progress-ledger.js
+++ b/src/firefox/src/agent/progress-ledger.js
@@ -5,8 +5,10 @@ const sanitizeText = (value, max = 240) => sanitizeSharedText(value, max, { coll
 const VALID_STATUSES = new Set(['pending', 'acted', 'processed', 'skipped', 'failed']);
 const TERMINAL_STATUSES = new Set(['processed', 'skipped', 'failed']);
 const CLICK_ACTION_TOOLS = new Set(['click', 'click_ax', 'iframe_click']);
-const APP_OWNED_FIELD_KEYS = new Set(['completionRequirement', 'classifierTarget']);
+const APP_OWNED_BOOLEAN_FIELD_KEYS = new Set(['completionRequirement', 'classifierTarget']);
+const APP_OWNED_INTEGER_FIELD_KEYS = new Set(['expectedOrdinal']);
 const ACTION_RE = /^\s*(follow|unfollow|star|unstar|watch|unwatch|connect|subscribe|unsubscribe|save|unsave|like|unlike|block|unblock|report|send|submit|add|remove)\b(?:\s+(.+?))?\s*$/i;
+const IDENTITY_ACTION_PREFIX_RE = /^\s*(?:follow|unfollow|star|unstar|watch|unwatch|connect|subscribe|unsubscribe|save|unsave|like|unlike|block|unblock|report|send|submit|add|remove|collect_email|collect_profile|process_item|visit|open)\s*[:\-]?\s+/i;
 const GENERIC_TARGET_RE = /^(button|link|item|result|profile|user|member|person|this|that|it|here|there|more|submit|save|send|add|remove|follow|unfollow|changes?|message|comment|reply|post|form|details|settings|preferences)$/i;
 
 export function normalizeLedgerStatus(value, fallback = 'pending') {
@@ -68,14 +70,128 @@ function stableIdFor(action, target, url) {
   return sanitizeText(compact, 160);
 }
 
+function normalizeIdentityText(value) {
+  let text = cleanTarget(value);
+  if (!text) return '';
+  try { text = text.normalize('NFKC'); } catch {}
+  text = text
+    .replace(IDENTITY_ACTION_PREFIX_RE, '')
+    .replace(/^\s*@/, '')
+    .replace(/\/+$/, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+  return text && !GENERIC_TARGET_RE.test(text) ? text : '';
+}
+
+function identityEntries(item) {
+  const entries = new Map();
+  const add = (key, strength) => {
+    if (!key) return;
+    entries.set(key, Math.max(strength, entries.get(key) || 0));
+  };
+  const addUrl = (value) => {
+    const raw = sanitizeText(value, 500);
+    if (!raw) return;
+    try {
+      const url = new URL(raw);
+      if (!/^https?:$/i.test(url.protocol)) return;
+      const host = url.hostname.toLowerCase();
+      const pathname = url.pathname.replace(/\/{2,}/g, '/').replace(/\/+$/, '') || '/';
+      add(`url:${host}${pathname.toLowerCase()}`, 4);
+      const parts = pathname.split('/').filter(Boolean);
+      if (!parts.length) return;
+      let tail = '';
+      try { tail = decodeURIComponent(parts[parts.length - 1] || ''); } catch { tail = parts[parts.length - 1] || ''; }
+      tail = normalizeIdentityText(tail);
+      if (!tail) return;
+      add(`profile:${host}/${tail}`, 3);
+      if (/^[^@\s]+@[^@\s]+$/.test(tail)) {
+        add(`acct:${tail}`, 3);
+      } else if ((parts[parts.length - 1] || '').startsWith('@')) {
+        add(`acct:${tail}@${host}`, 3);
+      }
+      add(`text:${tail}`, 1);
+    } catch {}
+  };
+  const addText = (value, strength = 1) => {
+    const raw = sanitizeText(value, 500);
+    if (!raw) return;
+    if (/^https?:\/\//i.test(raw)) {
+      addUrl(raw);
+      return;
+    }
+    const text = normalizeIdentityText(raw);
+    if (!text) return;
+    add(`text:${text}`, strength);
+    if (/^[^@\s]+@[^@\s]+$/.test(text)) add(`acct:${text}`, Math.max(3, strength));
+  };
+
+  const id = sanitizeText(item?.id, 180);
+  if (id && !/^(?:expected|requirement):/i.test(id)) addText(id, 2);
+  addText(item?.target, 2);
+  addText(item?.label, 1);
+  addUrl(item?.url || item?.href);
+  return entries;
+}
+
+export function progressIdentityKeys(item) {
+  return [...identityEntries(item).keys()];
+}
+
+export function progressIdentitiesAreUnique(items = []) {
+  const strongestKeys = (Array.isArray(items) ? items : []).map(item => {
+    const entries = identityEntries(item);
+    const strongest = Math.max(0, ...entries.values());
+    return new Set([...entries]
+      .filter(([, strength]) => strength === strongest)
+      .map(([key]) => key));
+  });
+  return strongestKeys.every(keys => keys.size > 0)
+    && strongestKeys.every((keys, index) => strongestKeys.every((other, otherIndex) => (
+      index === otherIndex || ![...keys].some(key => other.has(key))
+    )));
+}
+
+function identityMatchScore(left, right) {
+  const leftEntries = identityEntries(left);
+  const rightEntries = identityEntries(right);
+  let score = 0;
+  for (const [key, leftStrength] of leftEntries) {
+    const rightStrength = rightEntries.get(key);
+    if (rightStrength) score = Math.max(score, Math.min(leftStrength, rightStrength));
+  }
+  return score;
+}
+
+function isCanonicalProgressRow(row) {
+  const ordinal = Number(row?.fields?.expectedOrdinal);
+  return row?.fields?.completionRequirement === true
+    || row?.fields?.classifierTarget === true
+    || (Number.isInteger(ordinal) && ordinal > 0);
+}
+
+function actionsCompatible(left, right) {
+  const leftAction = sanitizeText(left?.action, 80).toLowerCase();
+  const rightAction = sanitizeText(right?.action, 80).toLowerCase();
+  return !leftAction || !rightAction || leftAction === rightAction;
+}
+
 function sanitizeFields(fields, opts = {}) {
   if (!fields || typeof fields !== 'object' || Array.isArray(fields)) return undefined;
   const out = {};
   for (const [key, value] of Object.entries(fields).slice(0, 20)) {
     const k = sanitizeText(key, 80);
     if (!k) continue;
-    if (APP_OWNED_FIELD_KEYS.has(k)) {
+    if (APP_OWNED_BOOLEAN_FIELD_KEYS.has(k)) {
       if (opts.allowAppOwnedFields === true && value === true) out[k] = true;
+      continue;
+    }
+    if (APP_OWNED_INTEGER_FIELD_KEYS.has(k)) {
+      const ordinal = Number(value);
+      if (opts.allowAppOwnedFields === true && Number.isInteger(ordinal) && ordinal > 0 && ordinal <= 1000) {
+        out[k] = ordinal;
+      }
       continue;
     }
     const cleaned = sanitizeFieldValue(value);
@@ -130,6 +246,7 @@ export function normalizeLedgerItem(item, opts = {}) {
   return {
     id,
     label,
+    ...(target ? { target } : {}),
     ...(url ? { url } : {}),
     status,
     ...(action ? { action } : {}),
@@ -143,6 +260,235 @@ export function normalizeLedgerItem(item, opts = {}) {
     firstSeenAt: Number.isFinite(Number(item.firstSeenAt)) ? Number(item.firstSeenAt) : now,
     updatedAt: now,
   };
+}
+
+export function reconcileLedgerItems(rows = [], items = [], opts = {}) {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const source = sanitizeText(opts.source || 'model', 40) || 'model';
+  const sessionId = sanitizeText(opts.sessionId || '', 120);
+  const reconciled = [];
+  const rawItems = Array.isArray(items) ? items : [];
+  const normalizedItems = rawItems.map(rawItem => normalizeLedgerItem(rawItem, {
+    source,
+    sessionId,
+    pageScope: opts.pageScope,
+    taskKey: opts.taskKey,
+    now: opts.now,
+  }));
+  const semanticBindingFor = incoming => {
+    if (!incoming) return null;
+    const exactRow = safeRows.find(row => ledgerRowKey(row) === ledgerRowKey(incoming));
+    if (exactRow && actionsCompatible(exactRow, incoming)) return null;
+    let bestScore = 0;
+    let matches = [];
+    for (const row of safeRows) {
+      const autoMayReuseRow = source === 'auto' && !isTerminalLedgerStatus(row?.status);
+      if ((!isCanonicalProgressRow(row) && !autoMayReuseRow) || !actionsCompatible(row, incoming)) continue;
+      const rowSessionId = sanitizeText(row?.sessionId || row?.session_id || '', 120);
+      if (rowSessionId !== incoming.sessionId) continue;
+      const score = identityMatchScore(row, incoming);
+      if (score > bestScore) {
+        bestScore = score;
+        matches = [row];
+      } else if (score > 0 && score === bestScore) {
+        matches.push(row);
+      }
+    }
+    return bestScore && matches.length === 1 && matches[0]?.id ? matches[0] : null;
+  };
+  const semanticBindings = new Map();
+  normalizedItems.forEach((item, index) => {
+    const canonical = semanticBindingFor(item);
+    if (canonical) semanticBindings.set(index, canonical);
+  });
+  const batchBindings = new Map();
+  if (source !== 'classifier' && sessionId) {
+    const exactIncomingKeys = new Set(normalizedItems.filter(Boolean).map(ledgerRowKey));
+    const availableExpected = safeRows
+      .filter(row => {
+        const ordinal = Number(row?.fields?.expectedOrdinal);
+        const rowSessionId = sanitizeText(row?.sessionId || row?.session_id || '', 120);
+        return Number.isInteger(ordinal) && ordinal > 0
+          && row?.fields?.classifierTarget !== true
+          && !row?.target
+          && !row?.url
+          && rowSessionId === sessionId
+          && !exactIncomingKeys.has(ledgerRowKey(row));
+      })
+      .sort((a, b) => Number(a.fields.expectedOrdinal) - Number(b.fields.expectedOrdinal));
+    const newIncoming = normalizedItems
+      .map((item, index) => ({ item, index }))
+      .filter(({ item, index }) => item
+        && !semanticBindings.has(index)
+        && !safeRows.some(row => ledgerRowKey(row) === ledgerRowKey(item) && actionsCompatible(row, item)));
+    const canBindPartialBatch = source === 'model' || source === 'observe';
+    const batchFitsAvailable = newIncoming.length === availableExpected.length
+      || (canBindPartialBatch && newIncoming.length > 0 && newIncoming.length < availableExpected.length);
+    if (availableExpected.length && batchFitsAvailable) {
+      const identitiesAreUnique = progressIdentitiesAreUnique(newIncoming.map(({ item }) => item));
+      const compatible = newIncoming.every(({ item }, index) => actionsCompatible(availableExpected[index], item));
+      if (identitiesAreUnique && compatible) {
+        newIncoming.forEach(({ index }, expectedIndex) => batchBindings.set(index, availableExpected[expectedIndex]));
+      }
+    }
+  }
+
+  const nextItems = rawItems.map((rawItem, itemIndex) => {
+    const incoming = normalizedItems[itemIndex];
+    const semanticCanonical = semanticBindings.get(itemIndex);
+    if (incoming && semanticCanonical?.id) {
+      reconciled.push({ incomingId: incoming.id, canonicalId: semanticCanonical.id });
+      return {
+        ...rawItem,
+        id: semanticCanonical.id,
+        sessionId: semanticCanonical.sessionId || incoming.sessionId || sessionId,
+      };
+    }
+    const batchCanonical = batchBindings.get(itemIndex);
+    if (incoming && batchCanonical?.id) {
+      reconciled.push({ incomingId: incoming.id, canonicalId: batchCanonical.id });
+      return {
+        ...rawItem,
+        id: batchCanonical.id,
+        target: rawItem?.target || incoming.target || incoming.label,
+        sessionId: batchCanonical.sessionId || incoming.sessionId || sessionId,
+      };
+    }
+    if (!incoming) return rawItem;
+    const exactRow = safeRows.find(row => ledgerRowKey(row) === ledgerRowKey(incoming));
+    if (exactRow && actionsCompatible(exactRow, incoming)) return rawItem;
+    return rawItem;
+  });
+  return { items: nextItems, reconciled };
+}
+
+function mergedProgressStatus(canonicalStatus, duplicateStatus) {
+  const canonical = normalizeStatus(canonicalStatus, 'pending');
+  const duplicate = normalizeStatus(duplicateStatus, 'pending');
+  if (isTerminalLedgerStatus(canonical) && isTerminalLedgerStatus(duplicate)) {
+    return canonical === duplicate ? canonical : '';
+  }
+  if (isTerminalLedgerStatus(canonical)) return canonical;
+  if (isTerminalLedgerStatus(duplicate)) return duplicate;
+  if (canonical === 'acted' || duplicate === 'acted') return 'acted';
+  return 'pending';
+}
+
+function mergeCanonicalProgressRows(canonical, duplicate) {
+  const status = mergedProgressStatus(canonical?.status, duplicate?.status);
+  if (!status) return null;
+  const ordinal = Number(canonical?.fields?.expectedOrdinal);
+  const firstSeenAt = [canonical?.firstSeenAt, duplicate?.firstSeenAt]
+    .map(Number).filter(Number.isFinite);
+  const updatedAt = [canonical?.updatedAt, duplicate?.updatedAt]
+    .map(Number).filter(Number.isFinite);
+  return {
+    ...canonical,
+    label: duplicate?.label || canonical?.label,
+    ...(duplicate?.target ? { target: duplicate.target } : {}),
+    ...(duplicate?.url ? { url: duplicate.url } : {}),
+    status,
+    ...(duplicate?.action ? { action: duplicate.action } : {}),
+    source: duplicate?.source || canonical?.source || 'model',
+    fields: {
+      ...(canonical?.fields || {}),
+      ...(duplicate?.fields || {}),
+      ...(canonical?.fields?.completionRequirement === true || duplicate?.fields?.completionRequirement === true
+        ? { completionRequirement: true } : {}),
+      ...(canonical?.fields?.classifierTarget === true || duplicate?.fields?.classifierTarget === true
+        ? { classifierTarget: true } : {}),
+      ...(Number.isInteger(ordinal) && ordinal > 0 ? { expectedOrdinal: ordinal } : {}),
+    },
+    attempts: Math.max(Number(canonical?.attempts || 0), Number(duplicate?.attempts || 0)),
+    ...(firstSeenAt.length ? { firstSeenAt: Math.min(...firstSeenAt) } : {}),
+    ...(updatedAt.length ? { updatedAt: Math.max(...updatedAt) } : {}),
+  };
+}
+
+export function reconcilePersistedLedgerRows(rows = []) {
+  let next = Array.isArray(rows)
+    ? rows.map(row => ({ ...row, fields: row?.fields ? { ...row.fields } : undefined }))
+    : [];
+  const reconciled = [];
+  const sessionIds = new Set(next
+    .map(row => sanitizeText(row?.sessionId || row?.session_id || '', 120))
+    .filter(Boolean));
+
+  for (const sessionId of sessionIds) {
+    const inSession = row => sanitizeText(row?.sessionId || row?.session_id || '', 120) === sessionId;
+    const expected = next.filter(row => inSession(row) && Number.isInteger(Number(row?.fields?.expectedOrdinal)))
+      .sort((a, b) => Number(a.fields.expectedOrdinal) - Number(b.fields.expectedOrdinal));
+    const requirements = next.filter(row => inSession(row)
+      && row?.fields?.classifierTarget === true
+      && /^requirement:/i.test(String(row?.id || '')))
+      .sort((a, b) => Number(String(a.id).match(/^requirement:(\d+)/i)?.[1] || 0)
+        - Number(String(b.id).match(/^requirement:(\d+)/i)?.[1] || 0));
+    if (expected.length && expected.length === requirements.length) {
+      const targetsAreUnique = progressIdentitiesAreUnique(requirements);
+      const ordinalsAreComplete = expected.every((row, index) => Number(row.fields.expectedOrdinal) === index + 1);
+      const compatible = expected.every((row, index) => actionsCompatible(row, requirements[index]));
+      const merged = expected.map((row, index) => mergeCanonicalProgressRows(row, requirements[index]));
+      if (targetsAreUnique && ordinalsAreComplete && compatible && merged.every(Boolean)) {
+        const replacementByKey = new Map(expected.map((row, index) => [ledgerRowKey(row), merged[index]]));
+        const removedKeys = new Set(requirements.map(ledgerRowKey));
+        next = next
+          .filter(row => !removedKeys.has(ledgerRowKey(row)))
+          .map(row => replacementByKey.get(ledgerRowKey(row)) || row);
+        requirements.forEach((row, index) => reconciled.push({ incomingId: row.id, canonicalId: expected[index].id }));
+      }
+    }
+
+    const unboundExpected = next.filter(row => inSession(row)
+      && Number.isInteger(Number(row?.fields?.expectedOrdinal))
+      && row?.fields?.classifierTarget !== true)
+      .sort((a, b) => Number(a.fields.expectedOrdinal) - Number(b.fields.expectedOrdinal));
+    const concreteRows = next.filter(row => inSession(row) && !isCanonicalProgressRow(row));
+    if (unboundExpected.length && unboundExpected.length === concreteRows.length) {
+      const identitiesAreUnique = progressIdentitiesAreUnique(concreteRows);
+      const ordinalsAreComplete = unboundExpected.every((row, index) => Number(row.fields.expectedOrdinal) === index + 1);
+      const compatible = unboundExpected.every((row, index) => actionsCompatible(row, concreteRows[index]));
+      const merged = unboundExpected.map((row, index) => mergeCanonicalProgressRows(row, concreteRows[index]));
+      if (identitiesAreUnique && ordinalsAreComplete && compatible && merged.every(Boolean)) {
+        const replacementByKey = new Map(unboundExpected.map((row, index) => [ledgerRowKey(row), merged[index]]));
+        const removedKeys = new Set(concreteRows.map(ledgerRowKey));
+        next = next
+          .filter(row => !removedKeys.has(ledgerRowKey(row)))
+          .map(row => replacementByKey.get(ledgerRowKey(row)) || row);
+        concreteRows.forEach((row, index) => reconciled.push({ incomingId: row.id, canonicalId: unboundExpected[index].id }));
+      }
+    }
+
+    const canonicalRows = next.filter(row => inSession(row)
+      && Number.isInteger(Number(row?.fields?.expectedOrdinal))
+      && row?.fields?.classifierTarget === true);
+    for (const duplicate of [...next]) {
+      if (!inSession(duplicate) || isCanonicalProgressRow(duplicate)) continue;
+      let bestScore = 0;
+      let matches = [];
+      for (const canonical of canonicalRows) {
+        if (!actionsCompatible(canonical, duplicate)) continue;
+        const score = identityMatchScore(canonical, duplicate);
+        if (score > bestScore) {
+          bestScore = score;
+          matches = [canonical];
+        } else if (score > 0 && score === bestScore) {
+          matches.push(canonical);
+        }
+      }
+      if (!bestScore || matches.length !== 1) continue;
+      const canonical = matches[0];
+      const merged = mergeCanonicalProgressRows(canonical, duplicate);
+      if (!merged) continue;
+      const canonicalKey = ledgerRowKey(canonical);
+      const duplicateKey = ledgerRowKey(duplicate);
+      next = next.filter(row => ledgerRowKey(row) !== duplicateKey)
+        .map(row => ledgerRowKey(row) === canonicalKey ? merged : row);
+      const canonicalIndex = canonicalRows.indexOf(canonical);
+      if (canonicalIndex >= 0) canonicalRows[canonicalIndex] = merged;
+      reconciled.push({ incomingId: duplicate.id, canonicalId: canonical.id });
+    }
+  }
+  return { rows: next, changed: reconciled.length > 0, reconciled };
 }
 
 export function progressCounts(rows = []) {
@@ -182,6 +528,7 @@ export function upsertLedgerItems(rows = [], items = [], opts = {}) {
   const now = Number.isFinite(opts.now) ? opts.now : Date.now();
   const source = sanitizeText(opts.source || 'model', 40) || 'model';
   const next = Array.isArray(rows) ? rows.map(row => ({ ...row, fields: row?.fields ? { ...row.fields } : undefined })) : [];
+  const reconciliation = reconcileLedgerItems(next, items, { ...opts, source, now });
   const indexByKey = new Map();
   next.forEach((row, idx) => {
     const key = ledgerRowKey(row);
@@ -190,7 +537,7 @@ export function upsertLedgerItems(rows = [], items = [], opts = {}) {
 
   const updated = [];
   const blockedDowngrades = [];
-  for (const rawItem of Array.isArray(items) ? items : []) {
+  for (const rawItem of reconciliation.items) {
     const incoming = normalizeLedgerItem(rawItem, { source, now, sessionId: opts.sessionId, pageScope: opts.pageScope, taskKey: opts.taskKey });
     if (!incoming) continue;
     const key = ledgerRowKey(incoming);
@@ -211,6 +558,7 @@ export function upsertLedgerItems(rows = [], items = [], opts = {}) {
     const merged = {
       ...existing,
       label: incoming.label || existing.label,
+      ...(incoming.target ? { target: incoming.target } : {}),
       ...(incoming.url ? { url: incoming.url } : {}),
       status: keepTerminal ? existing.status : incoming.status,
       ...(incoming.action ? { action: incoming.action } : {}),
@@ -234,7 +582,14 @@ export function upsertLedgerItems(rows = [], items = [], opts = {}) {
     updated.push(merged);
   }
 
-  return { rows: next, updated, counts: progressCounts(next), changed: updated.length > 0, blockedDowngrades };
+  return {
+    rows: next,
+    updated,
+    counts: progressCounts(next),
+    changed: updated.length > 0,
+    blockedDowngrades,
+    reconciled: reconciliation.reconciled,
+  };
 }
 
 export function formatLedgerRow(row) {

--- a/test/run.js
+++ b/test/run.js
@@ -68571,6 +68571,43 @@ test('expected ordinals are app-owned typed metadata', () => {
   assert.equal(Object.prototype.hasOwnProperty.call(forged.rows[0].fields || {}, 'expectedOrdinal'), false);
 });
 
+test('auto-recorded items need identity agreement before consuming the last expected slot', () => {
+  for (const upsert of [upsertLedgerItems, upsertLedgerItemsFx]) {
+    let state = upsert([], [{
+      id: 'expected:1', label: 'profile 1', action: 'follow', status: 'pending',
+      fields: { expectedOrdinal: 1, completionRequirement: true },
+    }], { source: 'classifier', sessionId: 'auto-guard', now: 100 });
+
+    state = upsert(state.rows, [{
+      id: 'stray-bob', label: 'Follow Bob', action: 'follow', status: 'acted',
+    }], { source: 'auto', sessionId: 'auto-guard', now: 200 });
+    assert.deepEqual(state.reconciled, [], 'unrelated auto click must not consume the placeholder positionally');
+    assert.equal(state.rows.find(row => row.id === 'expected:1').status, 'pending');
+    assert.ok(state.rows.some(row => row.id === 'stray-bob'), 'auto evidence is still recorded as its own row');
+
+    state = upsert(state.rows, [{
+      id: 'late-alice', target: 'profile 1', action: 'follow', status: 'acted',
+    }], { source: 'auto', sessionId: 'auto-guard', now: 300 });
+    assert.deepEqual(state.reconciled, [{ incomingId: 'late-alice', canonicalId: 'expected:1' }]);
+    assert.equal(state.rows.find(row => row.id === 'expected:1').status, 'acted');
+  }
+});
+
+test('batch-bound targets derive from labels without action verbs', () => {
+  for (const upsert of [upsertLedgerItems, upsertLedgerItemsFx]) {
+    let state = upsert([], [1, 2].map(ordinal => ({
+      id: `expected:${ordinal}`, label: `profile ${ordinal}`, action: 'follow', status: 'pending',
+      fields: { expectedOrdinal: ordinal, completionRequirement: true },
+    })), { source: 'classifier', sessionId: 'label-targets', now: 100 });
+    state = upsert(state.rows, [
+      { id: 'x1', label: 'Follow Alice', action: 'follow', status: 'pending' },
+      { id: 'x2', label: 'unfollow Bob', action: 'follow', status: 'pending' },
+    ], { source: 'model', sessionId: 'label-targets', now: 200 });
+    assert.equal(state.rows.length, 2);
+    assert.deepEqual(state.rows.map(row => row.target), ['Alice', 'Bob']);
+  }
+});
+
 test('progress ledger rejects malformed statuses and normalizes null-like fields', () => {
   assert.equal(isValidLedgerStatus('pending'), true);
   assert.equal(isValidLedgerStatus('「pending」'), true);

--- a/test/run.js
+++ b/test/run.js
@@ -68553,6 +68553,34 @@ test('progress ledger repairs persisted placeholder sets only when identities ar
   assert.equal(conflicting.rows.length, 2);
 });
 
+test('persisted reconciliation preserves canonical collected fields over duplicate nulls', () => {
+  for (const reconcile of [reconcilePersistedLedgerRows, reconcilePersistedLedgerRowsFx]) {
+    const keepsCollected = reconcile([
+      { id: 'expected:1', label: 'profile 1', action: 'follow', status: 'acted', sessionId: 'field-keep', fields: { expectedOrdinal: 1, email: 'alice@example.com' } },
+      { id: 'alice', label: 'Follow alice', action: 'follow', status: 'acted', sessionId: 'field-keep', attempts: 1, fields: { email: null } },
+    ]);
+    assert.equal(keepsCollected.changed, true);
+    assert.deepEqual(keepsCollected.rows.map(row => row.id), ['expected:1']);
+    assert.equal(keepsCollected.rows[0].fields.email, 'alice@example.com');
+
+    const fillsMissing = reconcile([
+      { id: 'expected:1', label: 'profile 2', action: 'follow', status: 'acted', sessionId: 'field-keep', fields: { expectedOrdinal: 1 } },
+      { id: 'carol', label: 'Follow carol', action: 'follow', status: 'acted', sessionId: 'field-keep', attempts: 1, fields: { email: 'carol@example.com' } },
+    ]);
+    assert.equal(fillsMissing.changed, true);
+    assert.deepEqual(fillsMissing.rows.map(row => row.id), ['expected:1']);
+    assert.equal(fillsMissing.rows[0].fields.email, 'carol@example.com');
+
+    const keepsExplicitNulls = reconcile([
+      { id: 'expected:1', label: 'profile 3', action: 'follow', status: 'processed', sessionId: 'field-keep', fields: { expectedOrdinal: 1, email: null } },
+      { id: 'dave', label: 'Follow dave', action: 'follow', status: 'processed', sessionId: 'field-keep', attempts: 1 },
+    ]);
+    assert.equal(keepsExplicitNulls.changed, true);
+    assert.ok(Object.prototype.hasOwnProperty.call(keepsExplicitNulls.rows[0].fields || {}, 'email'));
+    assert.equal(keepsExplicitNulls.rows[0].fields.email, null);
+  }
+});
+
 test('expected ordinals are app-owned typed metadata', () => {
   let state = upsertLedgerItems([], [{
     id: 'expected:1', label: 'alice', action: 'follow', status: 'pending',

--- a/test/run.js
+++ b/test/run.js
@@ -755,6 +755,9 @@ const {
   upsertLedgerItems,
   progressCounts,
   ledgerDoneBlock,
+  progressIdentityKeys,
+  reconcileLedgerItems,
+  reconcilePersistedLedgerRows,
 } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/agent/progress-ledger.js').replace(/\\/g, '/')
 );
@@ -762,6 +765,7 @@ const {
   detectProgressAction: detectProgressActionFx,
   isValidLedgerStatus: isValidLedgerStatusFx,
   upsertLedgerItems: upsertLedgerItemsFx,
+  reconcilePersistedLedgerRows: reconcilePersistedLedgerRowsFx,
 } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/agent/progress-ledger.js').replace(/\\/g, '/')
 );
@@ -67654,6 +67658,173 @@ test('planner progress-ledger policy disables fallback or enables the canonical 
   }
 });
 
+test('planner expected rows remain canonical when concrete bulk items arrive', async () => {
+  for (const [AgentClass, count] of [[AgentCh, 40], [AgentFx, 22]]) {
+    const agent = new AgentClass({ getActive: () => ({ contextWindow: 128000, supportsVision: false }) });
+    const tabId = count === 40 ? 23260 : 23261;
+    const taskText = `Follow these ${count} profiles.`;
+    const targets = Array.from({ length: count }, (_, index) => `profile-${String(index + 1).padStart(2, '0')}`);
+    agent._persist = () => {};
+    agent.conversationModes.set(tabId, 'act');
+    agent.conversations.set(tabId, [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: taskText },
+    ]);
+    agent._classifyProgressIntentWithProvider = async () => ({
+      mode: 'active',
+      allowedActions: ['follow'],
+      forbiddenActions: [],
+      targets,
+      confidence: 0.98,
+      pageScopePolicy: 'page',
+    });
+
+    const session = await agent._ensureProgressSessionForCurrentTask(tabId, {
+      taskText,
+      pageScope: 'https://example.test/profiles',
+      progressLedgerPolicy: 'enabled',
+      progressAction: 'follow',
+      expectedItems: {
+        count,
+        item_type: 'profile',
+        ordered: true,
+        required_fields: [],
+      },
+    });
+    const placeholders = agent._rowsForProgressSession(tabId, session.sessionId);
+    assert.equal(placeholders.length, count, `${AgentClass.name}: expected rows were not seeded once`);
+    assert.deepEqual(placeholders.map(row => row.id), targets.map((_, index) => `expected:${index + 1}`));
+
+    let reconciledCount = 0;
+    const splitAt = Math.floor(count / 2);
+    for (const batchTargets of [targets.slice(0, splitAt), targets.slice(splitAt)]) {
+      const concrete = agent._progressUpdate(tabId, {
+        items: batchTargets.map(target => ({
+          id: `follow:${target}`,
+          label: target,
+          target,
+          action: 'follow',
+          status: 'pending',
+          url: `https://example.test/${target}`,
+        })),
+      }, { sessionId: session.sessionId });
+      assert.equal(concrete.success, true, `${AgentClass.name}: concrete partial batch did not update expected slots`);
+      reconciledCount += concrete.reconciled?.length || 0;
+    }
+    assert.equal(reconciledCount, count, `${AgentClass.name}: concrete partial batches were not fully reconciled`);
+    const rows = agent._rowsForProgressSession(tabId, session.sessionId);
+    assert.equal(rows.length, count, `${AgentClass.name}: ${count} concrete targets doubled the ledger`);
+    assert.deepEqual(rows.map(row => row.id), targets.map((_, index) => `expected:${index + 1}`));
+    assert.deepEqual(rows.map(row => row.label), targets, `${AgentClass.name}: target order was not preserved`);
+    assert.deepEqual(rows.map(row => row.fields?.expectedOrdinal), targets.map((_, index) => index + 1));
+    assert.ok(rows.every(row => row.fields?.completionRequirement === true), `${AgentClass.name}: follow slots lost per-item evidence requirements`);
+  }
+});
+
+test('repeated concrete items do not consume a fresh expected slot in later partial batches', () => {
+  for (const upsert of [upsertLedgerItems, upsertLedgerItemsFx]) {
+    const sessionId = 'mixed-partial-batch';
+    let state = upsert([], [1, 2, 3].map(ordinal => ({
+      id: `expected:${ordinal}`,
+      label: `profile ${ordinal}`,
+      action: 'follow',
+      status: 'pending',
+      fields: { expectedOrdinal: ordinal, completionRequirement: true },
+    })), { source: 'classifier', sessionId, now: 100 });
+
+    state = upsert(state.rows, [{
+      id: 'follow:alice', label: 'Alice', target: 'Alice', action: 'follow', status: 'pending',
+    }], { source: 'model', sessionId, now: 200 });
+    assert.deepEqual(state.reconciled, [{ incomingId: 'follow:alice', canonicalId: 'expected:1' }]);
+
+    state = upsert(state.rows, [
+      { id: 'follow:alice', label: 'Alice', target: 'Alice', action: 'follow', status: 'acted' },
+      { id: 'follow:bob', label: 'Bob', target: 'Bob', action: 'follow', status: 'pending' },
+    ], { source: 'model', sessionId, now: 300 });
+    assert.equal(state.rows.length, 3);
+    assert.deepEqual(state.rows.map(row => row.id), ['expected:1', 'expected:2', 'expected:3']);
+    assert.deepEqual(state.rows.map(row => row.target || null), ['Alice', 'Bob', null]);
+    assert.deepEqual(state.rows.map(row => row.status), ['acted', 'pending', 'pending']);
+    assert.deepEqual(state.reconciled, [
+      { incomingId: 'follow:alice', canonicalId: 'expected:1' },
+      { incomingId: 'follow:bob', canonicalId: 'expected:2' },
+    ]);
+  }
+});
+
+test('classifier target mismatches keep expected rows without a second requirement set', () => {
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getActive: () => ({ contextWindow: 128000, supportsVision: false }) });
+    const tabId = AgentClass === AgentCh ? 23262 : 23263;
+    agent._persist = () => {};
+    agent.conversations.set(tabId, [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'Process three profiles.' },
+    ]);
+    const session = agent._setProgressSession(tabId, {
+      mode: 'active',
+      allowedActions: ['process_item'],
+      forbiddenActions: [],
+      targets: ['alice', 'bob'],
+      confidence: 0.9,
+    }, { taskText: 'Process three profiles.', source: 'classifier' });
+    agent._seedExpectedProgressItems(tabId, session, {
+      count: 3,
+      item_type: 'profile',
+      ordered: true,
+      required_fields: [],
+    });
+    const result = agent._seedClassifierProgressTargets(tabId, session);
+    assert.equal(result?.bindingDeferred, true, `${AgentClass.name}: count mismatch was not reported`);
+    const rows = agent._rowsForProgressSession(tabId, session.sessionId);
+    assert.equal(rows.length, 3, `${AgentClass.name}: count mismatch added duplicate classifier rows`);
+    assert.ok(rows.every(row => /^expected:\d+$/.test(row.id)));
+  }
+});
+
+test('concrete progress rows reconcile to canonical ordered slots before evidence checks', () => {
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({ getActive: () => ({ contextWindow: 128000, supportsVision: false }) });
+    const tabId = AgentClass === AgentCh ? 23264 : 23269;
+    agent._persist = () => {};
+    agent.conversationModes.set(tabId, 'act');
+    agent.conversations.set(tabId, [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'Follow Alice.' },
+    ]);
+    const session = agent._setProgressSession(tabId, {
+      mode: 'active', allowedActions: ['follow'], forbiddenActions: [], targets: ['Alice'], confidence: 0.95,
+    }, { taskText: 'Follow Alice.', source: 'classifier' });
+    agent._seedExpectedProgressItems(tabId, session, {
+      count: 1, item_type: 'profile', ordered: true, required_fields: [],
+    });
+    agent._progressUpdate(tabId, {
+      items: [{
+        id: 'expected:1', label: 'Alice', target: 'Alice', action: 'follow', status: 'pending',
+        fields: { expectedOrdinal: 1, completionRequirement: true, classifierTarget: true },
+      }],
+    }, { source: 'classifier', sessionId: session.sessionId });
+
+    const premature = agent._progressUpdate(tabId, {
+      items: [{ id: 'profile-alice', label: 'Follow Alice', action: 'follow', status: 'processed' }],
+    }, { sessionId: session.sessionId });
+    assert.equal(premature.success, false, `${AgentClass.name}: different concrete id bypassed completion evidence`);
+    assert.equal(premature.completionInvariant, true);
+    assert.equal(agent._rowsForProgressSession(tabId, session.sessionId).length, 1);
+
+    const acted = agent._progressUpdate(tabId, {
+      items: [{ id: 'profile-alice', label: 'Follow Alice', action: 'follow', status: 'acted', url: 'https://github.com/Alice' }],
+    }, { source: 'auto', sessionId: session.sessionId });
+    assert.equal(acted.success, true);
+    assert.deepEqual(acted.reconciled, [{ incomingId: 'profile-alice', canonicalId: 'expected:1' }]);
+    const row = agent._rowsForProgressSession(tabId, session.sessionId)[0];
+    assert.equal(row.id, 'expected:1');
+    assert.equal(row.status, 'acted');
+    assert.equal(row.url, 'https://github.com/Alice');
+    assert.equal(row.fields.expectedOrdinal, 1);
+  }
+});
+
 test('classifier targets become isolated app-owned completion obligations', async () => {
   for (const AgentClass of [AgentCh, AgentFx]) {
     const agent = new AgentClass({
@@ -68275,6 +68446,129 @@ test('progress ledger merges rows and does not downgrade terminal rows', () => {
     { id: 'octocat', label: 'follow octocat', action: 'follow', status: 'acted' },
   ], { source: 'auto', now: 100 });
   assert.equal(fx.counts.acted, 1);
+});
+
+test('progress ledger identity reconciliation preserves order and remote account hosts', () => {
+  let state = upsertLedgerItems([], [
+    {
+      id: 'expected:1', label: 'Alice', target: 'alice@one.social', action: 'follow', status: 'pending',
+      fields: { expectedOrdinal: 1, completionRequirement: true, classifierTarget: true },
+    },
+    {
+      id: 'expected:2', label: 'Alice', target: 'alice@two.social', action: 'follow', status: 'pending',
+      fields: { expectedOrdinal: 2, completionRequirement: true, classifierTarget: true },
+    },
+  ], { source: 'classifier', sessionId: 'bulk-remote', now: 100 });
+
+  state = upsertLedgerItems(state.rows, [{
+    id: 'remote-alice',
+    label: 'Alice',
+    action: 'follow',
+    status: 'acted',
+    url: 'https://home.social/@alice@two.social',
+  }], { source: 'model', sessionId: 'bulk-remote', now: 200 });
+  assert.equal(state.rows.length, 2);
+  assert.deepEqual(state.rows.map(row => row.id), ['expected:1', 'expected:2']);
+  assert.equal(state.rows[0].status, 'pending');
+  assert.equal(state.rows[1].status, 'acted');
+  assert.equal(state.rows[1].url, 'https://home.social/@alice@two.social');
+  assert.deepEqual(state.reconciled, [{ incomingId: 'remote-alice', canonicalId: 'expected:2' }]);
+
+  const ambiguous = reconcileLedgerItems(state.rows, [{
+    id: 'alice-only', label: 'Alice', action: 'follow', status: 'pending',
+  }], { source: 'model', sessionId: 'bulk-remote' });
+  assert.deepEqual(ambiguous.reconciled, [], 'hostless ambiguous identity must fail closed');
+  assert.equal(ambiguous.items[0].id, 'alice-only');
+  assert.ok(progressIdentityKeys({ url: 'https://one.social/@alice' }).includes('acct:alice@one.social'));
+
+  for (const upsert of [upsertLedgerItems, upsertLedgerItemsFx]) {
+    let remoteBatch = upsert([], [1, 2].map(ordinal => ({
+      id: `expected:${ordinal}`,
+      label: `profile ${ordinal}`,
+      action: 'follow',
+      status: 'pending',
+      fields: { expectedOrdinal: ordinal, completionRequirement: true },
+    })), { source: 'classifier', sessionId: 'remote-batch', now: 100 });
+    remoteBatch = upsert(remoteBatch.rows, [
+      {
+        id: 'follow:alice-one', label: 'Alice', target: 'alice@one.social', action: 'follow', status: 'pending',
+        url: 'https://home.social/@alice@one.social',
+      },
+      {
+        id: 'follow:alice-two', label: 'Alice', target: 'alice@two.social', action: 'follow', status: 'pending',
+        url: 'https://home.social/@alice@two.social',
+      },
+    ], { source: 'model', sessionId: 'remote-batch', now: 200 });
+    assert.equal(remoteBatch.rows.length, 2, 'different remote hosts should not block ordinal reconciliation');
+    assert.deepEqual(remoteBatch.rows.map(row => row.id), ['expected:1', 'expected:2']);
+    assert.deepEqual(remoteBatch.rows.map(row => row.target), ['alice@one.social', 'alice@two.social']);
+  }
+});
+
+test('progress ledger repairs persisted placeholder sets only when identities are unambiguous', () => {
+  const sessionId = 'persisted-bulk';
+  const rows = [
+    { id: 'expected:1', label: 'profile 1', action: 'follow', status: 'pending', sessionId, fields: { expectedOrdinal: 1 } },
+    { id: 'expected:2', label: 'profile 2', action: 'follow', status: 'pending', sessionId, fields: { expectedOrdinal: 2 } },
+    {
+      id: 'requirement:1:alice', label: 'alice', target: 'alice', action: 'follow', status: 'pending', sessionId,
+      fields: { completionRequirement: true, classifierTarget: true },
+    },
+    {
+      id: 'requirement:2:bob', label: 'bob', target: 'bob', action: 'follow', status: 'pending', sessionId,
+      fields: { completionRequirement: true, classifierTarget: true },
+    },
+    { id: 'alice', label: 'Follow alice', action: 'follow', status: 'acted', sessionId, attempts: 1 },
+    { id: 'bob', label: 'Follow bob', action: 'follow', status: 'processed', sessionId, fields: { email: null } },
+  ];
+  for (const reconcile of [reconcilePersistedLedgerRows, reconcilePersistedLedgerRowsFx]) {
+    const repaired = reconcile(rows);
+    assert.equal(repaired.changed, true);
+    assert.equal(repaired.rows.length, 2);
+    assert.deepEqual(repaired.rows.map(row => row.id), ['expected:1', 'expected:2']);
+    assert.deepEqual(repaired.rows.map(row => row.label), ['Follow alice', 'Follow bob']);
+    assert.deepEqual(repaired.rows.map(row => row.status), ['acted', 'processed']);
+    assert.deepEqual(repaired.rows.map(row => row.fields.expectedOrdinal), [1, 2]);
+    assert.ok(repaired.rows.every(row => row.fields.completionRequirement === true && row.fields.classifierTarget === true));
+  }
+
+  const directPlaceholderRepair = reconcilePersistedLedgerRows([
+    { id: 'expected:1', label: 'profile 1', action: 'follow', status: 'pending', sessionId, fields: { expectedOrdinal: 1 } },
+    { id: 'expected:2', label: 'profile 2', action: 'follow', status: 'pending', sessionId, fields: { expectedOrdinal: 2 } },
+    { id: 'alice', label: 'alice', action: 'follow', status: 'acted', sessionId },
+    { id: 'bob', label: 'bob', action: 'follow', status: 'processed', sessionId },
+  ]);
+  assert.equal(directPlaceholderRepair.rows.length, 2);
+  assert.deepEqual(directPlaceholderRepair.rows.map(row => row.id), ['expected:1', 'expected:2']);
+  assert.deepEqual(directPlaceholderRepair.rows.map(row => row.label), ['alice', 'bob']);
+
+  const conflicting = reconcilePersistedLedgerRows([
+    { id: 'expected:1', label: 'alice', action: 'follow', status: 'processed', sessionId, fields: { expectedOrdinal: 1 } },
+    {
+      id: 'requirement:1:alice', label: 'alice', action: 'follow', status: 'failed', sessionId,
+      fields: { completionRequirement: true, classifierTarget: true },
+    },
+  ]);
+  assert.equal(conflicting.changed, false, 'conflicting terminal results must not be guessed together');
+  assert.equal(conflicting.rows.length, 2);
+});
+
+test('expected ordinals are app-owned typed metadata', () => {
+  let state = upsertLedgerItems([], [{
+    id: 'expected:1', label: 'alice', action: 'follow', status: 'pending',
+    fields: { expectedOrdinal: 1, completionRequirement: true },
+  }], { source: 'classifier', sessionId: 'typed-ordinal', now: 100 });
+  state = upsertLedgerItems(state.rows, [{
+    id: 'expected:1', label: 'alice', action: 'follow', status: 'pending',
+    fields: { expectedOrdinal: 99, completionRequirement: false },
+  }], { source: 'model', sessionId: 'typed-ordinal', now: 200 });
+  assert.equal(state.rows[0].fields.expectedOrdinal, 1);
+  assert.equal(state.rows[0].fields.completionRequirement, true);
+
+  const forged = upsertLedgerItems([], [{
+    id: 'forged', label: 'forged', action: 'follow', status: 'pending', fields: { expectedOrdinal: 1 },
+  }], { source: 'model', sessionId: 'typed-ordinal', now: 300 });
+  assert.equal(Object.prototype.hasOwnProperty.call(forged.rows[0].fields || {}, 'expectedOrdinal'), false);
 });
 
 test('progress ledger rejects malformed statuses and normalizes null-like fields', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -68608,6 +68608,24 @@ test('batch-bound targets derive from labels without action verbs', () => {
   }
 });
 
+test('colon-namespaced action ids share identities with recorded clicks', () => {
+  for (const upsert of [upsertLedgerItems, upsertLedgerItemsFx]) {
+    assert.ok(progressIdentityKeys({ id: 'follow:alice' }).includes('text:alice'));
+    assert.ok(progressIdentityKeys({ label: 'Follow-up email' }).includes('text:follow-up email'));
+
+    const sessionId = 'colon-ids';
+    let state = upsert([], [{
+      id: 'follow:alice', label: 'Follow alice', action: 'follow', status: 'acted',
+    }], { source: 'auto', sessionId, now: 100 });
+
+    state = upsert(state.rows, [{
+      id: 'clicked-alice', label: 'Alice', target: 'alice', action: 'follow', status: 'acted',
+    }], { source: 'auto', sessionId, now: 200 });
+    assert.deepEqual(state.reconciled, [{ incomingId: 'clicked-alice', canonicalId: 'follow:alice' }]);
+    assert.equal(state.rows.length, 1);
+  }
+});
+
 test('progress ledger rejects malformed statuses and normalizes null-like fields', () => {
   assert.equal(isValidLedgerStatus('pending'), true);
   assert.equal(isValidLedgerStatus('「pending」'), true);

--- a/test/run.js
+++ b/test/run.js
@@ -68532,15 +68532,25 @@ test('progress ledger repairs persisted placeholder sets only when identities ar
     assert.ok(repaired.rows.every(row => row.fields.completionRequirement === true && row.fields.classifierTarget === true));
   }
 
-  const directPlaceholderRepair = reconcilePersistedLedgerRows([
+  const unrelatedConcreteRowsStaySeparate = reconcilePersistedLedgerRows([
     { id: 'expected:1', label: 'profile 1', action: 'follow', status: 'pending', sessionId, fields: { expectedOrdinal: 1 } },
     { id: 'expected:2', label: 'profile 2', action: 'follow', status: 'pending', sessionId, fields: { expectedOrdinal: 2 } },
     { id: 'alice', label: 'alice', action: 'follow', status: 'acted', sessionId },
     { id: 'bob', label: 'bob', action: 'follow', status: 'processed', sessionId },
   ]);
-  assert.equal(directPlaceholderRepair.rows.length, 2);
-  assert.deepEqual(directPlaceholderRepair.rows.map(row => row.id), ['expected:1', 'expected:2']);
-  assert.deepEqual(directPlaceholderRepair.rows.map(row => row.label), ['alice', 'bob']);
+  assert.equal(unrelatedConcreteRowsStaySeparate.changed, false, 'count agreement alone must not bind unrelated concrete rows');
+  assert.equal(unrelatedConcreteRowsStaySeparate.rows.length, 4);
+  assert.equal(unrelatedConcreteRowsStaySeparate.rows.find(row => row.id === 'expected:1').status, 'pending');
+
+  const identityBoundRepair = reconcilePersistedLedgerRows([
+    { id: 'expected:1', label: 'alice', action: 'follow', status: 'pending', sessionId, fields: { expectedOrdinal: 1 } },
+    { id: 'expected:2', label: 'bob', action: 'follow', status: 'pending', sessionId, fields: { expectedOrdinal: 2 } },
+    { id: 'alice', label: 'Follow alice', target: 'alice', action: 'follow', status: 'acted', sessionId, attempts: 1 },
+    { id: 'bob', label: 'Follow bob', target: 'bob', action: 'follow', status: 'processed', sessionId, attempts: 1 },
+  ]);
+  assert.equal(identityBoundRepair.changed, true, 'identity agreement still allows hydration repair');
+  assert.deepEqual(identityBoundRepair.rows.map(row => row.id), ['expected:1', 'expected:2']);
+  assert.deepEqual(identityBoundRepair.rows.map(row => row.status), ['acted', 'processed']);
 
   const conflicting = reconcilePersistedLedgerRows([
     { id: 'expected:1', label: 'alice', action: 'follow', status: 'processed', sessionId, fields: { expectedOrdinal: 1 } },
@@ -68556,28 +68566,41 @@ test('progress ledger repairs persisted placeholder sets only when identities ar
 test('persisted reconciliation preserves canonical collected fields over duplicate nulls', () => {
   for (const reconcile of [reconcilePersistedLedgerRows, reconcilePersistedLedgerRowsFx]) {
     const keepsCollected = reconcile([
-      { id: 'expected:1', label: 'profile 1', action: 'follow', status: 'acted', sessionId: 'field-keep', fields: { expectedOrdinal: 1, email: 'alice@example.com' } },
-      { id: 'alice', label: 'Follow alice', action: 'follow', status: 'acted', sessionId: 'field-keep', attempts: 1, fields: { email: null } },
+      { id: 'expected:1', label: 'alice', action: 'follow', status: 'acted', sessionId: 'field-keep', fields: { expectedOrdinal: 1, email: 'alice@example.com' } },
+      { id: 'alice', label: 'Follow alice', target: 'alice', action: 'follow', status: 'acted', sessionId: 'field-keep', attempts: 1, fields: { email: null } },
     ]);
     assert.equal(keepsCollected.changed, true);
     assert.deepEqual(keepsCollected.rows.map(row => row.id), ['expected:1']);
     assert.equal(keepsCollected.rows[0].fields.email, 'alice@example.com');
 
     const fillsMissing = reconcile([
-      { id: 'expected:1', label: 'profile 2', action: 'follow', status: 'acted', sessionId: 'field-keep', fields: { expectedOrdinal: 1 } },
-      { id: 'carol', label: 'Follow carol', action: 'follow', status: 'acted', sessionId: 'field-keep', attempts: 1, fields: { email: 'carol@example.com' } },
+      { id: 'expected:1', label: 'carol', action: 'follow', status: 'acted', sessionId: 'field-keep', fields: { expectedOrdinal: 1 } },
+      { id: 'carol', label: 'Follow carol', target: 'carol', action: 'follow', status: 'acted', sessionId: 'field-keep', attempts: 1, fields: { email: 'carol@example.com' } },
     ]);
     assert.equal(fillsMissing.changed, true);
     assert.deepEqual(fillsMissing.rows.map(row => row.id), ['expected:1']);
     assert.equal(fillsMissing.rows[0].fields.email, 'carol@example.com');
 
     const keepsExplicitNulls = reconcile([
-      { id: 'expected:1', label: 'profile 3', action: 'follow', status: 'processed', sessionId: 'field-keep', fields: { expectedOrdinal: 1, email: null } },
-      { id: 'dave', label: 'Follow dave', action: 'follow', status: 'processed', sessionId: 'field-keep', attempts: 1 },
+      { id: 'expected:1', label: 'dave', action: 'follow', status: 'processed', sessionId: 'field-keep', fields: { expectedOrdinal: 1, email: null } },
+      { id: 'dave', label: 'Follow dave', target: 'dave', action: 'follow', status: 'processed', sessionId: 'field-keep', attempts: 1 },
     ]);
     assert.equal(keepsExplicitNulls.changed, true);
     assert.ok(Object.prototype.hasOwnProperty.call(keepsExplicitNulls.rows[0].fields || {}, 'email'));
     assert.equal(keepsExplicitNulls.rows[0].fields.email, null);
+  }
+});
+
+test('persisted hydration never binds unrelated clicks into pending expected slots', () => {
+  for (const reconcile of [reconcilePersistedLedgerRows, reconcilePersistedLedgerRowsFx]) {
+    const strayClick = reconcile([
+      { id: 'expected:1', label: 'profile 1', action: 'follow', status: 'pending', sessionId: 'stray-guard', fields: { expectedOrdinal: 1 } },
+      { id: 'stray-bob', label: 'Follow Bob', action: 'follow', status: 'processed', sessionId: 'stray-guard', attempts: 1 },
+    ]);
+    assert.equal(strayClick.changed, false);
+    assert.equal(strayClick.rows.length, 2);
+    assert.equal(strayClick.rows.find(row => row.id === 'expected:1').status, 'pending');
+    assert.ok(strayClick.rows.some(row => row.id === 'stray-bob'), 'unrelated evidence rows must survive hydration');
   }
 });
 

--- a/web/blog/index.html
+++ b/web/blog/index.html
@@ -671,6 +671,18 @@
   "blogPost": [
     {
       "@type": "BlogPosting",
+      "headline": "Six budget Qwen vision models, compared: 600 requests, 54 cents on OpenRouter",
+      "url": "https://webbrain.one/blog/qwen-budget-vision-openrouter",
+      "datePublished": "2026-08-22",
+      "description": "We ran every current sub-dollar Qwen vision model on OpenRouter through WebBrain's 100-case browser-vision benchmark. Qwen3-VL-32B Instruct won on quality, the MoE 30B-A3B matched it at twice the speed, and the thinking variants billed four to five times the output tokens for little or no gain.",
+      "author": {
+        "@type": "Person",
+        "name": "Emre Sokullu",
+        "url": "https://emresokullu.com"
+      }
+    },
+    {
+      "@type": "BlogPosting",
       "headline": "Tiny Vision Models Compared II: WebBrain, Gemma 4, and Larger Qwen 3.5 Models Join the Race",
       "url": "https://webbrain.one/blog/tiny-vision-models-compared-ii",
       "datePublished": "2026-08-22",
@@ -1252,14 +1264,19 @@
         <kbd class="search-key" aria-hidden="true">/</kbd>
       </div>
       <div class="archive-status" role="status" aria-live="polite" aria-atomic="true">
-        <span id="results-count">45 notes</span>
+        <span id="results-count">46 notes</span>
         <span class="archive-status-rule" aria-hidden="true"></span>
         <span id="page-status"></span>
       </div>
     </section>
 
     <div class="post-list" id="post-list">
-      <a href="/blog/tiny-vision-models-compared-ii" class="post-card" data-search="Tiny Vision Models Compared II: WebBrain, Gemma 4, and Larger Qwen 3.5 Models Join the Race Tiny Vision Models Compared II: WebBrain, Gemma 4, and Larger Qwen 3.5 Models Join the Race A browser-specific 450M fine-tune reaches the same strict-pass band as Qwen 3.5 2B and Gemma 4 E4B while remaining small enough for WebGPU. It will become WebBrain&#39;s default local vision model. WebBrain VL 2 450M joins our 100-case browser-vision benchmark alongside Qwen 3.5 2B and 4B and Gemma 4 E4B, with the earlier Qwen and LFM baselines retained for context. August 22, 2026 2026-08-22 WebBrain VL 2 450M WebBrain Qwen 3.5 4B Qwen 3.5 2B Qwen 3.5 0.8B Gemma 4 E4B LFM2.5-VL WebGPU browser vision vision-language model">
+      <a href="/blog/qwen-budget-vision-openrouter" class="post-card" data-search="Six budget Qwen vision models, compared: 600 requests, 54 cents on OpenRouter Six budget Qwen vision models, compared: 600 requests, 54 cents on OpenRouter Dense 32B Instruct takes the quality crown at 69 strict passes. The MoE 30B-A3B lands one pass behind at half the latency. Both thinking variants cost 4-5x more output tokens and didn&#39;t beat their instruct siblings — except at 8B, where thinking was worth 13 passes. We ran every current sub-dollar Qwen vision model on OpenRouter through WebBrain&#39;s 100-case browser-vision benchmark. Qwen3-VL-32B Instruct won on quality, the MoE 30B-A3B matched it at twice the speed, and the thinking variants billed four to five times the output tokens for little or no gain. August 22, 2026 2026-08-22 Qwen3-VL OpenRouter vision model benchmark browser agent qwen3.5-35b-a3b Qwen3-VL-32B Instruct Qwen3-VL-30B-A3B reasoning models vision language model WebBrain">
+        <div class="post-meta">August 22, 2026 &middot; 7 min read</div>
+        <div class="post-title">Six budget Qwen vision models, compared: 600 requests, 54 cents on OpenRouter</div>
+        <div class="post-excerpt">Dense 32B Instruct takes the quality crown at 69 strict passes. The MoE 30B-A3B lands one pass behind at half the latency. Both thinking variants cost 4-5x more output tokens and didn&#39;t beat their instruct siblings — except at 8B, where thinking was worth 13 passes.</div>
+      </a>
+<a href="/blog/tiny-vision-models-compared-ii" class="post-card" data-search="Tiny Vision Models Compared II: WebBrain, Gemma 4, and Larger Qwen 3.5 Models Join the Race Tiny Vision Models Compared II: WebBrain, Gemma 4, and Larger Qwen 3.5 Models Join the Race A browser-specific 450M fine-tune reaches the same strict-pass band as Qwen 3.5 2B and Gemma 4 E4B while remaining small enough for WebGPU. It will become WebBrain&#39;s default local vision model. WebBrain VL 2 450M joins our 100-case browser-vision benchmark alongside Qwen 3.5 2B and 4B and Gemma 4 E4B, with the earlier Qwen and LFM baselines retained for context. August 22, 2026 2026-08-22 WebBrain VL 2 450M WebBrain Qwen 3.5 4B Qwen 3.5 2B Qwen 3.5 0.8B Gemma 4 E4B LFM2.5-VL WebGPU browser vision vision-language model">
         <div class="post-meta">August 22, 2026 &middot; 8 min read</div>
         <div class="post-title">Tiny Vision Models Compared II: WebBrain, Gemma 4, and Larger Qwen 3.5 Models Join the Race</div>
         <div class="post-excerpt">A browser-specific 450M fine-tune reaches the same strict-pass band as Qwen 3.5 2B and Gemma 4 E4B while remaining small enough for WebGPU. It will become WebBrain&#39;s default local vision model.</div>

--- a/web/blog/posts/qwen-budget-vision-openrouter.md
+++ b/web/blog/posts/qwen-budget-vision-openrouter.md
@@ -1,0 +1,126 @@
+---
+title: >
+  Six budget Qwen vision models, compared: 600 requests, 54 cents on OpenRouter
+slug: qwen-budget-vision-openrouter
+sortOrder: -250
+date: 2026-08-22
+readTime: 7 min read
+description: >
+  We ran every current sub-dollar Qwen vision model on OpenRouter through WebBrain's 100-case browser-vision benchmark. Qwen3-VL-32B Instruct won on quality, the MoE 30B-A3B matched it at twice the speed, and the thinking variants billed four to five times the output tokens for little or no gain.
+excerpt: >
+  Dense 32B Instruct takes the quality crown at 69 strict passes. The MoE 30B-A3B lands one pass behind at half the latency. Both thinking variants cost 4-5x more output tokens and didn't beat their instruct siblings — except at 8B, where thinking was worth 13 passes.
+titleTag: >
+  Six Budget Qwen Vision Models Compared on OpenRouter - WebBrain Blog
+ogTitle: >
+  Six budget Qwen vision models compared on OpenRouter
+ogDescription: >
+  600 image requests, zero errors, 54 cents total. Where Qwen's cheap vision models actually differ: latency, output-token burn, and a hard cliff below 30B.
+twitterTitle: >
+  Six budget Qwen vision models compared on OpenRouter
+twitterDescription: >
+  Qwen3-VL-32B Instruct wins our 100-case browser benchmark at $0.02 per full run. Thinking variants bill 4-5x the tokens. Full tables inside.
+keywords:
+  - Qwen3-VL
+  - OpenRouter
+  - vision model benchmark
+  - browser agent
+  - qwen3.5-35b-a3b
+  - Qwen3-VL-32B Instruct
+  - Qwen3-VL-30B-A3B
+  - reasoning models
+  - vision language model
+  - WebBrain
+author: Emre Sokullu
+authorUrl: https://emresokullu.com
+lede: >
+  **You don't need an expensive API to give a browser agent eyes.** We pushed all six of Qwen's current sub-dollar vision-capable models on OpenRouter through our [100-case browser-vision benchmark](https://github.com/esokullu/webbrain/tree/main/test/vision) — same screenshots, same production six-section prompt, same strict rubric we use to evaluate WebBrain's own vision subsystem. All 600 requests completed without a single error, and the entire sweep cost **$0.53**. The dense Qwen3-VL-32B Instruct won on quality. Its MoE sibling matched it at twice the speed. And the two "thinking" variants billed four to five times the output tokens for a gain you can count on one hand.
+---
+
+## The lineup
+
+Six model IDs, all served through the same OpenRouter account on August 22, 2026. Prices are OpenRouter list price per million tokens:
+
+| Model | Architecture | In / 1M tok | Out / 1M tok |
+| --- | --- | ---: | ---: |
+| `qwen/qwen3-vl-8b-instruct` | dense VL, 8B | $0.117 | $0.455 |
+| `qwen/qwen3-vl-8b-thinking` | dense VL, 8B + reasoning | $0.18 | $2.10 |
+| `qwen/qwen3-vl-30b-a3b-instruct` | MoE VL, ~3B active | $0.13 | $0.52 |
+| `qwen/qwen3-vl-30b-a3b-thinking` | MoE VL, ~3B active + reasoning | $0.20 | $2.40 |
+| `qwen/qwen3-vl-32b-instruct` | dense VL, 32B | $0.104 | $0.416 |
+| `qwen/qwen3.5-35b-a3b` | MoE generalist (text+image+video) | $0.25 | $1.25 |
+
+Note what's missing from that table: any expensive model. The priciest row costs a quarter of a cent per 1K input tokens. This is the budget tier, and the question is how much capability survives down here.
+
+## Results
+
+Every model saw all 100 cases with WebBrain's production screenshot contract: temperature 0, max 800 tokens, six required sections, strict rubric scoring against expected facts. A strict pass means the complete contract plus the case's weighted facts recovered without critical contradiction.
+
+| Model | Strict passes | Mean rubric | Mean latency | Output tokens | Cost / 100-case run |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| **Qwen3-VL-32B Instruct** | **69** | **91.9%** | 4.6 s | 22.2K | **$0.022** |
+| Qwen3-VL-30B-A3B Instruct | 68 | 91.3% | **2.2 s** | 17.1K | $0.024 |
+| Qwen3.5-35B-A3B | 67 | 90.8% | 5.2 s | 55.4K | $0.099 |
+| Qwen3-VL-30B-A3B Thinking | 62 | 88.9% | 6.3 s | 68.5K | $0.188 |
+| Qwen3-VL-8B Thinking | 61 | 86.7% | 6.4 s | 75.5K | $0.180 |
+| Qwen3-VL-8B Instruct | 48 | 84.0% | 2.1 s | 14.9K | $0.021 |
+
+Three things jump out.
+
+**First place is a tie in disguise.** The dense 32B scores one strict pass and half a point of rubric above the MoE 30B-A3B. But the MoE answers in 2.2 seconds where the dense model needs 4.6. For an interactive browser agent watching its own screenshots, latency compounds across every step of a task; we'd pick the MoE for production loops and the dense model when you want maximum accuracy per request.
+
+**The generalist doesn't beat the specialists.** Qwen3.5-35B-A3B is the flagship-shaped option — bigger context class, video input, newest generation. On browser screens it finished third, behind both dedicated VL siblings, while burning 2-4x their output tokens. If your workload is screenshots, the VL-tuned rows are simply better and cheaper.
+
+**The 8B instruct is a different product.** At 48 strict passes it trails the leaders by twenty points, and the shape of its failure curve matters more than the average, which we'll get to below.
+
+## What the extra money buys
+
+Strict-pass rate by difficulty band (20 cases each):
+
+| Band | 8B Inst | 8B Think | 30B MoE Inst | 30B MoE Think | 32B Inst | 35B A3B |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Easy | 60% | 65% | 70% | 65% | 70% | 80% |
+| Basic | 65% | 70% | 80% | 80% | 75% | 70% |
+| Intermediate | 50% | 65% | 70% | 65% | 80% | 60% |
+| Advanced | 35% | 55% | 60% | 50% | 65% | 70% |
+| Challenging | 30% | 50% | 60% | 50% | 55% | 55% |
+
+The 8B instruct falls off a cliff exactly where a browser agent needs help most: hard overlays, occluded controls, ambiguous states. Every model at 30B-plus holds a rough 55-70% floor across all five bands. Below 30B, only the thinking variant keeps that shape.
+
+## Thinking: worth it at 8B, not at 30B
+
+This is the cleanest experiment in the set, because both sizes ship paired instruct/thinking checkpoints:
+
+- **At 8B:** thinking adds **+13 strict passes** (61 vs 48). If you're stuck with small models, the reasoning checkpoint genuinely rescues hard cases — advanced band jumps from 35% to 55%.
+- **At 30B:** thinking *loses* six passes (62 vs 68). Whatever the extra tokens buy, they also buy overthinking easy screens.
+
+Either way you pay for it: the thinking variants emitted **4-5x the completion tokens** of their instruct siblings (75.5K vs 14.9K at 8B; 68.5K vs 17.1K at 30B), ran about three times slower, and cost roughly eight times more per run at list prices.
+
+One measurement caveat for anyone replicating this: our harness records OpenAI-style `reasoning_content`, while OpenRouter streams reasoning under its own `reasoning` field, so our captured reasoning text is empty even though the token usage makes clear the reasoning happened and was billed. Scores were computed on final content only, which is fair — but treat our "reasoning chars" fields in the committed results as zero by convention, not by observation.
+
+## Where they all break
+
+Category-level strict-pass rates expose shared blind spots that no amount of parameters in this tier fixed:
+
+| Category | Best of six | Worst of six |
+| --- | ---: | ---: |
+| form-validation | 20% (two models) | 0% (four models) |
+| modal-overlay | 20% (two models) | 0% (four models) |
+| multilingual-OCR | 40% (35B generalist) | 0% (three models) |
+| calendar | 100% | 20% (8B instruct) |
+| checkout | 80% | 20% (8B instruct) |
+| consent-banner | 100% | 0% (8B instruct) |
+
+Form validation and modal overlays are brutal across the board — these are precisely the states where an automation agent most needs reliable vision, and the whole budget tier mostly misses them. Meanwhile toast notifications, data tables, and chart reading are free wins at 100% nearly everywhere.
+
+Eighteen of the 100 cases failed for **all six models**. That's the honest floor of this price bracket today, and it's a useful target list for fine-tunes like [our 450M browser-specific model](/blog/tiny-vision-models-compared-ii).
+
+One for the road: on case 001 — an ordinary login screen — the *only* model to earn a perfect score was the 8B instruct, the worst performer overall. Every larger sibling dropped details. Small models are unreliable; so are rankings.
+
+## Which one should you call
+
+- **Production browser agent:** Qwen3-VL-30B-A3B Instruct — 90th-percentile accuracy at 2.2 s median and ~$0.24 per thousand screenshots.
+- **Maximum accuracy per request:** Qwen3-VL-32B Instruct, one pass better, twice as slow.
+- **Stuck under 10B:** take the thinking variant without guilt — it's the only small model here that doesn't collapse on hard pages.
+- **Skip for vision workloads:** Qwen3.5-35B-A3B (good model, wrong tool) and both thinking variants at 30B-plus (paying more to score less).
+
+The complete harness — screenshots, expected facts, scoring code, and all six committed result directories — lives in [`test/vision`](https://github.com/esokullu/webbrain/tree/main/test/vision) on GitHub.

--- a/web/blog/qwen-budget-vision-openrouter/index.html
+++ b/web/blog/qwen-budget-vision-openrouter/index.html
@@ -1,0 +1,611 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Six Budget Qwen Vision Models Compared on OpenRouter - WebBrain Blog</title>
+  <meta name="description" content="We ran every current sub-dollar Qwen vision model on OpenRouter through WebBrain&#39;s 100-case browser-vision benchmark. Qwen3-VL-32B Instruct won on quality, the MoE 30B-A3B matched it at twice the speed, and the thinking variants billed four to five times the output tokens for little or no gain.">
+  <meta name="keywords" content="Qwen3-VL, OpenRouter, vision model benchmark, browser agent, qwen3.5-35b-a3b, Qwen3-VL-32B Instruct, Qwen3-VL-30B-A3B, reasoning models, vision language model, WebBrain">
+  <meta property="og:title" content="Six budget Qwen vision models compared on OpenRouter">
+  <meta property="og:description" content="600 image requests, zero errors, 54 cents total. Where Qwen&#39;s cheap vision models actually differ: latency, output-token burn, and a hard cliff below 30B.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://webbrain.one/blog/qwen-budget-vision-openrouter">
+  <meta property="og:image" content="https://webbrain.one/og-image.png">
+  <meta property="og:image:secure_url" content="https://webbrain.one/og-image.png">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="WebBrain — Open-source AI browser agent">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Six budget Qwen vision models compared on OpenRouter">
+  <meta name="twitter:description" content="Qwen3-VL-32B Instruct wins our 100-case browser benchmark at $0.02 per full run. Thinking variants bill 4-5x the tokens. Full tables inside.">
+  <meta name="twitter:image" content="https://webbrain.one/twitter-image.png">
+  <meta name="twitter:image:alt" content="WebBrain — Open-source AI browser agent">
+  <link rel="icon" type="image/png" href="/favicon.png">
+  <link rel="canonical" href="https://webbrain.one/blog/qwen-budget-vision-openrouter">
+  <!-- Blog is English-only; alternates point to locale homepages. -->
+  <link rel="alternate" hreflang="en" href="https://webbrain.one/">
+  <link rel="alternate" hreflang="es" href="https://webbrain.one/es/">
+  <link rel="alternate" hreflang="fr" href="https://webbrain.one/fr/">
+  <link rel="alternate" hreflang="tr" href="https://webbrain.one/tr/">
+  <link rel="alternate" hreflang="zh" href="https://webbrain.one/zh/">
+  <link rel="alternate" hreflang="ru" href="https://webbrain.one/ru/">
+  <link rel="alternate" hreflang="uk" href="https://webbrain.one/uk/">
+  <link rel="alternate" hreflang="ar" href="https://webbrain.one/ar/">
+  <link rel="alternate" hreflang="ja" href="https://webbrain.one/ja/">
+  <link rel="alternate" hreflang="ko" href="https://webbrain.one/ko/">
+  <link rel="alternate" hreflang="id" href="https://webbrain.one/id/">
+  <link rel="alternate" hreflang="th" href="https://webbrain.one/th/">
+  <link rel="alternate" hreflang="ms" href="https://webbrain.one/ms/">
+  <link rel="alternate" hreflang="tl" href="https://webbrain.one/tl/">
+  <link rel="alternate" hreflang="he" href="https://webbrain.one/he/">
+  <link rel="alternate" hreflang="x-default" href="https://webbrain.one/">
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+    :root {
+      --bg: #0b0e17;
+      --bg-card: #111827;
+      --bg-card-hover: #1a2233;
+      --surface: #161d2e;
+      --border: rgba(255,255,255,0.07);
+      --text: #e4e4ec;
+      --text-dim: #8b8fa4;
+      --accent: #6c63ff;
+      --accent-glow: rgba(108,99,255,0.25);
+      --accent2: #a78bfa;
+      --success: #34d399;
+      --warning: #fbbf24;
+      --danger: #f87171;
+      --tint-soft: rgba(255,255,255,0.05);
+      --tint-soft-2: rgba(255,255,255,0.04);
+      --tint-medium: rgba(255,255,255,0.08);
+      --nav-bg: rgba(11,14,23,0.85);
+      --code-bg: #0a0e17;
+      --inline-code-bg: rgba(255,255,255,0.06);
+      --shadow-strong: rgba(0,0,0,0.40);
+      --radius: 12px;
+      --radius-lg: 16px;
+      --max-w: 760px;
+      color-scheme: dark;
+    }
+    :root[data-theme="light"] {
+      --bg: #f7f1e6;
+      --bg-card: #fffdf8;
+      --bg-card-hover: #f2e9d4;
+      --surface: #ede2cb;
+      --border: rgba(89,55,25,0.15);
+      --text: #2c1810;
+      --text-dim: #6b5b47;
+      --accent: #5b52e8;
+      --accent-glow: rgba(91,82,232,0.20);
+      --accent2: #7c6ce6;
+      --success: #2d8866;
+      --warning: #9a6500;
+      --danger: #b74747;
+      --tint-soft: rgba(89,55,25,0.05);
+      --tint-soft-2: rgba(89,55,25,0.07);
+      --tint-medium: rgba(89,55,25,0.10);
+      --nav-bg: rgba(247,241,230,0.85);
+      --code-bg: #fff7e6;
+      --inline-code-bg: rgba(89,55,25,0.08);
+      --shadow-strong: rgba(89,55,25,0.18);
+      color-scheme: light;
+    }
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.75;
+      font-size: 17px;
+      overflow-x: hidden;
+    }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .glow-bg {
+      position: fixed;
+      inset: 0;
+      z-index: -1;
+      pointer-events: none;
+      overflow: hidden;
+    }
+    .glow-bg::before,
+    .glow-bg::after {
+      content: '';
+      position: absolute;
+      border-radius: 50%;
+      filter: blur(120px);
+      opacity: 0.26;
+    }
+    .glow-bg::before {
+      width: 500px;
+      height: 500px;
+      background: var(--accent);
+      top: -220px;
+      left: -160px;
+    }
+    .glow-bg::after {
+      width: 500px;
+      height: 500px;
+      background: var(--accent2);
+      right: -180px;
+      bottom: -230px;
+      opacity: 0.18;
+    }
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: var(--nav-bg);
+      backdrop-filter: saturate(160%) blur(12px);
+      -webkit-backdrop-filter: saturate(160%) blur(12px);
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-inner {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 14px 24px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+    }
+    .nav-brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      flex-shrink: 0;
+      color: var(--text);
+      font-size: 18px;
+      font-weight: 700;
+      text-decoration: none;
+    }
+    .nav-brand:hover { text-decoration: none; }
+    .nav-brand .brand-logo { width: 26px; height: 26px; border-radius: 7px; flex: 0 0 auto; }
+    .nav-brand .domain { opacity: 0.5; font-weight: 400; }
+    .nav-links {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 16px;
+      min-width: 0;
+    }
+    .nav-links a {
+      position: relative;
+      color: var(--text-dim);
+      font-size: 14px;
+      font-weight: 500;
+      white-space: nowrap;
+    }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+    .nav-links a[aria-current="page"] { color: var(--text); }
+    .nav-links a[aria-current="page"]::after {
+      content: '';
+      position: absolute;
+      left: 1px;
+      right: 1px;
+      bottom: -7px;
+      height: 3px;
+      border-radius: 999px;
+      background: linear-gradient(90deg, var(--accent2), var(--accent));
+      box-shadow: 0 2px 12px var(--accent-glow);
+    }
+    .lang-dropdown {
+      background: var(--tint-soft);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 6px 10px;
+      font-size: 13px;
+      max-width: 120px;
+    }
+    .lang-dropdown:focus { outline: 2px solid var(--accent-glow); outline-offset: 1px; }
+    .lang-dropdown option { background-color: var(--bg-card-hover); color: var(--text); }
+    .theme-toggle {
+      appearance: none;
+      -webkit-appearance: none;
+      background: var(--tint-soft-2);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      width: 30px;
+      height: 30px;
+      padding: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      cursor: pointer;
+      color: var(--text-dim);
+      transition: background 0.2s, color 0.2s, border-color 0.2s, transform 0.1s;
+    }
+    .theme-toggle:hover {
+      background: var(--tint-medium);
+      border-color: var(--accent);
+      color: var(--text);
+      transform: translateY(-1px);
+    }
+    .theme-toggle:focus-visible {
+      outline: 2px solid var(--accent2);
+      outline-offset: 2px;
+    }
+    .theme-toggle svg { width: 16px; height: 16px; display: block; }
+    .theme-toggle .icon-sun { display: block; }
+    .theme-toggle .icon-moon { display: none; }
+    :root[data-theme="light"] .theme-toggle .icon-sun { display: none; }
+    :root[data-theme="light"] .theme-toggle .icon-moon { display: block; }
+    main,
+    article {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 64px 24px 80px;
+    }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+    h1 {
+      font-size: 38px;
+      line-height: 1.2;
+      font-weight: 700;
+      letter-spacing: 0;
+      margin-bottom: 16px;
+    }
+    .lede {
+      color: var(--text-dim);
+      line-height: 1.6;
+    }
+    .lede {
+      font-size: 19px;
+      margin-bottom: 40px;
+    }
+    .meta {
+      font-size: 13px;
+      color: var(--text-dim);
+      margin-bottom: 12px;
+      letter-spacing: 0;
+    }
+    h2 {
+      font-size: 24px;
+      font-weight: 700;
+      margin-top: 48px;
+      margin-bottom: 14px;
+      letter-spacing: 0;
+    }
+    h3 {
+      font-size: 18px;
+      font-weight: 600;
+      margin-top: 32px;
+      margin-bottom: 10px;
+      color: var(--text);
+    }
+    h4, h5, h6 {
+      color: var(--text);
+      margin-top: 28px;
+      margin-bottom: 10px;
+      line-height: 1.35;
+    }
+    p { margin-bottom: 16px; }
+    ul, ol { margin: 0 0 16px 20px; }
+    li { margin-bottom: 6px; }
+    code {
+      font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+      font-size: 0.88em;
+      background: var(--inline-code-bg);
+      padding: 2px 6px;
+      border-radius: 4px;
+      color: color-mix(in srgb, var(--accent2) 80%, var(--text));
+    }
+    pre {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 18px 20px;
+      overflow-x: auto;
+      margin: 20px 0;
+      font-size: 14px;
+      line-height: 1.55;
+      box-shadow: 0 18px 60px var(--shadow-strong);
+    }
+    pre code {
+      background: transparent;
+      padding: 0;
+      color: inherit;
+      font-size: inherit;
+    }
+    blockquote {
+      border-left: 3px solid var(--accent);
+      padding: 4px 0 4px 18px;
+      margin: 20px 0;
+      color: var(--text-dim);
+      font-style: italic;
+    }
+    blockquote p:last-child { margin-bottom: 0; }
+    hr {
+      border: 0;
+      border-top: 1px solid var(--border);
+      margin: 36px 0;
+    }
+    article img {
+      max-width: 100%;
+      height: auto;
+      display: block;
+      border-radius: var(--radius);
+      border: 1px solid var(--border);
+      margin: 24px 0;
+    }
+    .table-wrap { overflow-x: auto; margin: 24px 0; }
+    table {
+      width: 100%;
+      min-width: 560px;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+    th, td {
+      text-align: left;
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: top;
+    }
+    th {
+      color: var(--text-dim);
+      font-weight: 600;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0;
+      background: var(--tint-soft-2);
+    }
+    td code { font-size: 12px; }
+    .win { color: var(--success); font-weight: 600; }
+    .lose { color: var(--danger); }
+    .meh { color: var(--warning); }
+    .callout {
+      background: color-mix(in srgb, var(--accent) 10%, transparent);
+      border: 1px solid color-mix(in srgb, var(--accent) 24%, transparent);
+      border-radius: var(--radius);
+      padding: 16px 20px;
+      margin: 24px 0;
+      font-size: 15px;
+      line-height: 1.65;
+      color: var(--text-dim);
+    }
+    .callout strong { color: var(--text); }
+    .author-box {
+      margin-top: 64px;
+      padding-top: 32px;
+      border-top: 1px solid var(--border);
+      color: var(--text-dim);
+      font-size: 14px;
+    }
+    .post-list { display: flex; flex-direction: column; gap: 18px; }
+    .post-card {
+      display: block;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: 24px 26px;
+      transition: background 0.18s, border-color 0.18s, transform 0.18s;
+    }
+    .post-card:hover {
+      background: var(--bg-card-hover);
+      border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+      transform: translateY(-1px);
+      text-decoration: none;
+    }
+    .post-meta {
+      font-size: 12px;
+      color: var(--text-dim);
+      letter-spacing: 0;
+      margin-bottom: 8px;
+    }
+    .post-title {
+      font-size: 21px;
+      font-weight: 600;
+      color: var(--text);
+      margin-bottom: 6px;
+      letter-spacing: 0;
+      line-height: 1.35;
+    }
+    .post-excerpt {
+      color: var(--text-dim);
+      font-size: 15px;
+      line-height: 1.6;
+    }
+    footer {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 40px 24px;
+      border-top: 1px solid var(--border);
+      display: flex;
+      justify-content: space-between;
+      gap: 24px;
+      color: var(--text-dim);
+      font-size: 13px;
+    }
+    footer a { color: var(--text-dim); }
+    footer a:hover { color: var(--text); }
+    @media (max-width: 700px) {
+      body { font-size: 16px; }
+      .nav-inner { padding: 14px 20px; align-items: flex-start; }
+      .nav-links { gap: 12px; flex-wrap: wrap; }
+      .lang-dropdown { display: none; }
+      h1 { font-size: 28px; }
+      .lede { font-size: 16px; }
+      main, article { padding: 48px 20px 64px; }
+      h2 { font-size: 20px; margin-top: 36px; }
+      .post-card { padding: 20px; }
+      .post-title { font-size: 19px; }
+      footer { flex-direction: column; padding: 32px 20px; }
+    }
+    @media (max-width: 420px) {
+      .nav-inner { gap: 12px; }
+      .nav-links a[href="https://github.com/webbrain-one/webbrain"] { display: none; }
+      .theme-toggle { width: 28px; height: 28px; }
+    }
+  </style>
+  <script>
+    (function () {
+      try {
+        var saved = localStorage.getItem('webbrain-theme');
+        var theme = (saved === 'light' || saved === 'dark')
+          ? saved
+          : (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+        document.documentElement.setAttribute('data-theme', theme);
+      } catch (_) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      }
+    })();
+  </script>
+  <!-- Plausible analytics: start -->
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-yWGfwxkkKSVs-eTuaKYpy.js"></script>
+  <script>
+    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+    plausible.init()
+  </script>
+  <!-- Plausible analytics: end -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "Six budget Qwen vision models, compared: 600 requests, 54 cents on OpenRouter",
+  "description": "We ran every current sub-dollar Qwen vision model on OpenRouter through WebBrain's 100-case browser-vision benchmark. Qwen3-VL-32B Instruct won on quality, the MoE 30B-A3B matched it at twice the speed, and the thinking variants billed four to five times the output tokens for little or no gain.",
+  "author": {
+    "@type": "Person",
+    "name": "Emre Sokullu",
+    "url": "https://emresokullu.com"
+  },
+  "datePublished": "2026-08-22",
+  "image": "https://webbrain.one/og-image.png",
+  "publisher": {
+    "@type": "Organization",
+    "name": "WebBrain",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://webbrain.one/logo-github.png"
+    }
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://webbrain.one/blog/qwen-budget-vision-openrouter"
+  }
+}
+  </script>
+</head>
+<body>
+  <div class="glow-bg"></div>
+  <nav>
+    <div class="nav-inner">
+      <a href="/" class="nav-brand"><img class="brand-logo" src="/logo-github.png" alt="" aria-hidden="true"> WebBrain<span class="domain">.one</span></a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/docs/">Docs</a>
+        <a href="/blog" aria-current="page">Blog</a>
+        <select class="lang-dropdown" id="lang-dropdown" aria-label="Select language" data-current="en"><option value="en">English</option><option value="es">Español</option><option value="fr">Français</option><option value="tr">Türkçe</option><option value="zh">中文</option><option value="ru">Русский</option><option value="uk">Українська</option><option value="ar">العربية</option><option value="ja">日本語</option><option value="ko">한국어</option><option value="id">Bahasa Indonesia</option><option value="th">ไทย</option><option value="ms">Bahasa Melayu</option><option value="tl">Filipino</option><option value="he">עברית</option></select>
+        <button class="theme-toggle" type="button" id="theme-toggle" aria-label="Toggle light / dark theme" title="Toggle light / dark theme">
+          <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="4"/>
+            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+          </svg>
+          <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+          </svg>
+        </button>
+        <a href="https://github.com/webbrain-one/webbrain" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </div>
+  </nav>
+
+  <article>
+    <div class="meta">August 22, 2026 &middot; 7 min read &middot; <a href="/blog">&larr; All posts</a></div>
+    <h1>Six budget Qwen vision models, compared: 600 requests, 54 cents on OpenRouter</h1>
+    <p class="lede"><strong>You don&#39;t need an expensive API to give a browser agent eyes.</strong> We pushed all six of Qwen&#39;s current sub-dollar vision-capable models on OpenRouter through our <a href="https://github.com/esokullu/webbrain/tree/main/test/vision" target="_blank" rel="noopener">100-case browser-vision benchmark</a> — same screenshots, same production six-section prompt, same strict rubric we use to evaluate WebBrain&#39;s own vision subsystem. All 600 requests completed without a single error, and the entire sweep cost <strong>$0.53</strong>. The dense Qwen3-VL-32B Instruct won on quality. Its MoE sibling matched it at twice the speed. And the two &quot;thinking&quot; variants billed four to five times the output tokens for a gain you can count on one hand.</p>
+<h2 id="the-lineup">The lineup</h2>
+<p>Six model IDs, all served through the same OpenRouter account on August 22, 2026. Prices are OpenRouter list price per million tokens:</p>
+<div class="table-wrap"><table><thead><tr><th>Model</th><th>Architecture</th><th>In / 1M tok</th><th>Out / 1M tok</th></tr></thead><tbody><tr><td><code>qwen/qwen3-vl-8b-instruct</code></td><td>dense VL, 8B</td><td>$0.117</td><td>$0.455</td></tr><tr><td><code>qwen/qwen3-vl-8b-thinking</code></td><td>dense VL, 8B + reasoning</td><td>$0.18</td><td>$2.10</td></tr><tr><td><code>qwen/qwen3-vl-30b-a3b-instruct</code></td><td>MoE VL, ~3B active</td><td>$0.13</td><td>$0.52</td></tr><tr><td><code>qwen/qwen3-vl-30b-a3b-thinking</code></td><td>MoE VL, ~3B active + reasoning</td><td>$0.20</td><td>$2.40</td></tr><tr><td><code>qwen/qwen3-vl-32b-instruct</code></td><td>dense VL, 32B</td><td>$0.104</td><td>$0.416</td></tr><tr><td><code>qwen/qwen3.5-35b-a3b</code></td><td>MoE generalist (text+image+video)</td><td>$0.25</td><td>$1.25</td></tr></tbody></table></div>
+<p>Note what&#39;s missing from that table: any expensive model. The priciest row costs a quarter of a cent per 1K input tokens. This is the budget tier, and the question is how much capability survives down here.</p>
+<h2 id="results">Results</h2>
+<p>Every model saw all 100 cases with WebBrain&#39;s production screenshot contract: temperature 0, max 800 tokens, six required sections, strict rubric scoring against expected facts. A strict pass means the complete contract plus the case&#39;s weighted facts recovered without critical contradiction.</p>
+<div class="table-wrap"><table><thead><tr><th>Model</th><th>Strict passes</th><th>Mean rubric</th><th>Mean latency</th><th>Output tokens</th><th>Cost / 100-case run</th></tr></thead><tbody><tr><td><strong>Qwen3-VL-32B Instruct</strong></td><td><strong>69</strong></td><td><strong>91.9%</strong></td><td>4.6 s</td><td>22.2K</td><td><strong>$0.022</strong></td></tr><tr><td>Qwen3-VL-30B-A3B Instruct</td><td>68</td><td>91.3%</td><td><strong>2.2 s</strong></td><td>17.1K</td><td>$0.024</td></tr><tr><td>Qwen3.5-35B-A3B</td><td>67</td><td>90.8%</td><td>5.2 s</td><td>55.4K</td><td>$0.099</td></tr><tr><td>Qwen3-VL-30B-A3B Thinking</td><td>62</td><td>88.9%</td><td>6.3 s</td><td>68.5K</td><td>$0.188</td></tr><tr><td>Qwen3-VL-8B Thinking</td><td>61</td><td>86.7%</td><td>6.4 s</td><td>75.5K</td><td>$0.180</td></tr><tr><td>Qwen3-VL-8B Instruct</td><td>48</td><td>84.0%</td><td>2.1 s</td><td>14.9K</td><td>$0.021</td></tr></tbody></table></div>
+<p>Three things jump out.</p>
+<p><strong>First place is a tie in disguise.</strong> The dense 32B scores one strict pass and half a point of rubric above the MoE 30B-A3B. But the MoE answers in 2.2 seconds where the dense model needs 4.6. For an interactive browser agent watching its own screenshots, latency compounds across every step of a task; we&#39;d pick the MoE for production loops and the dense model when you want maximum accuracy per request.</p>
+<p><strong>The generalist doesn&#39;t beat the specialists.</strong> Qwen3.5-35B-A3B is the flagship-shaped option — bigger context class, video input, newest generation. On browser screens it finished third, behind both dedicated VL siblings, while burning 2-4x their output tokens. If your workload is screenshots, the VL-tuned rows are simply better and cheaper.</p>
+<p><strong>The 8B instruct is a different product.</strong> At 48 strict passes it trails the leaders by twenty points, and the shape of its failure curve matters more than the average, which we&#39;ll get to below.</p>
+<h2 id="what-the-extra-money-buys">What the extra money buys</h2>
+<p>Strict-pass rate by difficulty band (20 cases each):</p>
+<div class="table-wrap"><table><thead><tr><th>Band</th><th>8B Inst</th><th>8B Think</th><th>30B MoE Inst</th><th>30B MoE Think</th><th>32B Inst</th><th>35B A3B</th></tr></thead><tbody><tr><td>Easy</td><td>60%</td><td>65%</td><td>70%</td><td>65%</td><td>70%</td><td>80%</td></tr><tr><td>Basic</td><td>65%</td><td>70%</td><td>80%</td><td>80%</td><td>75%</td><td>70%</td></tr><tr><td>Intermediate</td><td>50%</td><td>65%</td><td>70%</td><td>65%</td><td>80%</td><td>60%</td></tr><tr><td>Advanced</td><td>35%</td><td>55%</td><td>60%</td><td>50%</td><td>65%</td><td>70%</td></tr><tr><td>Challenging</td><td>30%</td><td>50%</td><td>60%</td><td>50%</td><td>55%</td><td>55%</td></tr></tbody></table></div>
+<p>The 8B instruct falls off a cliff exactly where a browser agent needs help most: hard overlays, occluded controls, ambiguous states. Every model at 30B-plus holds a rough 55-70% floor across all five bands. Below 30B, only the thinking variant keeps that shape.</p>
+<h2 id="thinking-worth-it-at-8b-not-at-30b">Thinking: worth it at 8B, not at 30B</h2>
+<p>This is the cleanest experiment in the set, because both sizes ship paired instruct/thinking checkpoints:</p>
+<ul><li><strong>At 8B:</strong> thinking adds <strong>+13 strict passes</strong> (61 vs 48). If you&#39;re stuck with small models, the reasoning checkpoint genuinely rescues hard cases — advanced band jumps from 35% to 55%.</li><li><strong>At 30B:</strong> thinking <em>loses</em> six passes (62 vs 68). Whatever the extra tokens buy, they also buy overthinking easy screens.</li></ul>
+<p>Either way you pay for it: the thinking variants emitted <strong>4-5x the completion tokens</strong> of their instruct siblings (75.5K vs 14.9K at 8B; 68.5K vs 17.1K at 30B), ran about three times slower, and cost roughly eight times more per run at list prices.</p>
+<p>One measurement caveat for anyone replicating this: our harness records OpenAI-style <code>reasoning_content</code>, while OpenRouter streams reasoning under its own <code>reasoning</code> field, so our captured reasoning text is empty even though the token usage makes clear the reasoning happened and was billed. Scores were computed on final content only, which is fair — but treat our &quot;reasoning chars&quot; fields in the committed results as zero by convention, not by observation.</p>
+<h2 id="where-they-all-break">Where they all break</h2>
+<p>Category-level strict-pass rates expose shared blind spots that no amount of parameters in this tier fixed:</p>
+<div class="table-wrap"><table><thead><tr><th>Category</th><th>Best of six</th><th>Worst of six</th></tr></thead><tbody><tr><td>form-validation</td><td>20% (two models)</td><td>0% (four models)</td></tr><tr><td>modal-overlay</td><td>20% (two models)</td><td>0% (four models)</td></tr><tr><td>multilingual-OCR</td><td>40% (35B generalist)</td><td>0% (three models)</td></tr><tr><td>calendar</td><td>100%</td><td>20% (8B instruct)</td></tr><tr><td>checkout</td><td>80%</td><td>20% (8B instruct)</td></tr><tr><td>consent-banner</td><td>100%</td><td>0% (8B instruct)</td></tr></tbody></table></div>
+<p>Form validation and modal overlays are brutal across the board — these are precisely the states where an automation agent most needs reliable vision, and the whole budget tier mostly misses them. Meanwhile toast notifications, data tables, and chart reading are free wins at 100% nearly everywhere.</p>
+<p>Eighteen of the 100 cases failed for <strong>all six models</strong>. That&#39;s the honest floor of this price bracket today, and it&#39;s a useful target list for fine-tunes like <a href="/blog/tiny-vision-models-compared-ii">our 450M browser-specific model</a>.</p>
+<p>One for the road: on case 001 — an ordinary login screen — the <em>only</em> model to earn a perfect score was the 8B instruct, the worst performer overall. Every larger sibling dropped details. Small models are unreliable; so are rankings.</p>
+<h2 id="which-one-should-you-call">Which one should you call</h2>
+<ul><li><strong>Production browser agent:</strong> Qwen3-VL-30B-A3B Instruct — 90th-percentile accuracy at 2.2 s median and ~$0.24 per thousand screenshots.</li><li><strong>Maximum accuracy per request:</strong> Qwen3-VL-32B Instruct, one pass better, twice as slow.</li><li><strong>Stuck under 10B:</strong> take the thinking variant without guilt — it&#39;s the only small model here that doesn&#39;t collapse on hard pages.</li><li><strong>Skip for vision workloads:</strong> Qwen3.5-35B-A3B (good model, wrong tool) and both thinking variants at 30B-plus (paying more to score less).</li></ul>
+<p>The complete harness — screenshots, expected facts, scoring code, and all six committed result directories — lives in <a href="https://github.com/esokullu/webbrain/tree/main/test/vision" target="_blank" rel="noopener"><code>test/vision</code></a> on GitHub.</p>
+
+    <div class="author-box">
+      Written by <a href="https://emresokullu.com" target="_blank" rel="noopener">Emre Sokullu</a>. WebBrain 33.0.0 and later is GPL-3.0-or-later and open on <a href="https://github.com/webbrain-one/webbrain" target="_blank" rel="noopener">GitHub</a>.
+    </div>
+  </article>
+
+  <footer>
+    <div>&copy; 2026 WebBrain &middot; <a href="/privacy">Privacy</a></div>
+    <div><a href="https://github.com/webbrain-one/webbrain" target="_blank" rel="noopener">GitHub</a></div>
+  </footer>
+  <script>
+    (function () {
+      const btn = document.getElementById('theme-toggle');
+      if (!btn) return;
+      const root = document.documentElement;
+
+      function setTheme(theme, persist) {
+        root.setAttribute('data-theme', theme);
+        if (persist) {
+          try { localStorage.setItem('webbrain-theme', theme); } catch (_) {}
+        }
+      }
+
+      btn.addEventListener('click', function () {
+        const next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+        setTheme(next, true);
+      });
+
+      const mq = window.matchMedia('(prefers-color-scheme: light)');
+      function onMQ(e) {
+        try {
+          if (localStorage.getItem('webbrain-theme')) return;
+        } catch (_) {}
+        setTheme(e.matches ? 'light' : 'dark', false);
+      }
+      if (typeof mq.addEventListener === 'function') mq.addEventListener('change', onMQ);
+      else if (typeof mq.addListener === 'function') mq.addListener(onMQ);
+    })();
+  </script>
+  <script>
+    (function () {
+      const LOCALES = ["en","es","fr","tr","zh","ru","uk","ar","ja","ko","id","th","ms","tl","he"];
+      const sel = document.getElementById('lang-dropdown');
+      if (!sel) return;
+      sel.value = sel.dataset.current || 'en';
+      sel.addEventListener('change', function () {
+        const target = sel.value;
+        if (!LOCALES.includes(target)) return;
+        window.location.href = target === 'en' ? '/' : '/' + target + '/';
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- keep planner expected-item placeholders as the single ordered canonical ledger rows
- bind classifier targets and partial concrete model/observer batches without doubling 40-item or 22-item journeys
- match URL and federated-account identities safely, preserve evidence guards, and repair only unambiguous persisted duplicates
- keep Chrome and Firefox implementations in parity

## Validation

- `npm test`
- 2007/2007 main tests
- offline retrieval benchmark completed
- 60/60 injection security checks
- `git diff --check`
- Chrome/Firefox progress-ledger byte parity