### PR TITLE
Relax completion recovery bounds: 2 retry turns and 12k output cap

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -27456,7 +27456,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let emptyOutputRecoveryAttempted = false;
     let compressionPlaceholderRecoveryAttempted = false;
     let structuredOutputRecoveryAttempted = false;
-    let completionPlainFinalRecoveryAttempted = false;
+    let completionPlainFinalRecoveryAttempted = 0;
     let standaloneWikipediaModelSearchAttempted = false;
     let standaloneIncompleteAnswerRecoveryAttempted = false;
     let standaloneWebgpuBudgetRecoveryAttempted = false;
@@ -28103,7 +28103,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const readFinalBlock = this._readCompletenessBlock(tabId);
       const plainFinalBlocks = [progressFinalBlock, completionFinalBlock, readFinalBlock].filter(Boolean);
       if (plainFinalBlocks.length) {
-        if (completionFinalBlock && completionPlainFinalRecoveryAttempted) {
+        if (completionFinalBlock && completionPlainFinalRecoveryAttempted >= 2) {
           finalResponse = this._completionPlainFinalPartial(tabId, result.content, {
             progressBlocked: !!progressFinalBlock,
             readBlocked: !!readFinalBlock,
@@ -28116,7 +28116,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           await this._persistNow(tabId);
           return finalResponse;
         }
-        if (completionFinalBlock) completionPlainFinalRecoveryAttempted = true;
+          if (completionFinalBlock) completionPlainFinalRecoveryAttempted++;
         messages.push(this._withResponseItems({ role: 'assistant', content: result.content }, result.responseItems, result.reasoningContent, provider));
         messages.push({ role: 'user', content: plainFinalBlocks.join('\n\n') });
         onUpdate('warning', { message: readFinalBlock
@@ -28549,7 +28549,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // See processMessage — used to break the empty-response→nudge cycle.
     let emptyOutputRecoveryAttempted = false;
     let compressionPlaceholderRecoveryAttempted = false;
-    let completionPlainFinalRecoveryAttempted = false;
+    let completionPlainFinalRecoveryAttempted = 0;
     let standaloneWikipediaModelSearchAttempted = false;
     let standaloneIncompleteAnswerRecoveryAttempted = false;
     let standaloneWebgpuBudgetRecoveryAttempted = false;
@@ -28960,7 +28960,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         const readFinalBlock = this._readCompletenessBlock(tabId);
         const plainFinalBlocks = [progressFinalBlock, completionFinalBlock, readFinalBlock].filter(Boolean);
         if (plainFinalBlocks.length) {
-          if (completionFinalBlock && completionPlainFinalRecoveryAttempted) {
+          if (completionFinalBlock && completionPlainFinalRecoveryAttempted >= 2) {
             const partial = this._completionPlainFinalPartial(tabId, fullText, {
               progressBlocked: !!progressFinalBlock,
               readBlocked: !!readFinalBlock,
@@ -28972,7 +28972,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             await this._persistNow(tabId);
             return finish(partial, 'partial');
           }
-          if (completionFinalBlock) completionPlainFinalRecoveryAttempted = true;
+        if (completionFinalBlock) completionPlainFinalRecoveryAttempted++;
           messages.push(this._withResponseItems({ role: 'assistant', content: fullText }, responseItems, reasoningContent, provider));
           messages.push({ role: 'user', content: plainFinalBlocks.join('\n\n') });
           if (completionFinalBlock || readFinalBlock) onUpdate('text', { content: '', replace: true });

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -28116,7 +28116,20 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           await this._persistNow(tabId);
           return finalResponse;
         }
-          if (completionFinalBlock) completionPlainFinalRecoveryAttempted++;
+        if (completionFinalBlock) completionPlainFinalRecoveryAttempted++;
+        if (completionFinalBlock && completionPlainFinalRecoveryAttempted >= 2 && steps >= this.maxSteps) {
+          finalResponse = this._completionPlainFinalPartial(tabId, result.content, {
+            progressBlocked: !!progressFinalBlock,
+            readBlocked: !!readFinalBlock,
+          });
+          _traceStatus = 'partial';
+          messages.push({ role: 'assistant', content: finalResponse });
+          onUpdate('text', { content: finalResponse, replace: true });
+          onUpdate('warning', { message: 'Run stopped after a repeated unstructured completion response.' });
+          onUpdate('run_status', { status: 'partial', message: finalResponse });
+          await this._persistNow(tabId);
+          return finalResponse;
+        }
         messages.push(this._withResponseItems({ role: 'assistant', content: result.content }, result.responseItems, result.reasoningContent, provider));
         messages.push({ role: 'user', content: plainFinalBlocks.join('\n\n') });
         onUpdate('warning', { message: readFinalBlock
@@ -28972,7 +28985,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             await this._persistNow(tabId);
             return finish(partial, 'partial');
           }
-        if (completionFinalBlock) completionPlainFinalRecoveryAttempted++;
+          if (completionFinalBlock) completionPlainFinalRecoveryAttempted++;
+          if (completionFinalBlock && completionPlainFinalRecoveryAttempted >= 2 && steps >= this.maxSteps) {
+            const partial = this._completionPlainFinalPartial(tabId, fullText, {
+              progressBlocked: !!progressFinalBlock,
+              readBlocked: !!readFinalBlock,
+            });
+            messages.push({ role: 'assistant', content: partial });
+            onUpdate('text', { content: partial, replace: true });
+            onUpdate('warning', { message: 'Run stopped after a repeated unstructured completion response.' });
+            onUpdate('run_status', { status: 'partial', message: partial });
+            await this._persistNow(tabId);
+            return finish(partial, 'partial');
+          }
           messages.push(this._withResponseItems({ role: 'assistant', content: fullText }, responseItems, reasoningContent, provider));
           messages.push({ role: 'user', content: plainFinalBlocks.join('\n\n') });
           if (completionFinalBlock || readFinalBlock) onUpdate('text', { content: '', replace: true });

--- a/src/chrome/src/agent/completion-invariant.js
+++ b/src/chrome/src/agent/completion-invariant.js
@@ -529,7 +529,7 @@ export function completionPlainFinalPartial(state, content, { verificationPendin
     || !!state?.verificationDebt
     || !!state?.iframeFormVerificationDebt;
   const lines = [
-    'The run stopped after the model returned plain text twice instead of the required structured completion.',
+    'The run stopped after the model returned plain text repeatedly instead of the required structured completion.',
     'Outcome: partial.',
   ];
   if (mustVerify) {
@@ -539,7 +539,7 @@ export function completionPlainFinalPartial(state, content, { verificationPendin
   lines.push('The latest page state was observed, but the model did not complete the required done handoff.');
   const summary = String(content || '').trim();
   if (summary) {
-    const bounded = summary.length > 4000 ? `${summary.slice(0, 4000)}\n[Latest model output truncated]` : summary;
+    const bounded = summary.length > 12000 ? `${summary.slice(0, 12000)}\n[Latest model output truncated]` : summary;
     lines.push(`Latest model output (not accepted as verified completion):\n${bounded}`);
   }
   return lines.join('\n\n');

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -21085,7 +21085,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let emptyOutputRecoveryAttempted = false;
     let compressionPlaceholderRecoveryAttempted = false;
     let structuredOutputRecoveryAttempted = false;
-    let completionPlainFinalRecoveryAttempted = false;
+    let completionPlainFinalRecoveryAttempted = 0;
     let askStreamingDisabledForRun = false;
 
     // Keep trace persistence ordered without putting IndexedDB on the token
@@ -21642,7 +21642,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const readFinalBlock = this._readCompletenessBlock(tabId);
       const plainFinalBlocks = [progressFinalBlock, completionFinalBlock, readFinalBlock].filter(Boolean);
       if (plainFinalBlocks.length) {
-        if (completionFinalBlock && completionPlainFinalRecoveryAttempted) {
+        if (completionFinalBlock && completionPlainFinalRecoveryAttempted >= 2) {
           finalResponse = this._completionPlainFinalPartial(tabId, result.content, {
             progressBlocked: !!progressFinalBlock,
             readBlocked: !!readFinalBlock,
@@ -21655,7 +21655,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           await this._persistNow(tabId);
           return finalResponse;
         }
-        if (completionFinalBlock) completionPlainFinalRecoveryAttempted = true;
+          if (completionFinalBlock) completionPlainFinalRecoveryAttempted++;
         messages.push(this._withResponseItems({ role: 'assistant', content: result.content }, result.responseItems, result.reasoningContent, provider));
         messages.push({ role: 'user', content: plainFinalBlocks.join('\n\n') });
         onUpdate('warning', { message: readFinalBlock
@@ -22006,7 +22006,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // See processMessage — used to break the empty-response→nudge cycle.
     let emptyOutputRecoveryAttempted = false;
     let compressionPlaceholderRecoveryAttempted = false;
-    let completionPlainFinalRecoveryAttempted = false;
+    let completionPlainFinalRecoveryAttempted = 0;
     let pendingVisionFallbackMessages = null;
     let visionFallbackAttempted = false;
     let streamEmittedOutput = false;
@@ -22363,7 +22363,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         const readFinalBlock = this._readCompletenessBlock(tabId);
         const plainFinalBlocks = [progressFinalBlock, completionFinalBlock, readFinalBlock].filter(Boolean);
         if (plainFinalBlocks.length) {
-          if (completionFinalBlock && completionPlainFinalRecoveryAttempted) {
+          if (completionFinalBlock && completionPlainFinalRecoveryAttempted >= 2) {
             const partial = this._completionPlainFinalPartial(tabId, fullText, {
               progressBlocked: !!progressFinalBlock,
               readBlocked: !!readFinalBlock,
@@ -22375,7 +22375,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             await this._persistNow(tabId);
             return finish(partial, 'partial');
           }
-          if (completionFinalBlock) completionPlainFinalRecoveryAttempted = true;
+        if (completionFinalBlock) completionPlainFinalRecoveryAttempted++;
           messages.push(this._withResponseItems({ role: 'assistant', content: fullText }, responseItems, reasoningContent, provider));
           messages.push({ role: 'user', content: plainFinalBlocks.join('\n\n') });
           if (completionFinalBlock || readFinalBlock) onUpdate('text', { content: '', replace: true });

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -21655,7 +21655,20 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           await this._persistNow(tabId);
           return finalResponse;
         }
-          if (completionFinalBlock) completionPlainFinalRecoveryAttempted++;
+        if (completionFinalBlock) completionPlainFinalRecoveryAttempted++;
+        if (completionFinalBlock && completionPlainFinalRecoveryAttempted >= 2 && steps >= this.maxSteps) {
+          finalResponse = this._completionPlainFinalPartial(tabId, result.content, {
+            progressBlocked: !!progressFinalBlock,
+            readBlocked: !!readFinalBlock,
+          });
+          _traceStatus = 'partial';
+          messages.push({ role: 'assistant', content: finalResponse });
+          onUpdate('text', { content: finalResponse, replace: true });
+          onUpdate('warning', { message: 'Run stopped after a repeated unstructured completion response.' });
+          onUpdate('run_status', { status: 'partial', message: finalResponse });
+          await this._persistNow(tabId);
+          return finalResponse;
+        }
         messages.push(this._withResponseItems({ role: 'assistant', content: result.content }, result.responseItems, result.reasoningContent, provider));
         messages.push({ role: 'user', content: plainFinalBlocks.join('\n\n') });
         onUpdate('warning', { message: readFinalBlock
@@ -22375,7 +22388,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             await this._persistNow(tabId);
             return finish(partial, 'partial');
           }
-        if (completionFinalBlock) completionPlainFinalRecoveryAttempted++;
+          if (completionFinalBlock) completionPlainFinalRecoveryAttempted++;
+          if (completionFinalBlock && completionPlainFinalRecoveryAttempted >= 2 && steps >= this.maxSteps) {
+            const partial = this._completionPlainFinalPartial(tabId, fullText, {
+              progressBlocked: !!progressFinalBlock,
+              readBlocked: !!readFinalBlock,
+            });
+            messages.push({ role: 'assistant', content: partial });
+            onUpdate('text', { content: partial, replace: true });
+            onUpdate('warning', { message: 'Run stopped after a repeated unstructured completion response.' });
+            onUpdate('run_status', { status: 'partial', message: partial });
+            await this._persistNow(tabId);
+            return finish(partial, 'partial');
+          }
           messages.push(this._withResponseItems({ role: 'assistant', content: fullText }, responseItems, reasoningContent, provider));
           messages.push({ role: 'user', content: plainFinalBlocks.join('\n\n') });
           if (completionFinalBlock || readFinalBlock) onUpdate('text', { content: '', replace: true });

--- a/src/firefox/src/agent/completion-invariant.js
+++ b/src/firefox/src/agent/completion-invariant.js
@@ -529,7 +529,7 @@ export function completionPlainFinalPartial(state, content, { verificationPendin
     || !!state?.verificationDebt
     || !!state?.iframeFormVerificationDebt;
   const lines = [
-    'The run stopped after the model returned plain text twice instead of the required structured completion.',
+    'The run stopped after the model returned plain text repeatedly instead of the required structured completion.',
     'Outcome: partial.',
   ];
   if (mustVerify) {
@@ -539,7 +539,7 @@ export function completionPlainFinalPartial(state, content, { verificationPendin
   lines.push('The latest page state was observed, but the model did not complete the required done handoff.');
   const summary = String(content || '').trim();
   if (summary) {
-    const bounded = summary.length > 4000 ? `${summary.slice(0, 4000)}\n[Latest model output truncated]` : summary;
+    const bounded = summary.length > 12000 ? `${summary.slice(0, 12000)}\n[Latest model output truncated]` : summary;
     lines.push(`Latest model output (not accepted as verified completion):\n${bounded}`);
   }
   return lines.join('\n\n');

--- a/test/run.js
+++ b/test/run.js
@@ -72508,7 +72508,7 @@ test('non-stream and stream runs block plain finals and unverified success until
   }
 });
 
-test('repeated plain finals stop after one completion-protocol recovery with a partial outcome', async () => {
+test('repeated plain finals stop after two completion-protocol recovery turns with a partial outcome', async () => {
   const buildResponses = (verified) => [
     {
       content: null,
@@ -72524,6 +72524,7 @@ test('repeated plain finals stop after one completion-protocol recovery with a p
         function: { name: 'read_page', arguments: '{}' },
       }],
     }] : []),
+    { content: 'The requested action completed successfully.', toolCalls: [] },
     { content: 'The requested action completed successfully.', toolCalls: [] },
     { content: 'The requested action completed successfully.', toolCalls: [] },
   ];
@@ -72608,14 +72609,14 @@ test('repeated plain finals stop after one completion-protocol recovery with a p
         const final = await run(tabId, 'perform the action', (type, data) => updates.push({ type, data }), 'act');
 
         assert.match(final, /Outcome: partial\./, `${AgentClass.name}/${streaming}/${verified}: repeated plain final did not end as partial`);
-        assert.equal(provider.calls, verified ? 4 : 3, `${AgentClass.name}/${streaming}/${verified}: completion recovery was not bounded to one turn`);
+        assert.equal(provider.calls, verified ? 5 : 4, `${AgentClass.name}/${streaming}/${verified}: completion recovery was not bounded to two turns`);
         assert.equal(responses.length, 0, `${AgentClass.name}/${streaming}/${verified}: expected response sequence was not consumed`);
         assert.equal(ended?.status, 'partial', `${AgentClass.name}/${streaming}/${verified}: trace did not record the partial terminal outcome`);
         assert.equal(ended?.finalContent, final, `${AgentClass.name}/${streaming}/${verified}: trace final content diverged from the visible partial`);
         assert.equal(
           agent.conversations.get(tabId).filter(message => message.role === 'user' && /RUNTIME COMPLETION BLOCK/.test(message.content || '')).length,
-          1,
-          `${AgentClass.name}/${streaming}/${verified}: completion nudge was repeated`,
+          2,
+          `${AgentClass.name}/${streaming}/${verified}: completion nudge was not sent twice`,
         );
         assert.ok(
           updates.some(update => update.type === 'run_status' && update.data?.status === 'partial' && update.data?.message === final),

--- a/test/run.js
+++ b/test/run.js
@@ -72641,6 +72641,96 @@ test('repeated plain finals stop after two completion-protocol recovery turns wi
   }
 });
 
+test('repeated plain finals at the step limit emit partial instead of max_steps', async () => {
+  for (const streaming of [false, true]) {
+    for (const [browserIndex, AgentClass] of [AgentCh, AgentFx].entries()) {
+      const responses = [
+        {
+          content: null,
+          toolCalls: [{
+            id: 'step_limit_click',
+            function: { name: 'click_ax', arguments: JSON.stringify({ ref_id: 'ref_6' }) },
+          }],
+        },
+        { content: 'Done.', toolCalls: [] },
+        { content: 'Done.', toolCalls: [] },
+        { content: 'Done.', toolCalls: [] },
+      ];
+      const provider = {
+        supportsTools: true,
+        supportsVision: false,
+        promptTier: 'full',
+        contextWindow: 128000,
+        model: 'test-model',
+        name: 'test-provider',
+        calls: 0,
+      };
+      if (streaming) {
+        provider.chatStream = async function* () {
+          this.calls++;
+          const next = responses.shift();
+          assert.ok(next, `${AgentClass.name}: step-limit test consumed all responses`);
+          if (next.content) yield { type: 'text', content: next.content };
+          if (next.toolCalls?.length) {
+            yield {
+              type: 'tool_call',
+              content: next.toolCalls.map((call, index) => ({
+                index,
+                id: call.id,
+                function: call.function,
+              })),
+            };
+          }
+          yield { type: 'done' };
+        };
+      } else {
+        provider.chat = async () => {
+          provider.calls++;
+          const next = responses.shift();
+          assert.ok(next, `${AgentClass.name}: step-limit test consumed all responses`);
+          return next;
+        };
+      }
+
+      const agent = new AgentClass({
+        getActive: () => provider,
+        getVisionProvider: async () => null,
+      });
+      const tabId = 24900 + (streaming ? 100 : 0) + browserIndex;
+      agent.planBeforeAct = false;
+      agent._maybeRunPlannerGate = async () => ({
+        proceed: true,
+        requestKind: 'execute',
+        requiresStateChange: true,
+      });
+      agent.maxSteps = 3;
+      agent.autoScreenshot = 'off';
+      agent._skipPermissionGate = true;
+      agent._manageContext = async () => {};
+      agent._enrichUserMessageWithCurrentPage = async (_tabId, _messages, content) => ({ role: 'user', content });
+      agent._maybeReinjectAdapter = async () => {};
+      agent._ensureProgressSessionForCurrentTask = async () => ({ mode: 'inactive' });
+      agent._persist = () => {};
+      agent._startTraceRun = async () => {
+        const runId = `step_limit_${tabId}`;
+        agent.currentRunId.set(tabId, runId);
+        return runId;
+      };
+      agent._endTraceRun = () => {};
+      agent.executeTool = async (_toolTabId, name) => {
+        if (name === 'click_ax') return { success: true, verified: true, method: 'click_ax' };
+        throw new Error(`unexpected tool ${name}`);
+      };
+
+      const run = streaming ? agent.processMessageStream.bind(agent) : agent.processMessage.bind(agent);
+      const final = await run(tabId, 'perform the action', () => {}, 'act');
+
+      assert.match(final, /Outcome: partial\./, `${AgentClass.name}/${streaming}: step-limit plain final did not emit partial`);
+      assert.equal(provider.calls, 3, `${AgentClass.name}/${streaming}: step-limit test used wrong number of calls`);
+    }
+  }
+});
+
 test('repeated plain-final partials preserve active progress and complete-read limitations', () => {
   for (const [label, AgentClass, sourceRel] of [
     ['chrome', AgentCh, 'src/chrome/src/agent/agent.js'],


### PR DESCRIPTION
## Summary

- Change  from boolean to counter, allowing **two recovery turns** before partial termination (was one)
- Raise plain-text truncation limit from 4000 to **12000 characters** so the model's actual output is preserved in the partial outcome
- Update completion message from 'twice' to 'repeatedly' to reflect the new behavior
- Mirror all changes in Chrome and Firefox builds

## Motivation

PR #307 bounded repeated structured completion recovery to a single turn. While this prevents infinite loops, one recovery turn may not be enough for some models to learn the required structured format. This PR relaxes the bound to two turns, giving the model more opportunity to self-correct.

The 4000-character truncation introduced in #307 was also overly aggressive — since the run terminates with  anyway, preserving more of the model's output helps users understand what happened and avoids unnecessary information loss.

## Testing

- `node test/run.js`: 2048 passed; 2 unrelated existing failures (stale changelog entry + missing Chrome ZIP)
- Chrome and Firefox builds updated identically