### PR TITLE
fix: avoid 64 MiB sendResponse limit in /record slashcommand

### DIFF
--- a/src/chrome/src/offscreen/recorder.js
+++ b/src/chrome/src/offscreen/recorder.js
@@ -31,6 +31,12 @@
   // offscreen doc, and concurrent recordings would conflict anyway).
   let session = null;
 
+  // Holds the full data URL after stop() so the service worker can retrieve
+  // it in small chunks via 'recorder-get-data-chunk'. Chrome's
+  // chrome.runtime.sendMessage / sendResponse channel caps at 64 MiB, which
+  // a base64-encoded .webm recording easily exceeds.
+  let pendingDataUrl = null;
+
   function ts() {
     return new Date().toISOString();
   }
@@ -366,13 +372,17 @@
       const blob = new Blob(s.chunks, { type: bareType });
       const dataUrl = await blobToDataUrl(blob);
 
+      // Store the data URL for chunked retrieval. The sendResponse channel
+      // has a 64 MiB limit; a base64-encoded .webm can easily exceed it.
+      pendingDataUrl = dataUrl;
+
       return {
         ok: true,
         mimeType: s.mimeType,        // original, with codecs param
         blobType: bareType,          // what the data URL actually carries
         sizeBytes: blob.size,
         durationMs: Date.now() - s.startedAt,
-        dataUrl,
+        dataUrlLength: dataUrl.length,
       };
     } finally {
       if (session === s) session = null;
@@ -490,6 +500,22 @@
           sendResponse(r);
         } else if (msg.type === 'recorder-state') {
           sendResponse(stateSnapshot());
+        } else if (msg.type === 'recorder-get-data-chunk') {
+          if (!pendingDataUrl) {
+            sendResponse({ ok: false, error: 'no pending recording data' });
+          } else {
+            const offset = msg.offset || 0;
+            const length = msg.length || 4 * 1024 * 1024;
+            sendResponse({
+              ok: true,
+              data: pendingDataUrl.substring(offset, offset + length),
+              offset,
+              total: pendingDataUrl.length,
+            });
+          }
+        } else if (msg.type === 'recorder-release-data') {
+          pendingDataUrl = null;
+          sendResponse({ ok: true });
         } else {
           sendResponse({ ok: false, error: `unknown recorder message: ${msg.type}` });
         }

--- a/src/chrome/src/recorder/host.js
+++ b/src/chrome/src/recorder/host.js
@@ -407,6 +407,30 @@ async function stopRecordingForSafetyCap({ beforeFinalizeRecording = null } = {}
   return stopTabRecording({ reason: 'safety_cap' });
 }
 
+const DATA_CHUNK_SIZE = 4 * 1024 * 1024; // 4 MiB per chunk — well under the 64 MiB sendResponse limit
+
+async function fetchDataUrlFromOffscreen(totalLength) {
+  let offset = 0;
+  const parts = [];
+  while (offset < totalLength) {
+    const chunk = await chrome.runtime.sendMessage({
+      type: 'recorder-get-data-chunk',
+      offset,
+      length: DATA_CHUNK_SIZE,
+    });
+    if (!chunk?.ok) throw new Error(chunk?.error || 'chunk fetch failed');
+    if (chunk.total != null && chunk.total !== totalLength) {
+      throw new Error(`data URL length mismatch: expected ${totalLength}, got ${chunk.total}`);
+    }
+    if (!chunk.data || chunk.data.length === 0) {
+      throw new Error('received empty chunk before reaching totalLength');
+    }
+    parts.push(chunk.data);
+    offset += chunk.data.length;
+  }
+  return parts.join('');
+}
+
 export async function stopTabRecording(opts = {}) {
   await ensureRecordingStateLoaded();
   if (opts.expectedRecordingId
@@ -450,6 +474,8 @@ export async function stopTabRecording(opts = {}) {
     recordingState = { active: false };
     saveRecordingState();
     broadcast('stopped', { result: { ok: false, error } });
+    // No recorder-release-data needed here: stop() never succeeded, so
+    // pendingDataUrl was never populated in the offscreen doc.
     return { ok: true, cleared: true, warning: error };
   }
 
@@ -475,6 +501,23 @@ export async function stopTabRecording(opts = {}) {
   };
   saveRecordingState();
   broadcast('saving');
+
+  // Retrieve the full data URL in small chunks. The offscreen recorder
+  // keeps it in memory and sendsResponse can't handle payloads > 64 MiB.
+  let fetchError = null;
+  try {
+    res.dataUrl = await fetchDataUrlFromOffscreen(res.dataUrlLength);
+  } catch (e) {
+    fetchError = `data fetch failed: ${e.message}`;
+  }
+  if (fetchError) {
+    clearRecordingSafetyWatchdog();
+    recordingState = { active: false };
+    saveRecordingState();
+    broadcast('stopped', { result: { ok: false, error: fetchError } });
+    await chrome.runtime.sendMessage({ type: 'recorder-release-data' }).catch(() => {});
+    return { ok: true, cleared: true, warning: fetchError };
+  }
 
   // Save webm to Downloads. The data URL is safe — recorder.js strips
   // the codecs param before passing it to FileReader.readAsDataURL, so
@@ -536,6 +579,10 @@ export async function stopTabRecording(opts = {}) {
       console.error('[WebBrain] runTranscription crashed:', e);
     });
   }
+
+  // Free the offscreen copy now that the data URL has been copied into
+  // res.dataUrl (and the async download / transcription have their own ref).
+  chrome.runtime.sendMessage({ type: 'recorder-release-data' }).catch(() => {});
 
   return final;
 }


### PR DESCRIPTION
## Problem

The `/record` slashcommand fails with `Recording error: recorder-stop dispatch failed: Message exceeded maximum allowed size of 64MiB` for recordings longer than ~2-3 minutes.

The offscreen recorder's `stop()` was returning the full base64-encoded .webm data URL via `sendResponse()`, which Chrome caps at 64 MiB on the `chrome.runtime.sendMessage` channel.

## Fix

Instead of sending the entire data URL through `sendResponse`, the offscreen doc now stores it in memory and serves it in 4 MiB chunks via a new `recorder-get-data-chunk` message type. The service worker reassembles the full URL before proceeding with download/transcription.

### Files changed
- `src/chrome/src/offscreen/recorder.js` — store data URL after stop, add chunk + release message handlers
- `src/chrome/src/recorder/host.js` — add `fetchDataUrlFromOffscreen` helper, fetch data in chunks after stop

### Key details
- Each chunk is 4 MiB, well under Chrome's 64 MiB limit
- Defensive guards against empty chunks and length mismatches
- Data is released from the offscreen doc after download/transcription have their own references
- No new APIs or dependencies required