### PR TITLE
Compact sidebar header actions

### DIFF
--- a/src/chrome/src/ui/sidepanel.html
+++ b/src/chrome/src/ui/sidepanel.html
@@ -211,10 +211,9 @@
           <div class="provider-picker-menu language-picker-menu hidden" id="language-picker-menu" role="listbox" tabindex="-1"></div>
         </div>
         <button id="btn-history" data-i18n-title="sp.btn.history" data-i18n-aria-label="sp.btn.history">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M3 12a9 9 0 1 0 3-6.7"/>
-            <path d="M3 3v6h6"/>
-            <path d="M12 7v5l3 2"/>
+          <svg data-icon="messages-square" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M16 10a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 14.286V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/>
+            <path d="M20 9a2 2 0 0 1 2 2v10.286a.71.71 0 0 1-1.212.502l-2.202-2.202A2 2 0 0 0 17.172 19H10a2 2 0 0 1-2-2v-1"/>
           </svg>
         </button>
         <button id="btn-expand" data-i18n-title="sp.btn.expand" data-i18n-aria-label="sp.btn.expand">

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -827,7 +827,7 @@ body {
 .header-right {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 2px;
 }
 
 .status-dot {
@@ -1240,7 +1240,7 @@ body {
   border: none;
   color: var(--text-secondary);
   cursor: pointer;
-  padding: 4px;
+  padding: 4px 3px;
   border-radius: 4px;
   display: flex;
   align-items: center;

--- a/src/firefox/src/ui/sidepanel.html
+++ b/src/firefox/src/ui/sidepanel.html
@@ -177,10 +177,9 @@
           <div class="provider-picker-menu language-picker-menu hidden" id="language-picker-menu" role="listbox" tabindex="-1"></div>
         </div>
         <button id="btn-history" data-i18n-title="sp.btn.history" data-i18n-aria-label="sp.btn.history">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M3 12a9 9 0 1 0 3-6.7"/>
-            <path d="M3 3v6h6"/>
-            <path d="M12 7v5l3 2"/>
+          <svg data-icon="messages-square" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M16 10a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 14.286V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/>
+            <path d="M20 9a2 2 0 0 1 2 2v10.286a.71.71 0 0 1-1.212.502l-2.202-2.202A2 2 0 0 0 17.172 19H10a2 2 0 0 1-2-2v-1"/>
           </svg>
         </button>
         <button id="btn-expand" data-i18n-title="sp.btn.expand" data-i18n-aria-label="sp.btn.expand">

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -705,7 +705,7 @@ body {
 .header-right {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 2px;
 }
 
 .status-dot {
@@ -1077,7 +1077,7 @@ body {
   border: none;
   color: var(--text-secondary);
   cursor: pointer;
-  padding: 4px;
+  padding: 4px 3px;
   border-radius: 4px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- tighten spacing between the right-side header actions to leave more room for the provider picker
- replace the history clock/rewind glyph with a two-message icon that reads as chat history instead of reset
- keep Chrome and Firefox sidebar UI in parity

## Testing
- `node test/run.js` (2066 passed, 0 failed)