### PR TITLE
Fix planner fallback notice placement

### DIFF
--- a/src/chrome/src/agent/scheduler.js
+++ b/src/chrome/src/agent/scheduler.js
@@ -1684,9 +1684,13 @@ export class ScheduledJobManager {
           console.warn('[WebBrain] failed to resume scheduled job after clarify timeout:', e);
         });
       }
-      // Tag scheduled clarify prompts (and their auto-timeout follow-ups) with
-      // the job id so the sidepanel can scope cards and lock on timeout.
-      const withJob = (type === 'clarify' || type === 'clarify_timeout_extended' || type === 'clarify_auto')
+      // Tag scheduled clarify prompts and planner fallbacks with the job id so
+      // the sidepanel can bind them to the correct scheduled assistant turn.
+      const jobScopedUpdate = type === 'clarify'
+        || type === 'clarify_timeout_extended'
+        || type === 'clarify_auto'
+        || (type === 'warning' && data?.code === 'planner_failed_continue_act');
+      const withJob = jobScopedUpdate
         ? { ...data, scheduledJobId: job.id }
         : data;
       this.sendUpdate(tabId, type, withJob);

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -9455,7 +9455,7 @@ function handleAgentUpdateMessage(msg) {
           || retryPayloadForRunAssistant(targetAssistantEl);
         renderPlannerRequestFailure(targetAssistantEl, data, retryPayload);
       } else if (data?.code === 'planner_failed_continue_act') {
-        showComposerToast(data?.message || t('sp.plan.intent_unavailable'), { duration: 10000 });
+        addPlannerFallbackNote(data?.message || t('sp.plan.intent_unavailable'));
       } else if (data?.code === 'ask_stream_fallback') {
         showComposerToast(t('sp.streaming.fallback'), { duration: 6000 });
       } else if (data?.code === 'persistence_degraded') {
@@ -11514,6 +11514,34 @@ function addPlanAutoApprovedNote(data) {
   } else {
     messagesEl.appendChild(note);
   }
+  scrollToBottom();
+}
+
+function addPlannerFallbackNote(message) {
+  if (!currentAssistantEl || !message) return;
+
+  let note = currentAssistantEl.querySelector('.planner-fallback-note');
+  if (!note) {
+    const stepsContainer = getOrCreateStepsContainer();
+    if (!stepsContainer) return;
+
+    note = document.createElement('div');
+    note.className = 'planner-fallback-note';
+    note.setAttribute('role', 'status');
+    note.setAttribute('aria-live', 'polite');
+
+    const icon = document.createElement('span');
+    icon.className = 'planner-fallback-note-icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = '!';
+
+    const text = document.createElement('span');
+    text.className = 'planner-fallback-note-text';
+    note.append(icon, text);
+    stepsContainer.appendChild(note);
+  }
+
+  note.querySelector('.planner-fallback-note-text').textContent = message;
   scrollToBottom();
 }
 

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -2835,6 +2835,7 @@ function scheduledJobActions(job) {
 const SCHEDULED_VISIBLE_STATUSES = new Set(['pending', 'queued', 'paused', 'running', 'needs_user_input', 'failed', 'completed']);
 const COMPLETED_SCHEDULED_JOB_AUTO_HIDE_MS = 15 * 1000;
 const pinnedCompletedScheduledJobIds = new Set();
+const pendingScheduledPlannerFallbackMessages = new Map();
 let scheduledJobAutoHideTimer = null;
 
 function visibleScheduledJobs(jobs = []) {
@@ -2912,14 +2913,41 @@ function findScheduledAssistantMessageForJob(jobId) {
   return null;
 }
 
+function queueScheduledPlannerFallbackMessage(jobId, message) {
+  const id = String(jobId || '');
+  if (!id || !message) return;
+  pendingScheduledPlannerFallbackMessages.delete(id);
+  pendingScheduledPlannerFallbackMessages.set(id, message);
+  while (pendingScheduledPlannerFallbackMessages.size > 50) {
+    pendingScheduledPlannerFallbackMessages.delete(
+      pendingScheduledPlannerFallbackMessages.keys().next().value,
+    );
+  }
+}
+
+function flushScheduledPlannerFallbackMessage(jobId, assistantEl = null) {
+  const id = String(jobId || '');
+  if (!id || !pendingScheduledPlannerFallbackMessages.has(id)) return false;
+  if (!assistantEl) assistantEl = findScheduledAssistantMessageForJob(id);
+  if (!assistantEl) return false;
+  const message = pendingScheduledPlannerFallbackMessages.get(id);
+  pendingScheduledPlannerFallbackMessages.delete(id);
+  addPlannerFallbackNote(message, assistantEl);
+  return true;
+}
+
 function ensureScheduledTerminalMessage(job) {
   const jobId = job?.id ? String(job.id) : '';
   if (!jobId || !isUrlTargetScheduledJob(job)) return null;
   const existing = findScheduledAssistantMessageForJob(jobId);
-  if (existing) return existing;
+  if (existing) {
+    flushScheduledPlannerFallbackMessage(jobId, existing);
+    return existing;
+  }
   resetChatNavigation();
   const msgEl = addMessage('assistant', '');
   msgEl.dataset.scheduledJobId = jobId;
+  flushScheduledPlannerFallbackMessage(jobId, msgEl);
   return msgEl;
 }
 
@@ -3206,6 +3234,7 @@ async function handleScheduledJobEvent(data, tabId) {
       currentAssistantEl = addMessage('assistant', '');
     }
     if (jobId) currentAssistantEl.dataset.scheduledJobId = jobId;
+    flushScheduledPlannerFallbackMessage(jobId, currentAssistantEl);
     showActivity(t('sp.scheduled.running', { title }));
   } else if (event === 'completed') {
     ensureScheduledTerminalMessage(job);
@@ -9455,7 +9484,16 @@ function handleAgentUpdateMessage(msg) {
           || retryPayloadForRunAssistant(targetAssistantEl);
         renderPlannerRequestFailure(targetAssistantEl, data, retryPayload);
       } else if (data?.code === 'planner_failed_continue_act') {
-        addPlannerFallbackNote(data?.message || t('sp.plan.intent_unavailable'));
+        const message = data?.message || t('sp.plan.intent_unavailable');
+        const scheduledJobId = String(data?.scheduledJobId || '');
+        const scheduledAssistantEl = scheduledJobId
+          ? findScheduledAssistantMessageForJob(scheduledJobId)
+          : null;
+        if (scheduledJobId && !scheduledAssistantEl) {
+          queueScheduledPlannerFallbackMessage(scheduledJobId, message);
+        } else {
+          addPlannerFallbackNote(message, scheduledAssistantEl || eventAssistantEl || currentAssistantEl);
+        }
       } else if (data?.code === 'ask_stream_fallback') {
         showComposerToast(t('sp.streaming.fallback'), { duration: 6000 });
       } else if (data?.code === 'persistence_degraded') {
@@ -10341,9 +10379,9 @@ function placeAnsweredClarifyCardInTimeline(card) {
   content.insertBefore(card, textEl);
 }
 
-function getOrCreateStepsContainer() {
-  if (!currentAssistantEl) return null;
-  const content = currentAssistantEl.querySelector('.message-content');
+function getOrCreateStepsContainer(assistantEl = currentAssistantEl) {
+  if (!assistantEl) return null;
+  const content = assistantEl.querySelector('.message-content');
   const textEl = [...content.children]
     .find(child => child.classList.contains('message-text')) || null;
   if (!textEl) return null;
@@ -11517,12 +11555,12 @@ function addPlanAutoApprovedNote(data) {
   scrollToBottom();
 }
 
-function addPlannerFallbackNote(message) {
-  if (!currentAssistantEl || !message) return;
+function addPlannerFallbackNote(message, assistantEl = currentAssistantEl) {
+  if (!assistantEl || !message) return;
 
-  let note = currentAssistantEl.querySelector('.planner-fallback-note');
+  let note = assistantEl.querySelector('.planner-fallback-note');
   if (!note) {
-    const stepsContainer = getOrCreateStepsContainer();
+    const stepsContainer = getOrCreateStepsContainer(assistantEl);
     if (!stepsContainer) return;
 
     note = document.createElement('div');

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -2836,6 +2836,7 @@ const SCHEDULED_VISIBLE_STATUSES = new Set(['pending', 'queued', 'paused', 'runn
 const COMPLETED_SCHEDULED_JOB_AUTO_HIDE_MS = 15 * 1000;
 const pinnedCompletedScheduledJobIds = new Set();
 const pendingScheduledPlannerFallbackMessages = new Map();
+const scheduledAssistantPreparationJobIds = new Set();
 let scheduledJobAutoHideTimer = null;
 
 function visibleScheduledJobs(jobs = []) {
@@ -2903,8 +2904,11 @@ function findScheduledClarifyCardForJob(jobId) {
 function findScheduledAssistantMessageForJob(jobId) {
   const id = String(jobId || '');
   if (!id) return null;
-  for (const msgEl of messagesEl?.querySelectorAll?.('.message.assistant[data-scheduled-job-id]') || []) {
-    if (msgEl.dataset.scheduledJobId === id) return msgEl;
+  const messages = Array.from(
+    messagesEl?.querySelectorAll?.('.message.assistant[data-scheduled-job-id]') || [],
+  );
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i].dataset.scheduledJobId === id) return messages[i];
   }
   const card = findScheduledClarifyCardForJob(id);
   const msgEl = card?.closest?.('.message.assistant');
@@ -2940,6 +2944,7 @@ function ensureScheduledTerminalMessage(job) {
   const jobId = job?.id ? String(job.id) : '';
   if (!jobId || !isUrlTargetScheduledJob(job)) return null;
   const existing = findScheduledAssistantMessageForJob(jobId);
+  if (existing && scheduledAssistantPreparationJobIds.has(jobId)) return existing;
   if (existing) {
     flushScheduledPlannerFallbackMessage(jobId, existing);
     return existing;
@@ -3212,30 +3217,41 @@ async function handleScheduledJobEvent(data, tabId) {
     || terminalScheduledEvent
     || watchPollEvent
     || event === 'needs_user_input';
+  const preparingScheduledAssistant = event === 'running' && !!jobId;
+  if (preparingScheduledAssistant) scheduledAssistantPreparationJobIds.add(jobId);
   if (scopeChangingScheduledEvent && runTabId != null) {
-    await refreshConversationScopeState(runTabId);
+    try {
+      await refreshConversationScopeState(runTabId);
+    } catch (error) {
+      if (preparingScheduledAssistant) scheduledAssistantPreparationJobIds.delete(jobId);
+      throw error;
+    }
   }
 
   const title = scheduledJobTitle(job);
   if (event === 'created') {
     renderScheduledJobCreatedMessage(job);
   } else if (event === 'running') {
-    clearActiveChatPayloadForTab(runTabId);
-    setTabProcessing(runTabId, true);
-    setTabAbortRequested(runTabId, false);
-    syncSendButtonState();
-    if (job?.source === 'watch') {
-      hideRecommendedActions();
-      resetChatNavigation();
-      currentAssistantEl = ensureScheduledTerminalMessage(job);
-    } else {
-      hideRecommendedActions();
-      resetChatNavigation();
-      currentAssistantEl = addMessage('assistant', '');
+    try {
+      clearActiveChatPayloadForTab(runTabId);
+      setTabProcessing(runTabId, true);
+      setTabAbortRequested(runTabId, false);
+      syncSendButtonState();
+      if (job?.source === 'watch') {
+        hideRecommendedActions();
+        resetChatNavigation();
+        currentAssistantEl = ensureScheduledTerminalMessage(job);
+      } else {
+        hideRecommendedActions();
+        resetChatNavigation();
+        currentAssistantEl = addMessage('assistant', '');
+      }
+      if (jobId) currentAssistantEl.dataset.scheduledJobId = jobId;
+      flushScheduledPlannerFallbackMessage(jobId, currentAssistantEl);
+      showActivity(t('sp.scheduled.running', { title }));
+    } finally {
+      if (preparingScheduledAssistant) scheduledAssistantPreparationJobIds.delete(jobId);
     }
-    if (jobId) currentAssistantEl.dataset.scheduledJobId = jobId;
-    flushScheduledPlannerFallbackMessage(jobId, currentAssistantEl);
-    showActivity(t('sp.scheduled.running', { title }));
   } else if (event === 'completed') {
     ensureScheduledTerminalMessage(job);
     await settleScheduledRun(event, job, runTabId);
@@ -9486,10 +9502,11 @@ function handleAgentUpdateMessage(msg) {
       } else if (data?.code === 'planner_failed_continue_act') {
         const message = data?.message || t('sp.plan.intent_unavailable');
         const scheduledJobId = String(data?.scheduledJobId || '');
-        const scheduledAssistantEl = scheduledJobId
+        const scheduledAssistantPending = scheduledAssistantPreparationJobIds.has(scheduledJobId);
+        const scheduledAssistantEl = scheduledJobId && !scheduledAssistantPending
           ? findScheduledAssistantMessageForJob(scheduledJobId)
           : null;
-        if (scheduledJobId && !scheduledAssistantEl) {
+        if (scheduledJobId && (scheduledAssistantPending || !scheduledAssistantEl)) {
           queueScheduledPlannerFallbackMessage(scheduledJobId, message);
         } else {
           addPlannerFallbackNote(message, scheduledAssistantEl || eventAssistantEl || currentAssistantEl);

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -4345,6 +4345,40 @@ html[data-standalone="true"] #mode-toggle {
   color: var(--text-secondary);
 }
 
+.planner-fallback-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin: 2px 0 4px;
+  padding: 5px 7px;
+  border-inline-start: 2px solid var(--warning);
+  border-radius: 0 5px 5px 0;
+  background: color-mix(in srgb, var(--warning) 7%, transparent);
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.planner-fallback-note-icon {
+  display: grid;
+  flex: 0 0 14px;
+  place-items: center;
+  width: 14px;
+  height: 14px;
+  margin-top: 1px;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  color: var(--warning);
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.planner-fallback-note-text {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .plan-review-note {
   font-size: 12px;
   color: var(--text-secondary);

--- a/src/firefox/src/agent/scheduler.js
+++ b/src/firefox/src/agent/scheduler.js
@@ -1660,9 +1660,13 @@ export class ScheduledJobManager {
           console.warn('[WebBrain] failed to resume scheduled job after clarify timeout:', e);
         });
       }
-      // Tag scheduled clarify prompts (and their auto-timeout follow-ups) with
-      // the job id so the sidepanel can scope cards and lock on timeout.
-      const withJob = (type === 'clarify' || type === 'clarify_timeout_extended' || type === 'clarify_auto')
+      // Tag scheduled clarify prompts and planner fallbacks with the job id so
+      // the sidepanel can bind them to the correct scheduled assistant turn.
+      const jobScopedUpdate = type === 'clarify'
+        || type === 'clarify_timeout_extended'
+        || type === 'clarify_auto'
+        || (type === 'warning' && data?.code === 'planner_failed_continue_act');
+      const withJob = jobScopedUpdate
         ? { ...data, scheduledJobId: job.id }
         : data;
       this.sendUpdate(tabId, type, withJob);

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -8934,7 +8934,7 @@ function handleAgentUpdateMessage(msg) {
           || retryPayloadForRunAssistant(targetAssistantEl);
         renderPlannerRequestFailure(targetAssistantEl, data, retryPayload);
       } else if (data?.code === 'planner_failed_continue_act') {
-        showComposerToast(data?.message || t('sp.plan.intent_unavailable'), { duration: 10000 });
+        addPlannerFallbackNote(data?.message || t('sp.plan.intent_unavailable'));
       } else if (data?.code === 'ask_stream_fallback') {
         showComposerToast(t('sp.streaming.fallback'), { duration: 6000 });
       } else if (data?.code === 'persistence_degraded') {
@@ -11130,6 +11130,34 @@ function addPlanAutoApprovedNote(data) {
   } else {
     messagesEl.appendChild(note);
   }
+  scrollToBottom();
+}
+
+function addPlannerFallbackNote(message) {
+  if (!currentAssistantEl || !message) return;
+
+  let note = currentAssistantEl.querySelector('.planner-fallback-note');
+  if (!note) {
+    const stepsContainer = getOrCreateStepsContainer();
+    if (!stepsContainer) return;
+
+    note = document.createElement('div');
+    note.className = 'planner-fallback-note';
+    note.setAttribute('role', 'status');
+    note.setAttribute('aria-live', 'polite');
+
+    const icon = document.createElement('span');
+    icon.className = 'planner-fallback-note-icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = '!';
+
+    const text = document.createElement('span');
+    text.className = 'planner-fallback-note-text';
+    note.append(icon, text);
+    stepsContainer.appendChild(note);
+  }
+
+  note.querySelector('.planner-fallback-note-text').textContent = message;
   scrollToBottom();
 }
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -2690,6 +2690,7 @@ const SCHEDULED_VISIBLE_STATUSES = new Set(['pending', 'queued', 'paused', 'runn
 const COMPLETED_SCHEDULED_JOB_AUTO_HIDE_MS = 15 * 1000;
 const pinnedCompletedScheduledJobIds = new Set();
 const pendingScheduledPlannerFallbackMessages = new Map();
+const scheduledAssistantPreparationJobIds = new Set();
 let scheduledJobAutoHideTimer = null;
 
 function visibleScheduledJobs(jobs = []) {
@@ -2757,8 +2758,11 @@ function findScheduledClarifyCardForJob(jobId) {
 function findScheduledAssistantMessageForJob(jobId) {
   const id = String(jobId || '');
   if (!id) return null;
-  for (const msgEl of messagesEl?.querySelectorAll?.('.message.assistant[data-scheduled-job-id]') || []) {
-    if (msgEl.dataset.scheduledJobId === id) return msgEl;
+  const messages = Array.from(
+    messagesEl?.querySelectorAll?.('.message.assistant[data-scheduled-job-id]') || [],
+  );
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i].dataset.scheduledJobId === id) return messages[i];
   }
   const card = findScheduledClarifyCardForJob(id);
   const msgEl = card?.closest?.('.message.assistant');
@@ -2794,6 +2798,7 @@ function ensureScheduledTerminalMessage(job) {
   const jobId = job?.id ? String(job.id) : '';
   if (!jobId || !isUrlTargetScheduledJob(job)) return null;
   const existing = findScheduledAssistantMessageForJob(jobId);
+  if (existing && scheduledAssistantPreparationJobIds.has(jobId)) return existing;
   if (existing) {
     flushScheduledPlannerFallbackMessage(jobId, existing);
     return existing;
@@ -3066,30 +3071,41 @@ async function handleScheduledJobEvent(data, tabId) {
     || terminalScheduledEvent
     || watchPollEvent
     || event === 'needs_user_input';
+  const preparingScheduledAssistant = event === 'running' && !!jobId;
+  if (preparingScheduledAssistant) scheduledAssistantPreparationJobIds.add(jobId);
   if (scopeChangingScheduledEvent && runTabId != null) {
-    await refreshConversationScopeState(runTabId);
+    try {
+      await refreshConversationScopeState(runTabId);
+    } catch (error) {
+      if (preparingScheduledAssistant) scheduledAssistantPreparationJobIds.delete(jobId);
+      throw error;
+    }
   }
 
   const title = scheduledJobTitle(job);
   if (event === 'created') {
     renderScheduledJobCreatedMessage(job);
   } else if (event === 'running') {
-    clearActiveChatPayloadForTab(runTabId);
-    setTabProcessing(runTabId, true);
-    setTabAbortRequested(runTabId, false);
-    syncSendButtonState();
-    if (job?.source === 'watch') {
-      hideRecommendedActions();
-      resetChatNavigation();
-      currentAssistantEl = ensureScheduledTerminalMessage(job);
-    } else {
-      hideRecommendedActions();
-      resetChatNavigation();
-      currentAssistantEl = addMessage('assistant', '');
+    try {
+      clearActiveChatPayloadForTab(runTabId);
+      setTabProcessing(runTabId, true);
+      setTabAbortRequested(runTabId, false);
+      syncSendButtonState();
+      if (job?.source === 'watch') {
+        hideRecommendedActions();
+        resetChatNavigation();
+        currentAssistantEl = ensureScheduledTerminalMessage(job);
+      } else {
+        hideRecommendedActions();
+        resetChatNavigation();
+        currentAssistantEl = addMessage('assistant', '');
+      }
+      if (jobId) currentAssistantEl.dataset.scheduledJobId = jobId;
+      flushScheduledPlannerFallbackMessage(jobId, currentAssistantEl);
+      showActivity(t('sp.scheduled.running', { title }));
+    } finally {
+      if (preparingScheduledAssistant) scheduledAssistantPreparationJobIds.delete(jobId);
     }
-    if (jobId) currentAssistantEl.dataset.scheduledJobId = jobId;
-    flushScheduledPlannerFallbackMessage(jobId, currentAssistantEl);
-    showActivity(t('sp.scheduled.running', { title }));
   } else if (event === 'completed') {
     ensureScheduledTerminalMessage(job);
     settleScheduledRun(event, job, runTabId);
@@ -8965,10 +8981,11 @@ function handleAgentUpdateMessage(msg) {
       } else if (data?.code === 'planner_failed_continue_act') {
         const message = data?.message || t('sp.plan.intent_unavailable');
         const scheduledJobId = String(data?.scheduledJobId || '');
-        const scheduledAssistantEl = scheduledJobId
+        const scheduledAssistantPending = scheduledAssistantPreparationJobIds.has(scheduledJobId);
+        const scheduledAssistantEl = scheduledJobId && !scheduledAssistantPending
           ? findScheduledAssistantMessageForJob(scheduledJobId)
           : null;
-        if (scheduledJobId && !scheduledAssistantEl) {
+        if (scheduledJobId && (scheduledAssistantPending || !scheduledAssistantEl)) {
           queueScheduledPlannerFallbackMessage(scheduledJobId, message);
         } else {
           addPlannerFallbackNote(message, scheduledAssistantEl || eventAssistantEl || currentAssistantEl);

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -2689,6 +2689,7 @@ function scheduledJobActions(job) {
 const SCHEDULED_VISIBLE_STATUSES = new Set(['pending', 'queued', 'paused', 'running', 'needs_user_input', 'failed', 'completed']);
 const COMPLETED_SCHEDULED_JOB_AUTO_HIDE_MS = 15 * 1000;
 const pinnedCompletedScheduledJobIds = new Set();
+const pendingScheduledPlannerFallbackMessages = new Map();
 let scheduledJobAutoHideTimer = null;
 
 function visibleScheduledJobs(jobs = []) {
@@ -2766,14 +2767,41 @@ function findScheduledAssistantMessageForJob(jobId) {
   return null;
 }
 
+function queueScheduledPlannerFallbackMessage(jobId, message) {
+  const id = String(jobId || '');
+  if (!id || !message) return;
+  pendingScheduledPlannerFallbackMessages.delete(id);
+  pendingScheduledPlannerFallbackMessages.set(id, message);
+  while (pendingScheduledPlannerFallbackMessages.size > 50) {
+    pendingScheduledPlannerFallbackMessages.delete(
+      pendingScheduledPlannerFallbackMessages.keys().next().value,
+    );
+  }
+}
+
+function flushScheduledPlannerFallbackMessage(jobId, assistantEl = null) {
+  const id = String(jobId || '');
+  if (!id || !pendingScheduledPlannerFallbackMessages.has(id)) return false;
+  if (!assistantEl) assistantEl = findScheduledAssistantMessageForJob(id);
+  if (!assistantEl) return false;
+  const message = pendingScheduledPlannerFallbackMessages.get(id);
+  pendingScheduledPlannerFallbackMessages.delete(id);
+  addPlannerFallbackNote(message, assistantEl);
+  return true;
+}
+
 function ensureScheduledTerminalMessage(job) {
   const jobId = job?.id ? String(job.id) : '';
   if (!jobId || !isUrlTargetScheduledJob(job)) return null;
   const existing = findScheduledAssistantMessageForJob(jobId);
-  if (existing) return existing;
+  if (existing) {
+    flushScheduledPlannerFallbackMessage(jobId, existing);
+    return existing;
+  }
   resetChatNavigation();
   const msgEl = addMessage('assistant', '');
   msgEl.dataset.scheduledJobId = jobId;
+  flushScheduledPlannerFallbackMessage(jobId, msgEl);
   return msgEl;
 }
 
@@ -3060,6 +3088,7 @@ async function handleScheduledJobEvent(data, tabId) {
       currentAssistantEl = addMessage('assistant', '');
     }
     if (jobId) currentAssistantEl.dataset.scheduledJobId = jobId;
+    flushScheduledPlannerFallbackMessage(jobId, currentAssistantEl);
     showActivity(t('sp.scheduled.running', { title }));
   } else if (event === 'completed') {
     ensureScheduledTerminalMessage(job);
@@ -8934,7 +8963,16 @@ function handleAgentUpdateMessage(msg) {
           || retryPayloadForRunAssistant(targetAssistantEl);
         renderPlannerRequestFailure(targetAssistantEl, data, retryPayload);
       } else if (data?.code === 'planner_failed_continue_act') {
-        addPlannerFallbackNote(data?.message || t('sp.plan.intent_unavailable'));
+        const message = data?.message || t('sp.plan.intent_unavailable');
+        const scheduledJobId = String(data?.scheduledJobId || '');
+        const scheduledAssistantEl = scheduledJobId
+          ? findScheduledAssistantMessageForJob(scheduledJobId)
+          : null;
+        if (scheduledJobId && !scheduledAssistantEl) {
+          queueScheduledPlannerFallbackMessage(scheduledJobId, message);
+        } else {
+          addPlannerFallbackNote(message, scheduledAssistantEl || eventAssistantEl || currentAssistantEl);
+        }
       } else if (data?.code === 'ask_stream_fallback') {
         showComposerToast(t('sp.streaming.fallback'), { duration: 6000 });
       } else if (data?.code === 'persistence_degraded') {
@@ -9956,9 +9994,9 @@ function placeAnsweredClarifyCardInTimeline(card) {
   content.insertBefore(card, textEl);
 }
 
-function getOrCreateStepsContainer() {
-  if (!currentAssistantEl) return null;
-  const content = currentAssistantEl.querySelector('.message-content');
+function getOrCreateStepsContainer(assistantEl = currentAssistantEl) {
+  if (!assistantEl) return null;
+  const content = assistantEl.querySelector('.message-content');
   const textEl = [...content.children]
     .find(child => child.classList.contains('message-text')) || null;
   if (!textEl) return null;
@@ -11133,12 +11171,12 @@ function addPlanAutoApprovedNote(data) {
   scrollToBottom();
 }
 
-function addPlannerFallbackNote(message) {
-  if (!currentAssistantEl || !message) return;
+function addPlannerFallbackNote(message, assistantEl = currentAssistantEl) {
+  if (!assistantEl || !message) return;
 
-  let note = currentAssistantEl.querySelector('.planner-fallback-note');
+  let note = assistantEl.querySelector('.planner-fallback-note');
   if (!note) {
-    const stepsContainer = getOrCreateStepsContainer();
+    const stepsContainer = getOrCreateStepsContainer(assistantEl);
     if (!stepsContainer) return;
 
     note = document.createElement('div');

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -4189,6 +4189,40 @@ html[data-standalone="true"] #mode-toggle {
   color: var(--text-secondary);
 }
 
+.planner-fallback-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin: 2px 0 4px;
+  padding: 5px 7px;
+  border-inline-start: 2px solid var(--warning);
+  border-radius: 0 5px 5px 0;
+  background: color-mix(in srgb, var(--warning) 7%, transparent);
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.planner-fallback-note-icon {
+  display: grid;
+  flex: 0 0 14px;
+  place-items: center;
+  width: 14px;
+  height: 14px;
+  margin-top: 1px;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  color: var(--warning);
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.planner-fallback-note-text {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .plan-review-note {
   font-size: 12px;
   color: var(--text-secondary);

--- a/test/run.js
+++ b/test/run.js
@@ -90097,8 +90097,23 @@ test('planner request failures expose provider settings and retry actions in bot
     );
     assert.match(
       panel,
-      /data\?\.code === 'planner_failed_continue_act'[\s\S]*?showComposerToast\(data\?\.message \|\| t\('sp\.plan\.intent_unavailable'\), \{ duration: 10000 \}\);/,
-      `${label}: planner-failed Act continuation does not show the requested toast`,
+      /data\?\.code === 'planner_failed_continue_act'[\s\S]*?addPlannerFallbackNote\(data\?\.message \|\| t\('sp\.plan\.intent_unavailable'\)\);/,
+      `${label}: planner-failed Act continuation does not render in the active turn`,
+    );
+    assert.match(
+      panel,
+      /function addPlannerFallbackNote\(message\) \{[\s\S]*?currentAssistantEl\.querySelector\('\.planner-fallback-note'\)[\s\S]*?getOrCreateStepsContainer\(\)[\s\S]*?role', 'status'[\s\S]*?aria-live', 'polite'[\s\S]*?textContent = message;/,
+      `${label}: planner fallback note is not scoped, idempotent, or accessible`,
+    );
+    assert.doesNotMatch(
+      panel,
+      /showComposerToast\(data\?\.message \|\| t\('sp\.plan\.intent_unavailable'\)/,
+      `${label}: planner fallback still displaces the composer as a toast`,
+    );
+    assert.match(
+      css,
+      /\.planner-fallback-note \{[\s\S]*?border-inline-start: 2px solid var\(--warning\);[\s\S]*?\.planner-fallback-note-icon \{[\s\S]*?\.planner-fallback-note-text \{/,
+      `${label}: planner fallback note styling is missing`,
     );
     assert.equal(
       (panel.match(/plannerRequestFailureUpdate\(res\?\.updates\)/g) || []).length >= 2,

--- a/test/run.js
+++ b/test/run.js
@@ -41868,7 +41868,7 @@ test('clarify tool auto-timeout is configurable and mirrored across browsers', (
     );
     assert.match(
       scheduler,
-      /type === 'clarify' \|\| type === 'clarify_timeout_extended' \|\| type === 'clarify_auto'/,
+      /const jobScopedUpdate = type === 'clarify'\s*\|\| type === 'clarify_timeout_extended'\s*\|\| type === 'clarify_auto'/,
       `${label}: scheduled clarify deadline updates should carry scheduledJobId`,
     );
     assert.match(scheduler, /type === 'clarify_timeout_extended'[\s\S]*?pendingClarify:[\s\S]*?deadlineTs:/, `${label}: scheduled clarifies should persist renewed deadlines`);
@@ -46178,8 +46178,8 @@ test('sidepanel long replies use reading-first turn navigation', () => {
       `${label}: auto-selected clarification answers should establish a timeline boundary`,
     );
     const compactStepsSource = panel.slice(
-      panel.indexOf('function getOrCreateStepsContainer()'),
-      panel.indexOf('function appendCompactStep(', panel.indexOf('function getOrCreateStepsContainer()')),
+      panel.indexOf('function getOrCreateStepsContainer('),
+      panel.indexOf('function appendCompactStep(', panel.indexOf('function getOrCreateStepsContainer(')),
     );
     assert.match(
       compactStepsSource,
@@ -48137,6 +48137,39 @@ test('ScheduledJobManager keeps live scheduled clarifications resumable', async 
     assert.equal(job.status, 'completed', `${label}: original run should complete after answer`);
     assert.equal(job.lastResult, 'continued after answer');
     assert.equal(job.runCount, 1);
+  }
+});
+
+test('ScheduledJobManager scopes planner fallback warnings to the scheduled job', async () => {
+  const now = Date.UTC(2026, 0, 1, 12, 0, 0);
+  for (const [label, SchedulerMod] of [['chrome', SchedulerCh], ['firefox', SchedulerFx]]) {
+    const h = makeSchedulerHarness(SchedulerMod, {
+      now,
+      processMessage: async (_tabId, _message, onUpdate) => {
+        onUpdate('warning', {
+          code: 'planner_failed_continue_act',
+          message: 'Planning failed. Continuing in Act mode.',
+        });
+        return 'continued in Act mode';
+      },
+    });
+    const created = await h.manager.createResumeJob({
+      tabId: 77,
+      conversationId: 'conv-1',
+      args: { after_seconds: 60, reason: 'wait', resume_instruction: 'retry' },
+    });
+
+    await h.manager.handleAlarm(h.alarmName(created.jobId));
+
+    const warning = h.updates.find((update) => (
+      update.type === 'warning'
+      && update.data?.code === 'planner_failed_continue_act'
+    ));
+    assert.equal(
+      warning?.data?.scheduledJobId,
+      created.jobId,
+      `${label}: planner fallback warning should carry the scheduled job id`,
+    );
   }
 });
 
@@ -90059,6 +90092,10 @@ test('planner request failures expose provider settings and retry actions in bot
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
     const background = fs.readFileSync(path.join(ROOT, backgroundRel), 'utf8');
     const css = fs.readFileSync(path.join(ROOT, cssRel), 'utf8');
+    const scheduler = fs.readFileSync(
+      path.join(ROOT, panelRel.replace('src/ui/sidepanel.js', 'src/agent/scheduler.js')),
+      'utf8',
+    );
 
     assert.match(
       background,
@@ -90097,13 +90134,23 @@ test('planner request failures expose provider settings and retry actions in bot
     );
     assert.match(
       panel,
-      /data\?\.code === 'planner_failed_continue_act'[\s\S]*?addPlannerFallbackNote\(data\?\.message \|\| t\('sp\.plan\.intent_unavailable'\)\);/,
-      `${label}: planner-failed Act continuation does not render in the active turn`,
+      /data\?\.code === 'planner_failed_continue_act'[\s\S]*?const scheduledJobId = String\(data\?\.scheduledJobId \|\| ''\);[\s\S]*?findScheduledAssistantMessageForJob\(scheduledJobId\)[\s\S]*?queueScheduledPlannerFallbackMessage\(scheduledJobId, message\)[\s\S]*?addPlannerFallbackNote\(message, scheduledAssistantEl \|\| eventAssistantEl \|\| currentAssistantEl\);/,
+      `${label}: planner-failed Act continuation is not bound or queued for the correct turn`,
     );
     assert.match(
       panel,
-      /function addPlannerFallbackNote\(message\) \{[\s\S]*?currentAssistantEl\.querySelector\('\.planner-fallback-note'\)[\s\S]*?getOrCreateStepsContainer\(\)[\s\S]*?role', 'status'[\s\S]*?aria-live', 'polite'[\s\S]*?textContent = message;/,
+      /function addPlannerFallbackNote\(message, assistantEl = currentAssistantEl\) \{[\s\S]*?assistantEl\.querySelector\('\.planner-fallback-note'\)[\s\S]*?getOrCreateStepsContainer\(assistantEl\)[\s\S]*?role', 'status'[\s\S]*?aria-live', 'polite'[\s\S]*?textContent = message;/,
       `${label}: planner fallback note is not scoped, idempotent, or accessible`,
+    );
+    assert.match(
+      panel,
+      /function flushScheduledPlannerFallbackMessage\(jobId, assistantEl = null\) \{[\s\S]*?pendingScheduledPlannerFallbackMessages\.has\(id\)[\s\S]*?findScheduledAssistantMessageForJob\(id\)[\s\S]*?addPlannerFallbackNote\(message, assistantEl\);[\s\S]*?event === 'running'[\s\S]*?currentAssistantEl\.dataset\.scheduledJobId = jobId;[\s\S]*?flushScheduledPlannerFallbackMessage\(jobId, currentAssistantEl\);/,
+      `${label}: a planner fallback that arrives before the scheduled assistant turn is not flushed into that turn`,
+    );
+    assert.match(
+      scheduler,
+      /type === 'warning' && data\?\.code === 'planner_failed_continue_act'[\s\S]*?\{ \.\.\.data, scheduledJobId: job\.id \}/,
+      `${label}: scheduled planner fallback warnings are missing their job identity`,
     );
     assert.doesNotMatch(
       panel,

--- a/test/run.js
+++ b/test/run.js
@@ -90134,8 +90134,18 @@ test('planner request failures expose provider settings and retry actions in bot
     );
     assert.match(
       panel,
-      /data\?\.code === 'planner_failed_continue_act'[\s\S]*?const scheduledJobId = String\(data\?\.scheduledJobId \|\| ''\);[\s\S]*?findScheduledAssistantMessageForJob\(scheduledJobId\)[\s\S]*?queueScheduledPlannerFallbackMessage\(scheduledJobId, message\)[\s\S]*?addPlannerFallbackNote\(message, scheduledAssistantEl \|\| eventAssistantEl \|\| currentAssistantEl\);/,
+      /data\?\.code === 'planner_failed_continue_act'[\s\S]*?const scheduledJobId = String\(data\?\.scheduledJobId \|\| ''\);[\s\S]*?const scheduledAssistantPending = scheduledAssistantPreparationJobIds\.has\(scheduledJobId\);[\s\S]*?scheduledJobId && !scheduledAssistantPending[\s\S]*?findScheduledAssistantMessageForJob\(scheduledJobId\)[\s\S]*?scheduledJobId && \(scheduledAssistantPending \|\| !scheduledAssistantEl\)[\s\S]*?queueScheduledPlannerFallbackMessage\(scheduledJobId, message\)[\s\S]*?addPlannerFallbackNote\(message, scheduledAssistantEl \|\| eventAssistantEl \|\| currentAssistantEl\);/,
       `${label}: planner-failed Act continuation is not bound or queued for the correct turn`,
+    );
+    assert.match(
+      panel,
+      /function findScheduledAssistantMessageForJob\(jobId\) \{[\s\S]*?const messages = Array\.from[\s\S]*?for \(let i = messages\.length - 1; i >= 0; i -= 1\)[\s\S]*?return messages\[i\];/,
+      `${label}: recurring scheduled runs should resolve their newest assistant turn`,
+    );
+    assert.match(
+      panel,
+      /const preparingScheduledAssistant = event === 'running' && !!jobId;[\s\S]*?scheduledAssistantPreparationJobIds\.add\(jobId\);[\s\S]*?await refreshConversationScopeState\(runTabId\);[\s\S]*?flushScheduledPlannerFallbackMessage\(jobId, currentAssistantEl\);[\s\S]*?scheduledAssistantPreparationJobIds\.delete\(jobId\);/,
+      `${label}: fast recurring warnings can escape the new-turn preparation guard`,
     );
     assert.match(
       panel,


### PR DESCRIPTION
## Summary

- render the planner fallback as a compact status note inside the active assistant turn
- keep the temporary warning from shifting the mode selector and composer
- mirror the accessible, idempotent treatment across Chrome and Firefox with regression coverage

## Testing

- `node test/run.js` — 2,098 passed; 2 unrelated current-main release-artifact failures (`CHANGELOG.md` is 33.3.0 while `package.json` is 33.3.2, and `dist/webbrain-chrome-33.3.2.zip` is absent)
- `npm run test:toolbar-guard` — 33 passed
- `node scripts/benchmark-offline-relevance.mjs` — passed
- `npm run test:security` — 60 passed
- `git diff --check`
- visually inspected at a 360 CSS-pixel sidebar width