### PR TITLE
Fix selected-text chat action presentation

### DIFF
--- a/src/chrome/src/content/selection-shortcut.js
+++ b/src/chrome/src/content/selection-shortcut.js
@@ -25,7 +25,7 @@
     'hi', 'pt', 'vi', 'bn', 'fa', 'nl', 'de',
   ]);
   const LOCALIZATION_KEYS = Object.freeze([
-    'askSelection', 'openChat', 'summarize', 'explain', 'quiz',
+    'askSelection', 'askHighlightedText', 'openChat', 'summarize', 'explain', 'quiz',
     'proofread', 'humanize', 'translate', 'translateTo', 'askAbout',
     'askQuestion', 'sendQuestion', 'includePageContext', 'hideShortcut', 'sentManual', 'sendFailed',
   ]);
@@ -114,9 +114,9 @@
     const strings = localization.strings;
 host.lang = localization.locale;
     host.dir = localization.dir;
-    shortcut.setAttribute('aria-label', strings.askSelection);
-    shortcut.title = strings.askSelection;
-    popup.setAttribute('aria-label', strings.askSelection);
+    shortcut.setAttribute('aria-label', strings.askHighlightedText);
+    shortcut.title = strings.askHighlightedText;
+    popup.setAttribute('aria-label', strings.askHighlightedText);
     for (const action of ['summarize', 'explain', 'quiz', 'proofread', 'humanize', 'translate']) {
       const label = shadow.querySelector(`[data-action="${action}"] .action-label`);
       if (label) label.textContent = strings[action];
@@ -194,12 +194,12 @@ host.lang = localization.locale;
         }
         .shortcut {
           position:fixed; width:${BUTTON_SIZE}px; height:${BUTTON_SIZE}px; display:grid;
-          place-items:center; padding:0; border:1px solid rgba(23,23,34,.14);
-          border-radius:14px; background:#fff; color:#171722;
-          box-shadow:0 9px 20px rgba(23,23,34,.16),0 2px 5px rgba(23,23,34,.1);
+          place-items:center; padding:0; border:1px solid rgba(108,99,255,.34);
+          border-radius:14px; background:var(--bg); color:var(--accent);
+          box-shadow:0 10px 26px rgba(35,30,95,.22),0 2px 7px rgba(35,30,95,.12);
           cursor:pointer; pointer-events:auto; transition:transform 130ms ease,box-shadow 130ms ease;
         }
-        .shortcut:hover { transform:translateY(-1px) scale(1.03); box-shadow:0 12px 25px rgba(23,23,34,.2),0 3px 7px rgba(23,23,34,.12); }
+        .shortcut:hover { transform:translateY(-1px) scale(1.03); box-shadow:0 13px 30px rgba(35,30,95,.27),0 3px 8px rgba(35,30,95,.14); }
         .shortcut-icon {
           display:block; font:700 25px/1 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
           transform:translateY(-1px);
@@ -256,8 +256,7 @@ host.lang = localization.locale;
           width:auto; margin-left:auto; padding:5px 8px;
           color:var(--muted); font-size:12px; line-height:1.25;
         }
-        .shortcut:focus-visible { outline:3px solid rgba(23,23,34,.24); outline-offset:2px; }
-        .action:focus-visible,.hide:focus-visible,.send:focus-visible,textarea:focus-visible,.context-option input:focus-visible {
+        .shortcut:focus-visible,.action:focus-visible,.hide:focus-visible,.send:focus-visible,textarea:focus-visible,.context-option input:focus-visible {
           outline:3px solid rgba(108,99,255,.34); outline-offset:2px;
         }
         .toast {
@@ -276,10 +275,10 @@ host.lang = localization.locale;
         @media (prefers-reduced-motion:reduce) { .shortcut { transition:none; } }
       </style>
       <div class="selection-highlights" aria-hidden="true"></div>
-      <button class="shortcut" type="button" aria-label="Add to chat" title="Add to chat" hidden>
+      <button class="shortcut" type="button" aria-label="Ask WebBrain about this" title="Ask WebBrain about this" hidden>
         <span class="shortcut-icon" aria-hidden="true">?</span>
       </button>
-      <div class="popup" role="dialog" aria-label="Add to chat" hidden>
+      <div class="popup" role="dialog" aria-label="Ask WebBrain about this" hidden>
         <div class="main-view">
           <div class="actions">
             <button class="action" type="button" data-action="summarize">

--- a/src/chrome/src/selection-shortcut-i18n.js
+++ b/src/chrome/src/selection-shortcut-i18n.js
@@ -1,11 +1,13 @@
 /**
- * Localized copy for selected-text surfaces that run outside extension pages.
+ * Localized copy shared by webpage selection shortcuts and the sidepanel selected-answer action.
  * Keep the Chrome and Firefox copies byte-identical.
  */
 
 const STRINGS = Object.freeze({
   en: {
     askSelection: 'Add to chat',
+    askHighlightedText: 'Ask WebBrain about this',
+    addSelectionToChat: 'Add this to chat',
     openChat: 'Open WebBrain to chat',
     summarize: 'Summarize',
     explain: 'Explain',
@@ -24,6 +26,8 @@ const STRINGS = Object.freeze({
   },
   zh: {
     askSelection: '添加到聊天',
+    askHighlightedText: '向 WebBrain 询问此内容',
+    addSelectionToChat: '将此内容添加到聊天',
     openChat: '打开 WebBrain 进行对话',
     summarize: '总结',
     explain: '解释',
@@ -42,6 +46,8 @@ const STRINGS = Object.freeze({
   },
   ar: {
     askSelection: 'إضافة إلى الدردشة',
+    askHighlightedText: 'اسأل WebBrain عن هذا',
+    addSelectionToChat: 'إضافة هذا إلى الدردشة',
     openChat: 'افتح WebBrain للدردشة',
     summarize: 'تلخيص',
     explain: 'شرح',
@@ -60,6 +66,8 @@ const STRINGS = Object.freeze({
   },
   bn: {
     askSelection: 'চ্যাটে যোগ করুন',
+    askHighlightedText: 'এটি সম্পর্কে WebBrain-কে জিজ্ঞাসা করুন',
+    addSelectionToChat: 'এটি চ্যাটে যোগ করুন',
     openChat: 'চ্যাট করতে WebBrain খুলুন',
     summarize: 'সারসংক্ষেপ করুন',
     explain: 'ব্যাখ্যা করুন',
@@ -78,6 +86,8 @@ const STRINGS = Object.freeze({
   },
   de: {
     askSelection: 'Zum Chat hinzufügen',
+    askHighlightedText: 'WebBrain hierzu fragen',
+    addSelectionToChat: 'Dies zum Chat hinzufügen',
     openChat: 'WebBrain zum Chatten öffnen',
     summarize: 'Zusammenfassen',
     explain: 'Erklären',
@@ -96,6 +106,8 @@ const STRINGS = Object.freeze({
   },
   es: {
     askSelection: 'Añadir al chat',
+    askHighlightedText: 'Preguntar a WebBrain sobre esto',
+    addSelectionToChat: 'Añadir esto al chat',
     openChat: 'Abrir WebBrain para chatear',
     summarize: 'Resumir',
     explain: 'Explicar',
@@ -114,6 +126,8 @@ const STRINGS = Object.freeze({
   },
   fa: {
     askSelection: 'افزودن به چت',
+    askHighlightedText: 'درباره این از WebBrain بپرسید',
+    addSelectionToChat: 'افزودن این به گفتگو',
     openChat: 'WebBrain را برای گفتگو باز کنید',
     summarize: 'خلاصه‌سازی',
     explain: 'توضیح',
@@ -132,6 +146,8 @@ const STRINGS = Object.freeze({
   },
   fr: {
     askSelection: 'Ajouter au chat',
+    askHighlightedText: 'Interroger WebBrain à ce sujet',
+    addSelectionToChat: 'Ajouter ceci au chat',
     openChat: 'Ouvrir WebBrain pour discuter',
     summarize: 'Résumer',
     explain: 'Expliquer',
@@ -150,6 +166,8 @@ const STRINGS = Object.freeze({
   },
   he: {
     askSelection: 'הוספה לצ׳אט',
+    askHighlightedText: 'לשאול את WebBrain על זה',
+    addSelectionToChat: 'הוספת זה לצ׳אט',
     openChat: 'פתיחת WebBrain לצ׳אט',
     summarize: 'סיכום',
     explain: 'הסבר',
@@ -168,6 +186,8 @@ const STRINGS = Object.freeze({
   },
   hi: {
     askSelection: 'चैट में जोड़ें',
+    askHighlightedText: 'इसके बारे में WebBrain से पूछें',
+    addSelectionToChat: 'इसे चैट में जोड़ें',
     openChat: 'चैट के लिए WebBrain खोलें',
     summarize: 'सारांश बनाएँ',
     explain: 'समझाएँ',
@@ -186,6 +206,8 @@ const STRINGS = Object.freeze({
   },
   id: {
     askSelection: 'Tambahkan ke chat',
+    askHighlightedText: 'Tanyakan ini kepada WebBrain',
+    addSelectionToChat: 'Tambahkan ini ke chat',
     openChat: 'Buka WebBrain untuk mengobrol',
     summarize: 'Ringkas',
     explain: 'Jelaskan',
@@ -204,6 +226,8 @@ const STRINGS = Object.freeze({
   },
   ja: {
     askSelection: 'チャットに追加',
+    askHighlightedText: 'この内容について WebBrain に質問',
+    addSelectionToChat: 'これをチャットに追加',
     openChat: 'WebBrain を開いてチャット',
     summarize: '要約',
     explain: '説明',
@@ -222,6 +246,8 @@ const STRINGS = Object.freeze({
   },
   ko: {
     askSelection: '채팅에 추가',
+    askHighlightedText: '이 내용에 대해 WebBrain에 질문',
+    addSelectionToChat: '이 내용을 채팅에 추가',
     openChat: 'WebBrain을 열어 채팅',
     summarize: '요약',
     explain: '설명',
@@ -240,6 +266,8 @@ const STRINGS = Object.freeze({
   },
   ms: {
     askSelection: 'Tambahkan pada sembang',
+    askHighlightedText: 'Tanya WebBrain tentang ini',
+    addSelectionToChat: 'Tambahkan ini pada sembang',
     openChat: 'Buka WebBrain untuk berbual',
     summarize: 'Ringkaskan',
     explain: 'Terangkan',
@@ -258,6 +286,8 @@ const STRINGS = Object.freeze({
   },
   nl: {
     askSelection: 'Toevoegen aan chat',
+    askHighlightedText: 'WebBrain hierover vragen',
+    addSelectionToChat: 'Dit toevoegen aan de chat',
     openChat: 'WebBrain openen om te chatten',
     summarize: 'Samenvatten',
     explain: 'Uitleggen',
@@ -276,6 +306,8 @@ const STRINGS = Object.freeze({
   },
   pl: {
     askSelection: 'Dodaj do czatu',
+    askHighlightedText: 'Zapytaj WebBrain o to',
+    addSelectionToChat: 'Dodaj to do czatu',
     openChat: 'Otwórz WebBrain, aby porozmawiać',
     summarize: 'Podsumuj',
     explain: 'Wyjaśnij',
@@ -294,6 +326,8 @@ const STRINGS = Object.freeze({
   },
   pt: {
     askSelection: 'Adicionar ao chat',
+    askHighlightedText: 'Perguntar ao WebBrain sobre isto',
+    addSelectionToChat: 'Adicionar isto ao chat',
     openChat: 'Abrir o WebBrain para conversar',
     summarize: 'Resumir',
     explain: 'Explicar',
@@ -312,6 +346,8 @@ const STRINGS = Object.freeze({
   },
   ru: {
     askSelection: 'Добавить в чат',
+    askHighlightedText: 'Спросить WebBrain об этом',
+    addSelectionToChat: 'Добавить это в чат',
     openChat: 'Открыть WebBrain для чата',
     summarize: 'Кратко изложить',
     explain: 'Объяснить',
@@ -330,6 +366,8 @@ const STRINGS = Object.freeze({
   },
   th: {
     askSelection: 'เพิ่มไปยังแชท',
+    askHighlightedText: 'ถาม WebBrain เกี่ยวกับสิ่งนี้',
+    addSelectionToChat: 'เพิ่มสิ่งนี้ไปยังแชท',
     openChat: 'เปิด WebBrain เพื่อแชต',
     summarize: 'สรุป',
     explain: 'อธิบาย',
@@ -348,6 +386,8 @@ const STRINGS = Object.freeze({
   },
   tl: {
     askSelection: 'Idagdag sa chat',
+    askHighlightedText: 'Itanong ito sa WebBrain',
+    addSelectionToChat: 'Idagdag ito sa chat',
     openChat: 'Buksan ang WebBrain para makipag-chat',
     summarize: 'Ibuod',
     explain: 'Ipaliwanag',
@@ -366,6 +406,8 @@ const STRINGS = Object.freeze({
   },
   tr: {
     askSelection: 'Sohbete ekle',
+    askHighlightedText: 'Bunu WebBrain’e sor',
+    addSelectionToChat: 'Bunu sohbete ekle',
     openChat: 'Sohbet için WebBrain’i aç',
     summarize: 'Özetle',
     explain: 'Açıkla',
@@ -384,6 +426,8 @@ const STRINGS = Object.freeze({
   },
   uk: {
     askSelection: 'Додати до чату',
+    askHighlightedText: 'Запитати WebBrain про це',
+    addSelectionToChat: 'Додати це до чату',
     openChat: 'Відкрити WebBrain для чату',
     summarize: 'Підсумувати',
     explain: 'Пояснити',
@@ -402,6 +446,8 @@ const STRINGS = Object.freeze({
   },
   vi: {
     askSelection: 'Thêm vào cuộc trò chuyện',
+    askHighlightedText: 'Hỏi WebBrain về nội dung này',
+    addSelectionToChat: 'Thêm nội dung này vào cuộc trò chuyện',
     openChat: 'Mở WebBrain để trò chuyện',
     summarize: 'Tóm tắt',
     explain: 'Giải thích',

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -11384,11 +11384,11 @@ function positionSelectionAskAction(range) {
     Math.max(8, usable ? rect.left : (vw - actionWidth) / 2),
     Math.max(8, vw - actionWidth - 8),
   );
-  const belowTop = usable ? rect.bottom + gap : floor - actionHeight;
-  const preferredTop = usable && belowTop + actionHeight <= floor
-    ? belowTop
-    : Math.max(8, usable ? rect.top - actionHeight - gap : floor - actionHeight);
-  const top = Math.min(Math.max(8, floor - actionHeight), preferredTop);
+  const maxTop = Math.max(8, floor - actionHeight);
+  const aboveTop = usable ? rect.top - actionHeight - gap : maxTop;
+  const belowTop = usable ? rect.bottom + gap : maxTop;
+  const preferredTop = usable && aboveTop >= 8 ? aboveTop : belowTop;
+  const top = Math.min(maxTop, Math.max(8, preferredTop));
   selectionAskActionEl.style.left = `${left}px`;
   selectionAskActionEl.style.top = `${top}px`;
 }
@@ -11401,7 +11401,7 @@ function applySelectionAskActionLabel() {
     return;
   }
   selectionAskActionLocale = locale;
-  selectionAskActionLabel = getSelectionShortcutLocalization(locale).strings.askQuestion;
+  selectionAskActionLabel = getSelectionShortcutLocalization(locale).strings.addSelectionToChat;
   selectionAskActionEl.textContent = selectionAskActionLabel;
   selectionAskActionEl.title = selectionAskActionLabel;
   selectionAskActionEl.setAttribute('aria-label', selectionAskActionLabel);

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -2478,14 +2478,14 @@ body {
   position: fixed;
   z-index: 10000;
   display: block;
-  opacity: 0.8;
+  opacity: 1;
   max-width: calc(100vw - 16px);
   padding: 6px 10px;
-  border: 1px solid var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
   border-radius: 999px;
-  background: var(--accent);
+  background: var(--bg-secondary);
   box-shadow: 0 5px 16px color-mix(in srgb, var(--text-primary) 18%, transparent);
-  color: #fff;
+  color: var(--text-primary);
   cursor: pointer;
   font: inherit;
   font-size: 11px;
@@ -2501,9 +2501,8 @@ body {
 }
 
 .selection-ask-action:hover {
-  border-color: var(--accent-hover);
-  background: var(--accent-hover);
-  opacity: 1;
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-secondary));
 }
 
 .selection-ask-action:focus-visible {

--- a/src/firefox/src/content/selection-shortcut.js
+++ b/src/firefox/src/content/selection-shortcut.js
@@ -25,7 +25,7 @@
     'hi', 'pt', 'vi', 'bn', 'fa', 'nl', 'de',
   ]);
   const LOCALIZATION_KEYS = Object.freeze([
-    'askSelection', 'openChat', 'summarize', 'explain', 'quiz',
+    'askSelection', 'askHighlightedText', 'openChat', 'summarize', 'explain', 'quiz',
     'proofread', 'humanize', 'translate', 'translateTo', 'askAbout',
     'askQuestion', 'sendQuestion', 'includePageContext', 'hideShortcut', 'sentManual', 'sendFailed',
   ]);
@@ -114,9 +114,9 @@
     const strings = localization.strings;
 host.lang = localization.locale;
     host.dir = localization.dir;
-    shortcut.setAttribute('aria-label', strings.askSelection);
-    shortcut.title = strings.askSelection;
-    popup.setAttribute('aria-label', strings.askSelection);
+    shortcut.setAttribute('aria-label', strings.askHighlightedText);
+    shortcut.title = strings.askHighlightedText;
+    popup.setAttribute('aria-label', strings.askHighlightedText);
     for (const action of ['summarize', 'explain', 'quiz', 'proofread', 'humanize', 'translate']) {
       const label = shadow.querySelector(`[data-action="${action}"] .action-label`);
       if (label) label.textContent = strings[action];
@@ -194,12 +194,12 @@ host.lang = localization.locale;
         }
         .shortcut {
           position:fixed; width:${BUTTON_SIZE}px; height:${BUTTON_SIZE}px; display:grid;
-          place-items:center; padding:0; border:1px solid rgba(23,23,34,.14);
-          border-radius:14px; background:#fff; color:#171722;
-          box-shadow:0 9px 20px rgba(23,23,34,.16),0 2px 5px rgba(23,23,34,.1);
+          place-items:center; padding:0; border:1px solid rgba(108,99,255,.34);
+          border-radius:14px; background:var(--bg); color:var(--accent);
+          box-shadow:0 10px 26px rgba(35,30,95,.22),0 2px 7px rgba(35,30,95,.12);
           cursor:pointer; pointer-events:auto; transition:transform 130ms ease,box-shadow 130ms ease;
         }
-        .shortcut:hover { transform:translateY(-1px) scale(1.03); box-shadow:0 12px 25px rgba(23,23,34,.2),0 3px 7px rgba(23,23,34,.12); }
+        .shortcut:hover { transform:translateY(-1px) scale(1.03); box-shadow:0 13px 30px rgba(35,30,95,.27),0 3px 8px rgba(35,30,95,.14); }
         .shortcut-icon {
           display:block; font:700 25px/1 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
           transform:translateY(-1px);
@@ -256,8 +256,7 @@ host.lang = localization.locale;
           width:auto; margin-left:auto; padding:5px 8px;
           color:var(--muted); font-size:12px; line-height:1.25;
         }
-        .shortcut:focus-visible { outline:3px solid rgba(23,23,34,.24); outline-offset:2px; }
-        .action:focus-visible,.hide:focus-visible,.send:focus-visible,textarea:focus-visible,.context-option input:focus-visible {
+        .shortcut:focus-visible,.action:focus-visible,.hide:focus-visible,.send:focus-visible,textarea:focus-visible,.context-option input:focus-visible {
           outline:3px solid rgba(108,99,255,.34); outline-offset:2px;
         }
         .toast {
@@ -276,10 +275,10 @@ host.lang = localization.locale;
         @media (prefers-reduced-motion:reduce) { .shortcut { transition:none; } }
       </style>
       <div class="selection-highlights" aria-hidden="true"></div>
-      <button class="shortcut" type="button" aria-label="Add to chat" title="Add to chat" hidden>
+      <button class="shortcut" type="button" aria-label="Ask WebBrain about this" title="Ask WebBrain about this" hidden>
         <span class="shortcut-icon" aria-hidden="true">?</span>
       </button>
-      <div class="popup" role="dialog" aria-label="Add to chat" hidden>
+      <div class="popup" role="dialog" aria-label="Ask WebBrain about this" hidden>
         <div class="main-view">
           <div class="actions">
             <button class="action" type="button" data-action="summarize">

--- a/src/firefox/src/selection-shortcut-i18n.js
+++ b/src/firefox/src/selection-shortcut-i18n.js
@@ -1,11 +1,13 @@
 /**
- * Localized copy for selected-text surfaces that run outside extension pages.
+ * Localized copy shared by webpage selection shortcuts and the sidepanel selected-answer action.
  * Keep the Chrome and Firefox copies byte-identical.
  */
 
 const STRINGS = Object.freeze({
   en: {
     askSelection: 'Add to chat',
+    askHighlightedText: 'Ask WebBrain about this',
+    addSelectionToChat: 'Add this to chat',
     openChat: 'Open WebBrain to chat',
     summarize: 'Summarize',
     explain: 'Explain',
@@ -24,6 +26,8 @@ const STRINGS = Object.freeze({
   },
   zh: {
     askSelection: '添加到聊天',
+    askHighlightedText: '向 WebBrain 询问此内容',
+    addSelectionToChat: '将此内容添加到聊天',
     openChat: '打开 WebBrain 进行对话',
     summarize: '总结',
     explain: '解释',
@@ -42,6 +46,8 @@ const STRINGS = Object.freeze({
   },
   ar: {
     askSelection: 'إضافة إلى الدردشة',
+    askHighlightedText: 'اسأل WebBrain عن هذا',
+    addSelectionToChat: 'إضافة هذا إلى الدردشة',
     openChat: 'افتح WebBrain للدردشة',
     summarize: 'تلخيص',
     explain: 'شرح',
@@ -60,6 +66,8 @@ const STRINGS = Object.freeze({
   },
   bn: {
     askSelection: 'চ্যাটে যোগ করুন',
+    askHighlightedText: 'এটি সম্পর্কে WebBrain-কে জিজ্ঞাসা করুন',
+    addSelectionToChat: 'এটি চ্যাটে যোগ করুন',
     openChat: 'চ্যাট করতে WebBrain খুলুন',
     summarize: 'সারসংক্ষেপ করুন',
     explain: 'ব্যাখ্যা করুন',
@@ -78,6 +86,8 @@ const STRINGS = Object.freeze({
   },
   de: {
     askSelection: 'Zum Chat hinzufügen',
+    askHighlightedText: 'WebBrain hierzu fragen',
+    addSelectionToChat: 'Dies zum Chat hinzufügen',
     openChat: 'WebBrain zum Chatten öffnen',
     summarize: 'Zusammenfassen',
     explain: 'Erklären',
@@ -96,6 +106,8 @@ const STRINGS = Object.freeze({
   },
   es: {
     askSelection: 'Añadir al chat',
+    askHighlightedText: 'Preguntar a WebBrain sobre esto',
+    addSelectionToChat: 'Añadir esto al chat',
     openChat: 'Abrir WebBrain para chatear',
     summarize: 'Resumir',
     explain: 'Explicar',
@@ -114,6 +126,8 @@ const STRINGS = Object.freeze({
   },
   fa: {
     askSelection: 'افزودن به چت',
+    askHighlightedText: 'درباره این از WebBrain بپرسید',
+    addSelectionToChat: 'افزودن این به گفتگو',
     openChat: 'WebBrain را برای گفتگو باز کنید',
     summarize: 'خلاصه‌سازی',
     explain: 'توضیح',
@@ -132,6 +146,8 @@ const STRINGS = Object.freeze({
   },
   fr: {
     askSelection: 'Ajouter au chat',
+    askHighlightedText: 'Interroger WebBrain à ce sujet',
+    addSelectionToChat: 'Ajouter ceci au chat',
     openChat: 'Ouvrir WebBrain pour discuter',
     summarize: 'Résumer',
     explain: 'Expliquer',
@@ -150,6 +166,8 @@ const STRINGS = Object.freeze({
   },
   he: {
     askSelection: 'הוספה לצ׳אט',
+    askHighlightedText: 'לשאול את WebBrain על זה',
+    addSelectionToChat: 'הוספת זה לצ׳אט',
     openChat: 'פתיחת WebBrain לצ׳אט',
     summarize: 'סיכום',
     explain: 'הסבר',
@@ -168,6 +186,8 @@ const STRINGS = Object.freeze({
   },
   hi: {
     askSelection: 'चैट में जोड़ें',
+    askHighlightedText: 'इसके बारे में WebBrain से पूछें',
+    addSelectionToChat: 'इसे चैट में जोड़ें',
     openChat: 'चैट के लिए WebBrain खोलें',
     summarize: 'सारांश बनाएँ',
     explain: 'समझाएँ',
@@ -186,6 +206,8 @@ const STRINGS = Object.freeze({
   },
   id: {
     askSelection: 'Tambahkan ke chat',
+    askHighlightedText: 'Tanyakan ini kepada WebBrain',
+    addSelectionToChat: 'Tambahkan ini ke chat',
     openChat: 'Buka WebBrain untuk mengobrol',
     summarize: 'Ringkas',
     explain: 'Jelaskan',
@@ -204,6 +226,8 @@ const STRINGS = Object.freeze({
   },
   ja: {
     askSelection: 'チャットに追加',
+    askHighlightedText: 'この内容について WebBrain に質問',
+    addSelectionToChat: 'これをチャットに追加',
     openChat: 'WebBrain を開いてチャット',
     summarize: '要約',
     explain: '説明',
@@ -222,6 +246,8 @@ const STRINGS = Object.freeze({
   },
   ko: {
     askSelection: '채팅에 추가',
+    askHighlightedText: '이 내용에 대해 WebBrain에 질문',
+    addSelectionToChat: '이 내용을 채팅에 추가',
     openChat: 'WebBrain을 열어 채팅',
     summarize: '요약',
     explain: '설명',
@@ -240,6 +266,8 @@ const STRINGS = Object.freeze({
   },
   ms: {
     askSelection: 'Tambahkan pada sembang',
+    askHighlightedText: 'Tanya WebBrain tentang ini',
+    addSelectionToChat: 'Tambahkan ini pada sembang',
     openChat: 'Buka WebBrain untuk berbual',
     summarize: 'Ringkaskan',
     explain: 'Terangkan',
@@ -258,6 +286,8 @@ const STRINGS = Object.freeze({
   },
   nl: {
     askSelection: 'Toevoegen aan chat',
+    askHighlightedText: 'WebBrain hierover vragen',
+    addSelectionToChat: 'Dit toevoegen aan de chat',
     openChat: 'WebBrain openen om te chatten',
     summarize: 'Samenvatten',
     explain: 'Uitleggen',
@@ -276,6 +306,8 @@ const STRINGS = Object.freeze({
   },
   pl: {
     askSelection: 'Dodaj do czatu',
+    askHighlightedText: 'Zapytaj WebBrain o to',
+    addSelectionToChat: 'Dodaj to do czatu',
     openChat: 'Otwórz WebBrain, aby porozmawiać',
     summarize: 'Podsumuj',
     explain: 'Wyjaśnij',
@@ -294,6 +326,8 @@ const STRINGS = Object.freeze({
   },
   pt: {
     askSelection: 'Adicionar ao chat',
+    askHighlightedText: 'Perguntar ao WebBrain sobre isto',
+    addSelectionToChat: 'Adicionar isto ao chat',
     openChat: 'Abrir o WebBrain para conversar',
     summarize: 'Resumir',
     explain: 'Explicar',
@@ -312,6 +346,8 @@ const STRINGS = Object.freeze({
   },
   ru: {
     askSelection: 'Добавить в чат',
+    askHighlightedText: 'Спросить WebBrain об этом',
+    addSelectionToChat: 'Добавить это в чат',
     openChat: 'Открыть WebBrain для чата',
     summarize: 'Кратко изложить',
     explain: 'Объяснить',
@@ -330,6 +366,8 @@ const STRINGS = Object.freeze({
   },
   th: {
     askSelection: 'เพิ่มไปยังแชท',
+    askHighlightedText: 'ถาม WebBrain เกี่ยวกับสิ่งนี้',
+    addSelectionToChat: 'เพิ่มสิ่งนี้ไปยังแชท',
     openChat: 'เปิด WebBrain เพื่อแชต',
     summarize: 'สรุป',
     explain: 'อธิบาย',
@@ -348,6 +386,8 @@ const STRINGS = Object.freeze({
   },
   tl: {
     askSelection: 'Idagdag sa chat',
+    askHighlightedText: 'Itanong ito sa WebBrain',
+    addSelectionToChat: 'Idagdag ito sa chat',
     openChat: 'Buksan ang WebBrain para makipag-chat',
     summarize: 'Ibuod',
     explain: 'Ipaliwanag',
@@ -366,6 +406,8 @@ const STRINGS = Object.freeze({
   },
   tr: {
     askSelection: 'Sohbete ekle',
+    askHighlightedText: 'Bunu WebBrain’e sor',
+    addSelectionToChat: 'Bunu sohbete ekle',
     openChat: 'Sohbet için WebBrain’i aç',
     summarize: 'Özetle',
     explain: 'Açıkla',
@@ -384,6 +426,8 @@ const STRINGS = Object.freeze({
   },
   uk: {
     askSelection: 'Додати до чату',
+    askHighlightedText: 'Запитати WebBrain про це',
+    addSelectionToChat: 'Додати це до чату',
     openChat: 'Відкрити WebBrain для чату',
     summarize: 'Підсумувати',
     explain: 'Пояснити',
@@ -402,6 +446,8 @@ const STRINGS = Object.freeze({
   },
   vi: {
     askSelection: 'Thêm vào cuộc trò chuyện',
+    askHighlightedText: 'Hỏi WebBrain về nội dung này',
+    addSelectionToChat: 'Thêm nội dung này vào cuộc trò chuyện',
     openChat: 'Mở WebBrain để trò chuyện',
     summarize: 'Tóm tắt',
     explain: 'Giải thích',

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -10999,11 +10999,11 @@ function positionSelectionAskAction(range) {
     Math.max(8, usable ? rect.left : (vw - actionWidth) / 2),
     Math.max(8, vw - actionWidth - 8),
   );
-  const belowTop = usable ? rect.bottom + gap : floor - actionHeight;
-  const preferredTop = usable && belowTop + actionHeight <= floor
-    ? belowTop
-    : Math.max(8, usable ? rect.top - actionHeight - gap : floor - actionHeight);
-  const top = Math.min(Math.max(8, floor - actionHeight), preferredTop);
+  const maxTop = Math.max(8, floor - actionHeight);
+  const aboveTop = usable ? rect.top - actionHeight - gap : maxTop;
+  const belowTop = usable ? rect.bottom + gap : maxTop;
+  const preferredTop = usable && aboveTop >= 8 ? aboveTop : belowTop;
+  const top = Math.min(maxTop, Math.max(8, preferredTop));
   selectionAskActionEl.style.left = `${left}px`;
   selectionAskActionEl.style.top = `${top}px`;
 }
@@ -11016,7 +11016,7 @@ function applySelectionAskActionLabel() {
     return;
   }
   selectionAskActionLocale = locale;
-  selectionAskActionLabel = getSelectionShortcutLocalization(locale).strings.askQuestion;
+  selectionAskActionLabel = getSelectionShortcutLocalization(locale).strings.addSelectionToChat;
   selectionAskActionEl.textContent = selectionAskActionLabel;
   selectionAskActionEl.title = selectionAskActionLabel;
   selectionAskActionEl.setAttribute('aria-label', selectionAskActionLabel);

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -2315,14 +2315,14 @@ body {
   position: fixed;
   z-index: 10000;
   display: block;
-  opacity: 0.8;
+  opacity: 1;
   max-width: calc(100vw - 16px);
   padding: 6px 10px;
-  border: 1px solid var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
   border-radius: 999px;
-  background: var(--accent);
+  background: var(--bg-secondary);
   box-shadow: 0 5px 16px color-mix(in srgb, var(--text-primary) 18%, transparent);
-  color: #fff;
+  color: var(--text-primary);
   cursor: pointer;
   font: inherit;
   font-size: 11px;
@@ -2338,9 +2338,8 @@ body {
 }
 
 .selection-ask-action:hover {
-  border-color: var(--accent-hover);
-  background: var(--accent-hover);
-  opacity: 1;
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-secondary));
 }
 
 .selection-ask-action:focus-visible {

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -1196,11 +1196,11 @@ for (const [label, sourcePath, manualOpen] of [
     if (!state.selectionRect || rect.bottom > state.selectionRect.top) {
       throw new Error(`shortcut should prefer the top of the selected text: ${JSON.stringify(state)}`);
     }
-    if (state.shortcutLabel !== 'Add to chat'
+    if (state.shortcutLabel !== 'Ask WebBrain about this'
         || state.shortcutBackground !== 'rgb(255, 255, 255)'
-        || state.shortcutColor !== 'rgb(23, 23, 34)'
+        || state.shortcutColor !== 'rgb(108, 99, 255)'
         || state.shortcutBoxShadow === 'none') {
-      throw new Error(`shortcut should use the neutral Add to chat treatment: ${JSON.stringify(state)}`);
+      throw new Error(`shortcut should retain its purple selected-text treatment: ${JSON.stringify(state)}`);
     }
     await page.mouse.click(rect.left + rect.width / 2, rect.top + rect.height / 2);
     let popupState = await page.evaluate(() => window.__webbrainSelectionShortcut.getState());

--- a/test/run.js
+++ b/test/run.js
@@ -1423,9 +1423,11 @@ test('selection answer action wiring covers show, dismiss, and tab/conversation 
     assert.match(source, /const text = selectionTextFromRange\(range\) \|\| String\(range\.toString\?\.\(\) \|\| ''\)\.trim\(\);/);
     assert.match(source, /function applySelectionAskActionLabel\(\)/);
     assert.match(source, /if \(selectionAskActionLocale === locale && selectionAskActionLabel[\s\S]*?selectionAskActionEl\.textContent === selectionAskActionLabel\)/);
+    assert.match(source, /selectionAskActionLabel = getSelectionShortcutLocalization\(locale\)\.strings\.addSelectionToChat;/);
     assert.match(source, /selectionAskActionEl\.addEventListener\('click'/);
     assert.match(source, /const rect = range \? selectionRangeRect\(range\) : null;/);
     assert.match(source, /const usable = rect && selectionRangeIsVisible\(rect, \{ width: vw, height: vh \}\);/);
+    assert.match(source, /const aboveTop = usable \? rect\.top - actionHeight - gap : maxTop;[\s\S]*?const preferredTop = usable && aboveTop >= 8 \? aboveTop : belowTop;/);
     assert.match(source, /cloneRange/);
     assert.match(source, /ensureSelectionAskActionEl\(\);/);
     assert.match(source, /if \(!range\.startContainer\.isConnected \|\| !range\.endContainer\.isConnected\) return null;/);
@@ -1438,7 +1440,7 @@ test('selection answer action wiring covers show, dismiss, and tab/conversation 
     assert.match(sidepanelHtmlSources[index], /id="selection-ask-action"/);
     assert.doesNotMatch(sidepanelHtmlSources[index], /id="selection-ask-action"[^>]*aria-live/);
     assert.doesNotMatch(sidepanelHtmlSources[index], /<div id="app"[\s\S]*id="selection-ask-action"[\s\S]*<\/div>\s*<script/);
-    assert.match(sidepanelStyleSources[index], /\.selection-ask-action \{[\s\S]*?z-index:\s*10000;[\s\S]*?opacity:\s*0\.8;[\s\S]*?user-select:\s*none;/);
+    assert.match(sidepanelStyleSources[index], /\.selection-ask-action \{[\s\S]*?z-index:\s*10000;[\s\S]*?opacity:\s*1;[\s\S]*?background:\s*var\(--bg-secondary\);[\s\S]*?color:\s*var\(--text-primary\);[\s\S]*?user-select:\s*none;/);
   }
 });
 
@@ -43683,7 +43685,7 @@ test('selection shortcut localizations cover every interface locale with browser
     'ms', 'nl', 'pl', 'pt', 'ru', 'th', 'tl', 'tr', 'uk', 'vi', 'zh',
   ];
   const expectedKeys = [
-    'askAbout', 'askQuestion', 'askSelection', 'explain', 'hideShortcut',
+    'addSelectionToChat', 'askAbout', 'askHighlightedText', 'askQuestion', 'askSelection', 'explain', 'hideShortcut',
     'humanize', 'includePageContext', 'openChat', 'proofread', 'quiz', 'sendFailed', 'sendQuestion',
     'sentManual', 'summarize', 'translate', 'translateTo',
   ];
@@ -43706,7 +43708,9 @@ test('selection shortcut localizations cover every interface locale with browser
     assert.equal(chinese.strings.quiz, '测验我', `${label}: the Chinese shortcut should localize Quiz me`);
     assert.equal(chinese.strings.includePageContext, '包含页面和对话上下文', `${label}: the Chinese shortcut should localize the full-context choice`);
     assert.equal(chinese.strings.hideShortcut, '隐藏此项', `${label}: the Chinese shortcut should use the compact Hide this label`);
-    assert.equal(getLocalization('en').strings.askSelection, 'Add to chat', `${label}: the English shortcut should use the concise chat action label`);
+    assert.equal(getLocalization('en').strings.askSelection, 'Add to chat', `${label}: the native selection action should retain its concise label`);
+    assert.equal(getLocalization('en').strings.askHighlightedText, 'Ask WebBrain about this', `${label}: the webpage shortcut should retain its original prompt`);
+    assert.equal(getLocalization('en').strings.addSelectionToChat, 'Add this to chat', `${label}: the selected-answer action should use the explicit chat label`);
     assert.equal(getLocalization('en').strings.hideShortcut, 'Hide this', `${label}: the English shortcut should use the compact footer label`);
     assert.equal(chinese.dir, 'ltr', `${label}: Chinese should retain left-to-right layout`);
     assert.equal(getLocalization('ar').dir, 'rtl', `${label}: Arabic should use right-to-left layout`);
@@ -45113,9 +45117,10 @@ test('selection shortcut is shipped, enabled by default, and keeps browser-speci
     assert.match(content, /language: action === 'custom' \? undefined : \(language \|\| interfaceLanguage\)/, `${label}: fixed actions should carry the interface language while custom questions stay untouched`);
     assert.match(content, /\.\.\.\(action === 'custom' \? \{ includePageContext: includePageContext\?\.checked === true \} : \{\}\)/, `${label}: only custom questions should submit the full-context choice`);
     assert.match(content, /function applyLocalization\(\)[\s\S]*?host\.dir = localization\.dir;[\s\S]*?\.action-label`\);[\s\S]*?label\.textContent = strings\[action\];/, `${label}: localization should update action labels without replacing their icons`);
+    assert.match(content, /shortcut\.setAttribute\('aria-label', strings\.askHighlightedText\);[\s\S]*?popup\.setAttribute\('aria-label', strings\.askHighlightedText\);/, `${label}: webpage shortcut localization should retain the selected-text prompt`);
     assert.match(content, /class="shortcut-icon" aria-hidden="true">\?<\/span>/, `${label}: shortcut should use the compact question-mark icon`);
-    assert.match(content, /<button class="shortcut" type="button" aria-label="Add to chat" title="Add to chat" hidden>/, `${label}: shortcut fallback copy should use Add to chat before localization loads`);
-    assert.match(content, /\.shortcut \{[\s\S]*?border:1px solid rgba\(23,23,34,\.14\);[\s\S]*?background:#fff; color:#171722;[\s\S]*?box-shadow:0 9px 20px rgba\(23,23,34,\.16\)/, `${label}: shortcut should use a solid white neutral treatment with a lower shadow`);
+    assert.match(content, /<button class="shortcut" type="button" aria-label="Ask WebBrain about this" title="Ask WebBrain about this" hidden>/, `${label}: shortcut fallback copy should retain its original selected-text prompt`);
+    assert.match(content, /\.shortcut \{[\s\S]*?border:1px solid rgba\(108,99,255,\.34\);[\s\S]*?background:var\(--bg\); color:var\(--accent\);[\s\S]*?box-shadow:0 10px 26px rgba\(35,30,95,\.22\)/, `${label}: shortcut should retain its purple treatment`);
     assert.match(content, /\.popup \{[\s\S]*?max-height:calc\(100vh - 16px\); overflow-y:auto; overscroll-behavior:contain;/, `${label}: expanded popup should remain scrollable inside short viewports`);
     assert.doesNotMatch(content, /M6\.8 8\.5 9\.2 14l2\.8-3\.4 2\.8 3\.4 2\.4-5\.5/, `${label}: discarded WebBrain W outline should be removed`);
     assert.doesNotMatch(content, /M12 2\.8c\.65 3\.78/, `${label}: Claude-like sparkle icon should be removed`);


### PR DESCRIPTION
## Summary
- give the sidepanel selected-answer action dedicated localized “Add this to chat” copy
- place that action above the selection with a viewport-safe fallback and restore its white card treatment
- restore the webpage question-mark shortcut’s purple styling and original selected-text prompt without changing its current placement or highlight behavior
- keep Chrome and Firefox sources, localization, and regression coverage aligned

## Validation
- node test/run.js — 2,101 passed, 0 failed
- npm run test:toolbar-guard — 33 passed
- npm run test:fixtures — all Chrome and Firefox selection-shortcut fixtures passed; the full runner retained one unrelated rich-text toolbar dispatch-order failure (175 passed, 1 failed)