### PR TITLE
Add OpenRouter routing variant controls

### DIFF
--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -265,6 +265,7 @@ const DUPLICATE_BLANK_CONFIG_KEYS = [
   'cacheWrite1hCostPerMillionUsd',
   'outputCostPerMillionUsd',
   'promptTier',
+  'routingVariant',
   'visionMode',
   'visionDetection',
   'supportsVision',

--- a/src/chrome/src/providers/openai.js
+++ b/src/chrome/src/providers/openai.js
@@ -6,7 +6,7 @@ import {
   isOfficialOpenAIConfig,
   shouldUseOpenAIResponsesApi,
   supportsOpenAIAskStreaming,
-  withOpenRouterRoutingVariant,
+  applyOpenRouterRoutingVariant,
 } from './provider-compatibility.js';
 import { normalizeRuntimeTraceConfig } from '../trace/runtime-config.js';
 import { canonicalizeOllamaBaseUrl } from './context-windows.js';
@@ -462,7 +462,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
       body.tool_choice = options.toolChoice || 'auto';
     }
     body = this._mergeConfiguredRequestBody(body, options);
-    if (body.model) body.model = withOpenRouterRoutingVariant(body.model, this.config);
+    body = applyOpenRouterRoutingVariant(body, this.config);
     this._addWebBrainCloudContext(body, options);
     if (stream && body.tools && this.config.supportsToolStreamOption === true) {
       body.tool_stream = true;
@@ -600,7 +600,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     // base Responses shape. Reserved keys like model/input/stream/tools are
     // filtered out by mergeProviderRequestBody.
     body = this._mergeConfiguredRequestBody(body, options);
-    if (body.model) body.model = withOpenRouterRoutingVariant(body.model, this.config);
+    body = applyOpenRouterRoutingVariant(body, this.config);
 
     // Normalize Chat Completions-style reasoning_effort if a preset emitted it.
     if (typeof body.reasoning_effort === 'string') {

--- a/src/chrome/src/providers/openai.js
+++ b/src/chrome/src/providers/openai.js
@@ -6,6 +6,7 @@ import {
   isOfficialOpenAIConfig,
   shouldUseOpenAIResponsesApi,
   supportsOpenAIAskStreaming,
+  withOpenRouterRoutingVariant,
 } from './provider-compatibility.js';
 import { normalizeRuntimeTraceConfig } from '../trace/runtime-config.js';
 import { canonicalizeOllamaBaseUrl } from './context-windows.js';
@@ -461,6 +462,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
       body.tool_choice = options.toolChoice || 'auto';
     }
     body = this._mergeConfiguredRequestBody(body, options);
+    if (body.model) body.model = withOpenRouterRoutingVariant(body.model, this.config);
     this._addWebBrainCloudContext(body, options);
     if (stream && body.tools && this.config.supportsToolStreamOption === true) {
       body.tool_stream = true;
@@ -598,6 +600,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     // base Responses shape. Reserved keys like model/input/stream/tools are
     // filtered out by mergeProviderRequestBody.
     body = this._mergeConfiguredRequestBody(body, options);
+    if (body.model) body.model = withOpenRouterRoutingVariant(body.model, this.config);
 
     // Normalize Chat Completions-style reasoning_effort if a preset emitted it.
     if (typeof body.reasoning_effort === 'string') {

--- a/src/chrome/src/providers/provider-compatibility.js
+++ b/src/chrome/src/providers/provider-compatibility.js
@@ -50,15 +50,35 @@ export function openRouterRoutingVariant(config = {}) {
   return suffix ? suffix[1].toLowerCase() : 'standard';
 }
 
-export function withOpenRouterRoutingVariant(model, config = {}) {
-  const value = String(model || '');
-  if (clean(config.providerName) !== 'openrouter' || !Object.hasOwn(config, 'routingVariant')) {
-    return value;
-  }
+export function applyOpenRouterRoutingVariant(body, config = {}) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return body;
+  if (clean(config.providerName) !== 'openrouter' || !Object.hasOwn(config, 'routingVariant')) return body;
   const variant = clean(config.routingVariant);
-  if (!OPENROUTER_ROUTING_VARIANT_VALUES.has(variant)) return value;
-  const baseModel = value.replace(/:(?:nitro|exacto)$/i, '');
-  return variant === 'standard' ? baseModel : `${baseModel}:${variant}`;
+  if (!OPENROUTER_ROUTING_VARIANT_VALUES.has(variant)) return body;
+
+  const next = { ...body };
+  if (typeof next.model === 'string') {
+    next.model = next.model.replace(/:(?:nitro|exacto)$/i, '');
+  }
+
+  const hasProviderPreferences = next.provider
+    && typeof next.provider === 'object'
+    && !Array.isArray(next.provider);
+  if (variant === 'standard') {
+    if (hasProviderPreferences && Object.hasOwn(next.provider, 'sort')) {
+      const provider = { ...next.provider };
+      delete provider.sort;
+      if (Object.keys(provider).length) next.provider = provider;
+      else delete next.provider;
+    }
+    return next;
+  }
+
+  next.provider = {
+    ...(hasProviderPreferences ? next.provider : {}),
+    sort: variant === 'nitro' ? 'throughput' : 'exacto',
+  };
+  return next;
 }
 
 /**

--- a/src/chrome/src/providers/provider-compatibility.js
+++ b/src/chrome/src/providers/provider-compatibility.js
@@ -2,6 +2,8 @@ const COMPATIBILITY_PRESETS = new Set(['auto', 'openai', 'qwen', 'deepseek', 'op
 const REASONING_EFFORTS = new Set(['auto', 'off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
 const SYSTEM_PROMPT_ROLES = new Set(['auto', 'system', 'developer']);
 const MAX_TOKEN_FIELDS = new Set(['auto', 'max_tokens', 'max_completion_tokens']);
+const OPENROUTER_ROUTING_VARIANT_VALUES = new Set(['standard', 'nitro', 'exacto']);
+export const OPENROUTER_ROUTING_VARIANTS = Object.freeze(['standard', 'nitro', 'exacto']);
 const STRUCTURED_OUTPUT_PROVIDER_NAMES = new Set([
   'azure-openai',
   'llamacpp',
@@ -39,6 +41,24 @@ const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
 
 function clean(value) {
   return String(value || '').trim().toLowerCase();
+}
+
+export function openRouterRoutingVariant(config = {}) {
+  const configured = clean(config.routingVariant);
+  if (OPENROUTER_ROUTING_VARIANT_VALUES.has(configured)) return configured;
+  const suffix = String(config.model || '').trim().match(/:(nitro|exacto)$/i);
+  return suffix ? suffix[1].toLowerCase() : 'standard';
+}
+
+export function withOpenRouterRoutingVariant(model, config = {}) {
+  const value = String(model || '');
+  if (clean(config.providerName) !== 'openrouter' || !Object.hasOwn(config, 'routingVariant')) {
+    return value;
+  }
+  const variant = clean(config.routingVariant);
+  if (!OPENROUTER_ROUTING_VARIANT_VALUES.has(variant)) return value;
+  const baseModel = value.replace(/:(?:nitro|exacto)$/i, '');
+  return variant === 'standard' ? baseModel : `${baseModel}:${variant}`;
 }
 
 /**

--- a/src/chrome/src/providers/provider-compatibility.js
+++ b/src/chrome/src/providers/provider-compatibility.js
@@ -3,6 +3,7 @@ const REASONING_EFFORTS = new Set(['auto', 'off', 'minimal', 'low', 'medium', 'h
 const SYSTEM_PROMPT_ROLES = new Set(['auto', 'system', 'developer']);
 const MAX_TOKEN_FIELDS = new Set(['auto', 'max_tokens', 'max_completion_tokens']);
 const OPENROUTER_ROUTING_VARIANT_VALUES = new Set(['standard', 'nitro', 'exacto']);
+const OPENROUTER_MODEL_VARIANT_SUFFIXES = /(?::(?:free|extended|thinking|online|nitro|floor|exacto))+$/i;
 export const OPENROUTER_ROUTING_VARIANTS = Object.freeze(['standard', 'nitro', 'exacto']);
 const STRUCTURED_OUTPUT_PROVIDER_NAMES = new Set([
   'azure-openai',
@@ -58,13 +59,15 @@ export function applyOpenRouterRoutingVariant(body, config = {}) {
 
   const next = { ...body };
   if (typeof next.model === 'string') {
-    next.model = next.model.replace(/:(?:nitro|exacto)$/i, '');
+    next.model = variant === 'exacto'
+      ? `${next.model.replace(OPENROUTER_MODEL_VARIANT_SUFFIXES, '')}:exacto`
+      : next.model.replace(/:(?:nitro|exacto)$/i, '');
   }
 
   const hasProviderPreferences = next.provider
     && typeof next.provider === 'object'
     && !Array.isArray(next.provider);
-  if (variant === 'standard') {
+  if (variant !== 'nitro') {
     if (hasProviderPreferences && Object.hasOwn(next.provider, 'sort')) {
       const provider = { ...next.provider };
       delete provider.sort;
@@ -76,7 +79,7 @@ export function applyOpenRouterRoutingVariant(body, config = {}) {
 
   next.provider = {
     ...(hasProviderPreferences ? next.provider : {}),
-    sort: variant === 'nitro' ? 'throughput' : 'exacto',
+    sort: 'throughput',
   };
   return next;
 }

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -3295,6 +3295,7 @@ function renderProviders() {
       if (!input) return;
       const selectedModel = option.dataset.model || '';
       input.value = selectedModel;
+      syncInferredOpenRouterRoutingVariant(providerId, selectedModel);
       void saveProvider(providerId, { showFlash: false })
         .then(() => detectProviderContextWindowForModel(providerId, selectedModel))
         .catch(() => {});

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -33,10 +33,12 @@ import {
   normalizeCapsolverApiKey,
 } from '../agent/capsolver-config.js';
 import {
+  OPENROUTER_ROUTING_VARIANTS,
   detectedCompatibilityPreset,
   isNewOpenAIContractConfig,
   normalizeOpenAICompatibleBaseUrl,
   normalizeProviderCompatibility,
+  openRouterRoutingVariant,
   parseProviderExtraBodyJson,
   shouldUseOpenAIResponsesApi,
 } from '../providers/provider-compatibility.js';
@@ -2387,6 +2389,21 @@ function prettyCompatibilityValue(value) {
   return translated === key ? (value || '') : translated;
 }
 
+function prettyOpenRouterRoutingVariant(value) {
+  if (value === 'standard') return prettyCompatibilityValue(value);
+  return value === 'nitro' ? 'Nitro' : 'Exacto';
+}
+
+function shouldPersistProviderInput(input) {
+  return input.dataset.key !== 'routingVariant' || input.dataset.routingExplicit === 'true';
+}
+
+function syncInferredOpenRouterRoutingVariant(id, model) {
+  const select = document.querySelector(`select[data-provider="${id}"][data-key="routingVariant"]`);
+  if (!select || select.dataset.routingExplicit === 'true') return;
+  select.value = openRouterRoutingVariant({ model });
+}
+
 function automaticTokenField(config) {
   if (shouldUseOpenAIResponsesApi(config)) return 'max_output_tokens';
   const isNewOfficialContract = config.type === 'openai' && isNewOpenAIContractConfig(config);
@@ -2417,13 +2434,17 @@ function compatibilitySummary(config) {
   const extra = extraCount
     ? t(extraCount === 1 ? 'st.providers.compat.summary_extra' : 'st.providers.compat.summary_extra_plural', { count: extraCount })
     : '';
-  return t('st.providers.compat.summary', { preset, reasoning, role, tokens, extra });
+  const routing = String(config.providerName || '').toLowerCase() === 'openrouter'
+    ? ` · ${prettyOpenRouterRoutingVariant(openRouterRoutingVariant(config))}`
+    : '';
+  return `${t('st.providers.compat.summary', { preset, reasoning, role, tokens, extra })}${routing}`;
 }
 
 function currentProviderCompatibilityConfig(id) {
   const source = providersData[id] || {};
   const config = { ...source, compat: { ...(source.compat || {}) } };
   document.querySelectorAll(`.provider-compatibility [data-provider="${id}"]`).forEach((input) => {
+    if (!shouldPersistProviderInput(input)) return;
     if (input.dataset.type === 'json') {
       try { config.extraBody = parseProviderExtraBodyJson(input.value); } catch { config.extraBody = {}; }
       return;
@@ -2455,6 +2476,7 @@ function refreshProviderCompatibilitySummary(id) {
 function renderProviderCompatibilitySettings(id, config) {
   if (!supportsProviderCompatibilitySettings(id, config)) return '';
   const showCompatibilityControls = supportsProviderCompatibilityControls(id, config);
+  const showOpenRouterRouting = String(config.providerName || '').toLowerCase() === 'openrouter';
   const compat = normalizeProviderCompatibility(config);
   const extraBody = providerCompatibilityJsonDrafts.has(id)
     ? providerCompatibilityJsonDrafts.get(id)
@@ -2479,6 +2501,15 @@ function renderProviderCompatibilitySettings(id, config) {
               ${options([['auto', valueLabel('auto')], ['openai', valueLabel('openai')], ['qwen', valueLabel('qwen')], ['deepseek', valueLabel('deepseek')], ['openrouter', valueLabel('openrouter')], ['custom', valueLabel('custom')]], compat.preset)}
             </select>
           </div>
+          ${showOpenRouterRouting ? `
+          <div class="field">
+            <label>${escapeHtml(valueLabel('openrouter'))}</label>
+            <select data-provider="${id}" data-key="routingVariant" data-type="select"
+                    data-routing-explicit="${Object.hasOwn(config, 'routingVariant') ? 'true' : 'false'}">
+              ${options(OPENROUTER_ROUTING_VARIANTS.map((value) => [value, prettyOpenRouterRoutingVariant(value)]), openRouterRoutingVariant(config))}
+            </select>
+          </div>
+          ` : ''}
           <div class="field">
             <label>${escapeHtml(t('st.providers.compat.reasoning'))}</label>
             <select data-provider="${id}" data-key="compat.reasoningEffort" data-type="select">
@@ -2545,7 +2576,7 @@ function providerSearchTextForEntry(id, config, fieldDefs) {
     config.baseUrl,
     fieldText,
     supportsProviderCompatibilitySettings(id, config)
-      ? 'advanced model compatibility reasoning thinking system developer max tokens custom request body json'
+      ? `advanced model compatibility reasoning thinking system developer max tokens custom request body json${String(config.providerName || '').toLowerCase() === 'openrouter' ? ' openrouter routing standard nitro exacto speed throughput tool quality' : ''}`
       : '',
   ].filter(Boolean).join(' '));
 }
@@ -3199,6 +3230,7 @@ function renderProviders() {
         input.style.display = 'none';
         input.value = sel.value;
       }
+      syncInferredOpenRouterRoutingVariant(providerId, input.value);
       markProviderDirty(providerId);
       refreshProviderCompatibilitySummary(providerId);
       refreshVisionStatus(providerId);
@@ -3211,6 +3243,7 @@ function renderProviders() {
   document.querySelectorAll('.provider-compatibility select[data-provider], .provider-compatibility textarea[data-provider]').forEach((input) => {
     const eventName = input.tagName === 'TEXTAREA' ? 'input' : 'change';
     input.addEventListener(eventName, () => {
+      if (input.dataset.key === 'routingVariant') input.dataset.routingExplicit = 'true';
       if (input.tagName === 'TEXTAREA') {
         providerCompatibilityJsonDrafts.set(input.dataset.provider, input.value);
       }
@@ -3219,6 +3252,7 @@ function renderProviders() {
   });
   document.querySelectorAll('input[data-key="model"], input[data-key="baseUrl"]').forEach((input) => {
     input.addEventListener('input', () => {
+      if (input.dataset.key === 'model') syncInferredOpenRouterRoutingVariant(input.dataset.provider, input.value);
       refreshProviderCompatibilitySummary(input.dataset.provider);
       refreshVisionStatus(input.dataset.provider);
       if (providerDefinitionId(input.dataset.provider) === 'ollama') refreshVisionStatus(input.dataset.provider);
@@ -3228,7 +3262,14 @@ function renderProviders() {
     button.addEventListener('click', () => {
       const id = button.dataset.provider;
       const details = button.closest('.provider-compatibility');
-      details?.querySelectorAll('select[data-provider]').forEach((select) => { select.value = 'auto'; });
+      details?.querySelectorAll('select[data-provider]').forEach((select) => {
+        if (select.dataset.key === 'routingVariant') {
+          select.value = 'standard';
+          select.dataset.routingExplicit = 'true';
+        } else {
+          select.value = 'auto';
+        }
+      });
       const textarea = details?.querySelector('textarea[data-type="json"]');
       if (textarea) {
         textarea.value = '';
@@ -3585,6 +3626,7 @@ async function saveProvider(id, { showFlash = true, markConfigured = true } = {}
 
   try {
     inputs.forEach(input => {
+      if (!shouldPersistProviderInput(input)) return;
       const value = input.dataset.type === 'json'
         ? parseProviderExtraBodyJson(input.value)
         : providerInputValue(input);
@@ -3684,6 +3726,7 @@ function syncInputsIntoProvidersData() {
     const id = input.dataset.provider;
     const key = input.dataset.key;
     if (!id || !key || !providersData[id]) return;
+    if (!shouldPersistProviderInput(input)) return;
     // Keep extraBody as a parsed object in memory (matches saveProvider and
     // mergeProviderRequestBody). Invalid draft JSON is left unchanged so a
     // partial edit does not corrupt the last-known-good object.

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -241,6 +241,7 @@ const DUPLICATE_BLANK_CONFIG_KEYS = [
   'cacheWrite1hCostPerMillionUsd',
   'outputCostPerMillionUsd',
   'promptTier',
+  'routingVariant',
   'visionMode',
   'visionDetection',
   'supportsVision',

--- a/src/firefox/src/providers/openai.js
+++ b/src/firefox/src/providers/openai.js
@@ -6,7 +6,7 @@ import {
   isOfficialOpenAIConfig,
   shouldUseOpenAIResponsesApi,
   supportsOpenAIAskStreaming,
-  withOpenRouterRoutingVariant,
+  applyOpenRouterRoutingVariant,
 } from './provider-compatibility.js';
 import { normalizeRuntimeTraceConfig } from '../trace/runtime-config.js';
 import { canonicalizeOllamaBaseUrl } from './context-windows.js';
@@ -462,7 +462,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
       body.tool_choice = options.toolChoice || 'auto';
     }
     body = this._mergeConfiguredRequestBody(body, options);
-    if (body.model) body.model = withOpenRouterRoutingVariant(body.model, this.config);
+    body = applyOpenRouterRoutingVariant(body, this.config);
     this._addWebBrainCloudContext(body, options);
     if (stream && body.tools && this.config.supportsToolStreamOption === true) {
       body.tool_stream = true;
@@ -600,7 +600,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     // base Responses shape. Reserved keys like model/input/stream/tools are
     // filtered out by mergeProviderRequestBody.
     body = this._mergeConfiguredRequestBody(body, options);
-    if (body.model) body.model = withOpenRouterRoutingVariant(body.model, this.config);
+    body = applyOpenRouterRoutingVariant(body, this.config);
 
     // Normalize Chat Completions-style reasoning_effort if a preset emitted it.
     if (typeof body.reasoning_effort === 'string') {

--- a/src/firefox/src/providers/openai.js
+++ b/src/firefox/src/providers/openai.js
@@ -6,6 +6,7 @@ import {
   isOfficialOpenAIConfig,
   shouldUseOpenAIResponsesApi,
   supportsOpenAIAskStreaming,
+  withOpenRouterRoutingVariant,
 } from './provider-compatibility.js';
 import { normalizeRuntimeTraceConfig } from '../trace/runtime-config.js';
 import { canonicalizeOllamaBaseUrl } from './context-windows.js';
@@ -461,6 +462,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
       body.tool_choice = options.toolChoice || 'auto';
     }
     body = this._mergeConfiguredRequestBody(body, options);
+    if (body.model) body.model = withOpenRouterRoutingVariant(body.model, this.config);
     this._addWebBrainCloudContext(body, options);
     if (stream && body.tools && this.config.supportsToolStreamOption === true) {
       body.tool_stream = true;
@@ -598,6 +600,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     // base Responses shape. Reserved keys like model/input/stream/tools are
     // filtered out by mergeProviderRequestBody.
     body = this._mergeConfiguredRequestBody(body, options);
+    if (body.model) body.model = withOpenRouterRoutingVariant(body.model, this.config);
 
     // Normalize Chat Completions-style reasoning_effort if a preset emitted it.
     if (typeof body.reasoning_effort === 'string') {

--- a/src/firefox/src/providers/provider-compatibility.js
+++ b/src/firefox/src/providers/provider-compatibility.js
@@ -50,15 +50,35 @@ export function openRouterRoutingVariant(config = {}) {
   return suffix ? suffix[1].toLowerCase() : 'standard';
 }
 
-export function withOpenRouterRoutingVariant(model, config = {}) {
-  const value = String(model || '');
-  if (clean(config.providerName) !== 'openrouter' || !Object.hasOwn(config, 'routingVariant')) {
-    return value;
-  }
+export function applyOpenRouterRoutingVariant(body, config = {}) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return body;
+  if (clean(config.providerName) !== 'openrouter' || !Object.hasOwn(config, 'routingVariant')) return body;
   const variant = clean(config.routingVariant);
-  if (!OPENROUTER_ROUTING_VARIANT_VALUES.has(variant)) return value;
-  const baseModel = value.replace(/:(?:nitro|exacto)$/i, '');
-  return variant === 'standard' ? baseModel : `${baseModel}:${variant}`;
+  if (!OPENROUTER_ROUTING_VARIANT_VALUES.has(variant)) return body;
+
+  const next = { ...body };
+  if (typeof next.model === 'string') {
+    next.model = next.model.replace(/:(?:nitro|exacto)$/i, '');
+  }
+
+  const hasProviderPreferences = next.provider
+    && typeof next.provider === 'object'
+    && !Array.isArray(next.provider);
+  if (variant === 'standard') {
+    if (hasProviderPreferences && Object.hasOwn(next.provider, 'sort')) {
+      const provider = { ...next.provider };
+      delete provider.sort;
+      if (Object.keys(provider).length) next.provider = provider;
+      else delete next.provider;
+    }
+    return next;
+  }
+
+  next.provider = {
+    ...(hasProviderPreferences ? next.provider : {}),
+    sort: variant === 'nitro' ? 'throughput' : 'exacto',
+  };
+  return next;
 }
 
 /**

--- a/src/firefox/src/providers/provider-compatibility.js
+++ b/src/firefox/src/providers/provider-compatibility.js
@@ -2,6 +2,8 @@ const COMPATIBILITY_PRESETS = new Set(['auto', 'openai', 'qwen', 'deepseek', 'op
 const REASONING_EFFORTS = new Set(['auto', 'off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
 const SYSTEM_PROMPT_ROLES = new Set(['auto', 'system', 'developer']);
 const MAX_TOKEN_FIELDS = new Set(['auto', 'max_tokens', 'max_completion_tokens']);
+const OPENROUTER_ROUTING_VARIANT_VALUES = new Set(['standard', 'nitro', 'exacto']);
+export const OPENROUTER_ROUTING_VARIANTS = Object.freeze(['standard', 'nitro', 'exacto']);
 const STRUCTURED_OUTPUT_PROVIDER_NAMES = new Set([
   'azure-openai',
   'llamacpp',
@@ -39,6 +41,24 @@ const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
 
 function clean(value) {
   return String(value || '').trim().toLowerCase();
+}
+
+export function openRouterRoutingVariant(config = {}) {
+  const configured = clean(config.routingVariant);
+  if (OPENROUTER_ROUTING_VARIANT_VALUES.has(configured)) return configured;
+  const suffix = String(config.model || '').trim().match(/:(nitro|exacto)$/i);
+  return suffix ? suffix[1].toLowerCase() : 'standard';
+}
+
+export function withOpenRouterRoutingVariant(model, config = {}) {
+  const value = String(model || '');
+  if (clean(config.providerName) !== 'openrouter' || !Object.hasOwn(config, 'routingVariant')) {
+    return value;
+  }
+  const variant = clean(config.routingVariant);
+  if (!OPENROUTER_ROUTING_VARIANT_VALUES.has(variant)) return value;
+  const baseModel = value.replace(/:(?:nitro|exacto)$/i, '');
+  return variant === 'standard' ? baseModel : `${baseModel}:${variant}`;
 }
 
 /**

--- a/src/firefox/src/providers/provider-compatibility.js
+++ b/src/firefox/src/providers/provider-compatibility.js
@@ -3,6 +3,7 @@ const REASONING_EFFORTS = new Set(['auto', 'off', 'minimal', 'low', 'medium', 'h
 const SYSTEM_PROMPT_ROLES = new Set(['auto', 'system', 'developer']);
 const MAX_TOKEN_FIELDS = new Set(['auto', 'max_tokens', 'max_completion_tokens']);
 const OPENROUTER_ROUTING_VARIANT_VALUES = new Set(['standard', 'nitro', 'exacto']);
+const OPENROUTER_MODEL_VARIANT_SUFFIXES = /(?::(?:free|extended|thinking|online|nitro|floor|exacto))+$/i;
 export const OPENROUTER_ROUTING_VARIANTS = Object.freeze(['standard', 'nitro', 'exacto']);
 const STRUCTURED_OUTPUT_PROVIDER_NAMES = new Set([
   'azure-openai',
@@ -58,13 +59,15 @@ export function applyOpenRouterRoutingVariant(body, config = {}) {
 
   const next = { ...body };
   if (typeof next.model === 'string') {
-    next.model = next.model.replace(/:(?:nitro|exacto)$/i, '');
+    next.model = variant === 'exacto'
+      ? `${next.model.replace(OPENROUTER_MODEL_VARIANT_SUFFIXES, '')}:exacto`
+      : next.model.replace(/:(?:nitro|exacto)$/i, '');
   }
 
   const hasProviderPreferences = next.provider
     && typeof next.provider === 'object'
     && !Array.isArray(next.provider);
-  if (variant === 'standard') {
+  if (variant !== 'nitro') {
     if (hasProviderPreferences && Object.hasOwn(next.provider, 'sort')) {
       const provider = { ...next.provider };
       delete provider.sort;
@@ -76,7 +79,7 @@ export function applyOpenRouterRoutingVariant(body, config = {}) {
 
   next.provider = {
     ...(hasProviderPreferences ? next.provider : {}),
-    sort: variant === 'nitro' ? 'throughput' : 'exacto',
+    sort: 'throughput',
   };
   return next;
 }

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -2889,6 +2889,7 @@ function renderProviders() {
       if (!input) return;
       const selectedModel = option.dataset.model || '';
       input.value = selectedModel;
+      syncInferredOpenRouterRoutingVariant(providerId, selectedModel);
       void saveProvider(providerId, { showFlash: false })
         .then(() => detectProviderContextWindowForModel(providerId, selectedModel))
         .catch(() => {});

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -33,10 +33,12 @@ import {
   normalizeCapsolverApiKey,
 } from '../agent/capsolver-config.js';
 import {
+  OPENROUTER_ROUTING_VARIANTS,
   detectedCompatibilityPreset,
   isNewOpenAIContractConfig,
   normalizeOpenAICompatibleBaseUrl,
   normalizeProviderCompatibility,
+  openRouterRoutingVariant,
   parseProviderExtraBodyJson,
   shouldUseOpenAIResponsesApi,
 } from '../providers/provider-compatibility.js';
@@ -1989,6 +1991,21 @@ function prettyCompatibilityValue(value) {
   return translated === key ? (value || '') : translated;
 }
 
+function prettyOpenRouterRoutingVariant(value) {
+  if (value === 'standard') return prettyCompatibilityValue(value);
+  return value === 'nitro' ? 'Nitro' : 'Exacto';
+}
+
+function shouldPersistProviderInput(input) {
+  return input.dataset.key !== 'routingVariant' || input.dataset.routingExplicit === 'true';
+}
+
+function syncInferredOpenRouterRoutingVariant(id, model) {
+  const select = document.querySelector(`select[data-provider="${id}"][data-key="routingVariant"]`);
+  if (!select || select.dataset.routingExplicit === 'true') return;
+  select.value = openRouterRoutingVariant({ model });
+}
+
 function automaticTokenField(config) {
   if (shouldUseOpenAIResponsesApi(config)) return 'max_output_tokens';
   const isNewOfficialContract = config.type === 'openai' && isNewOpenAIContractConfig(config);
@@ -2019,13 +2036,17 @@ function compatibilitySummary(config) {
   const extra = extraCount
     ? t(extraCount === 1 ? 'st.providers.compat.summary_extra' : 'st.providers.compat.summary_extra_plural', { count: extraCount })
     : '';
-  return t('st.providers.compat.summary', { preset, reasoning, role, tokens, extra });
+  const routing = String(config.providerName || '').toLowerCase() === 'openrouter'
+    ? ` · ${prettyOpenRouterRoutingVariant(openRouterRoutingVariant(config))}`
+    : '';
+  return `${t('st.providers.compat.summary', { preset, reasoning, role, tokens, extra })}${routing}`;
 }
 
 function currentProviderCompatibilityConfig(id) {
   const source = providersData[id] || {};
   const config = { ...source, compat: { ...(source.compat || {}) } };
   document.querySelectorAll(`.provider-compatibility [data-provider="${id}"]`).forEach((input) => {
+    if (!shouldPersistProviderInput(input)) return;
     if (input.dataset.type === 'json') {
       try { config.extraBody = parseProviderExtraBodyJson(input.value); } catch { config.extraBody = {}; }
       return;
@@ -2057,6 +2078,7 @@ function refreshProviderCompatibilitySummary(id) {
 function renderProviderCompatibilitySettings(id, config) {
   if (!supportsProviderCompatibilitySettings(id, config)) return '';
   const showCompatibilityControls = supportsProviderCompatibilityControls(id, config);
+  const showOpenRouterRouting = String(config.providerName || '').toLowerCase() === 'openrouter';
   const compat = normalizeProviderCompatibility(config);
   const extraBody = providerCompatibilityJsonDrafts.has(id)
     ? providerCompatibilityJsonDrafts.get(id)
@@ -2081,6 +2103,15 @@ function renderProviderCompatibilitySettings(id, config) {
               ${options([['auto', valueLabel('auto')], ['openai', valueLabel('openai')], ['qwen', valueLabel('qwen')], ['deepseek', valueLabel('deepseek')], ['openrouter', valueLabel('openrouter')], ['custom', valueLabel('custom')]], compat.preset)}
             </select>
           </div>
+          ${showOpenRouterRouting ? `
+          <div class="field">
+            <label>${escapeHtml(valueLabel('openrouter'))}</label>
+            <select data-provider="${id}" data-key="routingVariant" data-type="select"
+                    data-routing-explicit="${Object.hasOwn(config, 'routingVariant') ? 'true' : 'false'}">
+              ${options(OPENROUTER_ROUTING_VARIANTS.map((value) => [value, prettyOpenRouterRoutingVariant(value)]), openRouterRoutingVariant(config))}
+            </select>
+          </div>
+          ` : ''}
           <div class="field">
             <label>${escapeHtml(t('st.providers.compat.reasoning'))}</label>
             <select data-provider="${id}" data-key="compat.reasoningEffort" data-type="select">
@@ -2147,7 +2178,7 @@ function providerSearchTextForEntry(id, config, fieldDefs) {
     config.baseUrl,
     fieldText,
     supportsProviderCompatibilitySettings(id, config)
-      ? 'advanced model compatibility reasoning thinking system developer max tokens custom request body json'
+      ? `advanced model compatibility reasoning thinking system developer max tokens custom request body json${String(config.providerName || '').toLowerCase() === 'openrouter' ? ' openrouter routing standard nitro exacto speed throughput tool quality' : ''}`
       : '',
   ].filter(Boolean).join(' '));
 }
@@ -2793,6 +2824,7 @@ function renderProviders() {
         input.style.display = 'none';
         input.value = sel.value;
       }
+      syncInferredOpenRouterRoutingVariant(providerId, input.value);
       markProviderDirty(providerId);
       refreshProviderCompatibilitySummary(providerId);
       refreshVisionStatus(providerId);
@@ -2805,6 +2837,7 @@ function renderProviders() {
   document.querySelectorAll('.provider-compatibility select[data-provider], .provider-compatibility textarea[data-provider]').forEach((input) => {
     const eventName = input.tagName === 'TEXTAREA' ? 'input' : 'change';
     input.addEventListener(eventName, () => {
+      if (input.dataset.key === 'routingVariant') input.dataset.routingExplicit = 'true';
       if (input.tagName === 'TEXTAREA') {
         providerCompatibilityJsonDrafts.set(input.dataset.provider, input.value);
       }
@@ -2813,6 +2846,7 @@ function renderProviders() {
   });
   document.querySelectorAll('input[data-key="model"], input[data-key="baseUrl"]').forEach((input) => {
     input.addEventListener('input', () => {
+      if (input.dataset.key === 'model') syncInferredOpenRouterRoutingVariant(input.dataset.provider, input.value);
       refreshProviderCompatibilitySummary(input.dataset.provider);
       refreshVisionStatus(input.dataset.provider);
       if (providerDefinitionId(input.dataset.provider) === 'ollama') refreshVisionStatus(input.dataset.provider);
@@ -2822,7 +2856,14 @@ function renderProviders() {
     button.addEventListener('click', () => {
       const id = button.dataset.provider;
       const details = button.closest('.provider-compatibility');
-      details?.querySelectorAll('select[data-provider]').forEach((select) => { select.value = 'auto'; });
+      details?.querySelectorAll('select[data-provider]').forEach((select) => {
+        if (select.dataset.key === 'routingVariant') {
+          select.value = 'standard';
+          select.dataset.routingExplicit = 'true';
+        } else {
+          select.value = 'auto';
+        }
+      });
       const textarea = details?.querySelector('textarea[data-type="json"]');
       if (textarea) {
         textarea.value = '';
@@ -3169,6 +3210,7 @@ async function saveProvider(id, { showFlash = true, markConfigured = true } = {}
 
   try {
     inputs.forEach(input => {
+      if (!shouldPersistProviderInput(input)) return;
       const value = input.dataset.type === 'json'
         ? parseProviderExtraBodyJson(input.value)
         : providerInputValue(input);
@@ -3262,6 +3304,7 @@ function syncInputsIntoProvidersData() {
     const id = input.dataset.provider;
     const key = input.dataset.key;
     if (!id || !key || !providersData[id]) return;
+    if (!shouldPersistProviderInput(input)) return;
     // Keep extraBody as a parsed object in memory (matches saveProvider and
     // mergeProviderRequestBody). Invalid draft JSON is left unchanged so a
     // partial edit does not corrupt the last-known-good object.

--- a/test/run.js
+++ b/test/run.js
@@ -63445,9 +63445,12 @@ test('OpenRouter advanced routing variants map Standard, Nitro, and Exacto onto 
     assert.equal(nitro.model, 'qwen/qwen3.8-27b');
     assert.deepEqual(nitro.provider, { sort: 'throughput' });
 
-    const exacto = requestBody({ routingVariant: 'exacto' });
-    assert.equal(exacto.model, 'qwen/qwen3.8-27b');
-    assert.deepEqual(exacto.provider, { sort: 'exacto' });
+    const exacto = requestBody({
+      routingVariant: 'exacto',
+      extraBody: { provider: { only: ['deepinfra'], sort: 'throughput' } },
+    });
+    assert.equal(exacto.model, 'qwen/qwen3.8-27b:exacto');
+    assert.deepEqual(exacto.provider, { only: ['deepinfra'] }, 'Exacto should use the model suffix without a conflicting provider sort');
 
     const freeNitro = requestBody({
       model: 'poolside/laguna-xs-2.1:free',
@@ -63456,6 +63459,10 @@ test('OpenRouter advanced routing variants map Standard, Nitro, and Exacto onto 
     });
     assert.equal(freeNitro.model, 'poolside/laguna-xs-2.1:free', 'routing must preserve a static model variant');
     assert.deepEqual(freeNitro.provider, { only: ['deepinfra'], sort: 'throughput' });
+
+    const freeExacto = requestBody({ model: 'poolside/laguna-xs-2.1:free', routingVariant: 'exacto' });
+    assert.equal(freeExacto.model, 'poolside/laguna-xs-2.1:exacto', 'Exacto should replace a conflicting static model variant');
+    assert.equal(freeExacto.provider, undefined);
 
     const responsesLegacy = responsesRequestBody({});
     assert.equal(responsesLegacy.model, 'qwen/qwen3.8-27b:exacto', 'Responses should preserve a legacy manual suffix');
@@ -63466,8 +63473,8 @@ test('OpenRouter advanced routing variants map Standard, Nitro, and Exacto onto 
     assert.equal(responsesNitro.model, 'poolside/laguna-xs-2.1:free');
     assert.deepEqual(responsesNitro.provider, { sort: 'throughput' });
     const responsesExacto = responsesRequestBody({ model: 'poolside/laguna-xs-2.1:free', routingVariant: 'exacto' });
-    assert.equal(responsesExacto.model, 'poolside/laguna-xs-2.1:free');
-    assert.deepEqual(responsesExacto.provider, { sort: 'exacto' });
+    assert.equal(responsesExacto.model, 'poolside/laguna-xs-2.1:exacto');
+    assert.equal(responsesExacto.provider, undefined);
 
     const nonOpenRouter = new Provider({
       providerName: 'together',

--- a/test/run.js
+++ b/test/run.js
@@ -41535,7 +41535,7 @@ test('settings async test controls surface rejected background results', () => {
     );
     assert.match(
       settings,
-      /document\.querySelectorAll\('\.loaded-model-dialog'\)\.forEach\(dialog => \{[\s\S]*?dialog\.addEventListener\('click', \(event\) => \{[\s\S]*?event\.target === dialog[\s\S]*?closeLoadedModelDialog\(dialog\);[\s\S]*?event\.target\.closest\('\.loaded-model-option'\);[\s\S]*?const providerId = dialog\.dataset\.loadedModelsFor;[\s\S]*?const selectedModel = option\.dataset\.model \|\| '';[\s\S]*?input\.value = selectedModel;[\s\S]*?saveProvider\(providerId, \{ showFlash: false \}\)[\s\S]*?detectProviderContextWindowForModel\(providerId, selectedModel\)[\s\S]*?closeLoadedModelDialog\(dialog\);[\s\S]*?\}\);[\s\S]*?\}\);/,
+      /document\.querySelectorAll\('\.loaded-model-dialog'\)\.forEach\(dialog => \{[\s\S]*?dialog\.addEventListener\('click', \(event\) => \{[\s\S]*?event\.target === dialog[\s\S]*?closeLoadedModelDialog\(dialog\);[\s\S]*?event\.target\.closest\('\.loaded-model-option'\);[\s\S]*?const providerId = dialog\.dataset\.loadedModelsFor;[\s\S]*?const selectedModel = option\.dataset\.model \|\| '';[\s\S]*?input\.value = selectedModel;[\s\S]*?syncInferredOpenRouterRoutingVariant\(providerId, selectedModel\);[\s\S]*?saveProvider\(providerId, \{ showFlash: false \}\)[\s\S]*?detectProviderContextWindowForModel\(providerId, selectedModel\)[\s\S]*?closeLoadedModelDialog\(dialog\);[\s\S]*?\}\);[\s\S]*?\}\);/,
       `${label}: choosing a loaded model should save it before detecting context for that model`,
     );
     assert.match(

--- a/test/run.js
+++ b/test/run.js
@@ -63407,7 +63407,7 @@ test('non-local OpenAI-compatible providers keep the legacy model fallback', () 
   }
 });
 
-test('OpenRouter advanced routing variants map Standard, Nitro, and Exacto onto the request model', () => {
+test('OpenRouter advanced routing variants map Standard, Nitro, and Exacto onto provider routing', () => {
   const messages = [{ role: 'user', content: 'hello' }];
   for (const compatibility of [ProviderCompatibilityCh, ProviderCompatibilityFx]) {
     assert.deepEqual(compatibility.OPENROUTER_ROUTING_VARIANTS, ['standard', 'nitro', 'exacto']);
@@ -63417,40 +63417,66 @@ test('OpenRouter advanced routing variants map Standard, Nitro, and Exacto onto 
   }
 
   for (const Provider of [OpenAIProviderCh, OpenAIProviderFx]) {
-    const requestModel = (config) => new Provider({
+    const requestBody = (config) => new Provider({
       providerName: 'openrouter',
       baseUrl: 'https://openrouter.ai/api/v1',
       model: 'qwen/qwen3.8-27b:exacto',
       ...config,
-    })._buildChatCompletionsBody(messages, {}, false).model;
-    const responsesRequestModel = (config) => new Provider({
+    })._buildChatCompletionsBody(messages, {}, false);
+    const responsesRequestBody = (config) => new Provider({
       providerName: 'openrouter',
       baseUrl: 'https://openrouter.ai/api/v1',
       apiFormat: 'responses',
       model: 'qwen/qwen3.8-27b:exacto',
       ...config,
-    })._responsesBody(messages, {}, false).model;
+    })._responsesBody(messages, {}, false);
 
-    assert.equal(requestModel({}), 'qwen/qwen3.8-27b:exacto', 'legacy manual suffix should remain untouched');
-    assert.equal(requestModel({ routingVariant: 'standard' }), 'qwen/qwen3.8-27b');
-    assert.equal(requestModel({ routingVariant: 'nitro' }), 'qwen/qwen3.8-27b:nitro');
-    assert.equal(requestModel({ routingVariant: 'exacto' }), 'qwen/qwen3.8-27b:exacto');
-    assert.equal(requestModel({ routingVariant: 'invalid' }), 'qwen/qwen3.8-27b:exacto', 'invalid stored values should fail closed');
-    assert.equal(responsesRequestModel({}), 'qwen/qwen3.8-27b:exacto', 'Responses should preserve a legacy manual suffix');
-    assert.equal(responsesRequestModel({ routingVariant: 'standard' }), 'qwen/qwen3.8-27b');
-    assert.equal(responsesRequestModel({ routingVariant: 'nitro' }), 'qwen/qwen3.8-27b:nitro');
-    assert.equal(responsesRequestModel({ routingVariant: 'exacto' }), 'qwen/qwen3.8-27b:exacto');
+    assert.equal(requestBody({}).model, 'qwen/qwen3.8-27b:exacto', 'legacy manual suffix should remain untouched');
+    assert.equal(requestBody({ routingVariant: 'invalid' }).model, 'qwen/qwen3.8-27b:exacto', 'invalid stored values should fail closed');
+
+    const standard = requestBody({
+      routingVariant: 'standard',
+      extraBody: { provider: { only: ['deepinfra'], sort: 'throughput' } },
+    });
+    assert.equal(standard.model, 'qwen/qwen3.8-27b');
+    assert.deepEqual(standard.provider, { only: ['deepinfra'] }, 'Standard should remove only the explicit routing sort');
+
+    const nitro = requestBody({ routingVariant: 'nitro' });
+    assert.equal(nitro.model, 'qwen/qwen3.8-27b');
+    assert.deepEqual(nitro.provider, { sort: 'throughput' });
+
+    const exacto = requestBody({ routingVariant: 'exacto' });
+    assert.equal(exacto.model, 'qwen/qwen3.8-27b');
+    assert.deepEqual(exacto.provider, { sort: 'exacto' });
+
+    const freeNitro = requestBody({
+      model: 'poolside/laguna-xs-2.1:free',
+      routingVariant: 'nitro',
+      extraBody: { provider: { only: ['deepinfra'] } },
+    });
+    assert.equal(freeNitro.model, 'poolside/laguna-xs-2.1:free', 'routing must preserve a static model variant');
+    assert.deepEqual(freeNitro.provider, { only: ['deepinfra'], sort: 'throughput' });
+
+    const responsesLegacy = responsesRequestBody({});
+    assert.equal(responsesLegacy.model, 'qwen/qwen3.8-27b:exacto', 'Responses should preserve a legacy manual suffix');
+    const responsesStandard = responsesRequestBody({ routingVariant: 'standard' });
+    assert.equal(responsesStandard.model, 'qwen/qwen3.8-27b');
+    assert.equal(responsesStandard.provider, undefined);
+    const responsesNitro = responsesRequestBody({ model: 'poolside/laguna-xs-2.1:free', routingVariant: 'nitro' });
+    assert.equal(responsesNitro.model, 'poolside/laguna-xs-2.1:free');
+    assert.deepEqual(responsesNitro.provider, { sort: 'throughput' });
+    const responsesExacto = responsesRequestBody({ model: 'poolside/laguna-xs-2.1:free', routingVariant: 'exacto' });
+    assert.equal(responsesExacto.model, 'poolside/laguna-xs-2.1:free');
+    assert.deepEqual(responsesExacto.provider, { sort: 'exacto' });
 
     const nonOpenRouter = new Provider({
       providerName: 'together',
       model: 'qwen/qwen3.8-27b:exacto',
       routingVariant: 'nitro',
     });
-    assert.equal(
-      nonOpenRouter._buildChatCompletionsBody(messages, {}, false).model,
-      'qwen/qwen3.8-27b:exacto',
-      'OpenRouter routing settings must not affect another provider',
-    );
+    const nonOpenRouterBody = nonOpenRouter._buildChatCompletionsBody(messages, {}, false);
+    assert.equal(nonOpenRouterBody.model, 'qwen/qwen3.8-27b:exacto', 'OpenRouter routing must not rewrite another provider model');
+    assert.equal(nonOpenRouterBody.provider, undefined, 'OpenRouter routing must not add preferences to another provider');
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -63407,6 +63407,100 @@ test('non-local OpenAI-compatible providers keep the legacy model fallback', () 
   }
 });
 
+test('OpenRouter advanced routing variants map Standard, Nitro, and Exacto onto the request model', () => {
+  const messages = [{ role: 'user', content: 'hello' }];
+  for (const compatibility of [ProviderCompatibilityCh, ProviderCompatibilityFx]) {
+    assert.deepEqual(compatibility.OPENROUTER_ROUTING_VARIANTS, ['standard', 'nitro', 'exacto']);
+    assert.equal(compatibility.openRouterRoutingVariant({ model: 'qwen/model:nitro' }), 'nitro');
+    assert.equal(compatibility.openRouterRoutingVariant({ model: 'qwen/model:exacto' }), 'exacto');
+    assert.equal(compatibility.openRouterRoutingVariant({ model: 'qwen/model' }), 'standard');
+  }
+
+  for (const Provider of [OpenAIProviderCh, OpenAIProviderFx]) {
+    const requestModel = (config) => new Provider({
+      providerName: 'openrouter',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      model: 'qwen/qwen3.8-27b:exacto',
+      ...config,
+    })._buildChatCompletionsBody(messages, {}, false).model;
+    const responsesRequestModel = (config) => new Provider({
+      providerName: 'openrouter',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      apiFormat: 'responses',
+      model: 'qwen/qwen3.8-27b:exacto',
+      ...config,
+    })._responsesBody(messages, {}, false).model;
+
+    assert.equal(requestModel({}), 'qwen/qwen3.8-27b:exacto', 'legacy manual suffix should remain untouched');
+    assert.equal(requestModel({ routingVariant: 'standard' }), 'qwen/qwen3.8-27b');
+    assert.equal(requestModel({ routingVariant: 'nitro' }), 'qwen/qwen3.8-27b:nitro');
+    assert.equal(requestModel({ routingVariant: 'exacto' }), 'qwen/qwen3.8-27b:exacto');
+    assert.equal(requestModel({ routingVariant: 'invalid' }), 'qwen/qwen3.8-27b:exacto', 'invalid stored values should fail closed');
+    assert.equal(responsesRequestModel({}), 'qwen/qwen3.8-27b:exacto', 'Responses should preserve a legacy manual suffix');
+    assert.equal(responsesRequestModel({ routingVariant: 'standard' }), 'qwen/qwen3.8-27b');
+    assert.equal(responsesRequestModel({ routingVariant: 'nitro' }), 'qwen/qwen3.8-27b:nitro');
+    assert.equal(responsesRequestModel({ routingVariant: 'exacto' }), 'qwen/qwen3.8-27b:exacto');
+
+    const nonOpenRouter = new Provider({
+      providerName: 'together',
+      model: 'qwen/qwen3.8-27b:exacto',
+      routingVariant: 'nitro',
+    });
+    assert.equal(
+      nonOpenRouter._buildChatCompletionsBody(messages, {}, false).model,
+      'qwen/qwen3.8-27b:exacto',
+      'OpenRouter routing settings must not affect another provider',
+    );
+  }
+});
+
+test('OpenRouter routing selector is confined to Advanced settings in both browser builds', () => {
+  for (const [label, prefix] of [
+    ['chrome', 'src/chrome'],
+    ['firefox', 'src/firefox'],
+  ]) {
+    const settings = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/settings.js'), 'utf8');
+    const manager = fs.readFileSync(path.join(ROOT, prefix, 'src/providers/manager.js'), 'utf8');
+    assert.match(
+      settings,
+      /function renderProviderCompatibilitySettings\(id, config\)[\s\S]*?showOpenRouterRouting = String\(config\.providerName \|\| ''\)\.toLowerCase\(\) === 'openrouter'[\s\S]*?<details class="provider-compatibility"[\s\S]*?showOpenRouterRouting \? `[\s\S]*?data-key="routingVariant"[\s\S]*?data-routing-explicit="\$\{Object\.hasOwn\(config, 'routingVariant'\) \? 'true' : 'false'\}"[\s\S]*?OPENROUTER_ROUTING_VARIANTS/,
+      `${label}: OpenRouter routing should render only inside the Advanced compatibility panel`,
+    );
+    assert.match(
+      settings,
+      /function shouldPersistProviderInput\(input\) \{[\s\S]*?input\.dataset\.key !== 'routingVariant' \|\| input\.dataset\.routingExplicit === 'true'[\s\S]*?\}/,
+      `${label}: an inferred routing value should not be serialized as an explicit override`,
+    );
+    assert.match(
+      settings,
+      /function syncInferredOpenRouterRoutingVariant\(id, model\) \{[\s\S]*?data-key="routingVariant"[\s\S]*?routingExplicit === 'true'[\s\S]*?openRouterRoutingVariant\(\{ model \}\)[\s\S]*?\}/,
+      `${label}: untouched routing selectors should follow model suffix edits`,
+    );
+    assert.match(
+      settings,
+      /input\.dataset\.key === 'routingVariant'\) input\.dataset\.routingExplicit = 'true'/,
+      `${label}: changing the Advanced selector should make it authoritative`,
+    );
+    assert.match(
+      settings,
+      /select\.dataset\.key === 'routingVariant'[\s\S]*?select\.value = 'standard';[\s\S]*?select\.dataset\.routingExplicit = 'true';/,
+      `${label}: Advanced reset should explicitly restore Standard routing`,
+    );
+    const saveStart = settings.indexOf('async function saveProvider(id, { showFlash = true, markConfigured = true } = {}) {');
+    const saveEnd = settings.indexOf('\n}\n\nfunction refreshProviderCardStatus', saveStart);
+    assert.match(
+      settings.slice(saveStart, saveEnd),
+      /inputs\.forEach\(input => \{[\s\S]*?if \(!shouldPersistProviderInput\(input\)\) return;[\s\S]*?setProviderConfigValue/,
+      `${label}: Save should omit an untouched inferred routing selector`,
+    );
+    assert.match(
+      manager,
+      /const DUPLICATE_BLANK_CONFIG_KEYS = \[[\s\S]*?'routingVariant'/,
+      `${label}: duplicated OpenRouter cards should not inherit a hidden routing choice`,
+    );
+  }
+});
+
 test('Responses reasoning effort is normalized for GPT-5 Pro model constraints', () => {
   for (const Provider of [OpenAIProviderCh, OpenAIProviderFx]) {
     for (const model of ['gpt-5-pro', 'gpt-5-pro-2025-10-06']) {


### PR DESCRIPTION
## Summary

- add an OpenRouter-only Standard, Nitro, and Exacto routing selector under Advanced model compatibility settings
- apply the selected route to Chat Completions and Responses request models in Chrome and Firefox
- preserve manually entered model suffixes until the Advanced selector is explicitly changed
- add mirrored regression coverage for request routing and settings persistence

## Testing

- node syntax checks for changed JavaScript files
- git diff --check
- node test/run.js: 2104 passed, with the single known unrelated failure caused by the absent dist/webbrain-chrome-33.5.0.zip artifact
- npm run test:toolbar-guard: 33 passed
- npm run test:security: 60 passed