### PR TITLE
Escape AX inventory values to clear CodeQL alerts on #320

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This changelog was generated from the repository Git history and release tags. V
 ### Fixed
 - Compact selected-workflow prompts now inject a brief execution contract and a shorter `progress_update.workflowReconciliation` schema; Mid/Full keep the full contract
 - YouTube `update-metadata` verification matches AX-truncated values via prefix plus `value_len`/`value_fp` after the same NFKC normalization used by verification, and values that equal the accessible name
+- AX inventory `value=` tokens escape backslash then quote, and inventory readback restores the app-owned string
 - Unknown metadata field names no longer discard the rest of the requirement list, but discarded classifier fields keep saved-state verification incomplete; playlist plural aliases are recognized
 - Form inventory emits `required=` only for explicit native/`aria-required` state, ignores decorative DOM depth, and omits erroring/empty third-party frames only when another frame already inventoried form controls; a lone failed cross-origin application frame stays incomplete
 

--- a/src/chrome/src/agent/adapter-workflow-evidence.js
+++ b/src/chrome/src/agent/adapter-workflow-evidence.js
@@ -83,6 +83,14 @@ export function invalidateWorkflowInventoryCompleteness(evidence) {
   };
 }
 
+// AX formatLine backslash-escapes `\` then `"` inside value="...". Inventory
+// readback must consume escaped quotes and restore the app-owned string.
+export function parseWorkflowAxQuotedValue(line) {
+  const match = /\bvalue="((?:[^"\\]|\\.)*)"/i.exec(String(line || ''));
+  if (!match) return undefined;
+  return match[1].replace(/\\([\\"])/g, '$1');
+}
+
 export function workflowRequiredRowsAreProcessed(rows = [], inventory = null, inventoryItems = []) {
   const requiredIds = new Set((inventory?.itemIds || []).map(id => String(id)));
   if (!requiredIds.size) return true;

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -37,6 +37,7 @@ import { formatAdapterWorkflowExecutionPolicy } from './adapter-workflow.js';
 import {
   invalidateWorkflowInventoryCompleteness,
   isExhaustiveAccessibilityInventoryRead,
+  parseWorkflowAxQuotedValue,
   shouldInvalidateFormInventoryAfterAction,
   workflowRequiredRowsAreProcessed,
 } from './adapter-workflow-evidence.js';
@@ -12359,7 +12360,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const id = `workflow:${this._workflowInventoryFingerprint(identity)}`;
       if (seen.has(id)) continue;
       seen.add(id);
-      const value = /\bvalue="([^"]*)"/i.exec(line)?.[1];
+      const value = parseWorkflowAxQuotedValue(line);
       const checked = /\b(?:aria-checked|checked)=(?:"?)(true|false)(?:"?)/i.exec(line)?.[1];
       const type = /\btype="([^"]+)"/i.exec(line)?.[1]?.toLowerCase() || '';
       const domId = /\bdom_id="([^"]*)"/i.exec(line)?.[1] || '';

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -718,14 +718,12 @@
       }
       return hash.toString(16).padStart(8, '0');
     };
-    const appendAxValue = (current, raw, escapeBackslash) => {
+    const appendAxValue = (current, raw) => {
       const v = axInventoryValue(raw);
       if (!v) return current;
       const truncated = v.length > AX_VALUE_MAX_LEN;
       const trimmed = truncated ? v.substring(0, AX_VALUE_MAX_LEN) + '...' : v;
-      const escaped = escapeBackslash
-        ? trimmed.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-        : trimmed.replace(/"/g, '\\"');
+      const escaped = trimmed.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
       current += ' value="' + escaped + '"';
       if (truncated) {
         current += ' value_len=' + v.length;
@@ -736,10 +734,10 @@
     if (tag === 'input' || tag === 'textarea') {
       const skipValueTypes = new Set(['submit', 'button', 'reset', 'file', 'checkbox', 'radio', 'image', 'hidden', 'color', 'range', 'password']);
       if (!skipValueTypes.has(inputType)) {
-        line = appendAxValue(line, el.value == null ? '' : String(el.value), false);
+        line = appendAxValue(line, el.value == null ? '' : String(el.value));
       }
     } else if (isEditableRoot(el)) {
-      line = appendAxValue(line, String(el.innerText || el.textContent || '').replace(/\s+/g, ' '), true);
+      line = appendAxValue(line, String(el.innerText || el.textContent || '').replace(/\s+/g, ' '));
     } else if (tag === 'select' || ['combobox', 'listbox'].includes(attrRole)) {
       let v = '';
       if (tag === 'select') {
@@ -761,7 +759,7 @@
         }
         if (!v) v = String(el.innerText || el.textContent || '').replace(/\s+/g, ' ').trim();
       }
-      line = appendAxValue(line, v, true);
+      line = appendAxValue(line, v);
     }
 
     return line;

--- a/src/firefox/src/agent/adapter-workflow-evidence.js
+++ b/src/firefox/src/agent/adapter-workflow-evidence.js
@@ -83,6 +83,14 @@ export function invalidateWorkflowInventoryCompleteness(evidence) {
   };
 }
 
+// AX formatLine backslash-escapes `\` then `"` inside value="...". Inventory
+// readback must consume escaped quotes and restore the app-owned string.
+export function parseWorkflowAxQuotedValue(line) {
+  const match = /\bvalue="((?:[^"\\]|\\.)*)"/i.exec(String(line || ''));
+  if (!match) return undefined;
+  return match[1].replace(/\\([\\"])/g, '$1');
+}
+
 export function workflowRequiredRowsAreProcessed(rows = [], inventory = null, inventoryItems = []) {
   const requiredIds = new Set((inventory?.itemIds || []).map(id => String(id)));
   if (!requiredIds.size) return true;

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -36,6 +36,7 @@ import { formatAdapterWorkflowExecutionPolicy } from './adapter-workflow.js';
 import {
   invalidateWorkflowInventoryCompleteness,
   isExhaustiveAccessibilityInventoryRead,
+  parseWorkflowAxQuotedValue,
   shouldInvalidateFormInventoryAfterAction,
   workflowRequiredRowsAreProcessed,
 } from './adapter-workflow-evidence.js';
@@ -10161,7 +10162,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const id = `workflow:${this._workflowInventoryFingerprint(identity)}`;
       if (seen.has(id)) continue;
       seen.add(id);
-      const value = /\bvalue="([^"]*)"/i.exec(line)?.[1];
+      const value = parseWorkflowAxQuotedValue(line);
       const checked = /\b(?:aria-checked|checked)=(?:"?)(true|false)(?:"?)/i.exec(line)?.[1];
       const type = /\btype="([^"]+)"/i.exec(line)?.[1]?.toLowerCase() || '';
       const domId = /\bdom_id="([^"]*)"/i.exec(line)?.[1] || '';

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -718,14 +718,12 @@
       }
       return hash.toString(16).padStart(8, '0');
     };
-    const appendAxValue = (current, raw, escapeBackslash) => {
+    const appendAxValue = (current, raw) => {
       const v = axInventoryValue(raw);
       if (!v) return current;
       const truncated = v.length > AX_VALUE_MAX_LEN;
       const trimmed = truncated ? v.substring(0, AX_VALUE_MAX_LEN) + '...' : v;
-      const escaped = escapeBackslash
-        ? trimmed.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-        : trimmed.replace(/"/g, '\\"');
+      const escaped = trimmed.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
       current += ' value="' + escaped + '"';
       if (truncated) {
         current += ' value_len=' + v.length;
@@ -736,10 +734,10 @@
     if (tag === 'input' || tag === 'textarea') {
       const skipValueTypes = new Set(['submit', 'button', 'reset', 'file', 'checkbox', 'radio', 'image', 'hidden', 'color', 'range', 'password']);
       if (!skipValueTypes.has(inputType)) {
-        line = appendAxValue(line, el.value == null ? '' : String(el.value), false);
+        line = appendAxValue(line, el.value == null ? '' : String(el.value));
       }
     } else if (isEditableRoot(el)) {
-      line = appendAxValue(line, String(el.innerText || el.textContent || '').replace(/\s+/g, ' '), true);
+      line = appendAxValue(line, String(el.innerText || el.textContent || '').replace(/\s+/g, ' '));
     } else if (tag === 'select' || ['combobox', 'listbox'].includes(attrRole)) {
       let v = '';
       if (tag === 'select') {
@@ -761,7 +759,7 @@
         }
         if (!v) v = String(el.innerText || el.textContent || '').replace(/\s+/g, ' ').trim();
       }
-      line = appendAxValue(line, v, true);
+      line = appendAxValue(line, v);
     }
 
     return line;

--- a/test/run.js
+++ b/test/run.js
@@ -303,6 +303,7 @@ const {
 const {
   isExhaustiveAccessibilityInventoryRead,
   invalidateWorkflowInventoryCompleteness,
+  parseWorkflowAxQuotedValue,
   shouldInvalidateFormInventoryAfterAction,
   workflowRequiredRowsAreProcessed,
 } = await import(
@@ -311,6 +312,7 @@ const {
 const {
   isExhaustiveAccessibilityInventoryRead: isExhaustiveAccessibilityInventoryReadFx,
   invalidateWorkflowInventoryCompleteness: invalidateWorkflowInventoryCompletenessFx,
+  parseWorkflowAxQuotedValue: parseWorkflowAxQuotedValueFx,
   shouldInvalidateFormInventoryAfterAction: shouldInvalidateFormInventoryAfterActionFx,
   workflowRequiredRowsAreProcessed: workflowRequiredRowsAreProcessedFx,
 } = await import(
@@ -7513,6 +7515,11 @@ test('adapter workflow evidence kernel is bounded and mirrored', () => {
     { id: 'optional-field', required: false },
   ]), true);
   assert.equal(workflowRequiredRowsAreProcessedFx(rows, inventory), false);
+  const quotedAx = 'textbox "Title" [ref_title] value="Launch \\"Video\\" from C:\\\\Temp"';
+  assert.equal(parseWorkflowAxQuotedValue(quotedAx), 'Launch "Video" from C:\\Temp');
+  assert.equal(parseWorkflowAxQuotedValueFx(quotedAx), 'Launch "Video" from C:\\Temp');
+  assert.equal(parseWorkflowAxQuotedValue('textbox "Title" [ref_title] value="plain"'), 'plain');
+  assert.equal(parseWorkflowAxQuotedValue('textbox "Title" [ref_title]'), undefined);
 });
 
 test('adapter workflow profile rejects unsafe or unverifiable job contracts', () => {
@@ -82139,6 +82146,18 @@ test('accessibility trees surface native and ARIA metadata choice values', () =>
     }), 0);
     assert.equal(titledLine, 'textbox "Launch Video" [ref_choice_3] type="text" value="Launch Video"',
       `${label}: text value equal to the accessible name was elided`);
+    const quotedTitle = 'Launch "Video" from C:\\Temp';
+    const quotedLine = formatLine(control({
+      tagName: 'INPUT',
+      role: 'textbox',
+      name: 'Title',
+      attributes: { type: 'text' },
+      value: quotedTitle,
+    }), 0);
+    assert.match(quotedLine, /value="Launch \\"Video\\" from C:\\\\Temp"/,
+      `${label}: quotes or backslashes were not escaped before value=`);
+    assert.doesNotMatch(source, /escapeBackslash/,
+      `${label}: incomplete quote-only value escaping path is still present`);
     const longDescription = `${'Launch the product with a detailed description that exceeds sixty characters and must still verify.'}`;
     assert.ok(longDescription.length > 60);
     const descriptionLine = formatLine(control({
@@ -82509,6 +82528,17 @@ test('workflow metadata matching accepts AX truncation and keeps valid fields', 
       compatDescription,
       { valueLength: nfkcDescription.length, valueFp: nfkcFp },
     ), true, `${AgentClass.name}: NFKC-normalized truncated metadata did not verify`);
+    const quotedTitle = 'Launch "Video" from C:\\Temp';
+    const quotedItems = agent._workflowFormInventoryItems({
+      pageContent: 'textbox "Title" [ref_title] value="Launch \\"Video\\" from C:\\\\Temp"',
+    }, 'bind', 'doc');
+    assert.equal(quotedItems[0]?.value, quotedTitle,
+      `${AgentClass.name}: escaped AX quotes/backslashes did not restore the app-owned title`);
+    assert.equal(agent._workflowMetadataRequirementsMatchInventory(
+      [{ field: 'title', value: quotedTitle }],
+      evidence([{ label: 'Title', value: quotedItems[0].value, observationSequence: 2 }]),
+      0,
+    ), true, `${AgentClass.name}: a title with quotes and backslashes did not verify`);
     assert.equal(agent._workflowMetadataRequirementsMatchInventory(
       [{ field: 'title', value: 'Launch Video' }],
       evidence([{ label: 'Title', value: 'Launch Video', observationSequence: 2 }]),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the two GitHub Advanced Security / CodeQL **high** alerts on [#320](https://github.com/esokullu/webbrain/pull/320):

> Incomplete string escaping or encoding — This does not escape backslash characters in the input.

**Where:** `src/chrome/src/content/accessibility-tree.js` and the Firefox mirror, `appendAxValue` (input/textarea path).

**What:** `value=` tokens now always escape `\` then `"`, matching the already-safe identity/`innerText` path. Inventory readback parses escaped quotes and restores the app-owned string so YouTube/form metadata verification still matches titles like `Launch "Video" from C:\Temp`.

Chrome/Firefox shared modules stay byte-identical. Stacked on `codex/report-driven-adapter-workflows` so #320 picks this up when merged.

## Tests
`node test/run.js`: 2142 passed. The remaining failure is pre-existing on the #320 branch (`adapter workflow jobs reach the executor...` — `taskKey` vs empty `evidenceTaskKey`) and is not caused by this escape fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ec5750c-9965-468b-8f06-070d93f78d73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ec5750c-9965-468b-8f06-070d93f78d73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

