### PR TITLE
Keep live workflow contracts after plan wording edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This changelog was generated from the repository Git history and release tags. V
 - AX inventory `value=` tokens escape backslash then quote, and inventory readback restores the app-owned string
 - Unknown metadata field names no longer discard the rest of the requirement list, but discarded classifier fields keep saved-state verification incomplete; playlist plural aliases are recognized
 - Form inventory emits `required=` only for explicit native/`aria-required` state, ignores decorative DOM depth, and omits erroring/empty third-party frames only when another frame already inventoried form controls; a lone failed cross-origin application frame stays incomplete
+- Reviewed plan wording edits re-resolve the live site-workflow contract instead of dropping it, and ARIA `searchbox` controls enter the form inventory
 
 ## [33.4.1] - 2026-08-27
 

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -12340,7 +12340,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const seen = new Set();
     const reviewThreadInventory = siteWorkflow?.adapterName === 'github'
       && siteWorkflow?.job?.id === 'resolve-review-threads';
-    const rolePattern = /^\s*(textbox|combobox|checkbox|radio|switch|slider|spinbutton|listbox|button)\b/i;
+    const rolePattern = /^\s*(textbox|searchbox|combobox|checkbox|radio|switch|slider|spinbutton|listbox|button)\b/i;
     for (const line of text.split(/\r?\n/)) {
       const roleMatch = rolePattern.exec(line);
       const refMatch = /\[(ref_[A-Za-z0-9_.:-]+)\]/.exec(line);
@@ -12415,7 +12415,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       && coversElement('textarea')
       && coversElement('select')
       && /\[contenteditable(?:\s*=|\s*\])/.test(value)
-      && ['textbox', 'combobox', 'checkbox', 'radio', 'switch', 'slider', 'spinbutton', 'listbox']
+      && ['textbox', 'searchbox', 'combobox', 'checkbox', 'radio', 'switch', 'slider', 'spinbutton', 'listbox']
         .every(coversRole);
   }
 
@@ -12436,7 +12436,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         const tag = String(match?.tag || '').toLowerCase();
         const type = String(match?.type || '').toLowerCase();
         const explicitRole = String(match?.role || '').toLowerCase();
-        let role = ['textbox', 'combobox', 'checkbox', 'radio', 'switch', 'slider', 'spinbutton', 'listbox', 'button']
+        let role = ['textbox', 'searchbox', 'combobox', 'checkbox', 'radio', 'switch', 'slider', 'spinbutton', 'listbox', 'button']
           .includes(explicitRole) ? explicitRole : '';
         if (!role) {
           if (tag === 'textarea' || match?.contentEditable === true) role = 'textbox';
@@ -12820,7 +12820,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const actionMatchesControl = name === 'upload_file'
       ? item.type === 'file'
       : (['type_ax', 'set_field', 'iframe_type'].includes(name)
-        ? ['textbox', 'combobox', 'listbox', 'spinbutton', 'slider'].includes(item.role)
+        ? ['textbox', 'searchbox', 'combobox', 'listbox', 'spinbutton', 'slider'].includes(item.role)
         : (name === 'set_checked'
           ? ['checkbox', 'radio', 'switch'].includes(item.role)
           : (['click_ax', 'iframe_click'].includes(name)
@@ -15030,9 +15030,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         && editedText
         && editedText !== String(markdown || '').trim();
       const approvedPlanEdited = verbosePlanEdited || compactPlanEdited;
-      // Any reviewed-text edit makes the visible approved text authoritative.
-      // Fail closed for compact and verbose edits instead of retaining hidden
-      // IDs or execution metadata from a stale planner object.
+      // Any reviewed-text edit makes the visible approved text authoritative
+      // for skill IDs and visible gate fields. The site-workflow contract is
+      // re-resolved against the live tab so a wording fix cannot drop
+      // transaction_fulfilled or form_confirmation.
       const approvedSkillIds = approvedPlanEdited ? [] : plan.skill_ids;
       const approvedSchedulingTool = approvedPlanEdited
         ? this._schedulingToolFromApprovedPlanText(approvedText)
@@ -15099,9 +15100,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         allowsPlannerShapedResult: plan.allows_planner_shaped_result === true,
         allowsAppStateToolEvidence: plan.allows_app_state_tool_evidence === true,
         requiredSchedulingTool: approvedSchedulingTool,
-        siteWorkflow: approvedPlanEdited
-          ? null
-          : await this._resolvePlannerSiteWorkflowForLiveTab(tabId, tabUrl, plan),
+        siteWorkflow: await this._resolvePlannerSiteWorkflowForLiveTab(tabId, tabUrl, plan),
         requiresDownload: approvedRequiresDownload,
         expectedItems: approvedExpectedItems,
         ...approvedProgressLedger,

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -10142,7 +10142,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const seen = new Set();
     const reviewThreadInventory = siteWorkflow?.adapterName === 'github'
       && siteWorkflow?.job?.id === 'resolve-review-threads';
-    const rolePattern = /^\s*(textbox|combobox|checkbox|radio|switch|slider|spinbutton|listbox|button)\b/i;
+    const rolePattern = /^\s*(textbox|searchbox|combobox|checkbox|radio|switch|slider|spinbutton|listbox|button)\b/i;
     for (const line of text.split(/\r?\n/)) {
       const roleMatch = rolePattern.exec(line);
       const refMatch = /\[(ref_[A-Za-z0-9_.:-]+)\]/.exec(line);
@@ -10217,7 +10217,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       && coversElement('textarea')
       && coversElement('select')
       && /\[contenteditable(?:\s*=|\s*\])/.test(value)
-      && ['textbox', 'combobox', 'checkbox', 'radio', 'switch', 'slider', 'spinbutton', 'listbox']
+      && ['textbox', 'searchbox', 'combobox', 'checkbox', 'radio', 'switch', 'slider', 'spinbutton', 'listbox']
         .every(coversRole);
   }
 
@@ -10238,7 +10238,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         const tag = String(match?.tag || '').toLowerCase();
         const type = String(match?.type || '').toLowerCase();
         const explicitRole = String(match?.role || '').toLowerCase();
-        let role = ['textbox', 'combobox', 'checkbox', 'radio', 'switch', 'slider', 'spinbutton', 'listbox', 'button']
+        let role = ['textbox', 'searchbox', 'combobox', 'checkbox', 'radio', 'switch', 'slider', 'spinbutton', 'listbox', 'button']
           .includes(explicitRole) ? explicitRole : '';
         if (!role) {
           if (tag === 'textarea' || match?.contentEditable === true) role = 'textbox';
@@ -10622,7 +10622,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const actionMatchesControl = name === 'upload_file'
       ? item.type === 'file'
       : (['type_ax', 'set_field', 'iframe_type'].includes(name)
-        ? ['textbox', 'combobox', 'listbox', 'spinbutton', 'slider'].includes(item.role)
+        ? ['textbox', 'searchbox', 'combobox', 'listbox', 'spinbutton', 'slider'].includes(item.role)
         : (name === 'set_checked'
           ? ['checkbox', 'radio', 'switch'].includes(item.role)
           : (['click_ax', 'iframe_click'].includes(name)
@@ -12813,9 +12813,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         && editedText
         && editedText !== String(markdown || '').trim();
       const approvedPlanEdited = verbosePlanEdited || compactPlanEdited;
-      // Any reviewed-text edit makes the visible approved text authoritative.
-      // Fail closed for compact and verbose edits instead of retaining hidden
-      // IDs or execution metadata from a stale planner object.
+      // Any reviewed-text edit makes the visible approved text authoritative
+      // for skill IDs and visible gate fields. The site-workflow contract is
+      // re-resolved against the live tab so a wording fix cannot drop
+      // transaction_fulfilled or form_confirmation.
       const approvedSkillIds = approvedPlanEdited ? [] : plan.skill_ids;
       const approvedSchedulingTool = approvedPlanEdited
         ? this._schedulingToolFromApprovedPlanText(approvedText)
@@ -12882,9 +12883,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         allowsPlannerShapedResult: plan.allows_planner_shaped_result === true,
         allowsAppStateToolEvidence: plan.allows_app_state_tool_evidence === true,
         requiredSchedulingTool: approvedSchedulingTool,
-        siteWorkflow: approvedPlanEdited
-          ? null
-          : await this._resolvePlannerSiteWorkflowForLiveTab(tabId, tabUrl, plan),
+        siteWorkflow: await this._resolvePlannerSiteWorkflowForLiveTab(tabId, tabUrl, plan),
         requiresDownload: approvedRequiresDownload,
         expectedItems: approvedExpectedItems,
         ...approvedProgressLedger,

--- a/test/run.js
+++ b/test/run.js
@@ -81739,7 +81739,7 @@ test('iframe-backed application forms expose a complete trusted inventory and ex
     const inventorySelector = [
       'input', 'textarea', 'select', '[contenteditable="true"]',
       '[role="textbox"]', '[role="combobox"]', '[role="checkbox"]', '[role="radio"]',
-      '[role="switch"]', '[role="slider"]', '[role="spinbutton"]', '[role="listbox"]',
+      '[role="searchbox"]', '[role="switch"]', '[role="slider"]', '[role="spinbutton"]', '[role="listbox"]',
     ].join(',');
     const inventory = agent._rememberWorkflowInventoryObservation(tabId, 'iframe_read', {
       selector: inventorySelector,
@@ -82678,7 +82678,7 @@ test('optional inventory rows may skip and noisy frames do not block iframe comp
     const inventorySelector = [
       'input', 'textarea', 'select', '[contenteditable="true"]',
       '[role="textbox"]', '[role="combobox"]', '[role="checkbox"]', '[role="radio"]',
-      '[role="switch"]', '[role="slider"]', '[role="spinbutton"]', '[role="listbox"]',
+      '[role="searchbox"]', '[role="switch"]', '[role="slider"]', '[role="spinbutton"]', '[role="listbox"]',
     ].join(',');
     const iframeInventory = agent._rememberWorkflowInventoryObservation(iframeTabId, 'iframe_read', {
       selector: inventorySelector,
@@ -82914,6 +82914,114 @@ test('site workflow bindings are revalidated on the live URL and preserved acros
     agent._currentUrl = async () => 'https://www.producthunt.com/';
     assert.equal(await agent._revalidateCarriedSiteWorkflow(tabId, selected), null,
       `${AgentClass.name}: carried workflow survived an adapter change`);
+  }
+});
+
+test('reviewed plan wording edits keep a live site-workflow contract', async () => {
+  await withPlannerBrowserGlobals(async () => {
+    for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+      const bookingUrl = 'https://kyfw.12306.cn/otn/confirmPassenger/initDc';
+      const runReviewedPlan = async (tabId, liveUrl, editPlan) => {
+        const agent = new AgentClass({
+          getActive: () => ({ promptTier: 'full', model: 'test', name: 'test' }),
+        });
+        agent.useSiteAdapters = true;
+        agent.setPlanReviewSettings({ mode: 'always' });
+        agent._currentUrl = async () => liveUrl;
+        agent._chatWithCostAllowance = async () => ({
+          content: plannerFixtureJson({
+            request_kind: 'execute',
+            site_job: 'rail-booking',
+            requires_state_change: true,
+            requires_submission: true,
+            summary: 'Book the selected 12306 train after review.',
+            localized: {
+              locale: 'en',
+              summary: 'Book the selected 12306 train after review.',
+              steps: [{ id: '1', action: 'Confirm the passenger and submit the official booking.' }],
+              risks: [],
+            },
+          }),
+        });
+        agent._waitForPlanReview = async (_tabId, _planId, _plan, compactMarkdown) => ({
+          action: 'approve',
+          editedText: editPlan(compactMarkdown),
+          markdownMode: 'compact',
+        });
+        return agent._runPlannerGate(
+          tabId,
+          { role: 'user', content: 'Book this train on 12306.' },
+          () => {},
+          null,
+          null,
+          '',
+          { tabUrl: bookingUrl, tabTitle: '12306' },
+          'try',
+          'act',
+          { locale: 'en' },
+        );
+      };
+
+      const kept = await runReviewedPlan(
+        label === 'chrome' ? 9301 : 9302,
+        bookingUrl,
+        text => text.replace('Book the selected', 'Book the chosen'),
+      );
+      assert.equal(kept.siteWorkflow?.job?.id, 'rail-booking',
+        `${label}: wording edit dropped the 12306 workflow`);
+      assert.equal(kept.siteWorkflow?.job?.stages?.includes('payment'), true,
+        `${label}: wording edit lost the payment fulfillment contract`);
+
+      const dropped = await runReviewedPlan(
+        label === 'chrome' ? 9303 : 9304,
+        'https://www.producthunt.com/',
+        text => text.replace('Book the selected', 'Book the chosen'),
+      );
+      assert.equal(dropped.siteWorkflow, null,
+        `${label}: a live adapter mismatch still bound the workflow`);
+    }
+  });
+});
+
+test('ARIA searchboxes enter the form inventory and accept text actions', () => {
+  for (const [index, AgentClass] of [AgentCh, AgentFx].entries()) {
+    const agent = new AgentClass({});
+    agent.useSiteAdapters = true;
+    const formUrl = 'https://forms.cloud.microsoft/pages/responsepage.aspx?id=x';
+    const selected = resolveAdapterWorkflowJob(formUrl, 'submit-form');
+    const tabId = 8970 + index;
+    agent.conversations.set(tabId, [
+      { role: 'system', content: 'system' },
+      { role: 'user', content: 'Submit every form question.' },
+    ]);
+    agent._startPlanExecutionGuard(tabId, 'act', {
+      requestKind: 'execute',
+      requiresStateChange: true,
+      requiresSubmission: true,
+      siteWorkflow: selected,
+    });
+    agent._lastAxScopes.set(tabId, { documentToken: 'searchbox-form-document', pageUrl: formUrl });
+    const inventory = agent._rememberWorkflowInventoryObservation(tabId, 'get_accessibility_tree', {
+      filter: 'all',
+      maxDepth: 15,
+    }, {
+      success: true,
+      pageContent: [
+        'textbox "Full name" [ref_name] required=true value=""',
+        'searchbox "Company" [ref_company] required=true value=""',
+      ].join('\n'),
+      treeRevision: 'tree-searchbox',
+    });
+    const company = inventory?.items?.find(item => item.ref_id === 'ref_company');
+    assert.equal(company?.role, 'searchbox',
+      `${AgentClass.name}: searchbox was omitted from the form inventory`);
+    agent._beginCompletionInvariant(tabId);
+    const proof = agent._rememberWorkflowControlActionEvidence(tabId, 'type_ax', {
+      ref_id: 'ref_company',
+      text: 'Acme',
+    }, { success: true, dispatched: true, verified: true }, { sequence: 1 });
+    assert.equal(proof?.directVerified, true,
+      `${AgentClass.name}: type_ax on a searchbox produced no action evidence`);
   }
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes two Codex findings on [#320](https://github.com/esokullu/webbrain/pull/320) (review of `03b44225`):

1. **P1 — Plan wording edits** — A compact/verbose wording fix no longer sets `siteWorkflow` to `null`. The planner job is re-resolved against the live tab, so 12306 `transaction_fulfilled` (and other job-bound contracts) stay in force when the page still matches. A live adapter mismatch still drops the binding.

2. **P2 — ARIA searchboxes** — Form inventories now parse `searchbox` (AX + iframe), require it in exhaustive iframe selectors, and accept `type_ax` / `set_field` / `iframe_type` as action evidence.

The other P1 (prefill/autofill as processed-without-mutation) is intentionally not taken: that would fail open.

Stacked on `codex/report-driven-adapter-workflows`.

## Tests
`node test/run.js`: 2144 passed. The remaining failure is pre-existing on #320 (`adapter workflow jobs reach the executor...` — `taskKey` vs empty `evidenceTaskKey`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ec5750c-9965-468b-8f06-070d93f78d73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ec5750c-9965-468b-8f06-070d93f78d73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

