### PR TITLE
Preserve max_steps in traces after step-limit handoff

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -3551,7 +3551,7 @@ export class Agent extends LoopDetector {
       : { ok: false, code: 'EMPTY_RESPONSE', ...extra };
   }
 
-  _traceTurnEndPayload(status, failureCode = null) {
+  _traceTurnEndPayload(status, failureCode = null, extra = {}) {
     const reason = String(status || 'done');
     const inferredCode = reason === 'cost_limit'
       ? 'COST_LIMIT'
@@ -3559,7 +3559,8 @@ export class Agent extends LoopDetector {
           ? 'EMPTY_RESPONSE'
           : (reason === 'error' ? 'UNKNOWN' : null));
     const code = failureCode || inferredCode;
-    return { status: reason, reason, ...(code ? { code } : {}) };
+    const detail = extra && typeof extra === 'object' ? extra : {};
+    return { status: reason, reason, ...(code ? { code } : {}), ...detail };
   }
 
   async _chatWithCostAllowance(provider, messages, options, costState, requestContext = null) {
@@ -33242,6 +33243,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let messageCompletion = null;
     let _traceStatus = 'done'; // updated on early exits
     let traceFailureCode = null;
+    let traceTurnEndExtra = {}; // step-limit handoff outcome; trace status keeps max_steps
     let lastTraceStep = 0; // step counter for turn_end, readable outside the loop
     let askStreamingTraceWrite = Promise.resolve();
     let shouldOrderInteractiveAskTrace = false;
@@ -34256,8 +34258,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             { phase: 'step_limit_recovery' },
           );
           finalResponse = recovery.content;
-          _traceStatus = recovery.status;
-          handoffCancelled = recovery.status === 'cancelled';
+          if (recovery.status === 'cancelled') {
+            _traceStatus = 'cancelled';
+            handoffCancelled = true;
+          } else {
+            // Keep the max_steps trace signal so Compass improvement traces
+            // still see the step-limit stop; the delivered handoff outcome
+            // travels separately in the turn_end payload (see finally).
+            traceTurnEndExtra = { handoffOutcome: recovery.status };
+          }
         } else {
           finalResponse = fallback;
           messages.push({ role: 'assistant', content: finalResponse });
@@ -34292,7 +34301,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (runId) await trace.recordTurnEnd(
         runId,
         lastTraceStep,
-        this._traceTurnEndPayload(_traceStatus, traceFailureCode),
+        this._traceTurnEndPayload(_traceStatus, traceFailureCode, traceTurnEndExtra),
       );
       await this._endTraceRun(tabId, runId, _traceStatus, finalResponse, { provider, messages, mode });
     }
@@ -34508,6 +34517,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let lastTraceStep = 0; // step counter for turn_end, readable outside the loop
     let _traceStatus = 'done';
     let traceFailureCode = null;
+    let traceTurnEndExtra = {}; // step-limit handoff outcome; trace status keeps max_steps
     const finish = (response, status = _traceStatus) => {
       finalResponse = response || '';
       _traceStatus = status;
@@ -35283,7 +35293,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // re-arming Continue there would also relabel the cancellation as a
     // step-limit error in the run journal.
     if (recovery.status !== 'cancelled') onUpdate('max_steps_reached', { steps: this.maxSteps });
-    return finish(recovery.content, recovery.status);
+    if (recovery.status === 'cancelled') return finish(recovery.content, 'cancelled');
+    // Keep the max_steps trace signal so Compass improvement traces still see
+    // the step-limit stop; finish() carries the delivered outcome to the UI
+    // while the trace close below re-asserts max_steps with handoffOutcome.
+    traceTurnEndExtra = { handoffOutcome: recovery.status };
+    const handoffResponse = finish(recovery.content, recovery.status);
+    _traceStatus = 'max_steps';
+    return handoffResponse;
     } catch (error) {
       const message = formatErrorMessage(error);
       _traceStatus = 'error';
@@ -35297,7 +35314,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (runId) await trace.recordTurnEnd(
         runId,
         lastTraceStep,
-        this._traceTurnEndPayload(_traceStatus, traceFailureCode),
+        this._traceTurnEndPayload(_traceStatus, traceFailureCode, traceTurnEndExtra),
       );
       await this._endTraceRun(tabId, runId, _traceStatus, finalResponse, { provider, messages, mode });
     }

--- a/src/chrome/src/trace/privacy.js
+++ b/src/chrome/src/trace/privacy.js
@@ -29,7 +29,7 @@ const STREAMING_METADATA_FIELDS = [
   'textChars', 'firstDeltaMs', 'durationMs', 'toolCallCount',
 ];
 
-const STEP_METADATA_FIELDS = ['step', 'ok', 'status', 'code', 'durationMs', 'reason'];
+const STEP_METADATA_FIELDS = ['step', 'ok', 'status', 'code', 'durationMs', 'reason', 'handoffOutcome'];
 
 const NOTE_METADATA_FIELDS = [
   'attempt', 'delayMs', 'code', 'status', 'progress', 'loaded', 'total',

--- a/src/chrome/src/trace/trajectory.js
+++ b/src/chrome/src/trace/trajectory.js
@@ -87,6 +87,9 @@ function markEnd(row, data) {
   const failed = data?.ok === false || FAILED_END_STATUSES.includes(data?.status);
   if (failed) row.status = 'error';
   else if (row.status !== 'error') row.status = 'done';
+  if (typeof data?.handoffOutcome === 'string' && data.handoffOutcome) {
+    row.handoffOutcome = data.handoffOutcome;
+  }
   if (data?.code && failed) addUnique(row.errorCodes, data.code, MAX_ERRORS);
   if (data?.repaired === true) row.repaired = true;
 }

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -3314,7 +3314,7 @@ export class Agent extends LoopDetector {
       : { ok: false, code: 'EMPTY_RESPONSE', ...extra };
   }
 
-  _traceTurnEndPayload(status, failureCode = null) {
+  _traceTurnEndPayload(status, failureCode = null, extra = {}) {
     const reason = String(status || 'done');
     const inferredCode = reason === 'cost_limit'
       ? 'COST_LIMIT'
@@ -3322,7 +3322,8 @@ export class Agent extends LoopDetector {
           ? 'EMPTY_RESPONSE'
           : (reason === 'error' ? 'UNKNOWN' : null));
     const code = failureCode || inferredCode;
-    return { status: reason, reason, ...(code ? { code } : {}) };
+    const detail = extra && typeof extra === 'object' ? extra : {};
+    return { status: reason, reason, ...(code ? { code } : {}), ...detail };
   }
 
   async _chatWithCostAllowance(provider, messages, options, costState, requestContext = null) {
@@ -26465,6 +26466,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let messageCompletion = null;
     let _traceStatus = 'done';
     let traceFailureCode = null;
+    let traceTurnEndExtra = {}; // step-limit handoff outcome; trace status keeps max_steps
     let lastTraceStep = 0; // step counter for turn_end, readable outside the loop
     let askStreamingTraceWrite = Promise.resolve();
     let shouldOrderInteractiveAskTrace = false;
@@ -27354,8 +27356,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             { phase: 'step_limit_recovery' },
           );
           finalResponse = recovery.content;
-          _traceStatus = recovery.status;
-          handoffCancelled = recovery.status === 'cancelled';
+          if (recovery.status === 'cancelled') {
+            _traceStatus = 'cancelled';
+            handoffCancelled = true;
+          } else {
+            // Keep the max_steps trace signal so Compass improvement traces
+            // still see the step-limit stop; the delivered handoff outcome
+            // travels separately in the turn_end payload (see finally).
+            traceTurnEndExtra = { handoffOutcome: recovery.status };
+          }
         } else {
           finalResponse = fallback;
           messages.push({ role: 'assistant', content: finalResponse });
@@ -27389,7 +27398,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (runId) await trace.recordTurnEnd(
         runId,
         lastTraceStep,
-        this._traceTurnEndPayload(_traceStatus, traceFailureCode),
+        this._traceTurnEndPayload(_traceStatus, traceFailureCode, traceTurnEndExtra),
       );
       await this._endTraceRun(tabId, runId, _traceStatus, finalResponse, { provider, messages, mode });
     }
@@ -27567,6 +27576,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let lastTraceStep = 0; // step counter for turn_end, readable outside the loop
     let _traceStatus = 'done';
     let traceFailureCode = null;
+    let traceTurnEndExtra = {}; // step-limit handoff outcome; trace status keeps max_steps
     const finish = (response, status = _traceStatus) => {
       finalResponse = response || '';
       _traceStatus = status;
@@ -28227,7 +28237,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // re-arming Continue there would also relabel the cancellation as a
     // step-limit error in the run journal.
     if (recovery.status !== 'cancelled') onUpdate('max_steps_reached', { steps: this.maxSteps });
-    return finish(recovery.content, recovery.status);
+    if (recovery.status === 'cancelled') return finish(recovery.content, 'cancelled');
+    // Keep the max_steps trace signal so Compass improvement traces still see
+    // the step-limit stop; finish() carries the delivered outcome to the UI
+    // while the trace close below re-asserts max_steps with handoffOutcome.
+    traceTurnEndExtra = { handoffOutcome: recovery.status };
+    const handoffResponse = finish(recovery.content, recovery.status);
+    _traceStatus = 'max_steps';
+    return handoffResponse;
     } catch (error) {
       const message = formatErrorMessage(error);
       _traceStatus = 'error';
@@ -28241,7 +28258,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (runId) await trace.recordTurnEnd(
         runId,
         lastTraceStep,
-        this._traceTurnEndPayload(_traceStatus, traceFailureCode),
+        this._traceTurnEndPayload(_traceStatus, traceFailureCode, traceTurnEndExtra),
       );
       await this._endTraceRun(tabId, runId, _traceStatus, finalResponse, { provider, messages, mode });
     }

--- a/src/firefox/src/trace/privacy.js
+++ b/src/firefox/src/trace/privacy.js
@@ -29,7 +29,7 @@ const STREAMING_METADATA_FIELDS = [
   'textChars', 'firstDeltaMs', 'durationMs', 'toolCallCount',
 ];
 
-const STEP_METADATA_FIELDS = ['step', 'ok', 'status', 'code', 'durationMs', 'reason'];
+const STEP_METADATA_FIELDS = ['step', 'ok', 'status', 'code', 'durationMs', 'reason', 'handoffOutcome'];
 
 const NOTE_METADATA_FIELDS = [
   'attempt', 'delayMs', 'code', 'status', 'progress', 'loaded', 'total',

--- a/src/firefox/src/trace/trajectory.js
+++ b/src/firefox/src/trace/trajectory.js
@@ -87,6 +87,9 @@ function markEnd(row, data) {
   const failed = data?.ok === false || FAILED_END_STATUSES.includes(data?.status);
   if (failed) row.status = 'error';
   else if (row.status !== 'error') row.status = 'done';
+  if (typeof data?.handoffOutcome === 'string' && data.handoffOutcome) {
+    row.handoffOutcome = data.handoffOutcome;
+  }
   if (data?.code && failed) addUnique(row.errorCodes, data.code, MAX_ERRORS);
   if (data?.repaired === true) row.repaired = true;
 }

--- a/test/run.js
+++ b/test/run.js
@@ -12194,6 +12194,11 @@ test('agent trace error classification: _traceErrorCodeFor maps failures to stab
     assert.deepEqual(agent._traceStepEndForResult({ content: '', toolCalls: [{ id: 'call_1' }] }, { retried: true }), { ok: true, retried: true }, `${label}: retried tool output must close as successful`);
     assert.deepEqual(agent._traceTurnEndPayload('error', 'TRANSPORT'), { status: 'error', reason: 'error', code: 'TRANSPORT' }, `${label}: failed turn must carry reason and code`);
     assert.deepEqual(agent._traceTurnEndPayload('done'), { status: 'done', reason: 'done' }, `${label}: successful turn must not invent a failure code`);
+    assert.deepEqual(
+      agent._traceTurnEndPayload('max_steps', null, { handoffOutcome: 'partial' }),
+      { status: 'max_steps', reason: 'max_steps', handoffOutcome: 'partial' },
+      `${label}: step-limit handoff must keep max_steps with the delivered outcome attached`,
+    );
   }
 });
 
@@ -13944,6 +13949,132 @@ test('step-limit recovery keeps Cloud observation checkpoints advisory but force
     assert.equal(invalidRecovery.status, 'delivery_recovery_failed', `${label}: invalid recovery was not visibly failed`);
     assert.equal(invalidMessages.at(-1)?.content, fallback, `${label}: deterministic fallback was not persisted`);
     assert.equal(invalidUpdates.some(update => update.type === 'error' && update.data?.message === fallback), true, `${label}: deterministic blocker was not shown`);
+  }
+});
+
+test('step-limit handoff keeps max_steps in traces with the delivered outcome attached', async () => {
+  for (const streaming of [false, true]) {
+    for (const [AgentClass, trajectory, privacy] of [
+      [AgentCh, TRACE_TRAJECTORY_CH, TRACE_PRIVACY_CH],
+      [AgentFx, TRACE_TRAJECTORY_FX, TRACE_PRIVACY_FX],
+    ]) {
+      const handoffSummary = 'One item was verified before the step limit.';
+      const responses = [
+        {
+          content: null,
+          toolCalls: [{
+            id: 'step_limit_trace_read',
+            function: { name: 'read_page', arguments: JSON.stringify({}) },
+          }],
+        },
+        {
+          content: null,
+          toolCalls: [{
+            id: 'step_limit_trace_done',
+            function: {
+              name: 'done',
+              arguments: JSON.stringify({ summary: handoffSummary, outcome: 'partial' }),
+            },
+          }],
+        },
+      ];
+      const provider = {
+        supportsTools: true,
+        supportsVision: false,
+        promptTier: 'full',
+        contextWindow: 128000,
+        model: 'test-model',
+        name: 'test-provider',
+        calls: 0,
+      };
+      if (streaming) {
+        provider.chatStream = async function* (_messages, _options) {
+          this.calls++;
+          const next = responses.shift();
+          assert.ok(next, `${AgentClass.name}: streamed model was called too many times`);
+          if (next.toolCalls?.length) {
+            yield {
+              type: 'tool_call',
+              content: next.toolCalls.map((call, index) => ({ index, id: call.id, function: call.function })),
+            };
+          }
+          yield { type: 'done' };
+        };
+        provider.chat = async () => {
+          provider.calls++;
+          const next = responses.shift();
+          assert.ok(next, `${AgentClass.name}: streamed recovery model was called too many times`);
+          return next;
+        };
+      } else {
+        provider.chat = async () => {
+          provider.calls++;
+          const next = responses.shift();
+          assert.ok(next, `${AgentClass.name}: model was called too many times`);
+          return next;
+        };
+      }
+
+      const agent = new AgentClass({
+        getActive: () => provider,
+        getVisionProvider: async () => null,
+      });
+      const tabId = (streaming ? 24914 : 24904) + (AgentClass === AgentFx ? 1 : 0);
+      agent.planBeforeAct = false;
+      agent._maybeRunPlannerGate = async () => ({
+        proceed: true,
+        requestKind: 'execute',
+        requiresStateChange: true,
+      });
+      agent.maxSteps = 1;
+      agent.autoScreenshot = 'off';
+      agent._skipPermissionGate = true;
+      agent._manageContext = async () => {};
+      agent._enrichUserMessageWithCurrentPage = async (_tabId, _messages, content) => ({ role: 'user', content });
+      agent._maybeReinjectAdapter = async () => {};
+      agent._ensureProgressSessionForCurrentTask = async () => ({ mode: 'inactive' });
+      agent._currentTaskLedgerRows = () => [];
+      agent._persist = () => {};
+      agent.executeTool = async (_toolTabId, name, args) => {
+        if (name === 'read_page') return { success: true, content: 'The action result is visible.' };
+        if (name === 'done') return { done: true, summary: args.summary, outcome: args.outcome };
+        throw new Error(`unexpected tool ${name}`);
+      };
+      const turnEndPayloads = [];
+      const realTurnEndPayload = agent._traceTurnEndPayload.bind(agent);
+      agent._traceTurnEndPayload = (...args) => {
+        const payload = realTurnEndPayload(...args);
+        turnEndPayloads.push(payload);
+        return payload;
+      };
+      let endTraceStatus = null;
+      agent._startTraceRun = async () => `step_limit_trace_${tabId}`;
+      agent._endTraceRun = (_endTabId, _runId, status) => { endTraceStatus = status; };
+
+      const updates = [];
+      const run = streaming ? agent.processMessageStream.bind(agent) : agent.processMessage.bind(agent);
+      const final = await run(tabId, 'collect every result', (type, data) => updates.push({ type, data }), 'act');
+
+      assert.equal(provider.calls, 2, `${AgentClass.name}/${streaming ? 'stream' : 'non-stream'}: step-limit run used the wrong number of turns`);
+      assert.match(final || '', /One item was verified/i, `${AgentClass.name}/${streaming ? 'stream' : 'non-stream'}: handoff summary did not reach the user`);
+      assert.ok(updates.some(update => update.type === 'max_steps_reached'), `${AgentClass.name}/${streaming ? 'stream' : 'non-stream'}: Continue was not enabled`);
+      assert.equal(endTraceStatus, 'max_steps', `${AgentClass.name}/${streaming ? 'stream' : 'non-stream'}: trace run did not preserve max_steps`);
+      const handoffPayload = turnEndPayloads.at(-1) || {};
+      assert.equal(handoffPayload.status, 'max_steps', `${AgentClass.name}/${streaming ? 'stream' : 'non-stream'}: turn_end lost the step-limit signal`);
+      assert.equal(handoffPayload.handoffOutcome, 'partial', `${AgentClass.name}/${streaming ? 'stream' : 'non-stream'}: turn_end lost the delivered handoff outcome`);
+
+      const rows = trajectory.buildTraceTrajectory([
+        { seq: 1, ts: 1000, kind: 'turn_start', data: { step: 0 } },
+        { seq: 2, ts: 1001, kind: 'turn_end', data: handoffPayload },
+      ]);
+      assert.equal(rows.length, 1, `${AgentClass.name}: trajectory did not collapse the turn to one row`);
+      assert.equal(rows[0]?.status, 'error', `${AgentClass.name}: step-limit handoff trajectory did not close as failed`);
+      assert.equal(rows[0]?.handoffOutcome, 'partial', `${AgentClass.name}: trajectory dropped the handoff outcome`);
+
+      const projected = privacy.projectTraceEventData('turn_end', handoffPayload);
+      assert.equal(projected.status, 'max_steps', `${AgentClass.name}: projected turn_end lost the step-limit signal`);
+      assert.equal(projected.handoffOutcome, 'partial', `${AgentClass.name}: projected turn_end stripped the handoff outcome`);
+    }
   }
 });
 


### PR DESCRIPTION
Fixes #337.

## Problem
#336's terminal handoff overwrote _traceStatus with the delivered done outcome (partial/failed/delivery_recovery_failed), so trajectory rows closed as done and the step-limit signal dropped out of Compass improvement traces. Only the UI-side max_steps_reached event remained, which traces don't record.

## Fix
- Keep max_steps as the trace end status (recordTurnEnd + endTraceRun) in Chrome and Firefox, streaming and non-streaming.
- Carry the delivered outcome separately as handoffOutcome in the turn_end payload (new optional extra arg on _traceTurnEndPayload), preserved on the trajectory row and kept in the privacy-safe projection.
- Cancellation during the handoff still traces as cancelled, preserving the #336 Stop semantics.
- The handoff extra is precomputed outside the trace-close finally so the existing trace-flush ordering shape is unchanged.

## Validation
- git diff --check clean; node --check clean on all touched files.
- node test/run.js: 2198 passed, 0 failed (includes new test 'step-limit handoff keeps max_steps in traces with the delivered outcome attached' covering both browsers x streaming, plus _traceTurnEndPayload unit and trajectory/projection assertions).